### PR TITLE
Add CloudWatch logs

### DIFF
--- a/.ebextensions/cwl-setup.config
+++ b/.ebextensions/cwl-setup.config
@@ -1,0 +1,138 @@
+########################################################################
+##
+########################################################################
+
+Conditions:
+  SNSTopicExists : { "Fn::Not" : [{ "Fn::Equals" : [ "", {"Fn::FindInMap" : ["AWSEBOptions", "options", "EBSNSTopicArn"]}]}]}    
+
+Outputs:
+  ElasticBeanstalkSNSTopicArn:
+    Description: "The SNS Topic ARN for Elastic Beanstalk event notifications. Empty string if none specified."
+    Value: { "Fn::FindInMap": ["AWSEBOptions", "options", "EBSNSTopicArn"] }
+
+
+Resources:
+  AWSEBAutoScalingGroup:
+    Metadata:
+      "AWS::CloudFormation::Init":
+        configSets:
+          "_OnInstanceBoot":
+            "CmpFn::Insert":
+              values:
+                - CWLogsAgentClearConfig
+                - CWLogsAgentConfigSetup
+                - CWLogsAgentUpdaterInstallation
+                - CWLogsAgentInstallation
+          "CWLogsAgentInstallation":
+            - CWLogsAgentClearConfig
+            - CWLogsAgentConfigSetup
+            - CWLogsAgentUpdaterInstallation
+            - CWLogsAgentInstallation
+          "CWLogsAgentConfigUpdate":
+            - CWLogsAgentClearConfig
+            - CWLogsAgentConfigSetup
+            - CWLogsAgentUpdateConfig
+        CWLogsAgentClearConfig:
+          commands:
+            01-clear-agent-config:
+              command: rm -rf /tmp/cwlogs/conf.d
+        CWLogsAgentConfigSetup:
+          files:
+            "/tmp/cwlogs/conf.d/general.conf":
+              content : |
+                [general]
+                state_file = /var/awslogs/state/agent-state
+              mode  : "000400"
+              owner : root
+              group : root
+          commands:
+            01-setup-agent-config:
+              ## Every .conf file in /tmp/cwlogs/conf.d/ will be concatenated together to form the cwl agent config file
+              command: |
+                cat /tmp/cwlogs/conf.d/*.conf > /tmp/cwlogs/cwlogs-config.conf
+        CWLogsAgentInstallation:
+          files:
+            "/tmp/cwlogs/awslogs-agent-setup.py" :
+              source : "https://s3.amazonaws.com/aws-cloudwatch/downloads/latest/awslogs-agent-setup.py"
+              mode  : "000700"
+              owner : root
+              group : root
+          commands:
+            01-setup-cwlogs-agent:
+              ## Install the cwlogs agent - this will also install the cli it needs (in a virtualenv)
+              command: |
+                setsid /tmp/cwlogs/awslogs-agent-setup.py -n -r `{"Ref" : "AWS::Region" }` -c /tmp/cwlogs/cwlogs-config.conf && exit 0;
+
+        ## Configuration deployment command - update agent if needed
+        CWLogsAgentUpdaterInstallation:
+          files:
+            "/opt/elasticbeanstalk/hooks/configdeploy/enact/00_update_cwlogs_agent.sh":
+              content: |
+                #!/bin/bash
+                . /etc/elasticbeanstalk/.aws-eb-stack.properties
+                /opt/aws/bin/cfn-init -v -s "$stack_name" -r "$resource" --region "$region" --configsets CWLogsAgentConfigUpdate > /var/log/eb-cfn-init-call.log 2>&1
+              mode  : "000700"
+              owner : root
+              group : root
+        CWLogsAgentUpdateConfig:
+          files:
+            "/tmp/cwlogs/bin/cwlogs-update.sh":
+              content: |
+                #!/bin/bash
+                log() {
+                   echo [$(date -u +"%Y-%m-%d %TZ")] $1
+                }
+                log "Executing cwlogs agent configuration update"
+
+                if cmp /var/awslogs/etc/awslogs.conf /tmp/cwlogs/cwlogs-config.conf > /dev/null 2>&1; then
+                   log "Configuration has not changed - not updating"
+                   exit 0;
+                fi
+                
+                log "Copying new cwlogs config to /var/awslogs/etc/awslogs.conf"
+                cp /tmp/cwlogs/cwlogs-config.conf /var/awslogs/etc/awslogs.conf;
+                log "Restarting awslogs service"
+                service awslogs restart;
+                log "awslogs service restart complete"
+                log "Completed cwlogs agent configuration update"
+                exit 0;
+              mode  : "000700"
+              owner : root
+              group : root
+          commands:
+            01-update-agent-config:
+              command: "/tmp/cwlogs/bin/cwlogs-update.sh >> /var/log/eb-cwlogs.log 2>&1"
+
+
+## Version deployment command - ensure agent is installed
+files:
+  "/tmp/cwlogs/bin/cwlogs-install.sh":
+    content: |
+      #!/bin/bash
+      log() {
+         echo [$(date -u +"%Y-%m-%d %TZ")] $1
+      }
+
+      log "Initiating cwlogs agent installation/update"
+      . /etc/elasticbeanstalk/.aws-eb-stack.properties
+      CONFIG_SET=CWLogsAgentInstallation
+
+      ## just do an update if we think it's already installed
+      if [ -f "/var/awslogs/etc/awslogs.conf" ]; then   
+        CONFIG_SET=CWLogsAgentConfigUpdate
+        log "Running agent configuration update"
+      else
+        log "Running agent installation"
+      fi
+
+      /opt/aws/bin/cfn-init -v -s "$stack_name" -r "$resource" --region "$region" --configsets $CONFIG_SET;
+      log "Completed cwlogs agent installation/update"
+      exit 0;
+    mode  : "000700"
+    owner : root
+    group : root
+    
+commands:
+  01-ensure-agent-installation:
+    command:  "/tmp/cwlogs/bin/cwlogs-install.sh >> /var/log/eb-cwlogs.log 2>&1"
+      

--- a/.ebextensions/cwl-webrequest-metrics.config
+++ b/.ebextensions/cwl-webrequest-metrics.config
@@ -1,0 +1,170 @@
+###############################################################################
+## Option Settings
+##    Namespace: "aws:elasticbeanstalk:application:environment"
+##    OptionName: WebRequestCWLogGroup
+##       Default:   <EnvironmentName>-webrequests
+##    Description: This is the name of the cloudwatch log group for web requests (access log)
+##
+## To get an SNS alert, add a subscription to the Elastic Beanstalk Notification
+##   topic.  (e.g. set your Notificiation Endpoint to your email address)
+##
+## Metrics
+##  Namespace:  ElasticBeanstalk/<EnvironmentName>
+##  Metrics:    CWLHttp4xx  CWLHttp5xx
+##
+## Cloudwatch Alarms
+##   CWLHttp5xxCount   - this alarm fires if the number of calls returning
+##                        5xx response codes > 10
+##   CWLHttp4xxPercent - this alarm fires if the percentage of calls returning
+##                        4xx response codes > 10%    
+##
+##  Note - this demo works with apache containers that are using the default common log format
+##      (python and php ruby containers do this - tomcat does not)
+###############################################################################
+
+
+# Apache access log pattern:
+## "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\""
+## remote_host  remote_logname  remote_user  time_received "request" status response_size "referrer" "user-agent"
+Mappings:
+  CWLogs:
+    WebRequestLogGroup:
+      LogFile: "/var/log/httpd/access_log"
+      TimestampFormat: "%d/%b/%Y:%H:%M:%S %z"
+    FilterPatterns:
+      Http4xxMetricFilter: "[..., status=4*, size, referer, agent]"  
+      HttpNon4xxMetricFilter: "[..., status!=4*, size, referer, agent]"
+      Http5xxMetricFilter: "[..., status=5*, size, referer, agent]"  
+      HttpNon5xxMetricFilter: "[..., status!=5*, size, referer, agent]"  
+
+
+Outputs:
+  WebRequestCWLogGroup:
+    Description: "The name of the Cloudwatch Logs Log Group created for this environments web server access logs. You can specify this by setting the value for the environment variable: WebRequestCWLogGroup. Please note: if you update this value, then you will need to go and clear out the old cloudwatch logs group and delete it through Cloudwatch Logs."
+    Value: { "Ref" : "AWSEBCloudWatchLogs8832c8d3f1a54c238a40e36f31ef55a0WebRequestLogGroup"}
+
+
+Resources :
+  AWSEBCloudWatchLogs8832c8d3f1a54c238a40e36f31ef55a0WebRequestLogGroup:    ## Must have prefix:  AWSEBCloudWatchLogs8832c8d3f1a54c238a40e36f31ef55a0
+    Type: "AWS::Logs::LogGroup"
+    DependsOn: AWSEBBeanstalkMetadata
+    DeletionPolicy: Retain     ## this is required
+    Properties:
+      LogGroupName: 
+        "Fn::GetOptionSetting":
+          Namespace: "aws:elasticbeanstalk:application:environment"
+          OptionName: WebRequestCWLogGroup
+          DefaultValue: {"Fn::Join":["-", [{ "Ref":"AWSEBEnvironmentName" }, "webrequests"]]}
+      RetentionInDays: 14
+
+
+  ## Register the files/log groups for monitoring
+  AWSEBAutoScalingGroup:
+    Metadata:
+      "AWS::CloudFormation::Init":
+        CWLogsAgentConfigSetup:
+          files:
+            ## any .conf file put into /tmp/cwlogs/conf.d will be added to the cwlogs config (see cwl-agent.config)
+            "/tmp/cwlogs/conf.d/apache-access.conf":
+              content : |
+                [apache-access_log]
+                file = `{"Fn::FindInMap":["CWLogs", "WebRequestLogGroup", "LogFile"]}`
+                log_group_name = `{ "Ref" : "AWSEBCloudWatchLogs8832c8d3f1a54c238a40e36f31ef55a0WebRequestLogGroup" }`
+                log_stream_name = {instance_id}
+                datetime_format = `{"Fn::FindInMap":["CWLogs", "WebRequestLogGroup", "TimestampFormat"]}`
+              mode  : "000400"
+              owner : root
+              group : root
+
+      
+  #######################################
+  ## Cloudwatch Logs Metric Filters
+
+  AWSEBCWLHttp4xxMetricFilter :
+    Type : "AWS::Logs::MetricFilter"
+    Properties :
+      LogGroupName: { "Ref" : "AWSEBCloudWatchLogs8832c8d3f1a54c238a40e36f31ef55a0WebRequestLogGroup" }
+      FilterPattern : {"Fn::FindInMap":["CWLogs", "FilterPatterns", "Http4xxMetricFilter"]}
+      MetricTransformations :
+        - MetricValue : 1
+          MetricNamespace: {"Fn::Join":["/", ["ElasticBeanstalk", {"Ref":"AWSEBEnvironmentName"}]]}
+          MetricName : CWLHttp4xx
+
+  AWSEBCWLHttpNon4xxMetricFilter :
+    Type : "AWS::Logs::MetricFilter"
+    DependsOn : AWSEBCWLHttp4xxMetricFilter
+    Properties :
+      LogGroupName: { "Ref" : "AWSEBCloudWatchLogs8832c8d3f1a54c238a40e36f31ef55a0WebRequestLogGroup" }
+      FilterPattern : {"Fn::FindInMap":["CWLogs", "FilterPatterns", "HttpNon4xxMetricFilter"]}
+      MetricTransformations :
+        - MetricValue : 0
+          MetricNamespace: {"Fn::Join":["/", ["ElasticBeanstalk", {"Ref":"AWSEBEnvironmentName"}]]}
+          MetricName : CWLHttp4xx
+
+  AWSEBCWLHttp5xxMetricFilter :
+    Type : "AWS::Logs::MetricFilter"
+    Properties :
+      LogGroupName: { "Ref" : "AWSEBCloudWatchLogs8832c8d3f1a54c238a40e36f31ef55a0WebRequestLogGroup" }
+      FilterPattern : {"Fn::FindInMap":["CWLogs", "FilterPatterns", "Http5xxMetricFilter"]}
+      MetricTransformations :
+        - MetricValue : 1
+          MetricNamespace: {"Fn::Join":["/", ["ElasticBeanstalk", {"Ref":"AWSEBEnvironmentName"}]]}
+          MetricName : CWLHttp5xx
+
+  AWSEBCWLHttpNon5xxMetricFilter :
+    Type : "AWS::Logs::MetricFilter"
+    DependsOn : AWSEBCWLHttp5xxMetricFilter
+    Properties :
+      LogGroupName: { "Ref" : "AWSEBCloudWatchLogs8832c8d3f1a54c238a40e36f31ef55a0WebRequestLogGroup" }
+      FilterPattern : {"Fn::FindInMap":["CWLogs", "FilterPatterns", "HttpNon5xxMetricFilter"]}
+      MetricTransformations :
+        - MetricValue : 0
+          MetricNamespace: {"Fn::Join":["/", ["ElasticBeanstalk", {"Ref":"AWSEBEnvironmentName"}]]}
+          MetricName : CWLHttp5xx
+
+
+  ######################################################
+  ## Alarms
+
+  AWSEBCWLHttp5xxCountAlarm :
+    Type : "AWS::CloudWatch::Alarm"
+    DependsOn : AWSEBCWLHttpNon5xxMetricFilter
+    Properties :
+      AlarmDescription: "Application is returning too many 5xx responses (count too high)."
+      MetricName: CWLHttp5xx
+      Namespace: {"Fn::Join":["/", ["ElasticBeanstalk", {"Ref":"AWSEBEnvironmentName"}]]}
+      Statistic: Sum
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 10
+      ComparisonOperator: GreaterThanThreshold
+      AlarmActions:
+        - "Fn::If":
+            - SNSTopicExists
+            - "Fn::FindInMap":
+                - AWSEBOptions
+                - options
+                - EBSNSTopicArn
+            - { "Ref" : "AWS::NoValue" }
+
+  AWSEBCWLHttp4xxPercentAlarm :
+    Type : "AWS::CloudWatch::Alarm"
+    DependsOn : AWSEBCWLHttpNon4xxMetricFilter
+    Properties :
+      AlarmDescription: "Application is returning too many 4xx responses (percentage too high)."
+      MetricName: CWLHttp4xx
+      Namespace: {"Fn::Join":["/", ["ElasticBeanstalk", {"Ref":"AWSEBEnvironmentName"}]]}
+      Statistic: Average
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 0.10    
+      ComparisonOperator: GreaterThanThreshold
+      AlarmActions:
+        - "Fn::If":
+            - SNSTopicExists
+            - "Fn::FindInMap":
+                - AWSEBOptions
+                - options
+                - EBSNSTopicArn
+            - { "Ref" : "AWS::NoValue" }
+

--- a/.ebextensions/cwl-webrequest-metrics.config
+++ b/.ebextensions/cwl-webrequest-metrics.config
@@ -55,7 +55,7 @@ Resources :
           Namespace: "aws:elasticbeanstalk:application:environment"
           OptionName: WebRequestCWLogGroup
           DefaultValue: {"Fn::Join":["-", [{ "Ref":"AWSEBEnvironmentName" }, "webrequests"]]}
-      RetentionInDays: 14
+      RetentionInDays: 3653
 
 
   ## Register the files/log groups for monitoring

--- a/.ebextensions/cwl-webrequest-metrics.config
+++ b/.ebextensions/cwl-webrequest-metrics.config
@@ -1,9 +1,8 @@
 ###############################################################################
 ## Option Settings
-##    Namespace: "aws:elasticbeanstalk:application:environment"
-##    OptionName: WebRequestCWLogGroup
-##       Default:   <EnvironmentName>-webrequests
-##    Description: This is the name of the cloudwatch log group for web requests (access log)
+##    Namespace: "aws:elasticbeanstalk:customoption"
+##    OptionName: LogGroupName
+##    Description: This is the name of the cloudwatch log group
 ##
 ## To get an SNS alert, add a subscription to the Elastic Beanstalk Notification
 ##   topic.  (e.g. set your Notificiation Endpoint to your email address)
@@ -28,9 +27,10 @@
 ## remote_host  remote_logname  remote_user  time_received "request" status response_size "referrer" "user-agent"
 Mappings:
   CWLogs:
-    WebRequestLogGroup:
+    AccessLogs:
       LogFile: "/var/log/httpd/access_log"
       TimestampFormat: "%d/%b/%Y:%H:%M:%S %z"
+      LogGroupName: {"Fn::GetOptionSetting": {"OptionName": "LogGroupName"}}
     FilterPatterns:
       Http4xxMetricFilter: "[..., status=4*, size, referer, agent]"  
       HttpNon4xxMetricFilter: "[..., status!=4*, size, referer, agent]"
@@ -41,7 +41,7 @@ Mappings:
 Outputs:
   WebRequestCWLogGroup:
     Description: "The name of the Cloudwatch Logs Log Group created for this environments web server access logs. You can specify this by setting the value for the environment variable: WebRequestCWLogGroup. Please note: if you update this value, then you will need to go and clear out the old cloudwatch logs group and delete it through Cloudwatch Logs."
-    Value: { "Fn::GetOptionSetting": {"OptionName": "LogGroup"} }
+    Value: {"Fn::FindInMap":["CWLogs", "AccessLogs", "LogGroupName"]}
 
 
 Resources :
@@ -55,10 +55,10 @@ Resources :
             "/tmp/cwlogs/conf.d/apache-access.conf":
               content : |
                 [apache-access_log]
-                file = `{"Fn::FindInMap":["CWLogs", "WebRequestLogGroup", "LogFile"]}`
-                log_group_name = `{ "Fn::GetOptionSetting": {"OptionName": "LogGroup"} }`
+                file = `{"Fn::FindInMap":["CWLogs", "AccessLogs", "LogFile"]}`
+                log_group_name = `{"Fn::FindInMap":["CWLogs", "AccessLogs", "LogGroupName"]}`
                 log_stream_name = access-logs
-                datetime_format = `{"Fn::FindInMap":["CWLogs", "WebRequestLogGroup", "TimestampFormat"]}`
+                datetime_format = `{"Fn::FindInMap":["CWLogs", "AccessLogs", "TimestampFormat"]}`
               mode  : "000400"
               owner : root
               group : root
@@ -70,7 +70,7 @@ Resources :
   AWSEBCWLHttp4xxMetricFilter :
     Type : "AWS::Logs::MetricFilter"
     Properties :
-      LogGroupName: { "Fn::GetOptionSetting": {"OptionName": "LogGroup"} }
+      LogGroupName: {"Fn::FindInMap":["CWLogs", "AccessLogs", "LogGroupName"]}
       FilterPattern : {"Fn::FindInMap":["CWLogs", "FilterPatterns", "Http4xxMetricFilter"]}
       MetricTransformations :
         - MetricValue : 1
@@ -81,7 +81,7 @@ Resources :
     Type : "AWS::Logs::MetricFilter"
     DependsOn : AWSEBCWLHttp4xxMetricFilter
     Properties :
-      LogGroupName: { "Fn::GetOptionSetting": {"OptionName": "LogGroup"} }
+      LogGroupName: {"Fn::FindInMap":["CWLogs", "AccessLogs", "LogGroupName"]}
       FilterPattern : {"Fn::FindInMap":["CWLogs", "FilterPatterns", "HttpNon4xxMetricFilter"]}
       MetricTransformations :
         - MetricValue : 0
@@ -91,7 +91,7 @@ Resources :
   AWSEBCWLHttp5xxMetricFilter :
     Type : "AWS::Logs::MetricFilter"
     Properties :
-      LogGroupName: { "Fn::GetOptionSetting": {"OptionName": "LogGroup"} }
+      LogGroupName: {"Fn::FindInMap":["CWLogs", "AccessLogs", "LogGroupName"]}
       FilterPattern : {"Fn::FindInMap":["CWLogs", "FilterPatterns", "Http5xxMetricFilter"]}
       MetricTransformations :
         - MetricValue : 1
@@ -102,7 +102,7 @@ Resources :
     Type : "AWS::Logs::MetricFilter"
     DependsOn : AWSEBCWLHttp5xxMetricFilter
     Properties :
-      LogGroupName: { "Fn::GetOptionSetting": {"OptionName": "LogGroup"} }
+      LogGroupName: {"Fn::FindInMap":["CWLogs", "AccessLogs", "LogGroupName"]}
       FilterPattern : {"Fn::FindInMap":["CWLogs", "FilterPatterns", "HttpNon5xxMetricFilter"]}
       MetricTransformations :
         - MetricValue : 0

--- a/.ebextensions/cwl-webrequest-metrics.config
+++ b/.ebextensions/cwl-webrequest-metrics.config
@@ -41,23 +41,10 @@ Mappings:
 Outputs:
   WebRequestCWLogGroup:
     Description: "The name of the Cloudwatch Logs Log Group created for this environments web server access logs. You can specify this by setting the value for the environment variable: WebRequestCWLogGroup. Please note: if you update this value, then you will need to go and clear out the old cloudwatch logs group and delete it through Cloudwatch Logs."
-    Value: { "Ref" : "AWSEBCloudWatchLogs8832c8d3f1a54c238a40e36f31ef55a0WebRequestLogGroup"}
+    Value: { "Fn::GetOptionSetting": {"OptionName": "LogGroup"} }
 
 
 Resources :
-  AWSEBCloudWatchLogs8832c8d3f1a54c238a40e36f31ef55a0WebRequestLogGroup:    ## Must have prefix:  AWSEBCloudWatchLogs8832c8d3f1a54c238a40e36f31ef55a0
-    Type: "AWS::Logs::LogGroup"
-    DependsOn: AWSEBBeanstalkMetadata
-    DeletionPolicy: Retain     ## this is required
-    Properties:
-      LogGroupName: 
-        "Fn::GetOptionSetting":
-          Namespace: "aws:elasticbeanstalk:application:environment"
-          OptionName: WebRequestCWLogGroup
-          DefaultValue: {"Fn::Join":["-", [{ "Ref":"AWSEBEnvironmentName" }, "webrequests"]]}
-      RetentionInDays: 3653
-
-
   ## Register the files/log groups for monitoring
   AWSEBAutoScalingGroup:
     Metadata:
@@ -69,8 +56,8 @@ Resources :
               content : |
                 [apache-access_log]
                 file = `{"Fn::FindInMap":["CWLogs", "WebRequestLogGroup", "LogFile"]}`
-                log_group_name = `{ "Ref" : "AWSEBCloudWatchLogs8832c8d3f1a54c238a40e36f31ef55a0WebRequestLogGroup" }`
-                log_stream_name = {instance_id}
+                log_group_name = `{ "Fn::GetOptionSetting": {"OptionName": "LogGroup"} }`
+                log_stream_name = access-logs
                 datetime_format = `{"Fn::FindInMap":["CWLogs", "WebRequestLogGroup", "TimestampFormat"]}`
               mode  : "000400"
               owner : root
@@ -83,7 +70,7 @@ Resources :
   AWSEBCWLHttp4xxMetricFilter :
     Type : "AWS::Logs::MetricFilter"
     Properties :
-      LogGroupName: { "Ref" : "AWSEBCloudWatchLogs8832c8d3f1a54c238a40e36f31ef55a0WebRequestLogGroup" }
+      LogGroupName: { "Fn::GetOptionSetting": {"OptionName": "LogGroup"} }
       FilterPattern : {"Fn::FindInMap":["CWLogs", "FilterPatterns", "Http4xxMetricFilter"]}
       MetricTransformations :
         - MetricValue : 1
@@ -94,7 +81,7 @@ Resources :
     Type : "AWS::Logs::MetricFilter"
     DependsOn : AWSEBCWLHttp4xxMetricFilter
     Properties :
-      LogGroupName: { "Ref" : "AWSEBCloudWatchLogs8832c8d3f1a54c238a40e36f31ef55a0WebRequestLogGroup" }
+      LogGroupName: { "Fn::GetOptionSetting": {"OptionName": "LogGroup"} }
       FilterPattern : {"Fn::FindInMap":["CWLogs", "FilterPatterns", "HttpNon4xxMetricFilter"]}
       MetricTransformations :
         - MetricValue : 0
@@ -104,7 +91,7 @@ Resources :
   AWSEBCWLHttp5xxMetricFilter :
     Type : "AWS::Logs::MetricFilter"
     Properties :
-      LogGroupName: { "Ref" : "AWSEBCloudWatchLogs8832c8d3f1a54c238a40e36f31ef55a0WebRequestLogGroup" }
+      LogGroupName: { "Fn::GetOptionSetting": {"OptionName": "LogGroup"} }
       FilterPattern : {"Fn::FindInMap":["CWLogs", "FilterPatterns", "Http5xxMetricFilter"]}
       MetricTransformations :
         - MetricValue : 1
@@ -115,7 +102,7 @@ Resources :
     Type : "AWS::Logs::MetricFilter"
     DependsOn : AWSEBCWLHttp5xxMetricFilter
     Properties :
-      LogGroupName: { "Ref" : "AWSEBCloudWatchLogs8832c8d3f1a54c238a40e36f31ef55a0WebRequestLogGroup" }
+      LogGroupName: { "Fn::GetOptionSetting": {"OptionName": "LogGroup"} }
       FilterPattern : {"Fn::FindInMap":["CWLogs", "FilterPatterns", "HttpNon5xxMetricFilter"]}
       MetricTransformations :
         - MetricValue : 0

--- a/.ebextensions/eb-logs.config
+++ b/.ebextensions/eb-logs.config
@@ -1,0 +1,39 @@
+##################################################################
+##  Sets up the elastic beanstalk log publication to include
+##   the admin logs for cloudwatch logs
+##################################################################
+
+Resources:
+  AWSEBAutoScalingGroup:
+    Metadata:
+      "AWS::CloudFormation::Init":
+        configSets:
+          "_OnInstanceBoot":
+            "CmpFn::Insert":
+              values:
+                - EBCWLLogPublicationSetup
+        EBCWLLogPublicationSetup:
+          files:
+            "/opt/elasticbeanstalk/tasks/taillogs.d/cwl-system.conf":
+              content: |
+                /var/log/awslogs-agent-setup.log
+                /var/log/awslogs.log
+                /var/log/eb-cwlogs.log
+              mode : "000644"
+            "/opt/elasticbeanstalk/tasks/bundlelogs.d/cwl-system.conf":
+              content: |
+                /var/log/awslogs-agent-setup.log
+                /var/log/awslogs.log
+                /var/log/eb-cwlogs.log
+              mode : "000644"
+            "/opt/elasticbeanstalk/tasks/systemtaillogs.d/cwl-system.conf":
+              content: |
+                /var/log/awslogs-agent-setup.log
+                /var/log/awslogs.log
+                /var/log/eb-cwlogs.log
+              mode : "000644"
+            "/opt/elasticbeanstalk/tasks/publishlogs.d/cwl-system.conf":
+              content: |
+                /var/log/awslogs-agent-setup.log    ## this isn't rotated
+                /var/log/awslogs.log*.gz
+              mode : "000644"


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/92328278

This uses the .ebextensions configs provided by amazon [1]. The `cwl-setup.config` and `eb-logs.config` files are unchanged. The `cwl-webrequest-metrics.config` has been updated to take the log group from the EB environment. This means that we can have multiple apps logging into the same log group.

This only implements Apache access logs. The intention is to add application logs in the story specifically about them. [2]

[1] http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/AWSHowTo.cloudwatchlogs.html#AWSHowTo.cloudwatchlogs.files
[2] https://www.pivotaltracker.com/story/show/92328310