### PR TITLE
Add supplier_id filter to /services

### DIFF
--- a/app/main/views.py
+++ b/app/main/views.py
@@ -73,7 +73,9 @@ def list_services():
     else:
         services = Service.query
 
-    services = services.paginate(page=page, per_page=10)
+    services = services.paginate(page=page, per_page=10, error_out=False)
+    if request.args and not services.items:
+        abort(404)
     return jsonify(
         services=list(map(jsonify_service, services.items)),
         links=pagination_links(services, '.list_services', request.args))

--- a/app/main/views.py
+++ b/app/main/views.py
@@ -121,7 +121,10 @@ def get_service(service_id):
 
 def jsonify_service(service):
     data = dict(service.data.items())
-    data['id'] = service.service_id
+    data.update({
+        'id': service.service_id,
+        'supplierId': service.supplier_id,
+    })
 
     data['links'] = [
         link("self", url_for(".get_service",

--- a/app/main/views.py
+++ b/app/main/views.py
@@ -58,7 +58,11 @@ def get_iaas():
 
 @main.route('/services', methods=['GET'])
 def list_services():
-    page = int(request.args.get('page', 1))
+    try:
+        page = int(request.args.get('page', 1))
+    except ValueError:
+        abort(400, "Invalid page argument")
+
     supplier_id = request.args.get('supplier_id')
     if supplier_id is not None:
         services = Service.query.filter(Service.supplier_id == supplier_id)

--- a/app/main/views.py
+++ b/app/main/views.py
@@ -65,6 +65,10 @@ def list_services():
 
     supplier_id = request.args.get('supplier_id')
     if supplier_id is not None:
+        try:
+            supplier_id = int(supplier_id)
+        except ValueError:
+            abort(400, "Invalid supplier_id")
         services = Service.query.filter(Service.supplier_id == supplier_id)
     else:
         services = Service.query

--- a/app/main/views.py
+++ b/app/main/views.py
@@ -59,7 +59,13 @@ def get_iaas():
 @main.route('/services', methods=['GET'])
 def list_services():
     page = int(request.args.get('page', 1))
-    services = Service.query.paginate(page=page, per_page=10)
+    supplier_id = request.args.get('supplier_id')
+    if supplier_id is not None:
+        services = Service.query.filter(Service.supplier_id == supplier_id)
+    else:
+        services = Service.query
+
+    services = services.paginate(page=page, per_page=10)
     return jsonify(
         services=list(map(jsonify_service, services.items)),
         links=pagination_links(services, '.list_services'))

--- a/app/main/views.py
+++ b/app/main/views.py
@@ -147,24 +147,14 @@ def url_for(*args, **kwargs):
 
 
 def pagination_links(pagination, endpoint, args):
-    return list(filter(None, [
-        link("next", paginate_next(pagination, endpoint, args)),
-        link("prev", paginate_prev(pagination, endpoint, args)),
-    ]))
-
-
-def paginate_next(pagination, endpoint, args):
-    if pagination.has_next:
-        args = args.copy()
-        args['page'] = pagination.next_num
-        return url_for(endpoint, **args)
-
-
-def paginate_prev(pagination, endpoint, args):
-    if pagination.has_prev:
-        args = args.copy()
-        args['page'] = pagination.prev_num
-        return url_for(endpoint, **args)
+    return [
+        link(rel, url_for(endpoint,
+                          **dict(list(args.items()) +
+                                 list({'page': page}.items()))))
+        for rel, page in [('next', pagination.next_num),
+                          ('prev', pagination.prev_num)]
+        if 0 < page <= pagination.pages
+    ]
 
 
 def get_json_from_request():

--- a/app/main/views.py
+++ b/app/main/views.py
@@ -76,7 +76,7 @@ def list_services():
     services = services.paginate(page=page, per_page=10)
     return jsonify(
         services=list(map(jsonify_service, services.items)),
-        links=pagination_links(services, '.list_services'))
+        links=pagination_links(services, '.list_services', request.args))
 
 
 @main.route('/services', methods=['POST'])
@@ -146,21 +146,25 @@ def url_for(*args, **kwargs):
     return base_url_for(*args, **kwargs)
 
 
-def pagination_links(pagination, endpoint):
+def pagination_links(pagination, endpoint, args):
     return list(filter(None, [
-        link("next", paginate_next(pagination, endpoint)),
-        link("prev", paginate_prev(pagination, endpoint)),
+        link("next", paginate_next(pagination, endpoint, args)),
+        link("prev", paginate_prev(pagination, endpoint, args)),
     ]))
 
 
-def paginate_next(pagination, endpoint):
+def paginate_next(pagination, endpoint, args):
     if pagination.has_next:
-        return url_for(endpoint, page=pagination.next_num)
+        args = args.copy()
+        args['page'] = pagination.next_num
+        return url_for(endpoint, **args)
 
 
-def paginate_prev(pagination, endpoint):
+def paginate_prev(pagination, endpoint, args):
     if pagination.has_prev:
-        return url_for(endpoint, page=pagination.prev_num)
+        args = args.copy()
+        args['page'] = pagination.prev_num
+        return url_for(endpoint, **args)
 
 
 def get_json_from_request():

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -49,7 +49,7 @@ class BaseApplicationTest(object):
         with self.app.app_context():
             for i in range(n):
                 db.session.add(Service(service_id=i,
-                                       supplier_id=i,
+                                       supplier_id=i % 3,
                                        updated_at=now,
                                        created_at=now,
                                        data={'foo': 'bar'}))

--- a/tests/app/test_services.py
+++ b/tests/app/test_services.py
@@ -64,6 +64,16 @@ class TestListServices(BaseApplicationTest):
 
         assert data['services'][0]['links'][0]['href'].startswith('https://')
 
+    def test_invalid_page_argument(self):
+        response = self.client.get('/services?page=a')
+
+        assert_equal(response.status_code, 400)
+
+    def test_invalid_supplier_id_argument(self):
+        response = self.client.get('/services?supplier_id=a')
+
+        assert_equal(response.status_code, 400)
+
 
 def first_by_rel(rel, links):
     for link in links:

--- a/tests/app/test_services.py
+++ b/tests/app/test_services.py
@@ -99,6 +99,16 @@ class TestListServices(BaseApplicationTest):
             data['services']
         )
 
+    def test_supplier_id_filter_pagination_links(self):
+        self.setup_dummy_services(45)
+
+        response = self.client.get('/services?supplier_id=1&page=1')
+        data = json.loads(response.get_data())
+
+        next_link = first_by_rel('next', data['links'])
+        assert_in("page=2", next_link['href'])
+        assert_in("supplier_id=1", next_link['href'])
+
     def test_unknown_supplier_id(self):
         self.setup_dummy_services(15)
         response = self.client.get('/services?supplier_id=100')

--- a/tests/app/test_services.py
+++ b/tests/app/test_services.py
@@ -112,11 +112,8 @@ class TestListServices(BaseApplicationTest):
     def test_unknown_supplier_id(self):
         self.setup_dummy_services(15)
         response = self.client.get('/services?supplier_id=100')
-        data = json.loads(response.get_data())
 
-        assert_equal(response.status_code, 200)
-        assert_equal(data['services'], [])
-        assert_equal(data['links'], [])
+        assert_equal(response.status_code, 404)
 
 
 def first_by_rel(rel, links):

--- a/tests/app/test_services.py
+++ b/tests/app/test_services.py
@@ -74,6 +74,40 @@ class TestListServices(BaseApplicationTest):
 
         assert_equal(response.status_code, 400)
 
+    def test_supplier_id_filter(self):
+        self.setup_dummy_services(15)
+
+        response = self.client.get('/services?supplier_id=1')
+        data = json.loads(response.get_data())
+
+        assert_equal(response.status_code, 200)
+        assert_equal(
+            list(filter(lambda s: s['supplierId'] == 1, data['services'])),
+            data['services']
+        )
+
+    def test_supplier_id_filter_pagination(self):
+        self.setup_dummy_services(45)
+
+        response = self.client.get('/services?supplier_id=1&page=2')
+        data = json.loads(response.get_data())
+
+        assert_equal(response.status_code, 200)
+        assert_equal(len(data['services']), 5)
+        assert_equal(
+            list(filter(lambda s: s['supplierId'] == 1, data['services'])),
+            data['services']
+        )
+
+    def test_unknown_supplier_id(self):
+        self.setup_dummy_services(15)
+        response = self.client.get('/services?supplier_id=100')
+        data = json.loads(response.get_data())
+
+        assert_equal(response.status_code, 200)
+        assert_equal(data['services'], [])
+        assert_equal(data['links'], [])
+
 
 def first_by_rel(rel, links):
     for link in links:


### PR DESCRIPTION
Adds `supplier_id` argument to `/services` endpoint.
Reworks a bit of pagination in the process (mostly related to preserving query arguments in next/prev links).
Adds 400 responses for non-integer `page` and `supplier_id`.
Requesting a valid but non-existent supplier_id will return a 404 response even for `page=1`.

Note: this is on top of `add-new-db-fields` branch, so should be rebased onto master once #15 is merged.

https://www.pivotaltracker.com/story/show/86991728