### PR TITLE
Drop additional fields in service update requests

### DIFF
--- a/app/main/views.py
+++ b/app/main/views.py
@@ -103,7 +103,9 @@ def update_service(service_id):
 
     update_json = json_payload['update_details']
     validate_updater_json_or_400(update_json)
-    service_update = json_payload['services']
+    service_update = drop_foreign_fields(
+        json_payload['services']
+    )
 
     data = dict(service.data.items())
     data.update(service_update)

--- a/app/validation.py
+++ b/app/validation.py
@@ -43,7 +43,9 @@ def validate_updater_json_or_400(submitted_json):
 
 def validate_json_or_400(submitted_json):
     if not validate_json(submitted_json):
-        abort(400, "JSON was not a valid format")
+        abort(400, "JSON was not a valid format. {}".format(
+            reason_for_failure(submitted_json))
+        )
 
 
 def validate_json(submitted_json):
@@ -56,7 +58,6 @@ def validate_json(submitted_json):
     elif validates_against_schema(G6_IAAS_VALIDATOR, submitted_json):
         return 'G6-IaaS'
     else:
-        # print_reason_for_failure(submitted_json)
         return False
 
 
@@ -69,25 +70,26 @@ def validates_against_schema(validator, submitted_json):
         return True
 
 
-def print_reason_for_failure(submitted_json):
-    print('FAILED TO VALIDATE:')
-    print(submitted_json)
+def reason_for_failure(submitted_json):
+    response = []
     try:
         validate(submitted_json, G6_SCS_SCHEMA)
     except ValidationError as e1:
-        print('Not SCS: %s' % e1.message)
+        response.append('Not SCS: %s' % e1.message)
 
     try:
         validate(submitted_json, G6_SAAS_SCHEMA)
     except ValidationError as e2:
-        print('Not SaaS: %s' % e2.message)
+        response.append('Not SaaS: %s' % e2.message)
 
     try:
         validate(submitted_json, G6_PAAS_SCHEMA)
     except ValidationError as e3:
-        print('Not PaaS: %s' % e3.message)
+        response.append('Not PaaS: %s' % e3.message)
 
     try:
         validate(submitted_json, G6_IAAS_SCHEMA)
     except ValidationError as e4:
-        print('Not IaaS: %s' % e4.message)
+        response.append('Not IaaS: %s' % e4.message)
+
+    return '. '.join(response)

--- a/tests/app/test_services.py
+++ b/tests/app/test_services.py
@@ -466,6 +466,25 @@ class TestPostService(BaseApplicationTest):
                 self.service_id).get_data()
             assert_equal(len(json.loads(archived_state)['services']), 5)
 
+    def test_writing_full_service_back(self):
+        with self.app.app_context():
+            response = self.client.get('/services/%s' % self.service_id)
+            data = json.loads(response.get_data())
+
+            response = self.client.post(
+                '/services/%s' % self.service_id,
+                data=json.dumps(
+                    {
+                        'update_details': {
+                            'updated_by': 'joeblogs',
+                            'update_reason': 'whateves'},
+                        'services': data['services']
+                    }
+                ),
+                content_type='application/json')
+
+            assert_equal(response.status_code, 200)
+
     def test_should_404_if_no_archived_service_found_by_pk(self):
         response = self.client.get('/archived-services/123')
         assert_equal(response.status_code, 404)

--- a/tests/app/test_services.py
+++ b/tests/app/test_services.py
@@ -357,8 +357,8 @@ class TestPostService(BaseApplicationTest):
                          'this is invalid': 'so I should never see this'}}),
                 content_type='application/json')
 
-            assert_equal(json.loads(
-                response.get_data())['error'], 'JSON was not a valid format')
+            assert_in('JSON was not a valid format',
+                      json.loads(response.get_data())['error'])
             assert_equal(response.status_code, 400)
 
     def test_invalid_field_not_accepted_on_update_for_saas(self):
@@ -373,8 +373,8 @@ class TestPostService(BaseApplicationTest):
                          'this is invalid': 'so I should never see this'}}),
                 content_type='application/json')
 
-            assert_equal(json.loads(
-                response.get_data())['error'], 'JSON was not a valid format')
+            assert_in('JSON was not a valid format',
+                      json.loads(response.get_data())['error'])
             assert_equal(response.status_code, 400)
 
     def test_invalid_field_not_accepted_on_update_for_paas(self):
@@ -389,8 +389,8 @@ class TestPostService(BaseApplicationTest):
                          'this is invalid': 'so I should never see this'}}),
                 content_type='application/json')
 
-            assert_equal(json.loads(
-                response.get_data())['error'], 'JSON was not a valid format')
+            assert_in('JSON was not a valid format',
+                      json.loads(response.get_data())['error'])
             assert_equal(response.status_code, 400)
 
     def test_invalid_field_not_accepted_on_update_for_scs(self):
@@ -405,8 +405,8 @@ class TestPostService(BaseApplicationTest):
                          'this is invalid': 'so I should never see this'}}),
                 content_type='application/json')
 
-            assert_equal(json.loads(
-                response.get_data())['error'], 'JSON was not a valid format')
+            assert_in('JSON was not a valid format',
+                      json.loads(response.get_data())['error'])
         assert_equal(response.status_code, 400)
 
     def test_invalid_field_value_not_accepted_on_update_for(self):
@@ -420,8 +420,8 @@ class TestPostService(BaseApplicationTest):
                         'priceUnit': 'euros'}}),
                 content_type='application/json')
 
-            assert_equal(json.loads(
-                response.get_data())['error'], 'JSON was not a valid format')
+            assert_in('JSON was not a valid format',
+                      json.loads(response.get_data())['error'])
             assert_equal(response.status_code, 400)
 
     def test_updated_service_should_be_archived(self):


### PR DESCRIPTION
Service update should ignore `links` and `supplierName` fields since they're present in the GET response. This is what `PUT /services/...` does right now.