### PR TITLE
Use X-Forwarded proxy headers

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -4,6 +4,7 @@ import os
 from flask import Flask
 from flask.ext.bootstrap import Bootstrap
 from flask.ext.sqlalchemy import SQLAlchemy
+from werkzeug.contrib.fixers import ProxyFix
 
 from config import config
 from .helpers import convert_to_boolean
@@ -15,6 +16,7 @@ db = SQLAlchemy()
 
 def create_app(config_name):
     application = Flask(__name__)
+    application.wsgi_app = ProxyFix(application.wsgi_app)
     application.config.from_object(config[config_name])
 
     for name in config_attrs(config[config_name]):

--- a/tests/app/test_services.py
+++ b/tests/app/test_services.py
@@ -54,6 +54,15 @@ class TestListServices(BaseApplicationTest):
         #       this is what Flask-SQLAlchemy does by default so is easy
         assert_equal(response.status_code, 404)
 
+    def test_x_forwarded_proto(self):
+        self.setup_dummy_services(1)
+
+        response = self.client.get('/services',
+                                   headers={'X-Forwarded-Proto': 'https'})
+        data = json.loads(response.get_data())
+
+        assert data['services'][0]['links'][0]['href'].startswith('https://')
+
 
 def first_by_rel(rel, links):
     for link in links:


### PR DESCRIPTION
Make use of werkzeug's ProxyFix WSGI wrapper to integrate X-Forwarded
headers. One thing that this does is uses X-Forwarded-Proto and
X-Forwarded-Host values in URL building.
https://www.pivotaltracker.com/story/show/87009916