### PR TITLE
Pc add supplier route

### DIFF
--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -14,3 +14,4 @@ def add_cache_control(response):
 
 
 from . import views, errors
+from views import suppliers

--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -13,5 +13,5 @@ def add_cache_control(response):
     return response
 
 
-from . import views, errors
-from views import suppliers
+from . import errors
+from .views import suppliers, services

--- a/app/main/errors.py
+++ b/app/main/errors.py
@@ -23,7 +23,7 @@ def forbidden(e):
 
 @main.app_errorhandler(404)
 def page_not_found(e):
-    return jsonify(error="Not found"), 404
+    return jsonify(error=e.description or "Not found"), 404
 
 
 @main.app_errorhandler(500)

--- a/app/main/views.py
+++ b/app/main/views.py
@@ -200,15 +200,6 @@ def get_service(service_id):
     return jsonify(services=jsonify_service(service))
 
 
-@main.route('/suppliers/<int:supplier_id>', methods=['GET'])
-def get_supplier(supplier_id):
-    supplier = Supplier.query.filter(
-        Supplier.supplier_id == supplier_id
-    ).first_or_404()
-
-    return jsonify(suppliers=jsonify_supplier(supplier))
-
-
 @main.route('/archived-services/<int:archived_service_id>', methods=['GET'])
 def get_archived_service(archived_service_id):
     """
@@ -236,16 +227,6 @@ def jsonify_service(service):
         link("self", url_for(".get_service",
                              service_id=data['id']))
     ]
-    return data
-
-
-def jsonify_supplier(supplier):
-    data = {
-        'id': supplier.id,
-        'supplier_id': supplier.supplier_id,
-        'name': supplier.name
-    }
-
     return data
 
 

--- a/app/main/views.py
+++ b/app/main/views.py
@@ -200,6 +200,15 @@ def get_service(service_id):
     return jsonify(services=jsonify_service(service))
 
 
+@main.route('/suppliers/<int:supplier_id>', methods=['GET'])
+def get_supplier(supplier_id):
+    supplier = Supplier.query.filter(
+        Supplier.supplier_id == supplier_id
+    ).first_or_404()
+
+    return jsonify(suppliers=jsonify_supplier(supplier))
+
+
 @main.route('/archived-services/<int:archived_service_id>', methods=['GET'])
 def get_archived_service(archived_service_id):
     """
@@ -227,6 +236,16 @@ def jsonify_service(service):
         link("self", url_for(".get_service",
                              service_id=data['id']))
     ]
+    return data
+
+
+def jsonify_supplier(supplier):
+    data = {
+        'id': supplier.id,
+        'supplier_id': supplier.supplier_id,
+        'name': supplier.name
+    }
+
     return data
 
 

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -3,11 +3,11 @@ from flask import jsonify, abort, request
 from flask import url_for as base_url_for
 from sqlalchemy.exc import IntegrityError, DatabaseError
 
-from . import main
-from .. import db
-from ..models import ArchivedService, Service, Supplier, Framework
+from .. import main
+from ... import db
+from ...models import ArchivedService, Service, Supplier, Framework
 import traceback
-from ..validation import validate_json_or_400, \
+from ...validation import validate_json_or_400, \
     validate_updater_json_or_400, is_valid_service_id
 
 API_FETCH_PAGE_SIZE = 100

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -15,7 +15,8 @@ def get_supplier(supplier_id):
 
 def row2dict(row):
     """
-    Creates a dictionary object from the {column_name}:{value} pairs of an sqlAlchemy query object
+    Creates a dictionary object from the {column_name}:{value} pairs
+    of an sqlAlchemy query object
     @see http://stackoverflow.com/questions/1958219/
             convert-sqlalchemy-row-object-to-python-dict#comment12704946_1960546
     """

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -3,6 +3,7 @@ from flask import jsonify, abort, request
 from .. import main
 from ...models import Supplier
 
