### PR TITLE
Add a status endpoint

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -30,6 +30,8 @@ def create_app(config_name):
 
     from .main import main as main_blueprint
     application.register_blueprint(main_blueprint)
+    from .status import status as status_blueprint
+    application.register_blueprint(status_blueprint)
 
     return application
 

--- a/app/authentication.py
+++ b/app/authentication.py
@@ -1,4 +1,3 @@
-from functools import wraps
 import os
 
 from flask import current_app, abort, request

--- a/app/main/views.py
+++ b/app/main/views.py
@@ -20,6 +20,11 @@ def index():
     ]), 200
 
 
+@main.route('/_status')
+def status():
+    return jsonify(status="ok")
+
+
 @main.route('/services/g6-scs-example')
 def get_scs():
     content = render_template('sample_static_responses/sample-scs.json')

--- a/app/main/views.py
+++ b/app/main/views.py
@@ -20,11 +20,6 @@ def index():
     ]), 200
 
 
-@main.route('/_status')
-def status():
-    return jsonify(status="ok")
-
-
 @main.route('/services/g6-scs-example')
 def get_scs():
     content = render_template('sample_static_responses/sample-scs.json')

--- a/app/status/__init__.py
+++ b/app/status/__init__.py
@@ -1,0 +1,5 @@
+from flask import Blueprint
+
+status = Blueprint('status', __name__)
+
+from . import views

--- a/app/status/views.py
+++ b/app/status/views.py
@@ -1,0 +1,8 @@
+from flask import jsonify
+
+from . import status
+
+
+@status.route('/_status')
+def status_no_db():
+    return jsonify(status="ok")


### PR DESCRIPTION
Add a status endpoint that can be used by the ELB to determine whether
the app is healthy. I have chosen not to touch the database on this
status endpoint as that is shared between all EC2 instances and
therefore a slow database would make all instances look like they're
slow.