### PR TITLE
Add update endpoint for service.status and relevant tests.

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -10,7 +10,8 @@ from sqlalchemy.exc import IntegrityError
 from ...validation import detect_framework_or_400, \
     validate_updater_json_or_400, is_valid_service_id_or_400
 from ...utils import url_for, pagination_links, drop_foreign_fields, link, \
-    json_has_matching_id, get_json_from_request, json_has_required_keys
+    json_has_matching_id, get_json_from_request, json_has_required_keys, \
+    display_list
 
 
 @main.route('/')
@@ -276,7 +277,14 @@ def update_service_status(service_id, status):
     ).first_or_404()
 
     if status not in valid_statuses:
-        abort(400, "'{0}' is not a valid status.".format(status))
+
+        valid_statuses_single_quotes = display_list(
+            ["\'{}\'".format(status) for status in valid_statuses]
+        )
+        abort(400, "\'{0}\' is not a valid status. "
+                   "Valid statuses are {1}"
+              .format(status, valid_statuses_single_quotes)
+              )
 
     service.status = status
     db.session.add(service)

--- a/app/utils.py
+++ b/app/utils.py
@@ -53,3 +53,12 @@ def drop_foreign_fields(json_object, list_of_keys):
 def json_has_matching_id(data, id):
     if 'id' in data and not id == data['id']:
         abort(400, "id parameter must match id in data")
+
+
+def display_list(l):
+    length = len(l)
+    if length <= 2:
+        return " and ".join(l)
+    else:
+        # oxford comma
+        return ", ".join(l[:-1]) + ", and " + l[-1]

--- a/tests/app/views/test_services.py
+++ b/tests/app/views/test_services.py
@@ -552,6 +552,54 @@ class TestPostService(BaseApplicationTest):
         assert_in(b'id parameter must match id in data',
                   response.get_data())
 
+    def test_should_update_service_with_valid_statuses(self):
+
+        # Statuses are defined in the Supplier model
+        valid_statuses = [
+            "published",
+            "enabled",
+            "disabled"
+        ]
+
+        for status in valid_statuses:
+            response = self.client.post(
+                '/services/{0}/status/{1}'.format(
+                    self.service_id,
+                    status
+                )
+            )
+
+            assert_equal(response.status_code, 200)
+            data = json.loads(response.get_data())
+            assert_equal(status, data['services']['status'])
+
+    def test_should_400_with_invalid_statuses(self):
+        invalid_statuses = [
+            "unpublished",  # not a permissible state
+            "enabeld",  # typo
+        ]
+
+        for status in invalid_statuses:
+            response = self.client.post(
+                '/services/{0}/status/{1}'.format(
+                    self.service_id,
+                    status
+                )
+            )
+
+            assert_equal(response.status_code, 400)
+            assert_in('is not a valid status',
+                      json.loads(response.get_data())['error'])
+
+    def test_should_404_without_status_parameter(self):
+        response = self.client.post(
+            '/services/{0}/status/'.format(
+                self.service_id
+            )
+        )
+
+        assert_equal(response.status_code, 404)
+
 
 class TestShouldCallSearchApiOnPutToCreateService(BaseApplicationTest):
     def setup(self):

--- a/tests/app/views/test_services.py
+++ b/tests/app/views/test_services.py
@@ -566,7 +566,13 @@ class TestPostService(BaseApplicationTest):
                 '/services/{0}/status/{1}'.format(
                     self.service_id,
                     status
-                )
+                ),
+                data=json.dumps(
+                    {'update_details': {
+                        'updated_by': 'joeblogs',
+                        'update_reason': 'Change status for unit test'}
+                     }),
+                content_type='application/json'
             )
 
             assert_equal(response.status_code, 200)
@@ -579,23 +585,60 @@ class TestPostService(BaseApplicationTest):
             "enabeld",  # typo
         ]
 
+        valid_statuses = [
+            "published",
+            "enabled",
+            "disabled"
+        ]
+
         for status in invalid_statuses:
             response = self.client.post(
                 '/services/{0}/status/{1}'.format(
                     self.service_id,
                     status
-                )
+                ),
+                data=json.dumps(
+                    {'update_details': {
+                        'updated_by': 'joeblogs',
+                        'update_reason': 'Change status for unit test'}
+                     }),
+                content_type='application/json'
             )
 
             assert_equal(response.status_code, 400)
             assert_in('is not a valid status',
                       json.loads(response.get_data())['error'])
+            # assert that valid status names are returned in the response
+            for valid_status in valid_statuses:
+                assert_in(valid_status,
+                          json.loads(response.get_data())['error'])
+
+    def test_should_400_without_update_details(self):
+        response = self.client.post(
+            '/services/{0}/status/{1}'.format(
+                self.service_id,
+                'enabled'
+            ),
+            data=json.dumps(
+                {}),
+            content_type='application/json'
+        )
+
+        assert_equal(response.status_code, 400)
+        assert_in('update_details',
+                  json.loads(response.get_data())['error'])
 
     def test_should_404_without_status_parameter(self):
         response = self.client.post(
             '/services/{0}/status/'.format(
-                self.service_id
-            )
+                self.service_id,
+            ),
+            data=json.dumps(
+                {'update_details': {
+                    'updated_by': 'joeblogs',
+                    'update_reason': 'Change status for unit test'}
+                 }),
+            content_type='application/json'
         )
 
         assert_equal(response.status_code, 404)


### PR DESCRIPTION
Adding a `[POST]` endpoint to update the status of Services.
Services can be:
- `published`
- `enabled`
- `disabled` 

With the constants defined within the route.
Successfully changing the status of a Service returns its updated JSON as a response.

##### Note: 

Figured we didn't need to archive services every time a status is updated.  Really, we're only changing meta-data.  
Sound off if you don't agree.