### PR TITLE
Serve static example JSON files for each lot

### DIFF
--- a/app/main/views.py
+++ b/app/main/views.py
@@ -1,4 +1,4 @@
-from flask import render_template, jsonify
+from flask import render_template, jsonify, Response
 
 from . import main
 from ..lib.authentication import requires_authentication
@@ -9,6 +9,42 @@ from ..models import Service
 @requires_authentication
 def index():
     return render_template('main.html')
+
+
+@main.route('/services/g6-scs-example')
+def get_scs():
+    content = render_template('sample_static_responses/sample-scs.json')
+    resp = Response(response=content,
+                    status=200,
+                    mimetype="application/json")
+    return resp
+
+
+@main.route('/services/g6-saas-example')
+def get_saas():
+    content = render_template('sample_static_responses/sample-saas.json')
+    resp = Response(response=content,
+                    status=200,
+                    mimetype="application/json")
+    return resp
+
+
+@main.route('/services/g6-paas-example')
+def get_paas():
+    content = render_template('sample_static_responses/sample-paas.json')
+    resp = Response(response=content,
+                    status=200,
+                    mimetype="application/json")
+    return resp
+
+
+@main.route('/services/g6-iaas-example')
+def get_iaas():
+    content = render_template('sample_static_responses/sample-iaas.json')
+    resp = Response(response=content,
+                    status=200,
+                    mimetype="application/json")
+    return resp
 
 
 @main.route('/services/<id>')

