### PR TITLE
Move /_status-related utils fns to app/status/utils.py

### DIFF
--- a/app/status/utils.py
+++ b/app/status/utils.py
@@ -1,0 +1,11 @@
+import os
+
+
+def get_version_label():
+    try:
+        path = os.path.join(os.path.dirname(__file__),
+                            '..', '..', 'version_label')
+        with open(path) as f:
+            return f.read().strip()
+    except IOError:
+        return None

--- a/app/status/views.py
+++ b/app/status/views.py
@@ -1,7 +1,7 @@
 from flask import jsonify
 
 from . import status
-from .. import utils
+from . import utils
 
 
 @status.route('/_status')

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,16 +1,5 @@
-import os
-
 from flask import url_for as base_url_for
 from flask import abort, request
-
-
-def get_version_label():
-    try:
-        path = os.path.join(os.path.dirname(__file__), '..', 'version_label')
-        with open(path) as f:
-            return f.read().strip()
-    except IOError:
-        return None
 
 
 def link(rel, href):


### PR DESCRIPTION
Keeping app/status self contains make it easier to move changes
between different apps