### PR TITLE
[#94850520] Fix bug updating g5 services

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from sqlalchemy.dialects.postgresql import JSON
 
 from . import db
@@ -223,6 +225,24 @@ class Service(db.Model):
         ]
 
         return data
+
+    def update_from_json(self, data, updated_by=None, updated_reason=None):
+        self.service_id = str(data.pop('id', self.service_id))
+        self.status = data.pop('status', self.status)
+
+        data.pop('supplierId', None)
+        data.pop('supplierName', None)
+        data.pop('frameworkName', None)
+        data.pop('links', None)
+
+        current_data = dict(self.data.items())
+        current_data.update(data)
+        self.data = current_data
+
+        now = datetime.now()
+        self.updated_at = now
+        self.updated_by = updated_by
+        self.updated_reason = updated_reason
 
 
 class ArchivedService(db.Model):

--- a/app/models.py
+++ b/app/models.py
@@ -228,11 +228,11 @@ class Service(db.Model):
 
     def update_from_json(self, data, updated_by=None, updated_reason=None):
         self.service_id = str(data.pop('id', self.service_id))
-        self.status = data.pop('status', self.status)
 
         data.pop('supplierId', None)
         data.pop('supplierName', None)
         data.pop('frameworkName', None)
+        data.pop('status', None)
         data.pop('links', None)
 
         current_data = dict(self.data.items())

--- a/app/validation.py
+++ b/app/validation.py
@@ -108,6 +108,16 @@ def validates_against_schema(validator_name, submitted_json):
 def reason_for_failure(submitted_json):
     response = []
     try:
+        get_validator('services-g4').validate(submitted_json)
+    except ValidationError as e1:
+        response.append('Not G4: %s' % e1.message)
+
+    try:
+        get_validator('services-g5').validate(submitted_json)
+    except ValidationError as e1:
+        response.append('Not G5: %s' % e1.message)
+
+    try:
         get_validator('services-g6-scs').validate(submitted_json)
     except ValidationError as e1:
         response.append('Not SCS: %s' % e1.message)

--- a/tests/app/views/test_services.py
+++ b/tests/app/views/test_services.py
@@ -771,6 +771,34 @@ class TestPostService(BaseApplicationTest):
             for key in non_json_fields:
                 assert_not_in(key, service.data)
 
+    def test_update_g5_service(self):
+        with self.app.app_context():
+            payload = self.load_example_listing('G5')
+
+            response = self.client.put('/services/{}'.format(payload['id']),
+                                       data=json.dumps({
+                                           'services': payload,
+                                           "update_details": {
+                                               "updated_by": "joeblogs",
+                                               "update_reason": "whatevs",
+                                           },
+                                       }),
+                                       content_type='application/json')
+            assert_equal(response.status_code, 201)
+
+            response = self.client.post('/services/{}'.format(payload['id']),
+                                        data=json.dumps({
+                                            "services": {
+                                                "serviceName": "fooo",
+                                            },
+                                            "update_details": {
+                                                "updated_by": "joeblogs",
+                                                "update_reason": "whatevs",
+                                            },
+                                        }),
+                                        content_type='application/json')
+            assert_equal(response.status_code, 200)
+
 
 @mock.patch('app.main.views.services.search_api_client')
 class TestShouldCallSearchApiOnPutToCreateService(BaseApplicationTest):
@@ -1176,6 +1204,7 @@ class TestPutService(BaseApplicationTest, JSONUpdateTestMixin):
         super(TestPutService, self).setup()
         now = datetime.now()
         payload = self.load_example_listing("G6-IaaS")
+        del payload['id']
         with self.app.app_context():
             db.session.add(
                 Supplier(supplier_id=1, name=u"Supplier 1")

--- a/tests/app/views/test_services.py
+++ b/tests/app/views/test_services.py
@@ -652,6 +652,24 @@ class TestPostService(BaseApplicationTest):
         assert_in(b'id parameter must match id in data',
                   response.get_data())
 
+    def test_should_not_update_status_through_service_post(self):
+        response = self.client.post(
+            '/services/%s' % self.service_id,
+            data=json.dumps(
+                {'update_details': {
+                    'updated_by': 'joeblogs',
+                    'update_reason': 'whateves'},
+                 'services': {
+                     'status': 'enabled'}}),
+            content_type='application/json')
+
+        assert_equal(response.status_code, 200)
+
+        response = self.client.get('/services/%s' % self.service_id)
+        data = json.loads(response.get_data())
+
+        assert_equal(data['services']['status'], 'published')
+
     def test_should_update_service_with_valid_statuses(self):
         # Statuses are defined in the Supplier model
         valid_statuses = [


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/94850520

## Change update_service to validate whole service
The change validates the entire serialized service object (minus a small number of foreign fields) against the JSON schema rather than just what is stored in the `data` field. This makes the JSON schema a better reflection of what the HTTP API accepts and produces.

## Make import_service more like update_service
Move code around so that it flows more similarly to update_service.

Dissallow updates via PUT. All our updates currently go through POST and the import_service method already makes assumptions about it always creating new services (it always returns a 201 status code and always updates the created_at field).

Remove some redundant tests that are either in the wrong place (testing post in the put test) or no longer necesarry (testing the search API is called on update through the PUT endpoint).

Ensure supplierId does not make it into the data field, it is in the supplier_id field of the model.