### PR TITLE
Refactor json schemas

### DIFF
--- a/json_schemas/contact-information.json
+++ b/json_schemas/contact-information.json
@@ -1,5 +1,5 @@
 {
-  "id": "G6 Contact Information Schema",
+  "title": "G6 Contact Information Schema",
   "type": "object",
   "additionalProperties": false,
   "properties": {

--- a/json_schemas/services-g4.json
+++ b/json_schemas/services-g4.json
@@ -1,5 +1,5 @@
 {
-  "id": "G4 Services Schema",
+  "title": "G4 Services Schema",
   "$schema": "http://json-schema.org/schema#",
   "type": "object",
   "additionalProperties": false,

--- a/json_schemas/services-g5.json
+++ b/json_schemas/services-g5.json
@@ -1,5 +1,5 @@
 {
-  "id": "G5 Services Schema",
+  "title": "G5 Services Schema",
   "$schema": "http://json-schema.org/schema#",
   "type": "object",
   "additionalProperties": false,

--- a/json_schemas/services-g6-iaas.json
+++ b/json_schemas/services-g6-iaas.json
@@ -1,5 +1,5 @@
 {
-  "id": "G6 Submissions IaaS Schema",
+  "title": "G6 Submissions IaaS Schema",
   "$schema": "http://json-schema.org/schema#",
   "type": "object",
   "additionalProperties": false,

--- a/json_schemas/services-g6-iaas.json
+++ b/json_schemas/services-g6-iaas.json
@@ -93,7 +93,7 @@
     },
     "priceInterval": {
       "type": "string",
-      "pattern": "^(||Second|Minute|Hour|Day|Week|Month|Quarter|6 months|Year)$"
+      "pattern": "^(Second|Minute|Hour|Day|Week|Month|Quarter|6 months|Year)?$"
     },
     "priceString": {
       "type": "string"

--- a/json_schemas/services-g6-paas.json
+++ b/json_schemas/services-g6-paas.json
@@ -1,5 +1,5 @@
 {
-  "id": "G6 Submissions PaaS Schema",
+  "title": "G6 Submissions PaaS Schema",
   "$schema": "http://json-schema.org/schema#",
   "type": "object",
   "additionalProperties": false,

--- a/json_schemas/services-g6-saas.json
+++ b/json_schemas/services-g6-saas.json
@@ -1,5 +1,5 @@
 {
-  "id": "G6 Submissions SaaS Schema",
+  "title": "G6 Submissions SaaS Schema",
   "$schema": "http://json-schema.org/schema#",
   "type": "object",
   "additionalProperties": false,

--- a/json_schemas/services-g6-scs.json
+++ b/json_schemas/services-g6-scs.json
@@ -1,5 +1,5 @@
 {
-   "id": "G6 Submissions SCS Schema",
+   "title": "G6 Submissions SCS Schema",
    "$schema": "http://json-schema.org/schema#",
    "type": "object",
    "additionalProperties": false,

--- a/json_schemas/services-update.json
+++ b/json_schemas/services-update.json
@@ -1,5 +1,5 @@
 {
-  "id": "API Updater Schema",
+  "title": "API Updater Schema",
   "$schema": "http://json-schema.org/schema#",
   "type": "object",
   "additionalProperties": false,

--- a/json_schemas/suppliers.json
+++ b/json_schemas/suppliers.json
@@ -1,5 +1,5 @@
 {
-  "id": "G6 Supplier Schema",
+  "title": "G6 Supplier Schema",
   "$schema": "http://json-schema.org/schema#",
   "type": "object",
   "additionalProperties": false,

--- a/json_schemas/users-auth.json
+++ b/json_schemas/users-auth.json
@@ -1,5 +1,5 @@
 {
-  "id": "API Updater Schema",
+  "title": "API Updater Schema",
   "$schema": "http://json-schema.org/schema#",
   "type": "object",
   "additionalProperties": false,

--- a/json_schemas/users.json
+++ b/json_schemas/users.json
@@ -1,5 +1,5 @@
 {
-  "id": "API Updater Schema",
+  "title": "API Updater Schema",
   "$schema": "http://json-schema.org/schema#",
   "type": "object",
   "additionalProperties": false,

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -36,7 +36,7 @@ def test_for_valid_service_id():
 def test_all_schemas_are_valid():
     for file_name in os.listdir('json_schemas'):
         file_path = 'json_schemas/%s' % file_name
-        if os.path.isfile(file_path):
+        if os.path.isfile(file_path) and file_path.endswith(".json"):
             yield check_schema_file, file_path
 
 


### PR DESCRIPTION
## Change JSON schema ids to titles
The spec states that ids must be valid URIs [1].
The title field [2] has no such restriction and seems more appropriate.

[1] http://json-schema.org/latest/json-schema-core.html#anchor27
[2] http://json-schema.org/latest/json-schema-validation.html#anchor98

## 	Refactor G6 IaaS priceInterval regex
Rather than having two empty alternation options doesn't compile in some
languages.

## Only test schemas with .json extension
Before this change tests fail if you have a schema open in vim (because
of the vim swap file).