+# TODO: This should probably not be here
 API_FETCH_PAGE_SIZE = 2
 
 

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -1,0 +1,29 @@
+from flask import jsonify
+
+from .. import main
+from ...models import Supplier
+
+
+@main.route('/suppliers/<int:supplier_id>', methods=['GET'])
+def get_supplier(supplier_id):
+    supplier = Supplier.query.filter(
+        Supplier.supplier_id == supplier_id
+    ).first_or_404()
+
+    return jsonify(suppliers=row2dict(supplier))
+
+"""
+Creates a dictionary from sqlAlchemy query object's {column_name}:{value}
+@see http://stackoverflow.com/questions/1958219/convert-sqlalchemy-row-object-to-python-dict#comment12704946_1960546
+"""
+row2dict = lambda row: dict((col, getattr(row, col)) for col in row.__table__.columns.keys())
+
+
+def jsonify_supplier(supplier):
+    data = {
+        'id': supplier.id,
+        'supplier_id': supplier.supplier_id,
+        'name': supplier.name
+    }
+
+    return data

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -4,7 +4,7 @@ from .. import main
 from ...models import Supplier
 
 # TODO: This should probably not be here
-API_FETCH_PAGE_SIZE = 2
+API_FETCH_PAGE_SIZE = 100
 
 
 @main.route('/suppliers', methods=['GET'])
@@ -27,8 +27,6 @@ def get_suppliers_by_prefix():
 
     if not suppliers.all():
         abort(404, "No suppliers found for \'{0}\'".format(prefix))
-
-    # suppliers_json = [supplier.serialize() for supplier in suppliers]
 
     suppliers = suppliers.paginate(
         page=page,

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -1,5 +1,4 @@
-from flask import jsonify
-from flask import request
+from flask import jsonify, abort, request
 
 from .. import main
 from ...models import Supplier
@@ -11,20 +10,17 @@ def get_suppliers_by_prefix():
     prefix = request.args.get('prefix', '')
 
     if not prefix:
-        return '<h1>Oops, please include a query with a `prefix` key</h1>'
+        abort(400, "No supplier name prefix provided")
 
+    # case insensitive LIKE comparison for matching supplier names
     suppliers = Supplier.query.filter(
         Supplier.name.ilike(prefix + '%')
     ).all()
 
     if not suppliers:
-        return '<h1>Oops, no suppliers found with names that start with "' \
-               + prefix + '"</h1>'
+        abort(404, "No suppliers found for \'%s\'" % prefix)
 
-    suppliers_json = []
-
-    for supplier in suppliers:
-        suppliers_json.append(jsonify_supplier(supplier))
+    suppliers_json = [supplier.serialize() for supplier in suppliers]
 
     return jsonify(suppliers=suppliers_json)
 

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -1,34 +1,9 @@
 from flask import jsonify, abort, request
-from flask import url_for as base_url_for
 
 from .. import main
 from ...models import Supplier
 
-
 API_FETCH_PAGE_SIZE = 2
-
-# get this copy+pasted code outta here
-def link(rel, href):
-    if href is not None:
-        return {
-            "rel": rel,
-            "href": href,
-        }
-
-def url_for(*args, **kwargs):
-    kwargs.setdefault('_external', True)
-    return base_url_for(*args, **kwargs)
-
-
-def pagination_links(pagination, endpoint, args):
-    return [
-        link(rel, url_for(endpoint,
-                          **dict(list(args.items()) +
-                                 list({'page': page}.items()))))
-        for rel, page in [('next', pagination.next_num),
-                          ('prev', pagination.prev_num)]
-        if 0 < page <= pagination.pages
-    ]
 
 
 @main.route('/suppliers', methods=['GET'])
@@ -54,17 +29,21 @@ def get_suppliers_by_prefix():
 
     # suppliers_json = [supplier.serialize() for supplier in suppliers]
 
-    suppliers = suppliers.paginate(page=page, per_page=API_FETCH_PAGE_SIZE,
-                                 error_out=False)
+    suppliers = suppliers.paginate(
+        page=page,
+        per_page=API_FETCH_PAGE_SIZE,
+        error_out=False
+    )
 
     if page > 1 and not suppliers:
         abort(404, "Page number out of range")
     return jsonify(
-        # suppliers=list(map(serialize, suppliers.items)),
-
         suppliers=[supplier.serialize() for supplier in suppliers.items],
-        links=pagination_links(suppliers, '.get_suppliers_by_prefix', request.args)
-    )
+        links=Supplier.pagination_links(
+            suppliers,
+            '.get_suppliers_by_prefix',
+            request.args
+        ))
 
 
 @main.route('/suppliers/<int:supplier_id>', methods=['GET'])

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -1,11 +1,43 @@
 from flask import jsonify, abort, request
+from flask import url_for as base_url_for
 
 from .. import main
 from ...models import Supplier
 
 
