### PR TITLE
Add max-age cache control for all requests

### DIFF
--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -7,4 +7,10 @@ main = Blueprint('main', __name__)
 main.before_request(requires_authentication)
 
 
+@main.after_request
+def add_cache_control(response):
+    response.cache_control.max_age = 24 * 60 * 60
+    return response
+
+
 from . import views, errors

--- a/tests/app/test_application.py
+++ b/tests/app/test_application.py
@@ -2,6 +2,7 @@
 Tests for the application infrastructure
 """
 from flask import json
+from nose.tools import assert_equal
 
 from .helpers import BaseApplicationTest
 
@@ -28,3 +29,7 @@ class TestApplication(BaseApplicationTest):
             '/',
             headers={'Authorization': 'Bearer invalid-token'})
         assert 403 == response.status_code
+
+    def test_max_age_is_one_day(self):
+        response = self.client.get('/')
+        assert_equal(86400, response.cache_control.max_age)


### PR DESCRIPTION
All requests should be cached for a day. This is a broad brush cache
control header for going live, it will be revisited when we add the
ability to change services.
https://www.pivotaltracker.com/story/show/87008244