### PR TITLE
Return 404 if service_id is not integer

### DIFF
--- a/app/main/views.py
+++ b/app/main/views.py
@@ -52,7 +52,7 @@ def add_service():
     return jsonify(error=message), 501
 
 
-@main.route('/services/<service_id>', methods=['PUT'])
+@main.route('/services/<int:service_id>', methods=['PUT'])
 def update_service(service_id):
     now = datetime.now()
     service = Service.query.filter(Service.service_id == service_id).first()
@@ -77,7 +77,7 @@ def update_service(service_id):
     return "", http_status
 
 
-@main.route('/services/<service_id>', methods=['GET'])
+@main.route('/services/<int:service_id>', methods=['GET'])
 def get_service(service_id):
     service = Service.query.filter(Service.service_id == service_id)\
                            .first_or_404()

--- a/tests/app/test_services.py
+++ b/tests/app/test_services.py
@@ -190,10 +190,22 @@ class TestPutService(BaseApplicationTest, JSONUpdateTestMixin):
 
         assert_equal(response.status_code, 400)
 
+    def test_invalid_service_id(self):
+        response = self.client.put(
+            '/services/abc123',
+            data=json.dumps({'services': {'id': 'abc123', 'foo': 'bar'}}),
+            content_type='application/json')
+
+        assert_equal(response.status_code, 404)
+
 
 class TestGetService(BaseApplicationTest):
     def test_get_non_existent_service(self):
         response = self.client.get('/services/123')
+        assert_equal(404, response.status_code)
+
+    def test_invalid_service_id(self):
+        response = self.client.get('/services/abc123')
         assert_equal(404, response.status_code)
 
     def test_get_service(self):


### PR DESCRIPTION
Checks that service_id in `/services/<service_id>` GET and PUT requests is integer and returns 404 if it's not. 

Fixes #23