+API_FETCH_PAGE_SIZE = 2
+
+# get this copy+pasted code outta here
+def link(rel, href):
+    if href is not None:
+        return {
+            "rel": rel,
+            "href": href,
+        }
+
+def url_for(*args, **kwargs):
+    kwargs.setdefault('_external', True)
+    return base_url_for(*args, **kwargs)
+
+
+def pagination_links(pagination, endpoint, args):
+    return [
+        link(rel, url_for(endpoint,
+                          **dict(list(args.items()) +
+                                 list({'page': page}.items()))))
+        for rel, page in [('next', pagination.next_num),
+                          ('prev', pagination.prev_num)]
+        if 0 < page <= pagination.pages
+    ]
+
+
 @main.route('/suppliers', methods=['GET'])
 def get_suppliers_by_prefix():
+
+    try:
+        page = int(request.args.get('page', 1))
+    except ValueError:
+        abort(400, "Invalid page argument")
 
     prefix = request.args.get('prefix', '')
 
@@ -15,14 +47,24 @@ def get_suppliers_by_prefix():
     # case insensitive LIKE comparison for matching supplier names
     suppliers = Supplier.query.filter(
         Supplier.name.ilike(prefix + '%')
-    ).all()
+    )
 
     if not suppliers:
-        abort(404, "No suppliers found for \'%s\'" % prefix)
+        abort(404, "No suppliers found for \'{0}\'".format(prefix))
 
-    suppliers_json = [supplier.serialize() for supplier in suppliers]
+    # suppliers_json = [supplier.serialize() for supplier in suppliers]
 
-    return jsonify(suppliers=suppliers_json)
+    suppliers = suppliers.paginate(page=page, per_page=API_FETCH_PAGE_SIZE,
+                                 error_out=False)
+
+    if page > 1 and not suppliers:
+        abort(404, "Page number out of range")
+    return jsonify(
+        # suppliers=list(map(serialize, suppliers.items)),
+
+        suppliers=[supplier.serialize() for supplier in suppliers.items],
+        links=pagination_links(suppliers, '.get_suppliers_by_prefix', request.args)
+    )
 
 
 @main.route('/suppliers/<int:supplier_id>', methods=['GET'])

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -24,7 +24,7 @@ def get_suppliers_by_prefix():
         Supplier.name.ilike(prefix + '%')
     )
 
-    if not suppliers:
+    if not suppliers.all():
         abort(404, "No suppliers found for \'{0}\'".format(prefix))
 
     # suppliers_json = [supplier.serialize() for supplier in suppliers]

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -12,11 +12,15 @@ def get_supplier(supplier_id):
 
     return jsonify(suppliers=row2dict(supplier))
 
-"""
-Creates a dictionary from sqlAlchemy query object's {column_name}:{value}
-@see http://stackoverflow.com/questions/1958219/convert-sqlalchemy-row-object-to-python-dict#comment12704946_1960546
-"""
-row2dict = lambda row: dict((col, getattr(row, col)) for col in row.__table__.columns.keys())
+
+def row2dict(row):
+    """
+    Creates a dictionary object from the {column_name}:{value} pairs of an sqlAlchemy query object
+    @see http://stackoverflow.com/questions/1958219/
+            convert-sqlalchemy-row-object-to-python-dict#comment12704946_1960546
+    """
+    return dict((col, getattr(row, col))
+                for col in row.__table__.columns.keys())
 
 
 def jsonify_supplier(supplier):

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -1,7 +1,32 @@
 from flask import jsonify
+from flask import request
 
 from .. import main
 from ...models import Supplier
+
+
+@main.route('/suppliers', methods=['GET'])
+def get_suppliers_by_prefix():
+
+    prefix = request.args.get('prefix', '')
+
+    if not prefix:
+        return '<h1>Oops, please include a query with a `prefix` key</h1>'
+
+    suppliers = Supplier.query.filter(
+        Supplier.name.ilike(prefix + '%')
+    ).all()
+
+    if not suppliers:
+        return '<h1>Oops, no suppliers found with names that start with "' \
+               + prefix + '"</h1>'
+
+    suppliers_json = []
+
+    for supplier in suppliers:
+        suppliers_json.append(jsonify_supplier(supplier))
+
+    return jsonify(suppliers=suppliers_json)
 
 
 @main.route('/suppliers/<int:supplier_id>', methods=['GET'])

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -10,14 +10,4 @@ def get_supplier(supplier_id):
         Supplier.supplier_id == supplier_id
     ).first_or_404()
 
