### PR TITLE
Filter None values from attributes list

### DIFF
--- a/scripts/process-g6-into-elastic-search.py
+++ b/scripts/process-g6-into-elastic-search.py
@@ -310,7 +310,7 @@ def attributes(data):
         if "Uptime Institute Tier 4" in data["datacentreTier"]:
             attributes.append({"name": "q32",  "q32": "tier4uptimeinstitute"})
 
-    return attributes
+    return filter(None, attributes)
 
 
 def boolean_attribute(g6_field_name, g5_field_name, data):


### PR DESCRIPTION
`boolean_attribute` returns `None` if field name is not found which ends up as `null` in Elasticsearch documents.