### PR TITLE
Add supplier name to services response

### DIFF
--- a/app/main/views.py
+++ b/app/main/views.py
@@ -61,15 +61,18 @@ def update_service(service_id):
         http_status = 201
         service = Service(service_id=service_id)
         service.created_at = now
-    data = get_json_from_request()
 
-    validate_json_or_400(data['services'])
+    service_data = drop_foreign_fields(
+        get_json_from_request()['services']
+    )
 
-    if str(data['services']['id']) != str(service_id):
+    validate_json_or_400(service_data)
+
+    if str(service_data['id']) != str(service_id):
         abort(400, "Invalid service ID provided")
 
-    service.data = data['services']
-    service.supplier_id = data['services']['supplierId']
+    service.data = service_data
+    service.supplier_id = service_data['supplierId']
     service.updated_at = now
 
     db.session.add(service)
@@ -105,6 +108,14 @@ def jsonify_service(service):
                              service_id=data['id']))
     ]
     return data
+
+
+def drop_foreign_fields(service):
+    service = service.copy()
+    for key in ['supplierName']:
+        service.pop(key, None)
+
+    return service
 
 
 def link(rel, href):

--- a/app/main/views.py
+++ b/app/main/views.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from flask import jsonify, abort, request
 from flask import url_for as base_url_for
+from sqlalchemy.exc import IntegrityError
 
 from . import main
 from .. import db
@@ -70,8 +71,14 @@ def update_service(service_id):
     service.data = data['services']
     service.supplier_id = data['services']['supplierId']
     service.updated_at = now
+
     db.session.add(service)
-    db.session.commit()
+
+    try:
+        db.session.commit()
+    except IntegrityError:
+        db.session.rollback()
+        abort(400, "Unknown supplier ID provided")
 
     return "", http_status
 

--- a/app/main/views.py
+++ b/app/main/views.py
@@ -1,6 +1,5 @@
 from datetime import datetime
-from flask import (jsonify, Response, abort, render_template,
-                   request)
+from flask import jsonify, abort, request
 from flask import url_for as base_url_for
 
 from . import main
@@ -28,14 +27,14 @@ def list_services():
         abort(400, "Invalid page argument")
 
     supplier_id = request.args.get('supplier_id')
+
+    services = Service.query
     if supplier_id is not None:
         try:
             supplier_id = int(supplier_id)
         except ValueError:
             abort(400, "Invalid supplier_id")
-        services = Service.query.filter(Service.supplier_id == supplier_id)
-    else:
-        services = Service.query
+        services = services.filter(Service.supplier_id == supplier_id)
 
     services = services.paginate(page=page, per_page=10, error_out=False)
     if request.args and not services.items:
@@ -79,8 +78,9 @@ def update_service(service_id):
 
 @main.route('/services/<int:service_id>', methods=['GET'])
 def get_service(service_id):
-    service = Service.query.filter(Service.service_id == service_id)\
-                           .first_or_404()
+    service = Service.query.filter(
+        Service.service_id == service_id
+    ).first_or_404()
 
     return jsonify(services=jsonify_service(service))
 
@@ -89,7 +89,8 @@ def jsonify_service(service):
     data = dict(service.data.items())
     data.update({
         'id': service.service_id,
-        'supplierId': service.supplier_id,
+        'supplierId': service.supplier.supplier_id,
+        'supplierName': service.supplier.name
     })
 
     data['links'] = [

--- a/app/models.py
+++ b/app/models.py
@@ -2,6 +2,15 @@ from . import db
 from sqlalchemy.dialects.postgresql import JSON
 
 
+class Supplier(db.Model):
+    __tablename__ = 'suppliers'
+
+    id = db.Column(db.Integer, primary_key=True)
+    supplier_id = db.Column(db.BigInteger,
+                            index=True, unique=True, nullable=False)
+    name = db.Column(db.String(255), nullable=False)
+
+
 class Service(db.Model):
     __tablename__ = 'services'
 
@@ -17,11 +26,4 @@ class Service(db.Model):
                            nullable=False)
     data = db.Column(JSON)
 