-    return jsonify(suppliers=jsonify_supplier(supplier))
-
-
-def jsonify_supplier(supplier):
-    data = {
-        'id': supplier.id,
-        'supplier_id': supplier.supplier_id,
-        'name': supplier.name
-    }
-
-    return data
+    return jsonify(suppliers=supplier.serialize())

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -10,18 +10,7 @@ def get_supplier(supplier_id):
         Supplier.supplier_id == supplier_id
     ).first_or_404()
 
-    return jsonify(suppliers=row2dict(supplier))
-
-
-def row2dict(row):
-    """
-    Creates a dictionary object from the {column_name}:{value} pairs
-    of an sqlAlchemy query object
-    @see http://stackoverflow.com/questions/1958219/
-            convert-sqlalchemy-row-object-to-python-dict#comment12704946_1960546
-    """
-    return dict((col, getattr(row, col))
-                for col in row.__table__.columns.keys())
+    return jsonify(suppliers=jsonify_supplier(supplier))
 
 
 def jsonify_supplier(supplier):

--- a/app/models.py
+++ b/app/models.py
@@ -21,6 +21,12 @@ class Supplier(db.Model):
                             index=True, unique=True, nullable=False)
     name = db.Column(db.String(255), nullable=False)
 
+    def serialize(self):
+        return {
+            'supplier_id': self.supplier_id,
+            'name': self.name
+        }
+
 
 class Service(db.Model):
     __tablename__ = 'services'

--- a/app/models.py
+++ b/app/models.py
@@ -2,28 +2,37 @@ from . import db
 from flask import url_for as base_url_for
 from sqlalchemy.dialects.postgresql import JSON
 
-# get this copy+pasted code outta here
-def link(rel, href):
-    if href is not None:
-        return {
-            "rel": rel,
-            "href": href,
-        }
 
-def url_for(*args, **kwargs):
-    kwargs.setdefault('_external', True)
-    return base_url_for(*args, **kwargs)
+class ModelExtended(db.Model):
+    """
+    Wrapper for db.Model to fill it up with methods
+    """
+    __abstract__ = True
 
+    @staticmethod
+    def link(rel, href):
+        if href is not None:
+            return {
+                "rel": rel,
+                "href": href,
+            }
 
-def pagination_links(pagination, endpoint, args):
-    return [
-        link(rel, url_for(endpoint,
-                          **dict(list(args.items()) +
-                                 list({'page': page}.items()))))
-        for rel, page in [('next', pagination.next_num),
-                          ('prev', pagination.prev_num)]
-        if 0 < page <= pagination.pages
-    ]
+    @staticmethod
+    def url_for(*args, **kwargs):
+        kwargs.setdefault('_external', True)
+        return base_url_for(*args, **kwargs)
+
+    @classmethod
+    def pagination_links(cls, pagination, endpoint, args):
+        return [
+            cls.link(rel, cls.url_for(endpoint,
+                                      **dict(list(args.items()) +
+                                             list({'page': page}.items()))))
+            for rel, page in [('next', pagination.next_num),
+                              ('prev', pagination.prev_num)]
+            if 0 < page <= pagination.pages
+        ]
+
 
 class Framework(db.Model):
     __tablename__ = 'frameworks'
@@ -36,7 +45,7 @@ class Framework(db.Model):
                         nullable=False)
 
 
-class Supplier(db.Model):
+class Supplier(ModelExtended):
     __tablename__ = 'suppliers'
 
     id = db.Column(db.Integer, primary_key=True)
@@ -45,11 +54,15 @@ class Supplier(db.Model):
     name = db.Column(db.String(255), nullable=False)
 
     def serialize(self):
-
         links = [
-            link("self", url_for(".get_supplier",
-                                 supplier_id=self.supplier_id)),
-            link("suppliers.list", url_for(".get_suppliers_by_prefix"))
+            self.link(
+                "self",
+                self.url_for(".get_supplier", supplier_id=self.supplier_id)
+            ),
+            self.link(
+                "suppliers.list",
+                self.url_for(".get_suppliers_by_prefix")
+            )
         ]
 
         return {
@@ -59,7 +72,7 @@ class Supplier(db.Model):
         }
 
 
-class Service(db.Model):
+class Service(ModelExtended):
     __tablename__ = 'services'
 
     id = db.Column(db.Integer, primary_key=True)
