### PR TITLE
Increase apache request timeout

### DIFF
--- a/.ebextensions/apache408.config
+++ b/.ebextensions/apache408.config
@@ -1,0 +1,26 @@
+commands:
+  create_app_hook_pre_dir:
+    command: "mkdir -p /opt/elasticbeanstalk/hooks/appdeploy/pre"
+    ignoreErrors: true
+
+  create_config_hook_pre_dir:
+    command: "mkdir -p /opt/elasticbeanstalk/hooks/configdeploy/pre"
+    ignoreErrors: true
+
+files:
+  "/opt/elasticbeanstalk/hooks/appdeploy/pre/99apache408.sh":
+    mode: "000755"
+    owner: root
+    group: root
+    content: |
+      #!/usr/bin/env bash
+      WSGI_FILE_PATH=$(/opt/elasticbeanstalk/bin/get-config container -k 'wsgi_staging_config')
+      sed -i 's/\(<\/VirtualHost>\)/RequestReadTimeout header=40,MinRate=500 body=40,MinRate=500\'$'\n\\1/g' "$WSGI_FILE_PATH"
+  "/opt/elasticbeanstalk/hooks/configdeploy/pre/99apache408.sh":
+    mode: "000755"
+    owner: root
+    group: root
+    content: |
+      #!/usr/bin/env bash
+      WSGI_FILE_PATH=$(/opt/elasticbeanstalk/bin/get-config container -k 'wsgi_staging_config')
+      sed -i 's/\(<\/VirtualHost>\)/RequestReadTimeout header=40,MinRate=500 body=40,MinRate=500\'$'\n\\1/g' "$WSGI_FILE_PATH"


### PR DESCRIPTION
We have been seeing a lot of 408 errors in the apache access logs. These
are cause by the ELB healthcheck. Discussion on the internet [1]
suggests this is related to Apache's mod_reqtimeout extension [2].
Rather than completely disabling the request timeout I have increased it
slightly. Testing this shows that it does stop the 408 log messages.

[1]
http://serverfault.com/questions/485063/getting-408-errors-on-our-logs-with-no-request-or-user-agent
[2] http://httpd.apache.org/docs/2.4/mod/mod_reqtimeout.html