### PR TITLE
Adding clients to supplier response + couple of tests.

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -113,7 +113,8 @@ class Supplier(db.Model):
             # 'dunsNumber': self.duns_number,
             # 'eSourcingId': self.esourcing_id,
             'contactInformation': contact_information_list,
-            'links': links
+            'links': links,
+            'clients': self.clients
         }
 
         return filter_null_value_fields(serialized)

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -79,7 +79,12 @@ class BaseApplicationTest(object):
         with self.app.app_context():
             for i in range(n):
                 db.session.add(
-                    Supplier(supplier_id=i, name=u"Supplier {}".format(i))
+                    Supplier(
+                        supplier_id=i,
+                        name=u"Supplier {}".format(i),
+                        description="",
+                        clients=[]
+                    )
                 )
                 db.session.add(
                     ContactInformation(


### PR DESCRIPTION
Where `Supplier['clients']` is either a list of client names or an empty list.  
This is in contrast to the way that some of our other keys are not in the response if they have `null` values.

Also added a few tests because I didn't think our unit tests are taking long enough to run.