### PR TITLE
Update to run on port 5000

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ python application.py runserver
 
 ### Using the API locally
 
-Calls to the API require a valid bearer token. Tokens to be accepted can be set using the AUTH_TOKENS environment variable, e.g.:
+The API runs on port 5000. Calls to the API require a valid bearer token. Tokens to be accepted can be set using the AUTH_TOKENS environment variable, e.g.:
 
 ```export AUTH_TOKENS=myToken```
 

--- a/application.py
+++ b/application.py
@@ -2,11 +2,12 @@
 
 import os
 from app import create_app, db
-from flask.ext.script import Manager
+from flask.ext.script import Manager, Server
 from flask.ext.migrate import Migrate, MigrateCommand
 
 application = create_app(os.getenv('FLASH_CONFIG') or 'development')
 manager = Manager(application)
+manager.add_command("runserver", Server(port=5000))
 migrate = Migrate(application, db)
 manager.add_command('db', MigrateCommand)
 


### PR DESCRIPTION
For development we will want to run multiple apps, so they should each bind to a different port number.
The default port is 5000 anyway, but we should state the port explicitly in the code which is why I've added it here.