### PR TITLE
Add API authentication

### DIFF
--- a/.ebextensions/wsgipassauth.config
+++ b/.ebextensions/wsgipassauth.config
@@ -1,0 +1,3 @@
+container_commands:
+  01_wsgipass:
+    command: 'echo "WSGIPassAuthorization On" >> ../wsgi.conf'

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -5,7 +5,7 @@ from flask import Flask
 from flask.ext.bootstrap import Bootstrap
 
 from config import config
-from .lib.helpers import boolify
+from .lib.helpers import convert_to_boolean
 
 bootstrap = Bootstrap()
 
@@ -16,7 +16,7 @@ def create_app(config_name):
 
     for name in config_attrs(config[config_name]):
         if name in os.environ:
-            application.config[name] = boolify(os.environ[name])
+            application.config[name] = convert_to_boolean(os.environ[name])
 
     config[config_name].init_app(application)
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,6 +1,11 @@
+import re
+import os
+
 from flask import Flask
 from flask.ext.bootstrap import Bootstrap
+
 from config import config
+from .lib.helpers import boolify
 
 bootstrap = Bootstrap()
 
@@ -8,6 +13,11 @@ bootstrap = Bootstrap()
 def create_app(config_name):
     application = Flask(__name__)
     application.config.from_object(config[config_name])
+
+    for name in config_attrs(config[config_name]):
+        if name in os.environ:
+            application.config[name] = boolify(os.environ[name])
+
     config[config_name].init_app(application)
 
     bootstrap.init_app(application)
@@ -16,3 +26,9 @@ def create_app(config_name):
     application.register_blueprint(main_blueprint)
 
     return application
+
+
+def config_attrs(config):
+    """Returns config attributes from a Config object"""
+    p = re.compile('^[A-Z_]+$')
+    return filter(lambda attr: bool(p.match(attr)), dir(config))

--- a/app/lib/authentication.py
+++ b/app/lib/authentication.py
@@ -1,0 +1,35 @@
+from functools import wraps
+
+from flask import current_app, abort, request
+
+
+def requires_authentication(view):
+    @wraps(view)
+    def wrapped_view(*args, **kwargs):
+        incoming_token = get_token_from_headers(request.headers)
+        tokens_path = current_app.config['AUTH_TOKENS_PATH']
+
+        if not incoming_token:
+            abort(401)
+        if not token_is_valid(tokens_path, incoming_token):
+            abort(403)
+
+        return view(*args, **kwargs)
+
+    return wrapped_view
+
+
+def token_is_valid(token_path, incoming_token):
+    return incoming_token in get_allowed_tokens(token_path)
+
+
+def get_allowed_tokens(token_path):
+    with open(token_path) as f:
+        return [token.strip() for token in f.readlines()]
+
+
+def get_token_from_headers(headers):
+    auth_header = headers.get('Authorization', '')
+    if auth_header[:7] != 'Bearer ':
+        return None
+    return auth_header[7:]

--- a/app/lib/authentication.py
+++ b/app/lib/authentication.py
@@ -6,13 +6,14 @@ from flask import current_app, abort, request
 def requires_authentication(view):
     @wraps(view)
     def wrapped_view(*args, **kwargs):
-        incoming_token = get_token_from_headers(request.headers)
-        tokens_path = current_app.config['AUTH_TOKENS_PATH']
+        if current_app.config['AUTH_REQUIRED']:
+            incoming_token = get_token_from_headers(request.headers)
+            tokens_path = current_app.config['AUTH_TOKENS_PATH']
 
-        if not incoming_token:
-            abort(401)
-        if not token_is_valid(tokens_path, incoming_token):
-            abort(403)
+            if not incoming_token:
+                abort(401)
+            if not token_is_valid(tokens_path, incoming_token):
+                abort(403)
 
         return view(*args, **kwargs)
 

--- a/app/lib/helpers.py
+++ b/app/lib/helpers.py
@@ -1,20 +1,20 @@
 from flask._compat import string_types
 
 
-def boolify(value):
+def convert_to_boolean(value):
     """Turn strings to bools if they look like them
 
     Truthy things should be True
     >>> for truthy in ['true', 'on', 'yes', '1']:
-    ...   assert boolify(truthy) == True
+    ...   assert convert_to_boolean(truthy) == True
 
     Falsey things should be False
     >>> for falsey in ['false', 'off', 'no', '0']:
-    ...   assert boolify(falsey) == False
+    ...   assert convert_to_boolean(falsey) == False
 
     Other things should be unchanged
     >>> for value in ['falsey', 'other', True, 0]:
-    ...   assert boolify(value) == value
+    ...   assert convert_to_boolean(value) == value
     """
     if isinstance(value, string_types):
         if value.lower() in ['t', 'true', 'on', 'yes', '1']:

