### PR TITLE
[#94576802] Update Json api format

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -20,16 +20,11 @@ from sqlalchemy.types import String
 @main.route('/')
 def index():
     """Entry point for the API, show the resources that are available."""
-    return jsonify(links=[
-        {
-            "rel": "services.list",
-            "href": url_for('.list_services', _external=True),
-        },
-        {
-            "rel": "suppliers.list",
-            "href": url_for('.list_suppliers', _external=True),
-        },
-    ]), 200
+    return jsonify(links={
+        "services.list": url_for('.list_services', _external=True),
+        "suppliers.list": url_for('.list_suppliers', _external=True)
+        }
+    ), 200
 
 
 @main.route('/services', methods=['GET'])

--- a/app/models.py
+++ b/app/models.py
@@ -95,12 +95,9 @@ class Supplier(db.Model):
     clients = db.Column(JSON)
 
     def serialize(self):
-        links = [
-            link(
-                "self",
-                url_for(".get_supplier", supplier_id=self.supplier_id)
-            )
-        ]
+        links = link(
+            "self", url_for(".get_supplier", supplier_id=self.supplier_id)
+        )
 
         contact_information_list = []
         for contact_information_instance in self.contact_information:
@@ -217,12 +214,9 @@ class Service(db.Model):
             'status': self.status
         })
 
-        data['links'] = [
-            link(
-                "self",
-                url_for(".get_service", service_id=data['id'])
-            )
-        ]
+        data['links'] = link(
+            "self", url_for(".get_service", service_id=data['id'])
+        )
 
         return data
 
@@ -301,12 +295,9 @@ class ArchivedService(db.Model):
             'supplierName': self.supplier.name,
         })
 
-        data['links'] = [
-            link(
-                "self",
-                url_for(".get_service", service_id=data['id'])
-            )
-        ]
+        data['links'] = link(
+            "self", url_for(".get_service", service_id=data['id'])
+        )
 
         return data
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -4,10 +4,7 @@ from flask import abort, request
 
 def link(rel, href):
     if href is not None:
-        return {
-            "rel": rel,
-            "href": href,
-            }
+        return {rel: href}
 
 
 def url_for(*args, **kwargs):
@@ -16,14 +13,20 @@ def url_for(*args, **kwargs):
 
 
 def pagination_links(pagination, endpoint, args):
-    return [
-        link(rel, url_for(endpoint,
-                          **dict(list(args.items()) +
-                                 list({'page': page}.items()))))
-        for rel, page in [('next', pagination.next_num),
-                          ('prev', pagination.prev_num)]
-        if 0 < page <= pagination.pages
-    ]
+    links = dict()
+    if pagination.has_prev:
+        links['prev'] = url_for(endpoint,
+                                **dict(list(args.items()) +
+                                       list({'page': pagination.prev_num}
+                                            .items()
+                                            )))
+    if pagination.has_next:
+        links['next'] = url_for(endpoint,
+                                **dict(list(args.items()) +
+                                       list({'page': pagination.next_num}
+                                            .items()
+                                            )))
+    return links
 
 
 def get_json_from_request():

--- a/config.py
+++ b/config.py
@@ -34,6 +34,7 @@ class Test(Config):
 
 class Development(Config):
     DEBUG = True
+    DM_API_SERVICES_PAGE_SIZE = 5
 
 
 class Live(Config):

--- a/config.py
+++ b/config.py
@@ -35,6 +35,7 @@ class Test(Config):
 class Development(Config):
     DEBUG = True
     DM_API_SERVICES_PAGE_SIZE = 5
+    DM_API_SUPPLIERS_PAGE_SIZE = 5
 
 
 class Live(Config):

--- a/scripts/import-from-api.py
+++ b/scripts/import-from-api.py
@@ -34,14 +34,9 @@ def request_services(api_url, api_access_token, page=1):
                 'Authorization': 'Bearer {}'.format(api_access_token),
             }
         ).json()
-
         for service in services_page['services']:
             yield service
-
-        page_url = list(
-            filter(lambda l: l == 'next', services_page['links']))
-        if page_url:
-            page_url = page_url[0]['href']
+        page_url = services_page['links'].get('next')
 
 
 def print_progress(counter, start_time):

--- a/scripts/import-from-api.py
+++ b/scripts/import-from-api.py
@@ -39,7 +39,7 @@ def request_services(api_url, api_access_token, page=1):
             yield service
 
         page_url = list(
-            filter(lambda l: l['rel'] == 'next', services_page['links']))
+            filter(lambda l: l == 'next', services_page['links']))
         if page_url:
             page_url = page_url[0]['href']
 

--- a/scripts/index_services.py
+++ b/scripts/index_services.py
@@ -38,7 +38,7 @@ def request_services(api_url, api_access_token, page=1):
         for service in services_page['services']:
             yield service
 
-        if list(filter(lambda l: l['rel'] == 'next', services_page['links'])):
+        if list(filter(lambda l: l == 'next', services_page['links'])):
             page += 1
         else:
             break

--- a/scripts/process-g6-into-elastic-search.py
+++ b/scripts/process-g6-into-elastic-search.py
@@ -384,7 +384,7 @@ def request_services(endpoint, token):
         for service in data["services"]:
             yield service
 
-            page_url = filter(lambda l: l['rel'] == 'next', data['links'])
+            page_url = filter(lambda l: l == 'next', data['links'])
             if page_url:
                 page_url = page_url[0]['href']
 

