### PR TITLE
Adding status and framework to service response json

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -3,7 +3,6 @@ from flask.ext.bootstrap import Bootstrap
 from flask.ext.sqlalchemy import SQLAlchemy
 from werkzeug.contrib.fixers import ProxyFix
 from .flask_search_api_client.search_api_client import SearchApiClient
-import os
 from dmutils import logging
 
 from config import config

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -128,7 +128,7 @@ def update_service(service_id):
     validate_updater_json_or_400(update_json)
     service_update = drop_foreign_fields(
         json_payload['services'],
-        ['supplierName', 'links','frameworkName','status']
+        ['supplierName', 'links', 'frameworkName', 'status']
     )
     json_has_matching_id(service_update, service_id)
 

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -128,7 +128,7 @@ def update_service(service_id):
     validate_updater_json_or_400(update_json)
     service_update = drop_foreign_fields(
         json_payload['services'],
-        ['supplierName', 'links']
+        ['supplierName', 'links','frameworkName','status']
     )
     json_has_matching_id(service_update, service_id)
 

--- a/app/models.py
+++ b/app/models.py
@@ -195,6 +195,8 @@ class Service(db.Model):
             'id': self.service_id,
             'supplierId': self.supplier.supplier_id,
             'supplierName': self.supplier.name,
+            'frameworkName': self.framework.name,
+            'status': self.status
         })
 
         data['links'] = [

--- a/tests/app/views/test_services.py
+++ b/tests/app/views/test_services.py
@@ -35,6 +35,22 @@ class TestListServices(BaseApplicationTest):
         assert_equal(len(data['services']), 1)
         assert_equal(data['services'][0]['id'], '0')
 
+    def test_list_services_returns_status(self):
+        self.setup_dummy_services_including_unpublished(1)
+        response = self.client.get('/services')
+        data = json.loads(response.get_data())
+        service = data['services'][0]
+
+        assert_equal(service['status'], u'published')
+
+    def test_list_services_returns_framework(self):
+        self.setup_dummy_services_including_unpublished(1)
+        response = self.client.get('/services')
+        data = json.loads(response.get_data())
+        service = data['services'][0]
+
+        assert_equal(service['frameworkName'], u'G-Cloud 6')
+
     def test_list_services_returns_supplier_info(self):
         self.setup_dummy_services_including_unpublished(1)
         response = self.client.get('/services')


### PR DESCRIPTION
Added the status and framework to the services fetch endpoints. 

Added to the serialize method on the model.

Needed to render the services on admin and supplier tools.