### PR TITLE
Link to suppliers list

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -19,8 +19,12 @@ def index():
     return jsonify(links=[
         {
             "rel": "services.list",
-            "href": url_for('.list_services', _external=True)
-        }
+            "href": url_for('.list_services', _external=True),
+        },
+        {
+            "rel": "suppliers.list",
+            "href": url_for('.list_suppliers', _external=True),
+        },
     ]), 200
 
 

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -8,7 +8,7 @@ API_FETCH_PAGE_SIZE = 100
 
 
 @main.route('/suppliers', methods=['GET'])
-def get_suppliers_by_prefix():
+def list_suppliers():
 
     try:
         page = int(request.args.get('page', 1))
@@ -17,30 +17,30 @@ def get_suppliers_by_prefix():
 
     prefix = request.args.get('prefix', '')
 
-    if not prefix:
-        abort(400, "No supplier name prefix provided")
+    suppliers = Supplier.query
 
-    # case insensitive LIKE comparison for matching supplier names
-    suppliers = Supplier.query.filter(
-        Supplier.name.ilike(prefix + '%')
-    )
-
-    if not suppliers.all():
-        abort(404, "No suppliers found for \'{0}\'".format(prefix))
+    if prefix:
+        # case insensitive LIKE comparison for matching supplier names
+        suppliers = suppliers.filter(
+            Supplier.name.ilike(prefix + '%'))
 
     suppliers = suppliers.paginate(
         page=page,
         per_page=API_FETCH_PAGE_SIZE,
-        error_out=False
+        error_out=False,
     )
 
-    if page > 1 and not suppliers:
-        abort(404, "Page number out of range")
+    if not suppliers.items:
+        if page > 1:
+            abort(404, "Page number out of range")
+        else:
+            abort(404, "No suppliers found for '{0}'".format(prefix))
+
     return jsonify(
         suppliers=[supplier.serialize() for supplier in suppliers.items],
         links=Supplier.pagination_links(
             suppliers,
-            '.get_suppliers_by_prefix',
+            '.list_suppliers',
             request.args
         ))
 

--- a/tests/app/views/test_suppliers.py
+++ b/tests/app/views/test_suppliers.py
@@ -32,9 +32,9 @@ class TestGetSupplier(BaseApplicationTest):
         assert_equal(u"Supplier 585274", data['suppliers']['name'])
 
 
-class TestGetSuppliers(BaseApplicationTest):
+class TestListSuppliers(BaseApplicationTest):
     def setup(self):
-        super(TestGetSuppliers, self).setup()
+        super(TestListSuppliers, self).setup()
 
         with self.app.app_context():
             db.session.add(
@@ -52,11 +52,11 @@ class TestGetSuppliers(BaseApplicationTest):
 
     def test_query_string_missing(self):
         response = self.client.get('/suppliers')
-        assert_equal(400, response.status_code)
+        assert_equal(200, response.status_code)
 
     def test_query_string_prefix_empty(self):
         response = self.client.get('/suppliers?prefix=')
-        assert_equal(400, response.status_code)
+        assert_equal(200, response.status_code)
 
     def test_query_string_prefix_returns_none(self):
         response = self.client.get('/suppliers?prefix=canada')
@@ -89,9 +89,9 @@ class TestGetSuppliers(BaseApplicationTest):
         assert_equal(u"Supplier 123456", data['suppliers'][1]['name'])
 
 
-class TestGetSuppliersPaginated(BaseApplicationTest):
+class TestListSuppliersPaginated(BaseApplicationTest):
     def setup(self):
-        super(TestGetSuppliersPaginated, self).setup()
+        super(TestListSuppliersPaginated, self).setup()
 
         # Supplier names like u"Supplier {n}"
         self.setup_dummy_suppliers(150)
@@ -117,7 +117,7 @@ class TestGetSuppliersPaginated(BaseApplicationTest):
     def test_query_string_prefix_page_out_of_range(self):
         response = self.client.get('/suppliers?prefix=s&page=10')
 
-        assert_equal(response.status_code, 200)
+        assert_equal(response.status_code, 404)
 
     def test_query_string_prefix_invalid_page_argument(self):
         response = self.client.get('/suppliers?prefix=s&page=a')


### PR DESCRIPTION
The requirement for services to be listed without providing a prefix
parameter was not explicity given in the story however, it is useful for
things like exporting all services or linking from the root path.