### PR TITLE
Add version to the /_status endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ venv
 .elasticbeanstalk/
 *.pyc
 __pycache__
+version_label

--- a/app/status/views.py
+++ b/app/status/views.py
@@ -1,8 +1,9 @@
 from flask import jsonify
 
 from . import status
+from .. import utils
 
 
 @status.route('/_status')
 def status_no_db():
-    return jsonify(status="ok")
+    return jsonify(status="ok", version=utils.get_version_label())

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,0 +1,10 @@
+import os
+
+
+def get_version_label():
+    try:
+        path = os.path.join(os.path.dirname(__file__), '..', 'version_label')
+        with open(path) as f:
+            return f.read().strip()
+    except IOError:
+        return None


### PR DESCRIPTION
This is pulled from a file in the root of the application which is placed by the release tool.

This is for review only at this stage. I thought it would be a good way of proving the deployment pipeline in the showcase.