--- a/app/templates/sample_static_responses/sample-iaas.json
+++ b/app/templates/sample_static_responses/sample-iaas.json
@@ -1,0 +1,334 @@
+{
+  "services": {
+    "id": 987654321,
+    "supplierId": 123456,
+    "lot": "IaaS",
+    "title": "IaaS a Nice Little Earner",
+    "lastUpdated": "2014-12-16T20:03:07Z",
+    "lastUpdatedByEmail": "kevin.keenoy@digital.cabinet-office.gov.uk",
+    "lastCompleted": "2014-12-16T20:09:29Z",
+    "lastCompletedByEmail": "kevin.keenoy@digital.cabinet-office.gov.uk",
+    "serviceTypes": [
+      "Compute",
+      "Storage"
+    ],
+    "serviceName": "IaaS a Nice Little Earner",
+    "serviceSummary": "The IaaS a Nice Little Earner is a flexible and powerful platform that enables your organisations to innovate quickly while increasing efficiency levels and retaining data sovereignty.\r\nOur IaaS your organisation with a VPC where you are in full control of your\r\ninfrastructure.",
+    "serviceBenefits": [
+      "EC2 compatible APIs, easy to change from Amazon EC2",
+      "Live migration during planned maintenance (no downtime)",
+      "High-availability with failed instances restarted automatically",
+      "Open system with no vendor lock in",
+      "Pay-as-you-go metered services and monitoring",
+      "Triggers and alarms created based on usage",
+      "No minimum spend per month",
+      "Rapid on-boarding",
+      "24/7 support",
+      "\u0027Adequately\u0027 protected overseas data storage"
+    ],
+    "serviceFeatures": [
+      "Quickly launch, manage and terminate compute instances (virtual machines)",
+      "Wide choice of instance sizes",
+      "Console access to your compute instances via the web browser",
+      "Full root access to your compute instances",
+      "Software defined networking",
+      "High-availability with running instances restarted automatically",
+      "High availability block storage",
+      "S3 compatible object storage",
+      "Upload of your own operating system or provided image",
+      "Open API access"
+    ],
+    "termsAndConditionsDocument": "Terms and Conditions.pdf",
+    "minimumContractPeriod": "Hour",
+    "terminationCost": false,
+    "termsAndConditionsDocumentURL": "https://s3-eu-west-1.amazonaws.com/gds-g6-submission-bucket-live/123456/987654321/987654321-terms-and-condtions.pdf",
+    "openStandardsSupported": true,
+    "serviceOffboarding": true,
+    "serviceOnboarding": true,
+    "analyticsAvailable": true,
+    "persistentStorage": true,
+    "elasticCloud": true,
+    "guaranteedResources": true,
+    "openSource": true,
+    "networksConnected": [
+      "Internet",
+      "Other"
+    ],
+    "supportedDevices": [
+      "PC",
+      "Mac"
+    ],
+    "offlineWorking": false,
+    "supportedBrowsers": [
+      "Internet Explorer 10+",
+      "Firefox",
+      "Chrome"
+    ],
+    "vendorCertifications": [
+      "N/A"
+    ],
+    "governanceFramework": {
+      "value": false,
+      "assurance": "Service provider assertion"
+    },
+    "configurationTracking": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "changeImpactAssessment": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "vulnerabilityAssessment": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "vulnerabilityMonitoring": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "vulnerabilityTimescales": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "vulnerabilityMitigationPrioritisation": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "vulnerabilityTracking": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "eventMonitoring": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "personnelSecurityChecks": {
+      "value": [
+        "Baseline personnel security standard (BPSS)",
+        "Employment checks"
+      ],
+      "assurance": "Service provider assertion"
+    },
+    "secureDesign": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "secureConfigurationManagement": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "secureDevelopment": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "userAuthenticateSupport": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "userAuthenticateManagement": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "managementInterfaceProtection": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "restrictAdministratorPermissions": {
+      "value": false,
+      "assurance": "Service provider assertion"
+    },
+    "userAccessControlManagement": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "interconnectionMethods": {
+      "value": [
+        "Private WAN"
+      ],
+      "assurance": "Service provider assertion"
+    },
+    "onboardingGuidance": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "serviceConfigurationGuidance": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "deviceAccessMethod": {
+      "value": [
+        "Corporate/enterprise devices"
+      ],
+      "assurance": "Service provider assertion"
+    },
+    "trainingProvided": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "selfServiceProvisioning": true,
+    "provisioningTime": "Up to 1 business day",
+    "deprovisioningTime": "Instantly - however billing is by the hour",
+    "apiType": "RESTful",
+    "apiAccess": true,
+    "dataExtractionRemoval": true,
+    "dataBackupRecovery": true,
+    "datacentreTier": "TIA-942 Tier 3",
+    "datacentresSpecifyLocation": false,
+    "datacentresEUCode": true,
+    "dataProtectionBetweenServices": {
+      "value": [
+        "No encryption"
+      ],
+      "assurance": "Service provider assertion"
+    },
+    "dataProtectionWithinService": {
+      "value": [
+        "VLAN"
+      ],
+      "assurance": "Service provider assertion"
+    },
+    "dataProtectionBetweenUserAndService": {
+      "value": [
+        "No encryption"
+      ],
+      "assurance": "Service provider assertion"
+    },
+    "dataRedundantEquipmentAccountsRevoked": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "dataSecureEquipmentDisposal": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "dataStorageMediaDisposal": {
+      "value": "Other destruction/erasure process",
+      "assurance": "Service provider assertion"
+    },
+    "dataSecureDeletion": {
+      "value": "Other secure erasure process",
+      "assurance": "Service provider assertion"
+    },
+    "dataAtRestProtections": {
+      "value": [
+        "Physical access control"
+      ],
+      "assurance": "Service provider assertion"
+    },
+    "datacentreProtectionDisclosure": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "legalJurisdiction": {
+      "value": "Rest of world",
+      "assurance": "Service provider assertion"
+    },
+    "serviceAvailabilityPercentage": {
+      "value": 99.95,
+      "assurance": "Service provider assertion"
+    },
+    "dataManagementLocations": {
+      "value": [
+        "UK",
+        "Rest of world"
+      ],
+      "assurance": "Service provider assertion"
+    },
+    "datacentreLocations": {
+      "value": [
+        "Rest of world"
+      ],
+      "assurance": "Service provider assertion"
+    },
+    "otherConsumers": {
+      "value": "Anyone - public",
+      "assurance": "Service provider assertion"
+    },
+    "servicesSeparation": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "servicesManagementSeparation": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "cloudDeploymentModel": {
+      "value": "Public cloud",
+      "assurance": "Service provider assertion"
+    },
+    "incidentDefinitionPublished": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "incidentManagementReporting": {
+      "value": false,
+      "assurance": "Service provider assertion"
+    },
+    "incidentManagementProcess": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "hardwareSoftwareVerification": {
+      "value": false,
+      "assurance": "Service provider assertion"
+    },
+    "thirdPartyRiskAssessment": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "thirdPartyComplianceMonitoring": {
+      "value": false,
+      "assurance": "Service provider assertion"
+    },
+    "thirdPartyDataSharingInformation": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "thirdPartySecurityRequirements": {
+      "value": false,
+      "assurance": "Service provider assertion"
+    },
+    "identityAuthenticationControls": {
+      "value": [
+        "Username and password"
+      ],
+      "assurance": "Service provider assertion"
+    },
+    "serviceManagementModel": {
+      "value": [
+        "Direct service management"
+      ],
+      "assurance": "Service provider assertion"
+    },
+    "auditInformationProvided": {
+      "value": "Data made available by negotiation",
+      "assurance": "Service provider assertion"
+    },
+    "supportForThirdParties": true,
+    "supportAvailability": "global 24x7 support is available ",
+    "supportResponseTime": "Critical support (where there is no service) will be provided within 2 hours.  Urgent support within 4 working hours",
+    "incidentEscalation": true,
+    "supportTypes": [
+      "Service desk",
+      "Email",
+      "Phone",
+      "Onsite"
+    ],
+    "serviceDefinitionDocument": "My Definition of IaaS v1.1.pdf",
+    "serviceDefinitionDocumentURL": "https://s3-eu-west-1.amazonaws.com/gds-g6-submission-bucket-live/123456/987654321/987654321-service-definition-document.pdf",
+    "priceInterval": "Hour",
+    "trialOption": true,
+    "priceUnit": "Instance",
+    "educationPricing": false,
+    "vatIncluded": false,
+    "priceString": "?0.025 per instance per hour",
+    "sfiaRateDocument": "My Rates for of IaaS v1.0.pdf",
+    "pricingDocument": "My Prices for of IaaS v1.0.pdf",
+    "priceMin": 0.025,
+    "freeOption": false,
+    "sfiaRateDocumentURL": "https://s3-eu-west-1.amazonaws.com/gds-g6-submission-bucket-live/123456/987654321/987654321-sfia-rate-card.pdf",
+    "pricingDocumentURL": "https://s3-eu-west-1.amazonaws.com/gds-g6-submission-bucket-live/123456/987654321/987654321-pricing-document.pdf"
+  }
+}
+

