### PR TITLE
Add pagination to service listing

### DIFF
--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -5,6 +5,7 @@ import json
 from nose.tools import assert_equal
 
 from app import create_app, db
+from app.models import Service
 
 
 class WSGIApplicationWithEnvironment(object):
@@ -41,6 +42,12 @@ class BaseApplicationTest(object):
     def setup_database(self):
         with self.app.app_context():
             db.create_all()
+
+    def setup_dummy_services(self, n):
+        with self.app.app_context():
+            for i in range(n):
+                db.session.add(Service(service_id=i,
+                                       data={'foo': 'bar'}))
 
     def teardown(self):
         self.teardown_authorization()


### PR DESCRIPTION
For review only, depends on #12 and #13. Please do not merge until those pull requests have been merged and this one has been rebased on them.

After discussion with @TheDoubleK and @minglis we have decided to put
the pagination links in the response under the 'links' section. This is
beacause it's more obvious to a user browsing the API than other
solutions such as Link headers.

Page size is not controllable by the user, it's simpler to just define
it and let them paginate.