### PR TITLE
Add an error handler for 403 errors

### DIFF
--- a/app/authentication.py
+++ b/app/authentication.py
@@ -11,7 +11,7 @@ def requires_authentication():
         if not incoming_token:
             abort(401)
         if not token_is_valid(incoming_token):
-            abort(403)
+            abort(403, incoming_token)
 
 
 def token_is_valid(incoming_token):

--- a/app/main/errors.py
+++ b/app/main/errors.py
@@ -14,6 +14,13 @@ def unauthorized(e):
     return jsonify(error=error_message), 401, [('WWW-Authenticate', 'Bearer')]
 
 
+@main.app_errorhandler(403)
+def forbidden(e):
+    error_message = "Forbidden, invalid bearer token provided '{}'".format(
+        e.description)
+    return jsonify(error=error_message), 403
+
+
 @main.app_errorhandler(404)
 def page_not_found(e):
     return jsonify(error="Not found"), 404


### PR DESCRIPTION
Previously this was not implemented resulting in forbidden requests
responding with the default HTML response. I have added the
invalid token in the response so that requesters can validate that what
they think they sent is what is getting through. It is not a security
risk putting it in the response as they have just provided it to us,
however, we should be carefull not to log it.