### PR TITLE
Mi fix explorer updates

### DIFF
--- a/app/main/views.py
+++ b/app/main/views.py
@@ -7,7 +7,7 @@ from . import main
 from .. import db
 from ..models import ArchivedService, Service, Supplier
 from ..validation import validate_json_or_400, validate_updater_json_or_400
-
+import traceback
 
 API_FETCH_PAGE_SIZE = 100
 
@@ -123,6 +123,7 @@ def update_service(service_id):
     try:
         db.session.commit()
     except DatabaseError:
+        traceback.print_exc()
         db.session.rollback()
         abort(500, "Database error")
 

--- a/app/static/explorer.js
+++ b/app/static/explorer.js
@@ -44,6 +44,10 @@ function updateService() {
     var value = $('#value').val()
     if(!isNaN(value)) {
         value = parseInt(value,10)
+    } else if(value == "true") {
+        value = true
+    } else if(value == "false") {
+        value = false
     }
     services[$('#key').val()] = value
 

--- a/app/static/explorer.js
+++ b/app/static/explorer.js
@@ -41,7 +41,11 @@ function updateService() {
     var services = {}
     update_details['updated_by'] = 'joeblogs'
     update_details['update_reason'] = 'whateves'
-    services[$('#key').val()] = $('#value').val()
+    var value = $('#value').val()
+    if(!isNaN(value)) {
+        value = parseInt(value,10)
+    }
+    services[$('#key').val()] = value
 
     var update = {}
     update['update_details'] = update_details


### PR DESCRIPTION
Quick pull request to make the explorer type aware - if a field can be a number, it is converted to an int, if it is the string "true" or "false" is converted to appropriate boolean. This just ensures the update testing works in the browser. This code isn't for public consumption just to enable to the explorer to work.

Not also I included traceback in the catch exception block.