### PR TITLE
Add 'state':'published' to G6 indexing script

### DIFF
--- a/scripts/process-g6-into-elastic-search.py
+++ b/scripts/process-g6-into-elastic-search.py
@@ -80,6 +80,7 @@ def g6_to_g5(data):
         'description': data['serviceSummary'],
         'enabled': True,
         'expired': False,
+        'state': 'published',
         'details': {
             'supplierId': data['supplierId'],
             'lot': data['lot'],


### PR DESCRIPTION
A change in the Marketplace app means that services are only returned in search results if they have a 'state' of 'published'.  (See: https://www.pivotaltracker.com/story/show/87000568)
 This change to the script adds that field to the G6 indexing job so that G6 services can once more be seen in the marketplace.

Already tested on QA against the new Marketplace code and it works.