### PR TITLE
Silence alembic [INFO] messages from tests (and bootstrapping).

### DIFF
--- a/migrations/alembic.ini
+++ b/migrations/alembic.ini
@@ -21,7 +21,7 @@ keys = generic
 
 [logger_root]
 level = WARN
-handlers = console
+handlers = 
 qualname =
 
 [logger_sqlalchemy]


### PR DESCRIPTION
Removing the `handlers = console` line from the `migrations/alembic.ini` file means we no longer have alembic.migration [INFO] messages in our unit tests. 
It also means we miss out on them when bootstrapping the app, just so we're all aware.