### PR TITLE
Fix 500 response when requesting services or suppliers ?page=0

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -61,10 +61,7 @@ def list_services():
     services = services.paginate(
         page=page,
         per_page=current_app.config['DM_API_SERVICES_PAGE_SIZE'],
-        error_out=False,
     )
-    if page > 1 and not services.items:
-        abort(404, "Page number out of range")
 
     return jsonify(
         services=[service.serialize() for service in services.items],
@@ -98,7 +95,7 @@ def list_archived_services_by_service_id():
     services = services.paginate(
         page=page,
         per_page=current_app.config['DM_API_SERVICES_PAGE_SIZE'],
-        error_out=False)
+    )
 
     if request.args and not services.items:
         abort(404)

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -29,14 +29,10 @@ def list_suppliers():
     suppliers = suppliers.paginate(
         page=page,
         per_page=current_app.config['DM_API_SUPPLIERS_PAGE_SIZE'],
-        error_out=False,
     )
 
     if not suppliers.items:
-        if page > 1:
-            abort(404, "Page number out of range")
-        else:
-            abort(404, "No suppliers found for '{0}'".format(prefix))
+        abort(404, "No suppliers found for '{0}'".format(prefix))
 
     return jsonify(
         suppliers=[supplier.serialize() for supplier in suppliers.items],

--- a/tests/app/views/test_services.py
+++ b/tests/app/views/test_services.py
@@ -127,6 +127,11 @@ class TestListServices(BaseApplicationTest):
 
         assert_equal(response.status_code, 404)
 
+    def test_below_one_page_number_is_404(self):
+        response = self.client.get('/services?page=0')
+
+        assert_equal(response.status_code, 404)
+
     def test_x_forwarded_proto(self):
         self.setup_dummy_services_including_unpublished(1)
 

--- a/tests/app/views/test_suppliers.py
+++ b/tests/app/views/test_suppliers.py
@@ -97,12 +97,16 @@ class TestListSuppliers(BaseApplicationTest):
         response = self.client.get('/suppliers?prefix=s&page=10')
 
         assert_equal(response.status_code, 404)
-        assert_in(b'Page number out of range', response.get_data())
 
     def test_query_string_prefix_invalid_page_argument(self):
         response = self.client.get('/suppliers?prefix=s&page=a')
 
         assert_equal(response.status_code, 400)
+
+    def test_below_one_page_number_is_404(self):
+        response = self.client.get('/suppliers?page=0')
+
+        assert_equal(response.status_code, 404)
 
 
 class TestPutSupplier(BaseApplicationTest, JSONUpdateTestMixin):


### PR DESCRIPTION
Flask-pagination skips the page number check when `error_out=False`,
which creates a query with a negative offset and causes an
SQLAlchemy exception.

Removing `error_out=False` makes pagination handle incorrect page
numbers, but the custom "Page number out of range" response is
replaced by generic Flask JSON 404.