### PR TITLE
[#94292928] Integrate custom proxy fix

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,8 +1,7 @@
 from flask import Flask
 from flask.ext.bootstrap import Bootstrap
 from flask.ext.sqlalchemy import SQLAlchemy
-from werkzeug.contrib.fixers import ProxyFix
-from dmutils import logging, config, apiclient
+from dmutils import logging, config, apiclient, proxy_fix
 
 from config import configs
 
@@ -13,10 +12,10 @@ search_api_client = apiclient.SearchAPIClient()
 
 def create_app(config_name):
     application = Flask(__name__)
-    application.wsgi_app = ProxyFix(application.wsgi_app)
     application.config['DM_ENVIRONMENT'] = config_name
     application.config.from_object(configs[config_name])
 
+    proxy_fix.init_app(application)
     logging.init_app(application)
     config.init_app(application)
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -14,10 +14,10 @@ def create_app(config_name):
     application = Flask(__name__)
     application.config['DM_ENVIRONMENT'] = config_name
     application.config.from_object(configs[config_name])
+    config.init_app(application)
 
     proxy_fix.init_app(application)
     logging.init_app(application)
-    config.init_app(application)
 
     bootstrap.init_app(application)
     db.init_app(application)

--- a/config.py
+++ b/config.py
@@ -6,6 +6,7 @@ class Config:
     ES_ENABLED = True
     ALLOW_EXPLORER = True
     AUTH_REQUIRED = True
+    DM_HTTP_PROTO = 'http'
 
     # Logging
     DM_LOG_LEVEL = 'DEBUG'

--- a/config.py
+++ b/config.py
@@ -38,6 +38,7 @@ class Development(Config):
 class Live(Config):
     DEBUG = False
     ALLOW_EXPLORER = False
+    DM_HTTP_PROTO = 'https'
 
 
 configs = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ Flask-Script==2.0.5
 Flask-SQLAlchemy==2.0
 psycopg2==2.5.4
 jsonschema==2.3.0
--e git+https://github.com/alphagov/digitalmarketplace-utils.git@0.11.0#egg=digitalmarketplace-utils
+git+https://github.com/alphagov/digitalmarketplace-utils.git@0.12.0#egg=digitalmarketplace-utils
 # For the import script
 requests==2.5.1
 docopt==0.6.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ Flask-Script==2.0.5
 Flask-SQLAlchemy==2.0
 psycopg2==2.5.4
 jsonschema==2.3.0
--e git+https://github.com/alphagov/digitalmarketplace-utils.git@0.9.0#egg=digitalmarketplace-utils
+-e git+https://github.com/alphagov/digitalmarketplace-utils.git@0.11.0#egg=digitalmarketplace-utils
 # For the import script
 requests==2.5.1
 docopt==0.6.2

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -36,13 +36,13 @@ class BaseApplicationTest(object):
     def setup(self):
         self.app = create_app('test')
         self.client = self.app.test_client()
-        self.setup_authorization()
+        self.setup_authorization(self.app)
 
-    def setup_authorization(self):
+    def setup_authorization(self, app):
         """Set up bearer token and pass on all requests"""
         valid_token = 'valid-token'
-        self.app.wsgi_app = WSGIApplicationWithEnvironment(
-            self.app.wsgi_app,
+        app.wsgi_app = WSGIApplicationWithEnvironment(
+            app.wsgi_app,
             HTTP_AUTHORIZATION='Bearer {}'.format(valid_token))
         self._auth_tokens = os.environ.get('DM_API_AUTH_TOKENS')
         os.environ['DM_API_AUTH_TOKENS'] = valid_token


### PR DESCRIPTION
AWS ELBs set the X-Forwarded-Proto to HTTP if they're configured port
80 -> 80. Because the apps are now internal and served over HTTP we lose
the X-Forwarded-Proto that is sent by Nginx. This change allows the HTTP
protocol to be configured per environment while still making use of
flasks ProxyFix middleware.