### PR TITLE
Move test db migration to package setup

### DIFF
--- a/tests/app/__init__.py
+++ b/tests/app/__init__.py
@@ -1,0 +1,32 @@
+import os
+from app import create_app, db
+from flask.ext.migrate import Migrate, MigrateCommand
+from flask.ext.script import Manager
+from alembic.command import upgrade
+from alembic.config import Config
+
+
+def setup():
+    print("Doing db setup")
+    app = create_app('test')
+    Migrate(app, db)
+    Manager(db, MigrateCommand)
+    ALEMBIC_CONFIG = \
+        os.path.join(os.path.dirname(__file__),
+                     '../../migrations/alembic.ini')
+    config = Config(ALEMBIC_CONFIG)
+    config.set_main_option(
+        "script_location",
+        "migrations")
+    with app.app_context():
+        upgrade(config, 'head')
+    print("Done db setup")
+
+
+def teardown():
+    app = create_app('test')
+    with app.app_context():
+        db.session.remove()
+        db.drop_all()
+        db.engine.execute("drop table alembic_version")
+        db.get_engine(app).dispose()

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -1,6 +1,4 @@
 from __future__ import absolute_import
-from flask.ext.migrate import Migrate, MigrateCommand
-from flask.ext.script import Manager
 
 import os
 import json
@@ -9,11 +7,7 @@ from datetime import datetime
 from nose.tools import assert_equal, assert_in
 
 from app import create_app, db
-from app.models import Service, Supplier, ContactInformation
-
-from alembic.command import upgrade, downgrade
-from alembic.config import Config
-from sqlalchemy.exc import ProgrammingError
+from app.models import Service, Supplier, ContactInformation, Framework
 
 TEST_SUPPLIERS_COUNT = 3
 
@@ -37,27 +31,13 @@ class BaseApplicationTest(object):
         "scs": "G6-SCS.json"
     }
 
-    ALEMBIC_CONFIG = \
-        os.path.join(os.path.dirname(__file__),
-                     '../../migrations/alembic.ini')
-
     config = None
 
     def setup(self):
         self.app = create_app('test')
         self.client = self.app.test_client()
-
-        Migrate(self.app, db)
-        Manager(db, MigrateCommand)
-
-        """Applies all alembic migrations."""
-        self.config = Config(self.ALEMBIC_CONFIG)
-        self.config.set_main_option(
-            "script_location",
-            "migrations")
-
         self.setup_authorization()
-        self.apply_migrations()
+        self.setup_frameworks()
 
     def setup_authorization(self):
         """Set up bearer token and pass on all requests"""
@@ -71,9 +51,16 @@ class BaseApplicationTest(object):
     def do_not_provide_access_token(self):
         self.app.wsgi_app = self.app.wsgi_app.app
 
-    def apply_migrations(self):
+    def setup_frameworks(self):
         with self.app.app_context():
-            upgrade(self.config, 'head')
+            if Framework.query.count() == 0:
+                db.session.add(
+                    Framework(id=1, name="G-Cloud 6", expired=False))
+                db.session.add(
+                    Framework(id=2, name="G-Cloud 4", expired=True))
+                db.session.add(
+                    Framework(id=3, name="G-Cloud 5", expired=False))
+                db.session.commit()
 
     def setup_dummy_suppliers(self, n):
         with self.app.app_context():
@@ -157,8 +144,8 @@ class BaseApplicationTest(object):
     def teardown_database(self):
         with self.app.app_context():
             db.session.remove()
-            db.drop_all()
-            db.engine.execute("drop table alembic_version")
+            for table in reversed(db.metadata.sorted_tables):
+                db.engine.execute(table.delete())
             db.get_engine(self.app).dispose()
 
     def load_example_listing(self, name):

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -37,7 +37,6 @@ class BaseApplicationTest(object):
         self.app = create_app('test')
         self.client = self.app.test_client()
         self.setup_authorization()
-        self.setup_frameworks()
 
     def setup_authorization(self):
         """Set up bearer token and pass on all requests"""
@@ -50,17 +49,6 @@ class BaseApplicationTest(object):
 
     def do_not_provide_access_token(self):
         self.app.wsgi_app = self.app.wsgi_app.app
-
-    def setup_frameworks(self):
-        with self.app.app_context():
-            if Framework.query.count() == 0:
-                db.session.add(
-                    Framework(id=1, name="G-Cloud 6", expired=False))
-                db.session.add(
-                    Framework(id=2, name="G-Cloud 4", expired=True))
-                db.session.add(
-                    Framework(id=3, name="G-Cloud 5", expired=False))
-                db.session.commit()
 
     def setup_dummy_suppliers(self, n):
         with self.app.app_context():
@@ -145,7 +133,10 @@ class BaseApplicationTest(object):
         with self.app.app_context():
             db.session.remove()
             for table in reversed(db.metadata.sorted_tables):
-                db.engine.execute(table.delete())
+                if table.name != "frameworks":
+                    db.engine.execute(table.delete())
+            Framework.query.filter(Framework.id >= 100).delete()
+            db.session.commit()
             db.get_engine(self.app).dispose()
 
     def load_example_listing(self, name):

--- a/tests/app/views/test_services.py
+++ b/tests/app/views/test_services.py
@@ -864,6 +864,7 @@ class TestShouldCallSearchApiOnPutToReplaceService(BaseApplicationTest):
 
             assert_equal(search_api_client.index.called, False)
             db.session.commit = Mock(side_effect=c)
+            db.session.rollback()
 
     def test_should_not_index_on_service_on_expired_frameworks(self):
         with self.app.app_context():


### PR DESCRIPTION
This speeds the tests up a lot (~45 seconds down to ~16).

Move the running of all migrations and dropping of all tables to a package
setup which means that it's only run once for all tests in that package.
The contents of tables are dropped after each test.

One bad thing in this pull request is that because we bootstrap the
frameworks table in migrations we have to do that bootstrapping manually
in the tests as well.