--- a/app/lib/helpers.py
+++ b/app/lib/helpers.py
@@ -1,0 +1,25 @@
+from flask._compat import string_types
+
+
+def boolify(value):
+    """Turn strings to bools if they look like them
+
+    Truthy things should be True
+    >>> for truthy in ['true', 'on', 'yes', '1']:
+    ...   assert boolify(truthy) == True
+
+    Falsey things should be False
+    >>> for falsey in ['false', 'off', 'no', '0']:
+    ...   assert boolify(falsey) == False
+
+    Other things should be unchanged
+    >>> for value in ['falsey', 'other', True, 0]:
+    ...   assert boolify(value) == value
+    """
+    if isinstance(value, string_types):
+        if value.lower() in ['t', 'true', 'on', 'yes', '1']:
+            return True
+        elif value.lower() in ['f', 'false', 'off', 'no', '0']:
+            return False
+
+    return value

--- a/app/main/errors.py
+++ b/app/main/errors.py
@@ -2,6 +2,11 @@ from flask import render_template
 from . import main
 
 
+@main.app_errorhandler(401)
+def unauthorized(e):
+    return render_template('401.html'), 401, [('WWW-Authenticate', 'Bearer')]
+
+
 @main.app_errorhandler(404)
 def page_not_found(e):
     return render_template('404.html'), 404

--- a/app/main/views.py
+++ b/app/main/views.py
@@ -1,7 +1,9 @@
 from flask import render_template
+from ..lib.authentication import requires_authentication
 from . import main
 
 
 @main.route('/')
+@requires_authentication
 def index():
     return render_template('main.html')

--- a/app/templates/401.html
+++ b/app/templates/401.html
@@ -1,0 +1,4 @@
+{% block body %}
+<h1>401</h1>
+<p>You must provide your bearer token to get access</p>
+{% endblock %}

--- a/config.py
+++ b/config.py
@@ -5,6 +5,7 @@ basedir = os.path.abspath(os.path.dirname(__file__))
 
 class Config:
     CONFIG_PROPERTY = "some_property"
+    AUTH_TOKENS_PATH = ""
 
     @staticmethod
     def init_app(app):
@@ -13,10 +14,12 @@ class Config:
 
 class Test(Config):
     DEBUG = True
+    AUTH_TOKENS_PATH = "./config/tokens"
 
 
 class Development(Config):
     DEBUG = True
+    AUTH_TOKENS_PATH = "./config/tokens"
 
 
 class Live(Config):

--- a/config.py
+++ b/config.py
@@ -5,7 +5,6 @@ basedir = os.path.abspath(os.path.dirname(__file__))
 
 class Config:
     CONFIG_PROPERTY = "some_property"
-    AUTH_TOKENS_PATH = ""
     AUTH_REQUIRED = True
 
     @staticmethod
@@ -15,12 +14,10 @@ class Config:
 
 class Test(Config):
     DEBUG = True
-    AUTH_TOKENS_PATH = "./config/tokens"
 
 
 class Development(Config):
     DEBUG = True
-    AUTH_TOKENS_PATH = "./config/tokens"
 
 
 class Live(Config):

--- a/config.py
+++ b/config.py
@@ -6,6 +6,7 @@ basedir = os.path.abspath(os.path.dirname(__file__))
 class Config:
     CONFIG_PROPERTY = "some_property"
     AUTH_TOKENS_PATH = ""
+    AUTH_REQUIRED = True
 
     @staticmethod
     def init_app(app):

--- a/config/tokens
+++ b/config/tokens
@@ -1,0 +1,1 @@
+valid-token

--- a/config/tokens
+++ b/config/tokens
@@ -1,1 +1,0 @@
-valid-token

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -25,5 +25,5 @@ pip install -r requirements_for_test.txt
 pep8 .
 display_result $? 1 "Code style check"
 
-nosetests -v
+nosetests -v -s
 display_result $? 2 "Unit tests"

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -25,5 +25,5 @@ pip install -r requirements_for_test.txt
 pep8 .
 display_result $? 1 "Code style check"
 
