### PR TITLE
Keep version history up-to-date

### DIFF
--- a/migrations/VERSION-HISTORY.txt
+++ b/migrations/VERSION-HISTORY.txt
@@ -19,3 +19,4 @@ c8bce0740af   -  add 'supplier_id', 'created_at' and 'updated_at'
 407e74de5553  -  add 'users' table
 3d5aabf7d291  -  add 'role' to 'users'
 550715127385  -  add 'contact_information' table and extend 'suppliers'
+10_adding_supplier_to_user_table - add 'supplier_id' to users table


### PR DESCRIPTION
As a side not on this, the latest migration (10_adding_supplier_to_user_table) will not run if there is already any user data in the database, because adding the constraint fails (users with 'supplier' role but no supplier_id).

This is OK for us at the moment because there is no user data in the prod databases, but we might want to get into the habit of adding constraints in two steps, making sure the database is in a consistent state before adding the constraint.