### PR TITLE
[#92423140] Add G6-style price fields to G5 schema

### DIFF
--- a/json_schemas/services-g5.json
+++ b/json_schemas/services-g5.json
@@ -66,7 +66,7 @@
     },
     "minimumContractPeriod": {
       "type": "string",
-      "pattern": "^(hour|day|month|year|other)$"
+      "pattern": "^([Hh]our|[Dd]ay|[Mm]onth|[Yy]ear|[Oo]ther)$"
     },
     "freeOption": {
       "type": "boolean"
@@ -85,6 +85,16 @@
     },
     "priceString": {
       "type": "string"
+    },
+    "priceMax": {
+      "type": ["number", "null"]
+    },
+    "priceInterval": {
+      "type": "string",
+      "pattern": "^(Second|Minute|Hour|Day|Week|Month|Quarter|6 months|Year)?$"
+    },
+    "vatIncluded": {
+      "type": "boolean"
     },
     "serviceTypes": {
       "oneOf": [


### PR DESCRIPTION
See this story: https://www.pivotaltracker.com/story/show/92423140

Following Rob's recent fix in the API this is the only further change required to make G5 services updateable by the admin app (at least those with a lot - "lot":"missing" servcies are another story...)

All scenarios listed in the "tasks" of the story have been tested and work.

After discussion with @quis and Nicole we agreed that updates to G5 services will need to adhere to the G6 rules: 
* Updated G5 descriptions must be up to 50 words plus Features and Benefits
* Updated G5 prices can additionally have priceMax, priceInterval and vatIncluded
* G5 document updates will be stored in S3 alongside G6 documents - not in Govstore