### PR TITLE
Fix multiline cloudwatch logs

### DIFF
--- a/.ebextensions/cwl-logs-application.config
+++ b/.ebextensions/cwl-logs-application.config
@@ -21,11 +21,15 @@ Resources:
                 log_group_name = `{"Fn::FindInMap":["CWLogs", "ApplicationLogs", "LogGroupName"]}`
                 log_stream_name = `{"Fn::Join": ["-", ["application", {"Fn::FindInMap":["CWLogs", "ApplicationLogs", "ApplicationName"]}]]}`
                 datetime_format = `{"Fn::FindInMap":["CWLogs", "ApplicationLogs", "TimestampFormat"]}`
+                multi_line_start_pattern = {datetime_format}
+
                 [application-logs-combined]
                 file = `{"Fn::FindInMap":["CWLogs", "ApplicationLogs", "LogFile"]}`
                 log_group_name = `{"Fn::FindInMap":["CWLogs", "ApplicationLogs", "LogGroupName"]}`
                 log_stream_name = application-combined
                 datetime_format = `{"Fn::FindInMap":["CWLogs", "ApplicationLogs", "TimestampFormat"]}`
+                multi_line_start_pattern = {datetime_format}
+
               mode  : "000400"
               owner : root
               group : root

--- a/.ebextensions/cwl-logs-application.config
+++ b/.ebextensions/cwl-logs-application.config
@@ -42,6 +42,6 @@ container_commands:
   02-create-file:
     command: "touch /var/log/digitalmarketplace/application.log"
   03-change-permissions:
-    command: "chmod 777 /var/log/digitalmarketplace/"
+    command: "chmod -R 777 /var/log/digitalmarketplace/"
   04-change-ownership:
-    command: "chown wsgi:wsgi /var/log/digitalmarketplace"
+    command: "chown -R wsgi:wsgi /var/log/digitalmarketplace"


### PR DESCRIPTION
Exception messages were split into three cloudwatch lines:
"Exception on", "Traceback" and error line. Setting multiline
format to only recognize lines starting with a timestamp groups
exception into a single line.