### PR TITLE
Ordering services listing

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -37,8 +37,6 @@ def list_services():
     except ValueError:
         abort(400, "Invalid page argument")
 
-    supplier_id = request.args.get('supplier_id')
-
     services = Service.query.order_by(
         asc(Service.framework_id),
         asc(Service.data['lot'].cast(String)),
@@ -50,18 +48,20 @@ def list_services():
             Service.status.in_(request.values.getlist('status'))
         )
 
+    supplier_id = request.args.get('supplier_id')
+
     if supplier_id is not None:
         try:
             supplier_id = int(supplier_id)
         except ValueError:
             abort(400, "Invalid supplier_id: %s" % supplier_id)
 
-    supplier = Supplier.query.filter(Supplier.supplier_id == supplier_id) \
-        .all()
-    if not supplier:
-        abort(404, "supplier_id '%d' not found" % supplier_id)
+        supplier = Supplier.query.filter(Supplier.supplier_id == supplier_id) \
+            .all()
+        if not supplier:
+            abort(404, "supplier_id '%d' not found" % supplier_id)
 
-    services = services.filter(Service.supplier_id == supplier_id)
+        services = services.filter(Service.supplier_id == supplier_id)
 
     services = services.paginate(
         page=page,

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -11,6 +11,7 @@ from ...validation import detect_framework_or_400, \
     validate_updater_json_or_400, is_valid_service_id_or_400
 from ...utils import url_for, pagination_links, drop_foreign_fields, link, \
     json_has_matching_id, get_json_from_request, json_has_required_keys
+from sqlalchemy.types import String
 
 
 @main.route('/')
@@ -37,7 +38,11 @@ def list_services():
 
     supplier_id = request.args.get('supplier_id')
 
-    services = Service.query
+    services = Service.query.order_by(
+        Service.framework_id.asc(),
+        Service.data['lot'].cast(String),
+        Service.data['serviceName'].cast(String)
+    )
 
     if request.args.get('status'):
         services = Service.query.filter(

--- a/migrations/versions/20_adding_json_index_to_services.py
+++ b/migrations/versions/20_adding_json_index_to_services.py
@@ -1,0 +1,22 @@
+"""empty message
+
+Revision ID: 10_adding_supplier_to_user_table
+Revises: 550715127385
+Create Date: 2015-04-21 07:45:29.958447
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '20_adding_json_index_to_services'
+down_revision = '10_adding_supplier_to_user_table'
+
+from alembic import op
+from sqlalchemy import text
+
+
+def upgrade():
+    op.create_index('ix_service_ordering', 'services', [text("framework_id, (data->>'lot'), (data->>'serviceName')")])
+
+
+def downgrade():
+    op.drop_index(op.f('ix_service_ordering'), table_name='services')

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ Flask-Script==2.0.5
 Flask-SQLAlchemy==2.0
 psycopg2==2.5.4
 jsonschema==2.3.0
--e git+https://github.com/alphagov/digitalmarketplace-utils.git@0.2.0#egg=digitalmarketplace-utils
+-e git+https://github.com/alphagov/digitalmarketplace-utils.git@0.2.0#egg=digitalmarketplace-utils-0.2.0
 # For the import script
 requests==2.5.1
 docopt==0.6.2

--- a/tests/app/views/test_services.py
+++ b/tests/app/views/test_services.py
@@ -18,6 +18,68 @@ def first_by_rel(rel, links):
             return link
 
 
+class TestListServicesOrdering(BaseApplicationTest):
+    def test_should_order_services_by_framework_lot_name(self):
+        with self.app.app_context():
+            self.app.config['DM_API_SERVICES_PAGE_SIZE'] = 10
+            now = datetime.now()
+
+            g5_saas = self.load_example_listing("G5")
+            g5_paas = self.load_example_listing("G5")
+            g6_iaas_1 = self.load_example_listing("G6-IaaS")
+            g6_iaas_2 = self.load_example_listing("G6-IaaS")
+            g6_paas_1 = self.load_example_listing("G6-PaaS")
+            g6_paas_2 = self.load_example_listing("G6-PaaS")
+            g6_saas = self.load_example_listing("G6-SaaS")
+            g6_scs = self.load_example_listing("G6-SCS")
+
+            db.session.add(
+                Supplier(supplier_id=1, name=u"Supplier 1")
+            )
+
+            def insert_service(listing, service_id, framework_id):
+                db.session.add(Service(service_id=service_id,
+                                       supplier_id=1,
+                                       updated_at=now,
+                                       status='published',
+                                       created_at=now,
+                                       updated_by="tests",
+                                       framework_id=framework_id,
+                                       updated_reason="test data",
+                                       data=listing))
+
+            # override certain fields to create ordering difference
+            g6_iaas_1['serviceName'] = "b service name"
+            g6_iaas_2['serviceName'] = "a service name"
+            g6_paas_1['serviceName'] = "b service name"
+            g6_paas_2['serviceName'] = "a service name"
+            g5_paas['lot'] = "PaaS"
+
+            insert_service(g5_paas, "g5_paas", 3)
+            insert_service(g5_saas, "g5_saas", 3)
+            insert_service(g6_iaas_1, "g6_iaas_1", 1)
+            insert_service(g6_iaas_2, "g6_iaas_2", 1)
+            insert_service(g6_paas_1, "g6_paas_1", 1)
+            insert_service(g6_paas_2, "g6_paas_2", 1)
+            insert_service(g6_saas, "g6_saas", 1)
+            insert_service(g6_scs, "g6_scs", 1)
+
+            db.session.commit()
+
+        response = self.client.get('/services')
+        data = json.loads(response.get_data())
+
+        assert_equal(response.status_code, 200)
+        assert_equal(data['services'][0]['id'], 'g6_iaas_2')
+        assert_equal(data['services'][1]['id'], 'g6_iaas_1')
+        assert_equal(data['services'][2]['id'], 'g6_paas_2')
+        assert_equal(data['services'][3]['id'], 'g6_paas_1')
+        assert_equal(data['services'][4]['id'], 'g6_scs')
+        assert_equal(data['services'][5]['id'], 'g6_saas')
+        assert_equal(data['services'][6]['id'], 'g5_paas')
+        assert_equal(data['services'][7]['id'], 'g5_saas')
+
+
 class TestListServices(BaseApplicationTest):
     def test_list_services_with_no_services(self):
         response = self.client.get('/services')

--- a/tests/app/views/test_services.py
+++ b/tests/app/views/test_services.py
@@ -25,13 +25,13 @@ class TestListServicesOrdering(BaseApplicationTest):
             now = datetime.now()
 
             g5_saas = self.load_example_listing("G5")
-            g5_paas = self.load_example_listing("G5")
-            g6_iaas_1 = self.load_example_listing("G6-IaaS")
-            g6_iaas_2 = self.load_example_listing("G6-IaaS")
-            g6_paas_1 = self.load_example_listing("G6-PaaS")
-            g6_paas_2 = self.load_example_listing("G6-PaaS")
-            g6_saas = self.load_example_listing("G6-SaaS")
             g6_scs = self.load_example_listing("G6-SCS")
+            g5_paas = self.load_example_listing("G5")
+            g6_paas_2 = self.load_example_listing("G6-PaaS")
+            g6_iaas_1 = self.load_example_listing("G6-IaaS")
+            g6_paas_1 = self.load_example_listing("G6-PaaS")
+            g6_saas = self.load_example_listing("G6-SaaS")
+            g6_iaas_2 = self.load_example_listing("G6-IaaS")
 
             db.session.add(
                 Supplier(supplier_id=1, name=u"Supplier 1")


### PR DESCRIPTION
Order list responses by:

- Framework
- Lot
- Service Name

- note this gives the following message under testing:
/Users/martyninglis/Envs/dm-api/lib/python2.7/site-packages/sqlalchemy/sql/base.py:530: SAWarning: Column 'CAST(services.data ->> :data_1 AS VARCHAR)' on table <sqlalchemy.sql.selectable.Select at 0x10de7c390; Select object> being replaced by <sqlalchemy.sql.elements.ColumnClause at 0x10de8dfd0; %(4528261328 anon)s>, which has the same key.  Consider use_labels for select() statements.
  (key, getattr(existing, 'table', None), value))

- Which is an advisory around syntax. To remove this would require using SQLAlchemy select not Flask::SQLAlchemy query for our queries. Whoever picks this up we should chat about implications.