### PR TITLE
Pc refactor services routes

### DIFF
--- a/app/main/utils.py
+++ b/app/main/utils.py
@@ -1,0 +1,50 @@
+from flask import url_for as base_url_for
+from flask import abort, request
+
+
+def link(rel, href):
+    if href is not None:
+        return {
+            "rel": rel,
+            "href": href,
+            }
+
+
+def url_for(*args, **kwargs):
+    kwargs.setdefault('_external', True)
+    return base_url_for(*args, **kwargs)
+
+
+def pagination_links(pagination, endpoint, args):
+    return [
+        link(rel, url_for(endpoint,
+                          **dict(list(args.items()) +
+                                 list({'page': page}.items()))))
+        for rel, page in [('next', pagination.next_num),
+                          ('prev', pagination.prev_num)]
+        if 0 < page <= pagination.pages
+    ]
+
+
+def get_json_from_request():
+    if request.content_type not in ['application/json',
+                                    'application/json; charset=UTF-8']:
+        abort(400, "Unexpected Content-Type, expecting 'application/json'")
+    data = request.get_json()
+    if data is None:
+        abort(400, "Invalid JSON; must be a valid JSON object")
+    return data
+
+
+def json_has_required_keys(data, keys):
+    for key in keys:
+        if key not in data.keys():
+            abort(400, "Invalid JSON must have '%s' key(s)" % keys)
+
+
+def drop_foreign_fields(json_object, list_of_keys):
+    json_object = json_object.copy()
+    for key in list_of_keys:
+        json_object.pop(key, None)
+
+    return json_object

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from app.main.utils import url_for, pagination_links
 from flask import jsonify, abort, request
 from sqlalchemy.exc import IntegrityError, DatabaseError
 