@@ -88,8 +101,28 @@ class Service(db.Model):
 
     framework = db.relationship(Framework, lazy='joined', innerjoin=True)
 
+    def serialize(self):
+        links = [
+            self.link(
+                "self",
+                self.url_for(".get_service", service_id=self.data['id'])
+            ),
+        ]
 
-class ArchivedService(db.Model):
+        return {
+            'id': self.service_id,
+            'supplierId': self.supplier.supplier_id,
+            'supplierName': self.supplier.name,
+            'createdAt': self.created_at,
+            'updatedAt': self.updated_at,
+            'updatedBy': self.updated_by,
+            'updatedReason': self.updated_reason,
+            'data': self.data,
+            'links': links
+        }
+    
+
+class ArchivedService(ModelExtended):
     __tablename__ = 'archived_services'
 
     id = db.Column(db.Integer, primary_key=True)

--- a/app/models.py
+++ b/app/models.py
@@ -3,9 +3,9 @@ from flask import url_for as base_url_for
 from sqlalchemy.dialects.postgresql import JSON
 
 
-class ModelExtended(db.Model):
+class DbModelExtended(db.Model):
     """
-    Wrapper for db.Model to fill it up with methods
+    Wrapper for db.Model that can be extended with other methods
     """
     __abstract__ = True
 
@@ -45,7 +45,8 @@ class Framework(db.Model):
                         nullable=False)
 
 
-class Supplier(ModelExtended):
+class Supplier(DbModelExtended):
+
     __tablename__ = 'suppliers'
 
     id = db.Column(db.Integer, primary_key=True)
@@ -72,7 +73,7 @@ class Supplier(ModelExtended):
         }
 
 
-class Service(ModelExtended):
+class Service(DbModelExtended):
     __tablename__ = 'services'
 
     id = db.Column(db.Integer, primary_key=True)
@@ -122,7 +123,7 @@ class Service(ModelExtended):
         }
     
 
-class ArchivedService(ModelExtended):
+class ArchivedService(DbModelExtended):
     __tablename__ = 'archived_services'
 
     id = db.Column(db.Integer, primary_key=True)

--- a/app/models.py
+++ b/app/models.py
@@ -23,7 +23,7 @@ class Supplier(db.Model):
 
     def serialize(self):
         return {
-            'supplier_id': self.supplier_id,
+            'id': self.supplier_id,
             'name': self.name
         }
 

--- a/app/models.py
+++ b/app/models.py
@@ -59,10 +59,6 @@ class Supplier(DbModelExtended):
             self.link(
                 "self",
                 self.url_for(".get_supplier", supplier_id=self.supplier_id)
-            ),
-            self.link(
-                "suppliers.list",
-                self.url_for(".get_suppliers_by_prefix")
             )
         ]
 
@@ -121,7 +117,7 @@ class Service(DbModelExtended):
             'data': self.data,
             'links': links
         }
-    
+
 
 class ArchivedService(DbModelExtended):
     __tablename__ = 'archived_services'

--- a/app/static/explorer.js
+++ b/app/static/explorer.js
@@ -2,6 +2,26 @@ function do_i_work() {
     console.log("yes i do");
 }
 