-nosetests -v -s
+nosetests -v -s --with-doctest
 display_result $? 2 "Unit tests"

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,46 @@
+from functools import wraps
+import os
+
+from app import create_app
+
+
+def with_application(func):
+    app = create_app('test').test_client()
+
+    @wraps(func)
+    def wrapped():
+        return func(app)
+
+    return wrapped
+
+
+def provide_access_token(func):
+    """Inject a valid Authorization header for testing"""
+    @wraps(func)
+    def wrapped(app):
+        def method_wrapper(original):
+            def wrapped(*args, **kwargs):
+                headers = kwargs.get('headers', {})
+                headers['Authorization'] = 'Bearer valid-token'
+                kwargs['headers'] = headers
+                return original(*args, **kwargs)
+            return wrapped
+
+        http_methods = (app.get, app.post, app.put, app.delete)
+        (app.get, app.post, app.put, app.delete) = map(
+            method_wrapper, http_methods)
+
+        # set up valid-token as a valid token
+        auth_tokens = os.environ.get('AUTH_TOKENS')
+        os.environ['AUTH_TOKENS'] = 'valid-token'
+
+        result = func(app)
+
+        if auth_tokens is None:
+            del os.environ['AUTH_TOKENS']
+        else:
+            os.environ['AUTH_TOKENS'] = auth_tokens
+
+        return result
+
+    return wrapped

--- a/tests/lib/test_authenticate.py
+++ b/tests/lib/test_authenticate.py
@@ -1,0 +1,17 @@
+from nose.tools import eq_
+
+from app.lib.authentication import get_token_from_headers
+
+
+def test_get_token_from_headers():
+    yield check_token, {'Authorization': 'Bearer foo-bar'}, 'foo-bar'
+    yield check_token, {'Authorization': 'Bearer bar-foo'}, 'bar-foo'
+    yield check_token, {'Authorization': 'Bearer '}, ''
+    yield (check_token, {'Authorisation': 'Bearer foo-bar'}, None,
+           "Authorization header misspelt")
+    yield (check_token, {'Authorization': 'Borrower foo-bar'}, None,
+           "Authorization header prefix invalid")
+
+
+def check_token(headers, expected_token, message=None):
+    eq_(get_token_from_headers(headers), expected_token, message)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,37 +1,4 @@
-from functools import wraps
-
-from app import create_app
-
-
-def with_application(func):
-    app = create_app('test').test_client()
-
-    @wraps(func)
-    def wrapped():
-        return func(app)
-
-    return wrapped
-
-
-def provide_access_token(func):
-    """Inject a valid Authorization header for testing"""
-    @wraps(func)
-    def wrapped(app):
-        def method_wrapper(original):
-            def wrapped(*args, **kwargs):
-                headers = kwargs.get('headers', {})
-                headers['Authorization'] = 'Bearer valid-token'
-                kwargs['headers'] = headers
-                return original(*args, **kwargs)
-            return wrapped
-
-        http_methods = (app.get, app.post, app.put, app.delete)
-        (app.get, app.post, app.put, app.delete) = map(
-            method_wrapper, http_methods)
-
-        return func(app)
-
-    return wrapped
+from .helpers import with_application, provide_access_token
 
 
 @with_application

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -3,7 +3,7 @@ from functools import wraps
 from app import create_app
 
 
-def with_app(func):
+def with_application(func):
     app = create_app('test').test_client()
 
     @wraps(func)
@@ -13,13 +13,49 @@ def with_app(func):
     return wrapped
 
 
-@with_app
+def provide_access_token(func):
+    """Inject a valid Authorization header for testing"""
+    @wraps(func)
+    def wrapped(app):
+        def method_wrapper(original):
+            def wrapped(*args, **kwargs):
+                headers = kwargs.get('headers', {})
+                headers['Authorization'] = 'Bearer valid-token'
+                kwargs['headers'] = headers
+                return original(*args, **kwargs)
+            return wrapped
+
+        http_methods = (app.get, app.post, app.put, app.delete)
+        (app.get, app.post, app.put, app.delete) = map(
+            method_wrapper, http_methods)
+
+        return func(app)
+
+    return wrapped
+
+
+@with_application
+@provide_access_token
 def test_index(app):
     response = app.get('/')
     assert u'Hello You Dogs' in response.data.decode('utf8')
 
 
-@with_app
+@with_application
+@provide_access_token
 def test_404(app):
     response = app.get('/not-found')
     assert u'<h1>404</h1>' in response.data.decode('utf8')
+
+
+@with_application
+def test_bearer_token_is_required(app):
+    response = app.get('/')
+    assert 401 == response.status_code
+    assert 'WWW-Authenticate' in response.headers
+
+
+@with_application
+def test_invalid_bearer_tokens_not_allowed(app):
+    response = app.get('/', headers={'Authorization': 'Bearer invalid-token'})
+    assert 403 == response.status_code


### PR DESCRIPTION
See Pivotal [#84570466](https://www.pivotaltracker.com/story/show/84570466)

Adds bearer token based authentication. Valid tokens are pulled from an environment variable (`AUTH_TOKENS`) for the moment as this can be easily provided to app without having to package secrets up in the deployment artefact.

Authentication can be switched off by setting the `AUTH_REQUIRED` environment variable to something 'falsey' (`no`, `off`, `false` or `0`).