### PR TITLE
Add datacentre tier for g4 g5

### DIFF
--- a/json_schemas/services-g4.json
+++ b/json_schemas/services-g4.json
@@ -181,10 +181,10 @@
     "openSource": {
       "type": "boolean"
     },
-    "serviceOnBoarding": {
+    "serviceOnboarding": {
       "type": "boolean"
     },
-    "serviceOffBoarding": {
+    "serviceOffboarding": {
       "type": "boolean"
     },
     "dataExtractionRemoval": {

--- a/json_schemas/services-g4.json
+++ b/json_schemas/services-g4.json
@@ -193,6 +193,9 @@
     "datacentresEUCode": {
       "type": "boolean"
     },
+    "datacentreTier": {
+      "type": "string"
+    },
     "dataBackupRecovery": {
       "type": "boolean"
     },

--- a/json_schemas/services-g5.json
+++ b/json_schemas/services-g5.json
@@ -180,10 +180,10 @@
     "openSource": {
       "type": "boolean"
     },
-    "serviceOnBoarding": {
+    "serviceOnboarding": {
       "type": "boolean"
     },
-    "serviceOffBoarding": {
+    "serviceOffboarding": {
       "type": "boolean"
     },
     "dataExtractionRemoval": {

--- a/json_schemas/services-g5.json
+++ b/json_schemas/services-g5.json
@@ -192,6 +192,9 @@
     "datacentresEUCode": {
       "type": "boolean"
     },
+    "datacentreTier": {
+      "type": "string"
+    },
     "dataBackupRecovery": {
       "type": "boolean"
     },


### PR DESCRIPTION
See: https://www.pivotaltracker.com/story/show/93547400

This modifies the JSON schemas for G4 and G5 services to:
* add (optional) datacentreTier, which was missing from the previous version of listings_dump
* fix capitalisation of serviceOnboarding and serviceOffboarding to be consistent with G6 services.

This matches the dump from Marketplace version 0.4.707 - see the latest dump files here: http://37.26.90.26:8080/job/DUMP%20DM%20tables%20as%20JSON/ws/