### PR TITLE
Added notion of 'other' to suppliers prefix

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -1,5 +1,6 @@
 from flask import jsonify, abort, request, current_app
 from sqlalchemy.exc import IntegrityError
+from sqlalchemy import not_
 
 from .. import main
 from ... import db
@@ -11,7 +12,6 @@ from ...utils import pagination_links, drop_foreign_fields, \
 
 @main.route('/suppliers', methods=['GET'])
 def list_suppliers():
-
     try:
         page = int(request.args.get('page', 1))
     except ValueError:
@@ -22,9 +22,13 @@ def list_suppliers():
     suppliers = Supplier.query.order_by(Supplier.name)
 
     if prefix:
-        # case insensitive LIKE comparison for matching supplier names
-        suppliers = suppliers.filter(
-            Supplier.name.ilike(prefix + '%'))
+        if prefix == 'other':
+            suppliers = suppliers.filter(
+                Supplier.name.op('~')('^[^A-z]+'))
+        else:
+            # case insensitive LIKE comparison for matching supplier names
+            suppliers = suppliers.filter(
+                Supplier.name.ilike(prefix + '%'))
 
     suppliers = suppliers.paginate(
         page=page,
@@ -59,7 +63,6 @@ def get_supplier(supplier_id):
 # Route to insert new Suppliers, not update existing ones
 @main.route('/suppliers/<int:supplier_id>', methods=['PUT'])
 def import_supplier(supplier_id):
-
     supplier_data = get_json_from_request()
 
     json_has_required_keys(
@@ -111,7 +114,6 @@ def import_supplier(supplier_id):
     supplier.clients = supplier_data.get('clients', None)
 
     for contact_information_data in contact_informations_data:
-
         contact_information = ContactInformation()
 
         contact_information.contact_name = \

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -24,7 +24,7 @@ def list_suppliers():
     if prefix:
         if prefix == 'other':
             suppliers = suppliers.filter(
-                Supplier.name.op('~')('^[^A-z]+'))
+                Supplier.name.op('~')('^[^A-Za-z]'))
         else:
             # case insensitive LIKE comparison for matching supplier names
             suppliers = suppliers.filter(

--- a/tests/app/views/test_suppliers.py
+++ b/tests/app/views/test_suppliers.py
@@ -75,6 +75,24 @@ class TestListSuppliers(BaseApplicationTest):
             data['suppliers'][0]['name']
         )
 
+    def test_other_prefix_returns_non_alphanumeric_suppliers(self):
+        with self.app.app_context():
+            db.session.add(
+                Supplier(supplier_id=999, name=u"123 Supplier")
+            )
+            db.session.commit()
+
+            response = self.client.get('/suppliers?prefix=other')
+
+            data = json.loads(response.get_data())
+            assert_equal(200, response.status_code)
+            assert_equal(1, len(data['suppliers']))
+            assert_equal(999, data['suppliers'][0]['id'])
+            assert_equal(
+                u"123 Supplier",
+                data['suppliers'][0]['name']
+            )
+
     def test_query_string_prefix_returns_paginated_page_one(self):
         response = self.client.get('/suppliers?prefix=s')
         data = json.loads(response.get_data())
@@ -141,7 +159,6 @@ class TestPutSupplier(BaseApplicationTest, JSONUpdateTestMixin):
 
             # Exact loop number is arbitrary
             for i in range(3):
-
                 response = self.put_import_supplier(payload)
 
                 assert_equal(response.status_code, 201)


### PR DESCRIPTION
Allows retrieval of suppliers starting with non-alphanumeric characters

- When getting suppliers the query string can contain the key 'prefix' this is used to retrieve suppliers with names commencing with the letter provided - ie prefix=a returns all the 'A' suppliers

- To support the companies with non-alphanumeric names the prefix param can contain the special value 'other' which will retrieve all the numerics and so on.