### PR TITLE
Change AUTH_TOKENS to DM_AUTH_TOKENS

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,15 @@ python application.py runserver
 
 ### Using the API locally
 
-The API runs on port 5000. Calls to the API require a valid bearer token. Tokens to be accepted can be set using the AUTH_TOKENS environment variable, e.g.:
+By default the API runs on port 5000. Calls to the API require a valid bearer token.
+Tokens to be accepted can be set using the DM_AUTH_TOKENS environment variable
+(a colon-separated list), e.g.:
 
-```export AUTH_TOKENS=myToken```
+```export DM_AUTH_TOKENS=myToken1:myToken2```
 
-and then you can include this token in your request headers, e.g.:
+If ``DM_AUTH_TOKENS`` is not explicitly set then the run_api.sh script sets it to 
+``myToken``. You should include a valid token in your request headers, e.g.:
+>>>>>>> Stashed changes
 
 ```
 curl -i -H "Authorization: Bearer myToken" 127.0.0.1:5000/services/123456789

--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ Tokens to be accepted can be set using the DM_AUTH_TOKENS environment variable
 
 If ``DM_AUTH_TOKENS`` is not explicitly set then the run_api.sh script sets it to 
 ``myToken``. You should include a valid token in your request headers, e.g.:
->>>>>>> Stashed changes
 
 ```
 curl -i -H "Authorization: Bearer myToken" 127.0.0.1:5000/services/123456789

--- a/app/authentication.py
+++ b/app/authentication.py
@@ -18,19 +18,19 @@ def token_is_valid(incoming_token):
 
 
 def get_allowed_tokens_from_environment():
-    """Return a list of allowed auth tokens from the AUTH_TOKENS env variable
+    """Return a list of allowed auth tokens from the DM_AUTH_TOKENS env variable
 
-    >>> os.environ['AUTH_TOKENS'] = ''
+    >>> os.environ['DM_AUTH_TOKENS'] = ''
     >>> list(get_allowed_tokens_from_environment())
     []
-    >>> del os.environ['AUTH_TOKENS']
+    >>> del os.environ['DM_AUTH_TOKENS']
     >>> list(get_allowed_tokens_from_environment())
     []
-    >>> os.environ['AUTH_TOKENS'] = 'ab:cd'
+    >>> os.environ['DM_AUTH_TOKENS'] = 'ab:cd'
     >>> list(get_allowed_tokens_from_environment())
     ['ab', 'cd']
     """
-    return filter(None, os.environ.get('AUTH_TOKENS', '').split(":"))
+    return filter(None, os.environ.get('DM_AUTH_TOKENS', '').split(":"))
 
 
 def get_token_from_headers(headers):

--- a/run.sh
+++ b/run.sh
@@ -1,2 +1,0 @@
-export AUTH_TOKENS=myToken
-python application.py runserver

--- a/run_api.sh
+++ b/run_api.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+source ./venv/bin/activate 2>/dev/null && echo "Virtual environment activated."
+
+# Use default environment vars for localhost if not already set
+export DM_AUTH_TOKENS=${DM_AUTH_TOKENS:=myToken}
+
+echo "Environment variables in use:" 
+env | grep DM_
+
+python application.py runserver

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -5,6 +5,9 @@
 # NOTE: This script expects to be run from the project root with
 # ./scripts/run_tests.sh
 
+# Use default environment vars for localhost if not already set
+export DM_AUTH_TOKENS=${DM_AUTH_TOKENS:=myToken}
+
 set -o pipefail
 
 function display_result {

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -34,8 +34,8 @@ class BaseApplicationTest(object):
         self.app.wsgi_app = WSGIApplicationWithEnvironment(
             self.app.wsgi_app,
             HTTP_AUTHORIZATION='Bearer {}'.format(valid_token))
-        self._auth_tokens = os.environ.get('AUTH_TOKENS')
-        os.environ['AUTH_TOKENS'] = valid_token
+        self._auth_tokens = os.environ.get('DM_AUTH_TOKENS')
+        os.environ['DM_AUTH_TOKENS'] = valid_token
 
     def do_not_provide_access_token(self):
         self.app.wsgi_app = self.app.wsgi_app.app
@@ -65,9 +65,9 @@ class BaseApplicationTest(object):
 
     def teardown_authorization(self):
         if self._auth_tokens is None:
-            del os.environ['AUTH_TOKENS']
+            del os.environ['DM_AUTH_TOKENS']
         else:
-            os.environ['AUTH_TOKENS'] = self._auth_tokens
+            os.environ['DM_AUTH_TOKENS'] = self._auth_tokens
 
     def teardown_database(self):
         with self.app.app_context():


### PR DESCRIPTION
All the other environment vars we use are prefixed with 'DM_'.  For consistency and ease of checking the current environment for DM apps I think it is worth prefixing all our environment vars with 'DM_'.

Note - this will need changes to be made to the ElasticBeanstalk configuration to reflect the new name.