### PR TITLE
Run Travis builds on the container infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+sudo: false
 python:
   - "2.7"
   - "3.4"


### PR DESCRIPTION
Travis now have faster, container based builds [1]. This repo should be
using those by default because it uses no sudo [2], however it doesn't
look like it is so this explicitly states no sudo is being used.

[1]
http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/
[2]
http://docs.travis-ci.com/user/workers/container-based-infrastructure/