### PR TITLE
Only run migrations on one instance

### DIFF
--- a/.ebextensions/dbmigrations.config
+++ b/.ebextensions/dbmigrations.config
@@ -1,3 +1,4 @@
 container_commands:
   upgrade:
     command: "python application.py db upgrade"
+    leader_only: true


### PR DESCRIPTION
The AWS rolling update [1] stuff does not work as expected and as such
migrations can run at the same time on more than one instance. This
makes beanstalk only run migrations on one instance.

[1] http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/using-features.rollingupdates.html