### PR TITLE
Updating indexing of services to index framework name

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -172,7 +172,8 @@ def update_service(service_id):
             search_api_client.index(
                 service_id,
                 service.data,
-                service.supplier.name)
+                service.supplier.name,
+                service.framework.name)
         return jsonify(message="done"), 200
     except IntegrityError as e:
         db.session.rollback()
@@ -236,7 +237,11 @@ def import_service(service_id):
     try:
         db.session.commit()
         if not framework.expired:
-            search_api_client.index(service_id, service.data, supplier.name)
+            search_api_client.index(
+                service_id,
+                service.data,
+                supplier.name,
+                framework.name)
     except IntegrityError as e:
         db.session.rollback()
         abort(400, "Database Error: {0}".format(e))
@@ -249,8 +254,8 @@ def get_service(service_id):
     is_valid_service_id_or_400(service_id)
 
     service = Service.query.filter(
-        Service.service_id == service_id)\
-        .filter(Service.framework.has(Framework.expired == false()))\
+        Service.service_id == service_id) \
+        .filter(Service.framework.has(Framework.expired == false())) \
         .first_or_404()
 
     return jsonify(services=service.serialize())
@@ -324,8 +329,11 @@ def update_service_status(service_id, status):
 
     try:
         db.session.commit()
-        search_api_client.index(service_id, service.data,
-                                service.supplier.name)
+        search_api_client.index(
+            service_id,
+            service.data,
+            service.supplier.name,
+            service.framework.name)
         return jsonify(services=service.serialize()), 200
     except IntegrityError as e:
         db.session.rollback()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ Flask-Script==2.0.5
 Flask-SQLAlchemy==2.0
 psycopg2==2.5.4
 jsonschema==2.3.0
--e git+https://github.com/alphagov/digitalmarketplace-utils.git@0.4.2#egg=digitalmarketplace-utils
+-e git+https://github.com/alphagov/digitalmarketplace-utils.git@0.9.0#egg=digitalmarketplace-utils
 # For the import script
 requests==2.5.1
 docopt==0.6.2

--- a/tests/app/views/test_services.py
+++ b/tests/app/views/test_services.py
@@ -768,7 +768,8 @@ class TestShouldCallSearchApiOnPutToCreateService(BaseApplicationTest):
             search_api_client.index.assert_called_with(
                 "1234567890123456",
                 service.data,
-                "Supplier 1"
+                "Supplier 1",
+                "G-Cloud 6"
             )
 
     def test_should_not_index_on_service_on_expired_frameworks(self):
@@ -835,7 +836,8 @@ class TestShouldCallSearchApiOnPutToReplaceService(BaseApplicationTest):
             search_api_client.index.assert_called_with(
                 "1234567890123456",
                 service.data,
-                "Supplier 1"
+                "Supplier 1",
+                "G-Cloud 6"
             )
 
     def test_should_not_index_on_service_put_if_db_exception(self):
@@ -937,7 +939,8 @@ class TestShouldCallSearchApiOnPost(BaseApplicationTest):
             search_api_client.index.assert_called_with(
                 "1234567890123456",
                 service.data,
-                "Supplier 1"
+                "Supplier 1",
+                "G-Cloud 6"
             )
 
     def test_should_not_index_on_service_post_if_db_exception(self):


### PR DESCRIPTION
Blocked until API Clent is released

- Indexing framework name into ES so that the ES index contains all data required to render a search result

Requires the following 2 pull requests in order for this to work:
https://github.com/alphagov/digitalmarketplace-utils/pull/26
https://github.com/alphagov/digitalmarketplace-search-api/pull/31

Part of:
https://www.pivotaltracker.com/story/show/94070088