### PR TITLE
Disallow additional fields in service JSON schema

### DIFF
--- a/app/main/views.py
+++ b/app/main/views.py
@@ -112,7 +112,7 @@ def jsonify_service(service):
 
 def drop_foreign_fields(service):
     service = service.copy()
-    for key in ['supplierName']:
+    for key in ['supplierName', 'links']:
         service.pop(key, None)
 
     return service

--- a/json_schemas/g6-iaas-schema.json
+++ b/json_schemas/g6-iaas-schema.json
@@ -2,6 +2,7 @@
   "id": "G6 Submissions IaaS Schema",
   "$schema": "http://json-schema.org/schema#",
   "type": "object",
+  "additionalProperties": false,
   "properties": {
     "id": {
       "type": "integer"

--- a/json_schemas/g6-paas-schema.json
+++ b/json_schemas/g6-paas-schema.json
@@ -2,6 +2,7 @@
   "id": "G6 Submissions PaaS Schema",
   "$schema": "http://json-schema.org/schema#",
   "type": "object",
+  "additionalProperties": false,
   "properties": {
     "id": {
       "type": "integer"

--- a/json_schemas/g6-saas-schema.json
+++ b/json_schemas/g6-saas-schema.json
@@ -2,6 +2,7 @@
   "id": "G6 Submissions SaaS Schema",
   "$schema": "http://json-schema.org/schema#",
   "type": "object",
+  "additionalProperties": false,
   "properties": {
     "id": {
       "type": "integer"

--- a/json_schemas/g6-scs-schema.json
+++ b/json_schemas/g6-scs-schema.json
@@ -2,6 +2,7 @@
    "id": "G6 Submissions SCS Schema",
    "$schema": "http://json-schema.org/schema#",
    "type": "object",
+   "additionalProperties": false,
    "properties": {
       "id": {
          "type": "integer"

--- a/tests/app/test_services.py
+++ b/tests/app/test_services.py
@@ -152,6 +152,7 @@ class TestPutService(BaseApplicationTest, JSONUpdateTestMixin):
     def setup(self):
         super(TestPutService, self).setup()
         now = datetime.now()
+        payload = self.load_example_listing("SSP-JSON-IaaS")
         with self.app.app_context():
             db.session.add(
                 Supplier(supplier_id=1, name=u"Supplier 1")
@@ -160,7 +161,7 @@ class TestPutService(BaseApplicationTest, JSONUpdateTestMixin):
                                    supplier_id=1,
                                    updated_at=now,
                                    created_at=now,
-                                   data={'foo': 'bar'}))
+                                   data=payload))
 
     def test_update_a_service(self):
         with self.app.app_context():
@@ -241,6 +242,16 @@ class TestPutService(BaseApplicationTest, JSONUpdateTestMixin):
 
             assert_equal(response.status_code, 200)
             assert_equal(data['services']['supplierName'], u'Supplier 1')
+
+    def test_write_service_response_back(self):
+        response = self.client.get('/services/2')
+
+        response = self.client.put(
+            '/services/2',
+            data=response.get_data(),
+            content_type='application/json')
+
+        assert_equal(response.status_code, 204)
 
 
 class TestGetService(BaseApplicationTest):

--- a/tests/test_json_validation.py
+++ b/tests/test_json_validation.py
@@ -34,6 +34,20 @@ def test_example_json_validates_correctly():
         yield assert_example, example, validate_json(data), expected
 
 
+def test_additional_fields_are_not_allowed():
+    cases = [
+        ("SSP-JSON-SCS", False),
+        ("SSP-JSON-SaaS", False),
+        ("SSP-JSON-PaaS", False),
+        ("SSP-JSON-IaaS", False),
+    ]
+
+    for example, expected in cases:
+        data = load_example_listing(example)
+        data.update({'newKey': 1})
+        yield assert_example, example, validate_json(data), expected
+
+
 def assert_example(name, result, expected):
     assert_equal(result, expected)
 


### PR DESCRIPTION
Ignores fields we add to the service response ourselves (`links` and `supplierName`) and returns 400 for everything else.

`links` and `supplierName` are not saved to the service.data JSON.