### PR TITLE
Only index current frameworks

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -147,6 +147,7 @@ def update_service(service_id):
     else:
         # It is a new service JSON with id removed from payload already
         data["id"] = service_id
+
     detect_framework_or_400(data)
 
     data = drop_foreign_fields(data, ['id'])
@@ -161,8 +162,11 @@ def update_service(service_id):
 
     try:
         db.session.commit()
-        search_api_client.index(service_id, service.data,
-                                service.supplier.name)
+        if not service.framework.expired:
+            search_api_client.index(
+                service_id,
+                service.data,
+                service.supplier.name)
         return jsonify(message="done"), 200
     except IntegrityError as e:
         db.session.rollback()

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from nose.tools import assert_equal, assert_in
 
 from app import create_app, db
-from app.models import Service, Supplier, ContactInformation, Framework
+from app.models import Service, Supplier, ContactInformation
 
 from alembic.command import upgrade, downgrade
 from alembic.config import Config

--- a/tests/app/views/test_services.py
+++ b/tests/app/views/test_services.py
@@ -787,7 +787,6 @@ class TestShouldCallSearchApiOnPutToReplaceService(BaseApplicationTest):
                 ),
                 content_type='application/json')
 
-            print res.get_data()
             assert_equal(res.status_code, 201)
             assert_is_not_none(Service.query.filter(
                 Service.service_id == payload["id"]).first())


### PR DESCRIPTION
- When PUTing a G4 service (or any expired framework) don't index it.

- Note POSTing G4 fails currently. We shouldn't be updating these so should be OK.