### PR TITLE
Fixing service ids for update

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -137,6 +137,7 @@ def update_service(service_id):
     detect_framework_or_400(data)
     data["id"] = str(data["id"])
 
+    data = drop_foreign_fields(data, ['id'])
     now = datetime.now()
     service.data = data
     service.updated_at = now
@@ -183,6 +184,7 @@ def import_service(service_id):
 
     framework = detect_framework_or_400(service_data)
 
+    service_data = drop_foreign_fields(service_data, ['id'])
     service.supplier_id = service_data['supplierId']
     service.framework_id = Framework.query.filter(
         Framework.name == framework).first().id

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -8,7 +8,6 @@ from .. import main
 from app.main import helpers
 from ... import db
 from ...models import ArchivedService, Service, Supplier, Framework
-import traceback
 from ...validation import detect_framework_or_400, \
     validate_updater_json_or_400, is_valid_service_id_or_400
 from ..utils import url_for, pagination_links, drop_foreign_fields, link, \
@@ -136,6 +135,7 @@ def update_service(service_id):
     data = dict(service.data.items())
     data.update(service_update)
     detect_framework_or_400(data)
+    data["id"] = str(data["id"])
 
     now = datetime.now()
     service.data = data

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -134,8 +134,13 @@ def update_service(service_id):
 
     data = dict(service.data.items())
     data.update(service_update)
+    if "id" in data:
+        # It is an old-style service JSON with an id field
+        data["id"] = str(data["id"])
+    else:
+        # It is a new service JSON with id removed from payload already
+        data["id"] = service_id
     detect_framework_or_400(data)
-    data["id"] = str(data["id"])
 
     data = drop_foreign_fields(data, ['id'])
     now = datetime.now()

--- a/tests/app/views/test_services.py
+++ b/tests/app/views/test_services.py
@@ -535,6 +535,7 @@ class TestPutService(BaseApplicationTest, JSONUpdateTestMixin):
 
             assert_equal(response.status_code, 201)
             now = datetime.now()
+            payload.pop('id', None)
             service = Service.query.filter(Service.service_id ==
                                            "1234567890123456").first()
             assert_equal(service.data, payload)
@@ -561,6 +562,7 @@ class TestPutService(BaseApplicationTest, JSONUpdateTestMixin):
             payload.pop('status', None)
             assert_equal(response.status_code, 201)
             now = datetime.now()
+            payload.pop('id', None)
             service = Service.query.filter(Service.service_id ==
                                            "4-disabled").first()
             assert_equal(service.status, 'disabled')
@@ -585,6 +587,7 @@ class TestPutService(BaseApplicationTest, JSONUpdateTestMixin):
             assert_equal(response.status_code, 200)
             assert_equal(json.loads(response.get_data()), {"message": "done"})
             now = datetime.now()
+            payload.pop('id', None)
             service = Service.query.filter(Service.service_id ==
                                            "1234567890123456").first()
             assert_equal(service.data, payload)


### PR DESCRIPTION
This addresses the bug here: https://www.pivotaltracker.com/story/show/92215088 and should allow us to deploy the updated API and admin app to prod without it breaking because of the old numeric ids that exist in the prod data.

The issue of numeric vs. string ids in the JSON 'data' fields for services is already avoided for GETs by using the service.serialize() method, which overwrites the value in the data with the string-valued `service_id` column - any 'id' that exists in the data is effectively ignored, so going forward we don't want/need to store any value for 'id' in the data at all.

This PR removes the 'id' field from the JSON payload for both PUTs and POSTs, so any newly added or updated services will not have an ID field in their JSON data.

Over time (as services are updated) the 'id' fields will disappear from the JSON in the data.  Meanwhile updates will work OK for all cases:
 * where the 'id' is a number (e.g. existing G6 services in legacy database), 
 * where the 'id' is a string (e.g. existing G4/G5/G6 services in recently upgraded dev databases)
 * where there is no 'id' in the data at all (e.g. all services added/updated in the future)
