### PR TITLE
Build sqlalchemy uri from rds

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -7,7 +7,6 @@ from flask.ext.sqlalchemy import SQLAlchemy
 from werkzeug.contrib.fixers import ProxyFix
 
 from config import config
-from .helpers import convert_to_boolean
 
 
 bootstrap = Bootstrap()
@@ -17,11 +16,6 @@ db = SQLAlchemy()
 def create_app(config_name):
     application = Flask(__name__)
     application.wsgi_app = ProxyFix(application.wsgi_app)
-    application.config.from_object(config[config_name])
-
-    for name in config_attrs(config[config_name]):
-        if name in os.environ:
-            application.config[name] = convert_to_boolean(os.environ[name])
 
     config[config_name].init_app(application)
 
@@ -34,9 +28,3 @@ def create_app(config_name):
     application.register_blueprint(status_blueprint)
 
     return application
-
-
-def config_attrs(config):
-    """Returns config attributes from a Config object"""
-    p = re.compile('^[A-Z_]+$')
-    return filter(lambda attr: bool(p.match(attr)), dir(config))

--- a/config.py
+++ b/config.py
@@ -1,4 +1,6 @@
 import os
+import re
+from .app.helpers import convert_to_boolean
 
 basedir = os.path.abspath(os.path.dirname(__file__))
 
@@ -8,10 +10,33 @@ class Config:
     SQLALCHEMY_COMMIT_ON_TEARDOWN = True
     SQLALCHEMY_RECORD_QUERIES = True
     SQLALCHEMY_DATABASE_URI = 'postgresql://localhost/digitalmarketplace'
+    RDS_DB_NAME = None
+    RDS_USERNAME = None
+    RDS_PASSWORD = None
+    RDS_HOSTNAME = None
+    RDS_PORT = None
 
-    @staticmethod
-    def init_app(app):
-        pass
+    @classmethod
+    def init_app(cls, app):
+        app.config.from_object(cls)
+        for name in config_attrs(cls):
+            if name in os.environ:
+                app.config[name] = convert_to_boolean(os.environ[name])
+        if cls._should_build_db_uri(app):
+            uri = 'postgresql://{}:{}@{}:{}/{}'.format(
+                app.config['RDS_USERNAME'], app.config['RDS_PASSWORD'],
+                app.config['RDS_HOSTNAME'], app.config['RDS_PORT'],
+                app.config['RDS_DB_NAME'])
+
+            app.config['SQLALCHEMY_DATABASE_URI'] = uri
+
+    @classmethod
+    def _should_build_db_uri(cls, app):
+        if 'SQLALCHEMY_DATABASE_URI' in os.environ:
+            return False
+        if app.config['RDS_DB_NAME'] is not None:
+            return True
+        return False
 
 
 class Test(Config):
@@ -25,6 +50,12 @@ class Development(Config):
 
 class Live(Config):
     DEBUG = False
+
+
+def config_attrs(config):
+    """Returns config attributes from a Config object"""
+    p = re.compile('^[A-Z_]+$')
+    return filter(lambda attr: bool(p.match(attr)), dir(config))
 
 
 config = {

--- a/config.py
+++ b/config.py
@@ -1,6 +1,6 @@
 import os
 import re
-from .app.helpers import convert_to_boolean
+from app.helpers import convert_to_boolean
 
 basedir = os.path.abspath(os.path.dirname(__file__))
 


### PR DESCRIPTION
When running a Beanstalk environment the RDS credentials are passed to
the app via a series of environment variables. The SQLAlchemy
environment variable is not provided but it can be created from the RDS
variables. This is a backwards compatible change that will generate the
SQLAlchemy URI from the RDS environment variables if it has not been
explicitly set in the environment.