--- a/app/templates/sample_static_responses/sample-paas.json
+++ b/app/templates/sample_static_responses/sample-paas.json
@@ -1,0 +1,338 @@
+{
+  "services": {
+    "id": 0
+    978654321,
+    "supplierId": 123456,
+    "lot": "PaaS",
+    "title": "She Keeps on PaaSing Me By (TM)",
+    "lastUpdated": "2014-12-12T14:27:16Z",
+    "lastUpdatedByEmail": "kevin.keenoy@digital.cabinet-office.gov.uk",
+    "lastCompleted": "2014-12-12T14:29:01Z",
+    "lastCompletedByEmail": "kevin.keenoy@digital.cabinet-office.gov.uk",
+    "openSource": true,
+    "serviceName": "She Keeps on PaaSing Me By (TM)",
+    "serviceSummary": "She Keeps on PaaSing Me By (TM) provides an open environment to support digital delivery and innovation for our clients. This significantly reduces development costs for new projects: providing managed services at the platform level through SLA-based capability, rather than duplicating support for each project; bringing operating costs under control.",
+    "dataProtectionBetweenServices": {
+      "value": [
+        "VPN using TLS, version 1.2 or later"
+      ],
+      "assurance": "Service provider assertion"
+    },
+    "dataProtectionWithinService": {
+      "value": [
+        "VLAN"
+      ],
+      "assurance": "Service provider assertion"
+    },
+    "dataProtectionBetweenUserAndService": {
+      "value": [
+        "VPN using TLS, version 1.2 or later"
+      ],
+      "assurance": "Service provider assertion"
+    },
+    "dataRedundantEquipmentAccountsRevoked": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "dataSecureEquipmentDisposal": {
+      "value": true,
+      "assurance": "Contractual commitment"
+    },
+    "dataStorageMediaDisposal": {
+      "value": "Other secure erasure process",
+      "assurance": "Service provider assertion"
+    },
+    "dataSecureDeletion": {
+      "value": "Other secure erasure process",
+      "assurance": "Service provider assertion"
+    },
+    "dataAtRestProtections": {
+      "value": [
+        "Physical access control"
+      ],
+      "assurance": "Service provider assertion"
+    },
+    "datacentreProtectionDisclosure": {
+      "value": true,
+      "assurance": "Contractual commitment"
+    },
+    "legalJurisdiction": {
+      "value": "UK",
+      "assurance": "Service provider assertion"
+    },
+    "serviceAvailabilityPercentage": {
+      "value": 99.9,
+      "assurance": "Service provider assertion"
+    },
+    "dataManagementLocations": {
+      "value": [
+        "UK",
+        "EU"
+      ],
+      "assurance": "Contractual commitment"
+    },
+    "datacentreLocations": {
+      "value": [
+        "UK",
+        "EU"
+      ],
+      "assurance": "Contractual commitment"
+    },
+    "otherConsumers": {
+      "value": "Anyone - public",
+      "assurance": "Service provider assertion"
+    },
+    "servicesSeparation": {
+      "value": true,
+      "assurance": "Assurance of service design"
+    },
+    "servicesManagementSeparation": {
+      "value": false,
+      "assurance": "Assurance of service design"
+    },
+    "cloudDeploymentModel": {
+      "value": "Private cloud",
+      "assurance": "Contractual commitment"
+    },
+    "supportForThirdParties": true,
+    "supportAvailability": "24/7",
+    "supportResponseTime": "Telephone: 60 seconds\r\nEmail: 30 minutes",
+    "incidentEscalation": true,
+    "supportTypes": [
+      "Service desk",
+      "Email",
+      "Phone",
+      "Live chat",
+      "Onsite"
+    ],
+    "selfServiceProvisioning": false,
+    "provisioningTime": "Depends on the size and extent of the service required.",
+    "deprovisioningTime": "Depends on the size and extent of the service required.",
+    "networksConnected": [
+      "Internet"
+    ],
+    "vendorCertifications": [
+      "Amazon Web Services Consultant",
+      "Microsoft Gold Partner",
+      "Sitecore Partner",
+      "Oracle Gold Partner",
+      "Redhat Partner"
+    ],
+    "openStandardsSupported": true,
+    "serviceBenefits": [
+      "Central digital platform for managing multiple sites across multiple channels",
+      "Central platform for capturing common content and digital assets",
+      "Lower cost to build and deploy digital applications",
+      "Faster time to market and reduced development time.",
+      "Lifecycle management for digital platform improvement",
+      "Re-use throughout to lower cost and risk",
+      "Flexible hosting environment",
+      "Best of breed software embedded in platform",
+      "Cross-channel coherence for an integrated experience",
+      "Self -service to configure and manage digital products and services"
+    ],
+    "serviceFeatures": [
+      "Site build tools for rapid development, testing, and automated deployment",
+      "User Experience Libraries providing reusable templates, content and digital assets.",
+      "Self service tools, including on-line documentation, project workbench, and SDK.",
+      "Shared digital services, including content management, workflow, and web analytics.",
+      "Flexible cloud-based hosting, including sandbox environment.",
+      "Platform management services, including supporting environments, network, security, and performance.",
+      "Specialist services for advanced platform support, e.g. mobile app development."
+    ],
+    "analyticsAvailable": true,
+    "persistentStorage": false,
+    "elasticCloud": true,
+    "guaranteedResources": false,
+    "userAuthenticateSupport": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "userAuthenticateManagement": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "managementInterfaceProtection": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "restrictAdministratorPermissions": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "userAccessControlManagement": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "apiType": "RESTful with responses in JSON.",
+    "apiAccess": true,
+    "supportedDevices": [
+      "PC",
+      "Mac",
+      "Smartphone",
+      "Tablet"
+    ],
+    "offlineWorking": false,
+    "supportedBrowsers": [
+      "Internet Explorer 8",
+      "Internet Explorer 9",
+      "Internet Explorer 10+",
+      "Firefox",
+      "Chrome",
+      "Safari",
+      "Opera"
+    ],
+    "governanceFramework": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "configurationTracking": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "changeImpactAssessment": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "secureDesign": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "secureConfigurationManagement": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "secureDevelopment": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "auditInformationProvided": {
+      "value": "Data made available by negotiation",
+      "assurance": "Service provider assertion"
+    },
+    "serviceConfigurationGuidance": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "deviceAccessMethod": {
+      "value": [
+        "Unknown devices"
+      ],
+      "assurance": "Service provider assertion"
+    },
+    "trainingProvided": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "serviceOffboarding": true,
+    "serviceOnboarding": true,
+    "personnelSecurityChecks": {
+      "value": [
+        "Background checks in accordance with BS7858:2012"
+      ],
+      "assurance": "Independent validation of assertion"
+    },
+    "identityAuthenticationControls": {
+      "value": [
+        "Limited access over dedicated link, enterprise or community network",
+        "Username and password",
+        "Username and strong password/passphrase enforcement"
+      ],
+      "assurance": "Independent testing of implementation"
+    },
+    "termsAndConditionsDocument": "PaaS Terms and Conditions for G-Cloud 6.pdf",
+    "minimumContractPeriod": "Year",
+    "terminationCost": true,
+    "termsAndConditionsDocumentURL": "https://s3-eu-west-1.amazonaws.com/gds-g6-submission-bucket-live/123456/0978654321/0978654321-terms-and-condtions.pdf",
+    "dataExtractionRemoval": true,
+    "dataBackupRecovery": true,
+    "datacentreTier": "Uptime Institute Tier 3",
+    "datacentresSpecifyLocation": true,
+    "datacentresEUCode": true,
+    "vulnerabilityAssessment": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "vulnerabilityMonitoring": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "vulnerabilityTimescales": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "vulnerabilityMitigationPrioritisation": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "vulnerabilityTracking": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "eventMonitoring": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "incidentDefinitionPublished": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "incidentManagementReporting": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "incidentManagementProcess": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "serviceManagementModel": {
+      "value": [
+        "Dedicated devices on a segregated network"
+      ],
+      "assurance": "Service provider assertion"
+    },
+    "hardwareSoftwareVerification": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "thirdPartyRiskAssessment": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "thirdPartyComplianceMonitoring": {
+      "value": false,
+      "assurance": "Service provider assertion"
+    },
+    "thirdPartyDataSharingInformation": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "thirdPartySecurityRequirements": {
+      "value": false,
+      "assurance": "Service provider assertion"
+    },
+    "interconnectionMethods": {
+      "value": [
+        "Private WAN"
+      ],
+      "assurance": "Service provider assertion"
+    },
+    "onboardingGuidance": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "priceInterval": "Day",
+    "trialOption": true,
+    "priceUnit": "Unit",
+    "educationPricing": false,
+    "vatIncluded": false,
+    "priceString": "?350 per unit per day",
+    "pricingDocument": "PaaS Pricing Document for G-Cloud 6.pdf",
+    "priceMin": 350,
+    "freeOption": false,
+    "pricingDocumentURL": "https://s3-eu-west-1.amazonaws.com/gds-g6-submission-bucket-live/123456/0978654321/0978654321-pricing-document.pdf",
+    "serviceDefinitionDocument": "PaaS Service Definition Document for G-Cloud 6.pdf",
+    "serviceDefinitionDocumentURL": "https://s3-eu-west-1.amazonaws.com/gds-g6-submission-bucket-live/123456/0978654321/0978654321-service-definition-document.pdf"
+  }
+}
+

