### PR TITLE
Pc mute migration messages

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -20,12 +20,12 @@ def index():
         {
             "rel": "services.list",
             "href": url_for('.list_services', _external=True),
-        },
+            },
         {
             "rel": "suppliers.list",
             "href": url_for('.list_suppliers', _external=True),
-        },
-    ]), 200
+            },
+        ]), 200
 
 
 @main.route('/services', methods=['GET'])
@@ -248,3 +248,38 @@ def get_archived_service(archived_service_id):
     ).first_or_404()
 
     return jsonify(services=service.serialize())
+
+
+@main.route(
+    '/services/<string:service_id>/status/<string:status>',
+    methods=['POST']
+)
+def update_service_status(service_id, status):
+
+    # Statuses are defined in the Supplier model
+    valid_statuses = [
+        "published",
+        "enabled",
+        "disabled"
+    ]
+
+    is_valid_service_id_or_400(service_id)
+
+    service = Service.query.filter(
+        Service.service_id == service_id
+    ).first_or_404()
+
+    if status not in valid_statuses:
+        abort(400, "'{0}' is not a valid status.".format(status))
+
+    service.status = status
+    db.session.add(service)
+
+    try:
+        db.session.commit()
+        search_api_client.index(service_id, service.data,
+                                service.supplier.name)
+        return jsonify(services=service.serialize()), 200
+    except IntegrityError as e:
+        db.session.rollback()
+        abort(400, e.orig)

--- a/migrations/alembic.ini
+++ b/migrations/alembic.ini
@@ -21,7 +21,7 @@ keys = generic
 
 [logger_root]
 level = WARN
-handlers = console
+handlers =
 qualname =
 
 [logger_sqlalchemy]

--- a/tests/app/views/test_services.py
+++ b/tests/app/views/test_services.py
@@ -514,6 +514,54 @@ class TestPostService(BaseApplicationTest):
         assert_in(b'id parameter must match id in data',
                   response.get_data())
 
+    def test_should_update_service_with_valid_statuses(self):
+
+        # Statuses are defined in the Supplier model
+        valid_statuses = [
+            "published",
+            "enabled",
+            "disabled"
+        ]
+
+        for status in valid_statuses:
+            response = self.client.post(
+                '/services/{0}/status/{1}'.format(
+                    self.service_id,
+                    status
+                )
+            )
+
+            assert_equal(response.status_code, 200)
+            data = json.loads(response.get_data())
+            assert_equal(status, data['services']['status'])
+
+    def test_should_400_with_invalid_statuses(self):
+        invalid_statuses = [
+            "unpublished",  # not a permissible state
+            "enabeld",  # typo
+        ]
+
+        for status in invalid_statuses:
+            response = self.client.post(
+                '/services/{0}/status/{1}'.format(
+                    self.service_id,
+                    status
+                )
+            )
+
+            assert_equal(response.status_code, 400)
+            assert_in('is not a valid status',
+                      json.loads(response.get_data())['error'])
+
+    def test_should_404_without_status_parameter(self):
+        response = self.client.post(
+            '/services/{0}/status/'.format(
+                self.service_id
+            )
+        )
+
+        assert_equal(response.status_code, 404)
+
 
 class TestShouldCallSearchApiOnPutToCreateService(BaseApplicationTest):
     def setup(self):


### PR DESCRIPTION
Pretty minimal commit.  Removing `handlers = console` from the `migrations/alembic.ini` file silences all of those helpful [INFO] messages that otherwise clutter up our unit tests.
We're also removing [INFO] messages during the bootstrapping process, just so we're aware of the wider implications.