### PR TITLE
Add multiple requirement profiles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python:
   - "2.7"
   - "3.4"
 install:
-  - pip install -r requirements.txt
+  - pip install -r requirements_for_test.txt
 script:
   - ./scripts/run_tests.sh
 notifications:

--- a/requirements_for_build.txt
+++ b/requirements_for_build.txt
@@ -1,0 +1,2 @@
+-r requirements_for_test.txt
+-e https://github.com/alphagov/digitalmarketplace-deployment

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1,2 +1,3 @@
+-r requirements.txt
 nose==1.3.4
 pep8==1.5.7

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -20,8 +20,6 @@ function display_result {
   fi
 }
 
-pip install -r requirements_for_test.txt
-
 pep8 .
 display_result $? 1 "Code style check"
 


### PR DESCRIPTION
After this commit we will have three requirements files for different situations.

* `requirements.txt` is the basic application requirements
* `requirements_for_test.txt` is the requirements for testing the application (it includes `requirements.txt` and adds some test dependencies)
* `requirements_for_build.txt` is the requirements for deploying the application (it includes `requirements_for_test.txt` and adds the dm-deploy package as well)