--- a/app/templates/sample_static_responses/sample-saas.json
+++ b/app/templates/sample_static_responses/sample-saas.json
@@ -1,0 +1,274 @@
+{
+  "services": {
+    "id": 6543210987,
+    "supplierId": 123456,
+    "lot": "SaaS",
+    "title": "My SaaS Brings All The Boys To The Yard",
+    "lastUpdated": "2014-12-17T13:46:12Z",
+    "lastUpdatedByEmail": "kevin.keenoy@digital.cabinet-office.gov.uk",
+    "lastCompleted": "2014-12-17T13:46:22Z",
+    "lastCompletedByEmail": "kevin.keenoy@digital.cabinet-office.gov.uk",
+    "serviceTypes": [
+      "Business intelligence and analytics",
+      "Data management"
+    ],
+    "serviceName": "My SaaS Brings All The Boys To The Yard",
+    "serviceSummary": "Using the power of cognitive computing and IBM Watson empower front of house staff with the right answers, quickly and efficiently based upon operating guides.",
+    "serviceBenefits": [
+      "Use simple questions to make sense of big data",
+      "Find the right answer quickly and efficiently",
+      "Improve corpus (AI), quality over time to improve business processes"
+    ],
+    "serviceFeatures": [
+      "Cognitive computing",
+      "Knowledgebase",
+      "Artificial Intelligence"
+    ],
+    "serviceDefinitionDocument": "SaaSy definition.pdf",
+    "serviceDefinitionDocumentURL": "https://s3-eu-west-1.amazonaws.com/gds-g6-submission-bucket-live/123456/6543210987/6543210987-service-definition-document.pdf",
+    "termsAndConditionsDocument": "SaaSy_Contract_2014.pdf",
+    "minimumContractPeriod": "Other",
+    "termsAndConditionsDocumentURL": "https://s3-eu-west-1.amazonaws.com/gds-g6-submission-bucket-live/123456/6543210987/6543210987-terms-and-condtions.pdf",
+    "openStandardsSupported": true,
+    "supportForThirdParties": true,
+    "supportAvailability": "9 to 5",
+    "supportResponseTime": "15 minute response",
+    "incidentEscalation": true,
+    "supportTypes": [
+      "Service desk",
+      "Email",
+      "Phone",
+      "Onsite"
+    ],
+    "serviceOffboarding": false,
+    "serviceOnboarding": true,
+    "analyticsAvailable": true,
+    "persistentStorage": true,
+    "elasticCloud": true,
+    "guaranteedResources": true,
+    "selfServiceProvisioning": true,
+    "provisioningTime": "Possible only after initial creation to increase user licenses",
+    "deprovisioningTime": "Manual control to minimum licenses agreed",
+    "openSource": false,
+    "codeLibraryLanguages": [
+      "JavaScript",
+      "HTML",
+      "Cordova",
+      "Node.JS"
+    ],
+    "apiType": "",
+    "apiAccess": false,
+    "networksConnected": [
+      "Internet"
+    ],
+    "supportedDevices": [
+      "PC",
+      "Mac",
+      "Smartphone",
+      "Tablet"
+    ],
+    "offlineWorking": false,
+    "supportedBrowsers": [
+      "Chrome"
+    ],
+    "vendorCertifications": [
+    ],
+    "identityStandards": [
+    ],
+    "dataExtractionRemoval": true,
+    "dataBackupRecovery": true,
+    "datacentreTier": "TIA-942 Tier 1",
+    "datacentresSpecifyLocation": false,
+    "datacentresEUCode": true,
+    "dataProtectionBetweenUserAndService": {
+      "value": [
+        "VPN using TLS, version 1.2 or later"
+      ],
+      "assurance": "Service provider assertion"
+    },
+    "dataSecureDeletion": {
+      "value": "Other erasure process",
+      "assurance": "Service provider assertion"
+    },
+    "dataAtRestProtections": {
+      "value": [
+        "Physical access control"
+      ],
+      "assurance": "Service provider assertion"
+    },
+    "datacentreProtectionDisclosure": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "legalJurisdiction": {
+      "value": "UK",
+      "assurance": "Service provider assertion"
+    },
+    "serviceAvailabilityPercentage": {
+      "value": 98.5,
+      "assurance": "Service provider assertion"
+    },
+    "dataManagementLocations": {
+      "value": [
+        "UK"
+      ],
+      "assurance": "Service provider assertion"
+    },
+    "datacentreLocations": {
+      "value": [
+        "EU",
+        "USA - Safe Harbor"
+      ],
+      "assurance": "Service provider assertion"
+    },
+    "otherConsumers": {
+      "value": "Anyone - public",
+      "assurance": "Service provider assertion"
+    },
+    "servicesSeparation": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "servicesManagementSeparation": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "cloudDeploymentModel": {
+      "value": "Hybrid cloud",
+      "assurance": "Contractual commitment"
+    },
+    "governanceFramework": {
+      "value": false,
+      "assurance": "Service provider assertion"
+    },
+    "changeImpactAssessment": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "vulnerabilityAssessment": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "vulnerabilityMonitoring": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "vulnerabilityTimescales": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "vulnerabilityMitigationPrioritisation": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "vulnerabilityTracking": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "eventMonitoring": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "incidentDefinitionPublished": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "incidentManagementReporting": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "incidentManagementProcess": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "personnelSecurityChecks": {
+      "value": [
+        "Employment checks"
+      ],
+      "assurance": "Service provider assertion"
+    },
+    "secureDesign": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "secureConfigurationManagement": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "secureDevelopment": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "thirdPartyRiskAssessment": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "thirdPartyComplianceMonitoring": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "thirdPartyDataSharingInformation": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "thirdPartySecurityRequirements": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "userAuthenticateSupport": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "userAuthenticateManagement": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "restrictAdministratorPermissions": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "userAccessControlManagement": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "identityAuthenticationControls": {
+      "value": [
+        "Username and password"
+      ],
+      "assurance": "Service provider assertion"
+    },
+    "serviceManagementModel": {
+      "value": [
+        "Dedicated devices for multiple community service management"
+      ],
+      "assurance": "Service provider assertion"
+    },
+    "auditInformationProvided": {
+      "value": "None",
+      "assurance": "Service provider assertion"
+    },
+    "deviceAccessMethod": {
+      "value": [
+        "Corporate/enterprise devices"
+      ],
+      "assurance": "Service provider assertion"
+    },
+    "trainingProvided": {
+      "value": true,
+      "assurance": "Service provider assertion"
+    },
+    "priceInterval": "Year",
+    "trialOption": true,
+    "educationPricing": false,
+    "priceUnit": "Instance",
+    "vatIncluded": false,
+    "priceString": "?250000 per instance per year",
+    "sfiaRateDocument": "Rate Card.pdf",
+    "pricingDocument": "pricing list.pdf",
+    "freeOption": false,
+    "priceMin": 250000,
+    "sfiaRateDocumentURL": "https://s3-eu-west-1.amazonaws.com/gds-g6-submission-bucket-live/123456/6543210987/6543210987-sfia-rate-card.pdf",
+    "pricingDocumentURL": "https://s3-eu-west-1.amazonaws.com/gds-g6-submission-bucket-live/123456/6543210987/6543210987-pricing-document.pdf"
+  }
+}
+