+//if enter key is clicked and input fields are not empty, click event is triggered on first visible button
+function enter_key_clicks_first_visible_button_if_inputs_not_empty() {
+    $(document).keyup(function (e) {
+        //if 'enter' key is pressed'
+        if (e.keyCode == 13) {
+
+            $empty_inputs = $('.input-group input').filter(function() { return $(this).val() == ""; });
+
+            if( $empty_inputs.length === 0 )
+                $('.btn.btn-primary:visible').first().trigger('click');
+
+        }
+    });
+}
+
+$( document ).ready(function() {
+
+    enter_key_clicks_first_visible_button_if_inputs_not_empty();
+});
+
 function fetchService() {
     var request = $.ajax({
            url: "/services/" + $('#service_id').val(),
@@ -22,6 +42,23 @@ function fetchService() {
 function fetchArchivedService() {
     var request = $.ajax({
            url: "/archived-services?service-id=" + $('#service_id').val(),
+           type: "GET",
+           contentType: "application/json",
+           headers: commonHeaders()
+           });
+    request.fail(function (jqXHR, textStatus, errorThrown){
+             var obj = JSON.parse(jqXHR.responseText);
+             $("#response").html(printHTMLResponse(jqXHR, obj));
+         });
+    request.done(function (response, textStatus, jqXHR){
+              var obj = JSON.parse(jqXHR.responseText);
+              $("#response").html(printHTMLResponse(jqXHR, obj));
+         });
+}
+
+function fetchSupplier() {
+    var request = $.ajax({
+           url: "/suppliers/" + $('#service_id').val(),
            type: "GET",
            contentType: "application/json",
            headers: commonHeaders()

--- a/app/templates/explorer.html
+++ b/app/templates/explorer.html
@@ -25,6 +25,7 @@
                 <li><a href="#" id="update-link" data-toggle="collapse" data-target="#update-block">Update</a></li>
                 <li><a href="#" id="fetch-link" data-toggle="collapse" data-target="#fetch-block">Fetch</a></li>
                 <li><a href="#" id="fetch-archive-link" data-toggle="collapse" data-target="#fetch-archive-block">Fetch Archive</a></li>
+                <li><a href="#" id="fetch-supplier-link" data-toggle="collapse" data-target="#fetch-supplier-block">Fetch Supplier</a></li>
             </ul>
         </div>
     </div>
@@ -41,14 +42,16 @@
     <div class="input-group">
         <p>
             <span class="input-group-token" id="token">Bearer Token</span>
-            <input id="bearer-token" type="text" class="form-control" placeholder="enter you're bearer token here"
+            <input id="bearer-token" type="text" class="form-control" placeholder="enter your bearer token here"
                    aria-describedby="bearer token">
         </p>
         <p>
-            <label><h6>Service ID</h6></label>
+            <label><h6>Service/Supplier ID</h6></label>
             <input id="service_id" type="text"/>
         </p>
     </div>
+
+    <hr>
 
     <div class="container collapse" id="import-block">
         <h3>Import a new service</h3>
@@ -63,7 +66,7 @@
         <div class="row">
             <div class="span12">
                 <p>
-                    <button class="btn btn-primary" type="button"
+                        <button class="btn btn-primary" type="button"
                             onclick='importService()'>Import It!
                     </button>
                 </p>
@@ -116,6 +119,20 @@
                 <p>
                     <button class="btn btn-primary" type="button"
                             onclick='fetchArchivedService();'>Fetch It!
+                    </button>
+                </p>
+            </div>
+        </div>
+    </div>
+
+    <div class="container collapse" id="fetch-supplier-block">
+        <h3>Fetch a supplier</h3>
+
+        <div class="row">
+            <div class="span12">
+                <p>
+                    <button class="btn btn-primary" type="button"
+                            onclick='fetchSupplier();'>Fetch It!
                     </button>
                 </p>
             </div>

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -54,16 +54,21 @@ class BaseApplicationTest(object):
         with self.app.app_context():
             db.create_all()
 
+    def setup_dummy_suppliers(self, n):
+        with self.app.app_context():
+
+            for i in range(n):
+                db.session.add(
+                    Supplier(supplier_id=i, name=u"Supplier {}".format(i))
+                )
+
     def setup_dummy_services(self, n):
         now = datetime.now()
         with self.app.app_context():
             db.session.add(
                 Framework(id=1, expired=False, name="G-Cloud 6")
             )
-            for i in range(TEST_SUPPLIERS_COUNT):
-                db.session.add(
-                    Supplier(supplier_id=i, name=u"Supplier {}".format(i))
-                )
+            self.setup_dummy_suppliers(TEST_SUPPLIERS_COUNT)
             for i in range(n):
                 db.session.add(Service(service_id=i,
                                        supplier_id=i % TEST_SUPPLIERS_COUNT,
@@ -98,6 +103,11 @@ class BaseApplicationTest(object):
         file_path = os.path.join("example_listings", "{}.json".format(name))
         with open(file_path) as f:
             return json.load(f)
+
+    def first_by_rel(self, rel, links):
+        for link in links:
+            if link['rel'] == rel:
+                return link
 
 
 class JSONUpdateTestMixin(object):

--- a/tests/app/views/test_services.py
+++ b/tests/app/views/test_services.py
@@ -42,7 +42,7 @@ class TestListServices(BaseApplicationTest):
 
         assert_equal(response.status_code, 200)
         assert_equal(len(data['services']), 100)
-        next_link = first_by_rel('next', data['links'])
+        next_link = self.first_by_rel('next', data['links'])
         assert_in("page=2", next_link['href'])
 
     def test_paginated_list_services_page_two(self):
@@ -53,7 +53,7 @@ class TestListServices(BaseApplicationTest):
 
         assert_equal(response.status_code, 200)
         assert_equal(len(data['services']), 50)
-        prev_link = first_by_rel('prev', data['links'])
+        prev_link = self.first_by_rel('prev', data['links'])
         assert_in("page=1", prev_link['href'])
 
     def test_paginated_list_services_page_out_of_range(self):
@@ -132,7 +132,7 @@ class TestListServices(BaseApplicationTest):
         response = self.client.get('/services?supplier_id=1&page=1')
         data = json.loads(response.get_data())
 
-        next_link = first_by_rel('next', data['links'])
+        next_link = self.first_by_rel('next', data['links'])
         assert_in("page=2", next_link['href'])
         assert_in("supplier_id=1", next_link['href'])
 
@@ -141,12 +141,6 @@ class TestListServices(BaseApplicationTest):
         response = self.client.get('/services?supplier_id=100')
 
         assert_equal(response.status_code, 404)
-
-
-def first_by_rel(rel, links):
-    for link in links:
-        if link['rel'] == rel:
-            return link
 
 
 class TestPostService(BaseApplicationTest):

--- a/tests/app/views/test_services.py
+++ b/tests/app/views/test_services.py
@@ -5,7 +5,7 @@ from nose.tools import assert_equal, assert_in, assert_not_equal, \
 from app import db
 from app.models import Service, Supplier, Framework
 from datetime import datetime, timedelta
-from .helpers import BaseApplicationTest, JSONUpdateTestMixin, \
+from ..helpers import BaseApplicationTest, JSONUpdateTestMixin, \
     TEST_SUPPLIERS_COUNT
 
 

--- a/tests/app/views/test_suppliers.py
+++ b/tests/app/views/test_suppliers.py
@@ -1,5 +1,5 @@
 from flask import json
-from nose.tools import assert_equal
+from nose.tools import assert_equal, assert_in
 
 from app import db
 from app.models import Supplier
@@ -87,3 +87,39 @@ class TestGetSuppliers(BaseApplicationTest):
         assert_equal(2, len(data['suppliers']))
         assert_equal(585274, data['suppliers'][0]['id'])
         assert_equal(u"Supplier 123456", data['suppliers'][1]['name'])
+
+
+class TestGetSuppliersPaginated(BaseApplicationTest):
+    def setup(self):
+        super(TestGetSuppliersPaginated, self).setup()
+
+        # Supplier names like u"Supplier {n}"
+        self.setup_dummy_suppliers(150)
+
+    def test_query_string_prefix_returns_paginated_page_one(self):
+        response = self.client.get('/suppliers?prefix=s')
+        data = json.loads(response.get_data())
+
+        assert_equal(200, response.status_code)
+        assert_equal(100, len(data['suppliers']))
+        next_link = self.first_by_rel('next', data['links'])
+        assert_in("page=2", next_link['href'])
+
+    def test_query_string_prefix_returns_paginated_page_two(self):
+        response = self.client.get('/suppliers?prefix=s&page=2')
+        data = json.loads(response.get_data())
+
+        assert_equal(response.status_code, 200)
+        assert_equal(len(data['suppliers']), 50)
+        prev_link = self.first_by_rel('prev', data['links'])
+        assert_in("page=1", prev_link['href'])
+
+    def test_query_string_prefix_page_out_of_range(self):
+        response = self.client.get('/suppliers?prefix=s&page=10')
+
+        assert_equal(response.status_code, 200)
+
+    def test_query_string_prefix_invalid_page_argument(self):
+        response = self.client.get('/suppliers?prefix=s&page=a')
+
+        assert_equal(response.status_code, 400)

--- a/tests/app/views/test_suppliers.py
+++ b/tests/app/views/test_suppliers.py
@@ -28,5 +28,5 @@ class TestGetSupplier(BaseApplicationTest):
 
         data = json.loads(response.get_data())
         assert_equal(200, response.status_code)
-        assert_equal(585274, data['suppliers']['supplier_id'])
+        assert_equal(585274, data['suppliers']['id'])
         assert_equal(u"Supplier 585274", data['suppliers']['name'])

--- a/tests/app/views/test_suppliers.py
+++ b/tests/app/views/test_suppliers.py
@@ -1,0 +1,33 @@
+from flask import json
+from nose.tools import assert_equal
+
+from app import db
+from app.models import Supplier
+from ..helpers import BaseApplicationTest
+
+
+class TestGetSupplier(BaseApplicationTest):
+    def setup(self):
+        super(TestGetSupplier, self).setup()
+
+        with self.app.app_context():
+            db.session.add(
+                Supplier(supplier_id=585274, name=u"Supplier 585274")
+            )
+
+    def test_get_non_existent_supplier(self):
+        response = self.client.get('/suppliers/100')
+        assert_equal(404, response.status_code)
+
+    def test_invalid_supplier_id(self):
+        response = self.client.get('/suppliers/abc123')
+        assert_equal(404, response.status_code)
+
+    def test_get_supplier(self):
+        response = self.client.get('/suppliers/585274')
+
+        data = json.loads(response.get_data())
+        assert_equal(200, response.status_code)
+        assert_equal(1, data['suppliers']['id'])
+        assert_equal(585274, data['suppliers']['supplier_id'])
+        assert_equal(u"Supplier 585274", data['suppliers']['name'])

--- a/tests/app/views/test_suppliers.py
+++ b/tests/app/views/test_suppliers.py
@@ -30,3 +30,60 @@ class TestGetSupplier(BaseApplicationTest):
         assert_equal(200, response.status_code)
         assert_equal(585274, data['suppliers']['id'])
         assert_equal(u"Supplier 585274", data['suppliers']['name'])
+
+
+class TestGetSuppliers(BaseApplicationTest):
+    def setup(self):
+        super(TestGetSuppliers, self).setup()
+
+        with self.app.app_context():
+            db.session.add(
+                Supplier(supplier_id=585274, name=u"Supplier 585274")
+            )
+            db.session.add(
+                Supplier(supplier_id=123456, name=u"Supplier 123456")
+            )
+            db.session.add(
+                Supplier(
+                    supplier_id=3,
+                    name=u"Cloudy Clouds Inc Clouded Hosting"
+                )
+            )
+
+    def test_query_string_missing(self):
+        response = self.client.get('/suppliers')
+        assert_equal(400, response.status_code)
+
+    def test_query_string_prefix_empty(self):
+        response = self.client.get('/suppliers?prefix=')
+        assert_equal(400, response.status_code)
+
+    def test_query_string_prefix_returns_none(self):
+        response = self.client.get('/suppliers?prefix=canada')
+        assert_equal(404, response.status_code)
+
+    def test_query_string_prefix_sql_injection_wont_work(self):
+        response = \
+            self.client.get('/suppliers?prefix=;DROP%20TABLE%20suppliers;')
+        assert_equal(404, response.status_code)
+
+    def test_query_string_prefix_returns_single(self):
+        response = self.client.get('/suppliers?prefix=cloud')
+
+        data = json.loads(response.get_data())
+        assert_equal(200, response.status_code)
+        assert_equal(1, len(data['suppliers']))
+        assert_equal(3, data['suppliers'][0]['id'])
+        assert_equal(
+            u"Cloudy Clouds Inc Clouded Hosting",
+            data['suppliers'][0]['name']
+        )
+
+    def test_query_string_prefix_returns_multiple(self):
+        response = self.client.get('/suppliers?prefix=s')
+
+        data = json.loads(response.get_data())
+        assert_equal(200, response.status_code)
+        assert_equal(2, len(data['suppliers']))
+        assert_equal(585274, data['suppliers'][0]['id'])
+        assert_equal(u"Supplier 123456", data['suppliers'][1]['name'])

--- a/tests/app/views/test_suppliers.py
+++ b/tests/app/views/test_suppliers.py
@@ -28,6 +28,5 @@ class TestGetSupplier(BaseApplicationTest):
 
         data = json.loads(response.get_data())
         assert_equal(200, response.status_code)
-        assert_equal(1, data['suppliers']['id'])
         assert_equal(585274, data['suppliers']['supplier_id'])
         assert_equal(u"Supplier 585274", data['suppliers']['name'])


### PR DESCRIPTION
Hey everyone, added in a `/supplier/{supplier_id}` endpoint to the API

This also meant:
* Adding a few unit tests
* Updating the explorer files to return suppliers
* And, finally, renaming the `app/main/views.py` file to `app/main/views/services.py`, in order to avoid a cryptic error (thanks @allait!)