### PR TITLE
Add G4 and G5 frameworks to database

### DIFF
--- a/migrations/versions/3a5eba38e4e8_set_g6_services_to_be_published_rather_.py
+++ b/migrations/versions/3a5eba38e4e8_set_g6_services_to_be_published_rather_.py
@@ -1,0 +1,33 @@
+"""Set G6 services to be published rather than enabled
+
+Revision ID: 3a5eba38e4e8
+Revises: 3e6c454a6fc7
+Create Date: 2015-04-02 16:18:30.609595
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '3a5eba38e4e8'
+down_revision = '3e6c454a6fc7'
+
+from alembic import op
+from sqlalchemy.sql import column, table
+from sqlalchemy import String
+import sqlalchemy as sa
+
+services = table('services', column('status', String))
+
+
+def upgrade():
+    op.execute(
+        services.update(). \
+        values({'status': op.inline_literal('published')})
+    )
+
+
+def downgrade():
+    op.execute(
+        services.update(). \
+        where(services.c.status == 'published'). \
+        values({'status': op.inline_literal('enabled')})
+    )

--- a/migrations/versions/3e6c454a6fc7_add_older_g_cloud_framewoks.py
+++ b/migrations/versions/3e6c454a6fc7_add_older_g_cloud_framewoks.py
@@ -1,0 +1,41 @@
+"""Add older G-Cloud Framewoks
+
+Revision ID: 3e6c454a6fc7
+Revises: 3acf60608a7d
+Create Date: 2015-04-02 15:31:57.243449
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '3e6c454a6fc7'
+down_revision = '3acf60608a7d'
+
+from alembic import op
+from sqlalchemy.sql import table, column
+from sqlalchemy import String, Boolean
+import sqlalchemy as sa
+
+frameworks = table('frameworks',
+                   column('name', String),
+                   column('expired', Boolean)
+)
+
+
+def upgrade():
+    op.execute(
+        frameworks.insert(). \
+        values({'name': op.inline_literal('G-Cloud 4'), 'expired': op.inline_literal(True)})
+    )
+    op.execute(
+        frameworks.insert(). \
+        values({'name': op.inline_literal('G-Cloud 5'), 'expired': op.inline_literal(False)})
+    )
+
+
+def downgrade():
+    op.execute(
+        frameworks.delete().where(frameworks.c.name == 'G-Cloud 4')
+    )
+    op.execute(
+        frameworks.delete().where(frameworks.c.name == 'G-Cloud 5')
+    )


### PR DESCRIPTION
Database migration script to add G-Cloud 4 and G-Cloud 5 to the Frameworks table.
Also change 'enabled' status of G6 services to 'published'.  They should have been 'published' in the first place, as 'enabled' will only be visible to admin and the supplier of the service.

Code that uses these coming soon.