--- a/app/templates/sample_static_responses/sample-scs.json
+++ b/app/templates/sample_static_responses/sample-scs.json
@@ -1,0 +1,72 @@
+{
+  "services": {
+    "id": 12345609876,
+    "supplierId": 123456,
+    "lot": "SCS",
+    "title": "Kev's SCS One-Stop Shop",
+    "lastUpdated": "2014-12-17T11:05:28Z",
+    "lastUpdatedByEmail": "kevin.keenoy@digital.cabinet-office.gov.uk",
+    "lastCompleted": "2014-12-17T11:05:41Z",
+    "lastCompletedByEmail": "kevin.keenoy@digital.cabinet-office.gov.uk",
+    "serviceTypes": [
+      "Implementation",
+      "Ongoing support",
+      "Planning",
+      "Testing",
+      "Training"
+    ],
+    "serviceName": "Kev's SCS One-Stop Shop",
+    "serviceSummary": "Identify the root cause of application performance problems. Deploy specialist troubleshooting tools, together with expert analytical skill to pinpoint the reasons for degrading application performance. Our Application Performance Troubleshooting Service provides the tools and expertise necessary to identify the root cause of performance issues, and radically accelerates problem resolution. \r\n\r\n",
+    "serviceBenefits": [
+      "Identify the root cause of application performance problems",
+      "Deploy specialist troubleshooting tools, together with expert mystical skill ",
+      "Pinpoint the reasons for degrading application performance",
+      "Radically accelerate problem resolution",
+      "Isolate the source of application delay "
+    ],
+    "serviceFeatures": [
+      "Identify \u0026 Resolve Application Performance Issues",
+      "Multi-Tier Application Flow Response Analysis",
+      "Passive Analysis Without The Need For Software Agent Installation",
+      "Application Traffic Volume Analysis; Including Load-Balanced Traffic Verification",
+      "Accelerated Problem Resolution",
+      "Technical Report with Recommendations"
+    ],
+    "supportForThirdParties": false,
+    "supportAvailability": "Office Hours - 09:00 - 17:30 Monday to Friday",
+    "supportResponseTime": "Within 4 hours during business working hours (09:00 - 17:30 Monday to Friday)",
+    "incidentEscalation": false,
+    "supportTypes": [
+      "Service desk",
+      "Email",
+      "Phone",
+      "Onsite"
+    ],
+    "vendorCertifications": [
+      "Kev's Mum Certified Solutions Professional - WAN Optimisation (KMCSP-W)",
+      "Kev's Mum Certified Solutions Associate ? WAN Optimisation (KMCSA-W)",
+      "Kev's Mum Certified Solutions Professional ? Network Performance Management (KMCSP-NPM)",
+      "Kev's Mum Certified Solutions Associate ? Network Performance Management (KMCSA-NPM)",
+      "Kev's Mum Certified Solutions Professional ? Storage Delivery (KMCSP-SD)",
+      "Kev's Mum Certified Solutions Associate ? Storage Delivery (KMCSA-SD)",
+      "Kev's Mum Certified Solutions Associate ? Application Performance Management (KMCSA-APM)"
+    ],
+    "serviceDefinitionDocument": "Application Performance Troubleshooting.pdf",
+    "serviceDefinitionDocumentURL": "https://s3-eu-west-1.amazonaws.com/gds-g6-submission-bucket-live/123456/12345609876/12345609876-service-definition-document.pdf",
+    "termsAndConditionsDocument": "Kev's OSS G-Cloud Terms and Conditions.pdf",
+    "minimumContractPeriod": "Other",
+    "terminationCost": false,
+    "termsAndConditionsDocumentURL": "https://s3-eu-west-1.amazonaws.com/gds-g6-submission-bucket-live/123456/12345609876/12345609876-terms-and-condtions.pdf",
+    "priceInterval": "Day",
+    "educationPricing": false,
+    "priceUnit": "Person",
+    "vatIncluded": false,
+    "priceString": "?800 per person per day",
+    "sfiaRateDocument": "Kev's OSS Rate Card.pdf",
+    "pricingDocument": "Kev's OSS G-Cloud Pricing Document.pdf",
+    "priceMin": 800,
+    "sfiaRateDocumentURL": "https://s3-eu-west-1.amazonaws.com/gds-g6-submission-bucket-live/123456/12345609876/12345609876-sfia-rate-card.pdf",
+    "pricingDocumentURL": "https://s3-eu-west-1.amazonaws.com/gds-g6-submission-bucket-live/123456/12345609876/12345609876-pricing-document.pdf"
+  }
+}
+


### PR DESCRIPTION
This creates four hard-coded endpoints that each return a JSON listing for a different G6 lot. These will be useful for frontend development until the actual G6 data is loaded.

Test the endpoints with, e.g.:
```
curl -i -H "Authorization: Bearer myToken" 127.0.0.1:5000/services/g6-scs-example
curl -i -H "Authorization: Bearer myToken" 127.0.0.1:5000/services/g6-saas-example
curl -i -H "Authorization: Bearer myToken" 127.0.0.1:5000/services/g6-paas-example
curl -i -H "Authorization: Bearer myToken" 127.0.0.1:5000/services/g6-iaas-example
```