### PR TITLE
Delete ContactInformation when overwriting Suppliers

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -97,13 +97,15 @@ def import_supplier(supplier_id):
     ).first()
 
     if supplier is None:
-            supplier = Supplier(supplier_id=supplier_data['id'])
+        supplier = Supplier(supplier_id=supplier_data['id'])
+
+    # if a supplier was found, remove all contact information
+    else:
+        for contact in supplier.contact_information:
+            db.session.delete(contact)
 
     supplier.name = supplier_data.get('name', None)
     supplier.description = supplier_data.get('description', None)
-
-    # TODO: this erases all prior contact information :/
-    supplier.contact_information = []
     supplier.duns_number = supplier_data.get('dunsNumber', None)
     supplier.esourcing_id = supplier_data.get('eSourcingId', None)
     supplier.clients = supplier_data.get('clients', None)

--- a/tests/app/views/test_suppliers.py
+++ b/tests/app/views/test_suppliers.py
@@ -143,6 +143,43 @@ class TestPutSupplier(BaseApplicationTest, JSONUpdateTestMixin):
             ).first()
             assert_equal(supplier.name, payload['name'])
 
+    def test_reinserting_the_same_supplier(self):
+        with self.app.app_context():
+            payload = self.load_example_listing("Supplier")
+            example_listing_contact_information = payload['contactInformation']
+
+            # Exact loop number is arbitrary
+            for i in range(3):
+
+                response = self.put_import_supplier(payload)
+
+                assert_equal(response.status_code, 201)
+
+                supplier = Supplier.query.filter(
+                    Supplier.supplier_id == 123456
+                ).first()
+                assert_equal(supplier.name, payload['name'])
+
+                contact_informations = ContactInformation.query.filter(
+                    ContactInformation.supplier_id == supplier.supplier_id
+                ).all()
+
+                assert_equal(
+                    len(example_listing_contact_information),
+                    len(contact_informations)
+                )
+
+                # Contact Information without a supplier_id should not exist
+                contact_informations_no_supplier_id = \
+                    ContactInformation.query.filter(
+                        ContactInformation.supplier_id == None  # noqa
+                    ).all()
+
+                assert_equal(
+                    0,
+                    len(contact_informations_no_supplier_id)
+                )
+
     def test_cannot_put_to_root_suppliers_url(self):
         payload = self.load_example_listing("Supplier")
 


### PR DESCRIPTION
Overwriting an existing Supplier would remove the _reference_ between a Supplier and its prior Contact Information, but not delete the Contact Information outright.

Small update deletes Contact Information if a Supplier is found.