### PR TITLE
[FD][86795762] Put features and benefits into Details so they can be sea...

### DIFF
--- a/scripts/process-g6-into-elastic-search.py
+++ b/scripts/process-g6-into-elastic-search.py
@@ -83,7 +83,9 @@ def g6_to_g5(data):
         'details': {
             'supplierId': data['supplierId'],
             'lot': data['lot'],
-            'categories': categories
+            'categories': categories,
+            'features': data['serviceFeatures'],
+            'benefits': data['serviceBenefits']
         }
     }
 


### PR DESCRIPTION
Just adds the serviceFeatures and serviceBenefits fields into the details JSON in the index. This mimics how the DM does it which makes both features and benefits from G5 / G6 searchable.

Note: The change to DM to exploit this is pending and will be merged later today.