### PR TITLE
Allow priceMax to be null

### DIFF
--- a/json_schemas/g6-iaas-schema.json
+++ b/json_schemas/g6-iaas-schema.json
@@ -85,7 +85,7 @@
       "type": "number"
     },
     "priceMax": {
-      "type": "number"
+      "type": ["number", "null"]
     },
     "priceUnit": {
       "type": "string",

--- a/json_schemas/g6-paas-schema.json
+++ b/json_schemas/g6-paas-schema.json
@@ -76,7 +76,7 @@
       "type": "number"
     },
     "priceMax": {
-      "type": "number"
+      "type": ["number", "null"]
     },
     "priceUnit": {
       "type": "string",

--- a/json_schemas/g6-saas-schema.json
+++ b/json_schemas/g6-saas-schema.json
@@ -82,7 +82,7 @@
       "type": "number"
     },
     "priceMax": {
-      "type": "number"
+      "type": ["number", "null"]
     },
     "priceUnit": {
       "type": "string",

--- a/json_schemas/g6-scs-schema.json
+++ b/json_schemas/g6-scs-schema.json
@@ -85,7 +85,7 @@
          "type": "number"
       },
       "priceMax": {
-         "type": "number"
+         "type": ["number", "null"]
       },
       "priceUnit": {
          "type": "string",


### PR DESCRIPTION
Fixes this bug: https://www.pivotaltracker.com/story/show/91481374

Updates to remove a value of priceMax (an optional field in the SSP) are failing because `None is not of type 'number'`.
This update to the G6 JSON schemas allows null values as well as the number type for priceMax.

We don't need similar changes for other optional fields because they are strings or lists, and can happily be set to an empty string or empty list if an update is made to remove an answer to one of these optional questions.

I have tested this with the following request and seems to work fine:
`curl -i -XPOST -H "Content-Type: application/json" -H "Authorization: Bearer myToken" -d '{"update_details":{"updated_by":"Kevin Keenoy","update_reason":"Pricing Update requested by supplier"},"services":{"minimumContractPeriod":"Month", "pricingDocument":"Kev Pricing 2005.pdf", "priceMax": null, "priceString": "£0.04 per unit"}}' http://localhost:5000/services/4794360793137152`

Response before the change:
```
HTTP/1.0 400 BAD REQUEST
Content-Type: application/json
Content-Length: 231
Cache-Control: max-age=86400
Server: Werkzeug/0.10.4 Python/2.7.8
Date: Thu, 02 Apr 2015 13:20:17 GMT

{
  "error": "JSON was not a valid format. Not SCS: None is not of type u'number'. Not SaaS: u'trialOption' is a required property. Not PaaS: u'trialOption' is a required property. Not IaaS: u'trialOption' is a required property"
}
```

And after the change:
```
HTTP/1.0 200 OK
Content-Type: application/json
Content-Length: 23
Cache-Control: max-age=86400
Server: Werkzeug/0.10.4 Python/2.7.8
Date: Thu, 02 Apr 2015 13:22:07 GMT

{
  "message": "done"
}
```