@@ -57,7 +58,7 @@ def list_services():
         abort(404, "Page number out of range")
     return jsonify(
         services=[service.serialize() for service in services.items],
-        links=Service.pagination_links(
+        links=pagination_links(
             services,
             '.list_services',
             request.args
@@ -94,7 +95,7 @@ def list_archived_services_by_service_id():
         abort(404)
     return jsonify(
         services=[service.serialize() for service in services.items],
-        links=ArchivedService.pagination_links(
+        links=pagination_links(
             services,
             '.list_services',
             request.args
@@ -198,7 +199,7 @@ def import_service(service_id):
         db.session.rollback()
         abort(400, "Unknown supplier ID provided")
 
-    return "", 201
+    return "", http_status
 
 
 @main.route('/services/<string:service_id>', methods=['GET'])

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -1,10 +1,37 @@
 from flask import jsonify, abort, request
+from flask import url_for as base_url_for
 
 from .. import main
 from ...models import Supplier
 
 # TODO: This should probably not be here
 API_FETCH_PAGE_SIZE = 100
+
+
+API_FETCH_PAGE_SIZE = 2
+
+# get this copy+pasted code outta here
+def link(rel, href):
+    if href is not None:
+        return {
+            "rel": rel,
+            "href": href,
+        }
+
+def url_for(*args, **kwargs):
+    kwargs.setdefault('_external', True)
+    return base_url_for(*args, **kwargs)
+
+
+def pagination_links(pagination, endpoint, args):
+    return [
+        link(rel, url_for(endpoint,
+                          **dict(list(args.items()) +
+                                 list({'page': page}.items()))))
+        for rel, page in [('next', pagination.next_num),
+                          ('prev', pagination.prev_num)]
+        if 0 < page <= pagination.pages
+    ]
 
 
 @main.route('/suppliers', methods=['GET'])

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -2,6 +2,7 @@ from flask import jsonify, abort, request
 
 from .. import main
 from ...models import Supplier
+from app.main.utils import pagination_links
 
 # TODO: This should probably not be here
 API_FETCH_PAGE_SIZE = 100
@@ -38,7 +39,7 @@ def list_suppliers():
 
     return jsonify(
         suppliers=[supplier.serialize() for supplier in suppliers.items],
-        links=Supplier.pagination_links(
+        links=pagination_links(
             suppliers,
             '.list_suppliers',
             request.args

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -1,37 +1,10 @@
 from flask import jsonify, abort, request
-from flask import url_for as base_url_for
 
 from .. import main
 from ...models import Supplier
 
 # TODO: This should probably not be here
 API_FETCH_PAGE_SIZE = 100
-
-
-API_FETCH_PAGE_SIZE = 2
-
-# get this copy+pasted code outta here
-def link(rel, href):
-    if href is not None:
-        return {
-            "rel": rel,
-            "href": href,
-        }
-
-def url_for(*args, **kwargs):
-    kwargs.setdefault('_external', True)
-    return base_url_for(*args, **kwargs)
-
-
-def pagination_links(pagination, endpoint, args):
-    return [
-        link(rel, url_for(endpoint,
-                          **dict(list(args.items()) +
-                                 list({'page': page}.items()))))
-        for rel, page in [('next', pagination.next_num),
-                          ('prev', pagination.prev_num)]
-        if 0 < page <= pagination.pages
-    ]
 
 
 @main.route('/suppliers', methods=['GET'])

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -2,7 +2,7 @@ from flask import jsonify, abort, request
 
 from .. import main
 from ...models import Supplier
-from app.main.utils import pagination_links
+from ..utils import pagination_links
 
 # TODO: This should probably not be here
 API_FETCH_PAGE_SIZE = 100

--- a/app/models.py
+++ b/app/models.py
@@ -2,28 +2,6 @@ from . import db
 from flask import url_for as base_url_for
 from sqlalchemy.dialects.postgresql import JSON
 
-# get this copy+pasted code outta here
-def link(rel, href):
-    if href is not None:
-        return {
-            "rel": rel,
-            "href": href,
-        }
-
-def url_for(*args, **kwargs):
-    kwargs.setdefault('_external', True)
-    return base_url_for(*args, **kwargs)
-
-
-def pagination_links(pagination, endpoint, args):
-    return [
-        link(rel, url_for(endpoint,
-                          **dict(list(args.items()) +
-                                 list({'page': page}.items()))))
-        for rel, page in [('next', pagination.next_num),
-                          ('prev', pagination.prev_num)]
-        if 0 < page <= pagination.pages
-    ]
 
 class DbModelExtended(db.Model):
     """
@@ -77,11 +55,14 @@ class Supplier(DbModelExtended):
     name = db.Column(db.String(255), nullable=False)
 
     def serialize(self):
-
         links = [
             self.link(
                 "self",
                 self.url_for(".get_supplier", supplier_id=self.supplier_id)
+            ),
+            self.link(
+                "suppliers.list",
+                self.url_for(".get_suppliers_by_prefix")
             )
         ]
 
@@ -93,6 +74,7 @@ class Supplier(DbModelExtended):
 
 
 class Service(DbModelExtended):
+
     __tablename__ = 'services'
 
     id = db.Column(db.Integer, primary_key=True)
@@ -143,6 +125,7 @@ class Service(DbModelExtended):
 
 
 class ArchivedService(DbModelExtended):
+
     __tablename__ = 'archived_services'
 
     id = db.Column(db.Integer, primary_key=True)

--- a/app/models.py
+++ b/app/models.py
@@ -46,7 +46,6 @@ class Framework(db.Model):
 
 
 class Supplier(DbModelExtended):
-
     __tablename__ = 'suppliers'
 
     id = db.Column(db.Integer, primary_key=True)
@@ -74,7 +73,6 @@ class Supplier(DbModelExtended):
 
 
 class Service(DbModelExtended):
-
     __tablename__ = 'services'
 
     id = db.Column(db.Integer, primary_key=True)
@@ -125,7 +123,6 @@ class Service(DbModelExtended):
 
 
 class ArchivedService(DbModelExtended):
-
     __tablename__ = 'archived_services'
 
     id = db.Column(db.Integer, primary_key=True)

--- a/app/models.py
+++ b/app/models.py
@@ -58,10 +58,6 @@ class Supplier(DbModelExtended):
             self.link(
                 "self",
                 self.url_for(".get_supplier", supplier_id=self.supplier_id)
-            ),
-            self.link(
-                "suppliers.list",
-                self.url_for(".get_suppliers_by_prefix")
             )
         ]
 

--- a/app/models.py
+++ b/app/models.py
@@ -98,24 +98,27 @@ class Service(DbModelExtended):
     framework = db.relationship(Framework, lazy='joined', innerjoin=True)
 
     def serialize(self):
-        links = [
-            self.link(
-                "self",
-                self.url_for(".get_service", service_id=self.data['id'])
-            ),
-        ]
+        """
+        Pretty much a direct translation of the old `jsonify_service` function
+        :return: dictionary representation of a service
+        """
 
-        return {
+        data = dict(self.data.items())
+
+        data.update({
             'id': self.service_id,
             'supplierId': self.supplier.supplier_id,
             'supplierName': self.supplier.name,
-            'createdAt': self.created_at,
-            'updatedAt': self.updated_at,
-            'updatedBy': self.updated_by,
-            'updatedReason': self.updated_reason,
-            'data': self.data,
-            'links': links
-        }
+        })
+
+        data['links'] = [
+            self.link(
+                "self",
+                self.url_for(".get_service", service_id=data['id'])
+            )
+        ]
+
+        return data
 
 
 class ArchivedService(DbModelExtended):
@@ -160,3 +163,26 @@ class ArchivedService(DbModelExtended):
             data=service.data,
             status=service.status
         )
+
+    def serialize(self):
+        """
+        Pretty much a direct translation of the old `jsonify_service` function
+        :return: dictionary representation of a service
+        """
+
+        data = dict(self.data.items())
+
+        data.update({
+            'id': self.service_id,
+            'supplierId': self.supplier.supplier_id,
+            'supplierName': self.supplier.name,
+        })
+
+        data['links'] = [
+            self.link(
+                "self",
+                self.url_for(".get_service", service_id=data['id'])
+            )
+        ]
+
+        return data

--- a/app/models.py
+++ b/app/models.py
@@ -1,37 +1,6 @@
 from . import db
-from flask import url_for as base_url_for
+from app.main.utils import link, url_for
 from sqlalchemy.dialects.postgresql import JSON
-
-
-class DbModelExtended(db.Model):
-    """
-    Wrapper for db.Model that can be extended with other methods
-    """
-    __abstract__ = True
-
-    @staticmethod
-    def link(rel, href):
-        if href is not None:
-            return {
-                "rel": rel,
-                "href": href,
-            }
-
-    @staticmethod
-    def url_for(*args, **kwargs):
-        kwargs.setdefault('_external', True)
-        return base_url_for(*args, **kwargs)
-
-    @classmethod
-    def pagination_links(cls, pagination, endpoint, args):
-        return [
-            cls.link(rel, cls.url_for(endpoint,
-                                      **dict(list(args.items()) +
-                                             list({'page': page}.items()))))
-            for rel, page in [('next', pagination.next_num),
-                              ('prev', pagination.prev_num)]
-            if 0 < page <= pagination.pages
-        ]
 
 
 class Framework(db.Model):
@@ -45,7 +14,7 @@ class Framework(db.Model):
                         nullable=False)
 
 
-class Supplier(DbModelExtended):
+class Supplier(db.Model):
     __tablename__ = 'suppliers'
 
     id = db.Column(db.Integer, primary_key=True)
@@ -55,9 +24,9 @@ class Supplier(DbModelExtended):
 
     def serialize(self):
         links = [
-            self.link(
+            link(
                 "self",
-                self.url_for(".get_supplier", supplier_id=self.supplier_id)
+                url_for(".get_supplier", supplier_id=self.supplier_id)
             )
         ]
 
@@ -68,7 +37,7 @@ class Supplier(DbModelExtended):
         }
 
 
-class Service(DbModelExtended):
+class Service(db.Model):
     __tablename__ = 'services'
 
     id = db.Column(db.Integer, primary_key=True)
@@ -112,16 +81,16 @@ class Service(DbModelExtended):
         })
 
         data['links'] = [
-            self.link(
+            link(
                 "self",
-                self.url_for(".get_service", service_id=data['id'])
+                url_for(".get_service", service_id=data['id'])
             )
         ]
 
         return data
 
 
-class ArchivedService(DbModelExtended):
+class ArchivedService(db.Model):
     __tablename__ = 'archived_services'
 
     id = db.Column(db.Integer, primary_key=True)
@@ -179,9 +148,9 @@ class ArchivedService(DbModelExtended):
         })
 
         data['links'] = [
-            self.link(
+            link(
                 "self",
-                self.url_for(".get_service", service_id=data['id'])
+                url_for(".get_service", service_id=data['id'])
             )
         ]
 

--- a/app/models.py
+++ b/app/models.py
@@ -2,6 +2,28 @@ from . import db
 from flask import url_for as base_url_for
 from sqlalchemy.dialects.postgresql import JSON
 
+# get this copy+pasted code outta here
+def link(rel, href):
+    if href is not None:
+        return {
+            "rel": rel,
+            "href": href,
+        }
+
+def url_for(*args, **kwargs):
+    kwargs.setdefault('_external', True)
+    return base_url_for(*args, **kwargs)
+
+
+def pagination_links(pagination, endpoint, args):
+    return [
+        link(rel, url_for(endpoint,
+                          **dict(list(args.items()) +
+                                 list({'page': page}.items()))))
+        for rel, page in [('next', pagination.next_num),
+                          ('prev', pagination.prev_num)]
+        if 0 < page <= pagination.pages
+    ]
 
 class DbModelExtended(db.Model):
     """
@@ -55,6 +77,7 @@ class Supplier(DbModelExtended):
     name = db.Column(db.String(255), nullable=False)
 
     def serialize(self):
+
         links = [
             self.link(
                 "self",

--- a/app/models.py
+++ b/app/models.py
@@ -1,5 +1,5 @@
 from . import db
-from app.main.utils import link, url_for
+from .main.utils import link, url_for
 from sqlalchemy.dialects.postgresql import JSON
 
 


### PR DESCRIPTION
Just refactoring `app/main/views/services.py` to be more in line with how `suppliers.py` looks.

This meant, for example, removing methods like `paginate_links` that were near the bottom of `services.py` and putting them in the (Archived)Supplier models themselves.  
Also added `.serialize()` methods to the models in lieu of the prior `jsonify_service`.

Functionality is unchanged -- all the tests still run OK, and the logic is the same -- just the code is a bit cleaner.