### PR TITLE
Use underscores in service_id request argument

### DIFF
--- a/app/main/views.py
+++ b/app/main/views.py
@@ -65,7 +65,7 @@ def list_archived_services_by_service_id():
     """
 
     try:
-        service_id = int(request.args.get("service-id", "no service id"))
+        service_id = int(request.args.get("service_id", "no service id"))
     except ValueError:
         abort(400, "Invalid service id supplied")
 

--- a/tests/app/test_services.py
+++ b/tests/app/test_services.py
@@ -439,7 +439,7 @@ class TestPostService(BaseApplicationTest):
             assert_equal(response.status_code, 200)
 
             archived_state = self.client.get(
-                '/archived-services?service-id=' +
+                '/archived-services?service_id=' +
                 self.service_id).get_data()
             archived_service_json = json.loads(archived_state)['services'][0]
 
@@ -462,7 +462,7 @@ class TestPostService(BaseApplicationTest):
                 assert_equal(response.status_code, 200)
 
             archived_state = self.client.get(
-                '/archived-services?service-id=' +
+                '/archived-services?service_id=' +
                 self.service_id).get_data()
             assert_equal(len(json.loads(archived_state)['services']), 5)
 
@@ -471,7 +471,7 @@ class TestPostService(BaseApplicationTest):
         assert_equal(response.status_code, 404)
 
     def test_return_empty_list_if_no_archived_service_by_service_id(self):
-        response = self.client.get('/archived-services?service-id=123')
+        response = self.client.get('/archived-services?service_id=123')
         assert_equal(response.status_code, 404)
 
     def test_should_404_if_non_int_pk(self):


### PR DESCRIPTION
We are already using underscores for supplier_id in the /services view.
This view is being used by another service (the Grails app) and would
therefore be harder to change.