--- a/scripts/process-g6-into-elastic-search.py
+++ b/scripts/process-g6-into-elastic-search.py
@@ -384,9 +384,7 @@ def request_services(endpoint, token):
         for service in data["services"]:
             yield service
 
-            page_url = filter(lambda l: l == 'next', data['links'])
-            if page_url:
-                page_url = page_url[0]['href']
+            page_url = data['links'].get('next')
 
 
 def process_json_files_in_directory(dirname):

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -144,11 +144,6 @@ class BaseApplicationTest(object):
         with open(file_path) as f:
             return json.load(f)
 
-    def first_by_rel(self, rel, links):
-        for link in links:
-            if link['rel'] == rel:
-                return link
-
 
 class JSONUpdateTestMixin(object):
     """

--- a/tests/app/views/test_services.py
+++ b/tests/app/views/test_services.py
@@ -230,7 +230,7 @@ class TestListServices(BaseApplicationTest):
         else:
             os.environ['DM_HTTP_PROTO'] = prev_environ
 
-        assert data['links'][0]['href'].startswith('https://')
+        assert data['links']['services.list'].startswith('https://')
 
     def test_invalid_page_argument(self):
         response = self.client.get('/services?page=a')

--- a/tests/app/views/test_services.py
+++ b/tests/app/views/test_services.py
@@ -13,12 +13,6 @@ from ..helpers import BaseApplicationTest, JSONUpdateTestMixin, \
 from sqlalchemy.exc import IntegrityError
 
 
-def first_by_rel(rel, links):
-    for link in links:
-        if link['rel'] == rel:
-            return link
-
-
 class TestListServicesOrdering(BaseApplicationTest):
     def test_should_order_services_by_framework_lot_name(self):
         with self.app.app_context():
@@ -194,8 +188,8 @@ class TestListServices(BaseApplicationTest):
 
         assert_equal(response.status_code, 200)
         assert_equal(len(data['services']), 5)
-        next_link = self.first_by_rel('next', data['links'])
-        assert_in('page=2', next_link['href'])
+        next_link = data['links']['next']
+        assert_in('page=2', next_link)
 
     def test_paginated_list_services_page_two(self):
         self.setup_dummy_services_including_unpublished(7)
@@ -205,8 +199,8 @@ class TestListServices(BaseApplicationTest):
 
         assert_equal(response.status_code, 200)
         assert_equal(len(data['services']), 4)
-        prev_link = self.first_by_rel('prev', data['links'])
-        assert_in('page=1', prev_link['href'])
+        prev_link = data['links']['prev']
+        assert_in('page=1', prev_link)
 
     def test_paginated_list_services_page_out_of_range(self):
         self.setup_dummy_services_including_unpublished(10)
@@ -300,9 +294,9 @@ class TestListServices(BaseApplicationTest):
         response = self.client.get('/services?supplier_id=1&page=1')
         data = json.loads(response.get_data())
 
-        next_link = self.first_by_rel('next', data['links'])
-        assert_in('page=2', next_link['href'])
-        assert_in('supplier_id=1', next_link['href'])
+        next_link = data['links']['next']
+        assert_in('page=2', next_link)
+        assert_in('supplier_id=1', next_link)
 
     def test_unknown_supplier_id(self):
         self.setup_dummy_services_including_unpublished(15)

--- a/tests/app/views/test_suppliers.py
+++ b/tests/app/views/test_suppliers.py
@@ -125,8 +125,8 @@ class TestListSuppliers(BaseApplicationTest):
 
         assert_equal(200, response.status_code)
         assert_equal(5, len(data['suppliers']))
-        next_link = self.first_by_rel('next', data['links'])
-        assert_in('page=2', next_link['href'])
+        next_link = data['links']['next']
+        assert_in('page=2', next_link)
 
     def test_query_string_prefix_returns_paginated_page_two(self):
         response = self.client.get('/suppliers?prefix=s&page=2')
@@ -134,8 +134,8 @@ class TestListSuppliers(BaseApplicationTest):
 
         assert_equal(response.status_code, 200)
         assert_equal(len(data['suppliers']), 2)
-        prev_link = self.first_by_rel('prev', data['links'])
-        assert_in('page=1', prev_link['href'])
+        prev_link = data['links']['prev']
+        assert_in('page=1', prev_link)
 
     def test_query_string_prefix_page_out_of_range(self):
         response = self.client.get('/suppliers?prefix=s&page=10')


### PR DESCRIPTION
See this story in Pivotal: https://www.pivotaltracker.com/story/show/94576802 - the main aim is to make API response formats consistent across the Data and Search APIs.

There are FOUR related pull-requests to complete this story. The other three are:
https://github.com/alphagov/digitalmarketplace-search-api/pull/42
https://github.com/alphagov/digitalmarketplace-utils/pull/39
https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/60

Changes in the data API are to the 'links' element - instead of 'rel':'x' and 'href':'y' the 'rel' value is now the key for the link e.g. 'x':'y'.  This is already the way the search API formats the links element.

See these gists for examples of the new API responses:
[Example services data API response](https://gist.github.com/TheDoubleK/0d7cd9363440e700a50d)
[Example suppliers data API response](https://gist.github.com/TheDoubleK/4fde0400e052f20ed2c0)
[Example services search API response](https://gist.github.com/TheDoubleK/8e82782502e611faabcc)