-
-class Supplier(db.Model):
-    __tablename__ = 'suppliers'
-
-    id = db.Column(db.Integer, primary_key=True)
-    supplier_id = db.Column(db.BigInteger,
-                            index=True, unique=True, nullable=False)
-    name = db.Column(db.String(255), nullable=False)
+    supplier = db.relationship(Supplier, lazy='joined', innerjoin=True)

--- a/app/models.py
+++ b/app/models.py
@@ -8,8 +8,9 @@ class Service(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     service_id = db.Column(db.BigInteger,
                            index=True, unique=True, nullable=False)
-    supplier_id = db.Column(db.BigInteger, index=True, unique=False,
-                            nullable=False)
+    supplier_id = db.Column(db.BigInteger,
+                            db.ForeignKey('suppliers.supplier_id'),
+                            index=True, unique=False, nullable=False)
     created_at = db.Column(db.DateTime, index=False, unique=False,
                            nullable=False)
     updated_at = db.Column(db.DateTime, index=False, unique=False,

--- a/migrations/versions/21eb9b29c651_make_supplier_id_a_foreign_key.py
+++ b/migrations/versions/21eb9b29c651_make_supplier_id_a_foreign_key.py
@@ -1,0 +1,21 @@
+"""Make supplier_id a foreign key
+
+Revision ID: 21eb9b29c651
+Revises: 1e74a2d74d2d
+Create Date: 2015-02-12 14:12:43.074568
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '21eb9b29c651'
+down_revision = '1e74a2d74d2d'
+
+from alembic import op
+
+
+def upgrade():
+    op.create_foreign_key(None, 'services', 'suppliers', ['supplier_id'], ['supplier_id'])
+
+
+def downgrade():
+    op.drop_constraint(None, 'services', type_='foreignkey')

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -5,7 +5,7 @@ import json
 from nose.tools import assert_equal
 
 from app import create_app, db
-from app.models import Service
+from app.models import Service, Supplier
 from datetime import datetime
 
 
@@ -46,10 +46,15 @@ class BaseApplicationTest(object):
 
     def setup_dummy_services(self, n):
         now = datetime.now()
+        suppliers_count = 3
         with self.app.app_context():
+            for i in range(suppliers_count):
+                db.session.add(
+                    Supplier(supplier_id=i, name=u"Supplier {}".format(i))
+                )
             for i in range(n):
                 db.session.add(Service(service_id=i,
-                                       supplier_id=i % 3,
+                                       supplier_id=i % suppliers_count,
                                        updated_at=now,
                                        created_at=now,
                                        data={'foo': 'bar'}))

--- a/tests/app/test_services.py
+++ b/tests/app/test_services.py
@@ -222,6 +222,26 @@ class TestPutService(BaseApplicationTest, JSONUpdateTestMixin):
 
             assert_equal(response.status_code, 400)
 
+    def test_supplier_name_in_service_data_is_shadowed(self):
+        with self.app.app_context():
+            payload = self.load_example_listing("SSP-JSON-IaaS")
+            payload['id'] = 3
+            payload['supplierId'] = 1
+            payload['supplierName'] = u'New Name'
+
+            response = self.client.put(
+                '/services/3',
+                data=json.dumps({'services': payload}),
+                content_type='application/json')
+
+            assert_equal(response.status_code, 201)
+
+            response = self.client.get('/services/3')
+            data = json.loads(response.get_data())
+
+            assert_equal(response.status_code, 200)
+            assert_equal(data['services']['supplierName'], u'Supplier 1')
+
 
 class TestGetService(BaseApplicationTest):
     def setup(self):

--- a/tests/app/test_services.py
+++ b/tests/app/test_services.py
@@ -210,6 +210,18 @@ class TestPutService(BaseApplicationTest, JSONUpdateTestMixin):
 
         assert_equal(response.status_code, 404)
 
+    def test_add_a_service_with_unknown_supplier_id(self):
+        with self.app.app_context():
+            payload = self.load_example_listing("SSP-JSON-IaaS")
+            payload['id'] = 3
+            payload['supplierId'] = 100
+            response = self.client.put(
+                '/services/3',
+                data=json.dumps({'services': payload}),
+                content_type='application/json')
+
+            assert_equal(response.status_code, 400)
+
 
 class TestGetService(BaseApplicationTest):
     def setup(self):

--- a/tests/app/test_services.py
+++ b/tests/app/test_services.py
@@ -3,7 +3,7 @@ from nose.tools import assert_equal, assert_in, assert_not_equal, \
     assert_almost_equal
 
 from app import db
-from app.models import Service
+from app.models import Service, Supplier
 from datetime import datetime, timedelta
 from .helpers import BaseApplicationTest, JSONUpdateTestMixin
 
@@ -23,6 +23,15 @@ class TestListServices(BaseApplicationTest):
 
         assert_equal(response.status_code, 200)
         assert_equal(len(data['services']), 1)
+
+    def test_list_services_returns_supplier_info(self):
+        self.setup_dummy_services(1)
+        response = self.client.get('/services')
+        data = json.loads(response.get_data())
+        service = data['services'][0]
+
+        assert_equal(service['supplierId'], 0)
+        assert_equal(service['supplierName'], u'Supplier 0')
 
     def test_paginated_list_services_page_one(self):
         self.setup_dummy_services(15)
@@ -144,8 +153,11 @@ class TestPutService(BaseApplicationTest, JSONUpdateTestMixin):
         super(TestPutService, self).setup()
         now = datetime.now()
         with self.app.app_context():
+            db.session.add(
+                Supplier(supplier_id=1, name=u"Supplier 1")
+            )
             db.session.add(Service(service_id=2,
-                                   supplier_id=321,
+                                   supplier_id=1,
                                    updated_at=now,
                                    created_at=now,
                                    data={'foo': 'bar'}))
@@ -200,8 +212,21 @@ class TestPutService(BaseApplicationTest, JSONUpdateTestMixin):
 
 
 class TestGetService(BaseApplicationTest):
+    def setup(self):
+        super(TestGetService, self).setup()
+        now = datetime.now()
+        with self.app.app_context():
+            db.session.add(
+                Supplier(supplier_id=1, name=u"Supplier 1")
+            )
+            db.session.add(Service(service_id=123,
+                                   supplier_id=1,
+                                   updated_at=now,
+                                   created_at=now,
+                                   data={'foo': 'bar'}))
+
     def test_get_non_existent_service(self):
-        response = self.client.get('/services/123')
+        response = self.client.get('/services/100')
         assert_equal(404, response.status_code)
 
     def test_invalid_service_id(self):
@@ -209,15 +234,15 @@ class TestGetService(BaseApplicationTest):
         assert_equal(404, response.status_code)
 
     def test_get_service(self):
-        now = datetime.now()
-        with self.app.app_context():
-            db.session.add(Service(service_id=123,
-                                   supplier_id=321,
-                                   updated_at=now,
-                                   created_at=now,
-                                   data={'foo': 'bar'}))
         response = self.client.get('/services/123')
 
         data = json.loads(response.get_data())
         assert_equal(200, response.status_code)
         assert_equal(123, data['services']['id'])
+
+    def test_get_service_returns_supplier_info(self):
+        response = self.client.get('/services/123')
+
+        data = json.loads(response.get_data())
+        assert_equal(data['services']['supplierId'], 1)
+        assert_equal(data['services']['supplierName'], u'Supplier 1')


### PR DESCRIPTION
The second part of #28 

Creates a foreign key relationship between services.supplier_id and suppliers.supplier_id and adds a new supplierName field to the services response JSON. When a new service is added the supplier_id has to exist in the suppliers table.

There's small note in dcc2cc7 about sending the supplierName back in PUT requests.