### PR TITLE
Updates to DATA API:

### DIFF
--- a/app/formats.py
+++ b/app/formats.py
@@ -1,0 +1,1 @@
+DATE_FORMAT = "%Y-%m-%dT%H:%M:%S%Z"

--- a/app/main/views/drafts.py
+++ b/app/main/views/drafts.py
@@ -91,7 +91,8 @@ def list_drafts():
     services = DraftService.query.order_by(
         asc(DraftService.framework_id),
         asc(DraftService.data['lot'].cast(String).label('data_lot')),
-        asc(DraftService.data['serviceName'].cast(String).label('data_servicename'))
+        asc(DraftService.data['serviceName'].
+            cast(String).label('data_servicename'))
     )
 
     items = services.filter(DraftService.supplier_id == supplier_id).all()

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -61,7 +61,11 @@ def list_services():
         if not supplier:
             abort(404, "supplier_id '%d' not found" % supplier_id)
 
-        services = services.filter(Service.supplier_id == supplier_id)
+        items = services.filter(Service.supplier_id == supplier_id).all()
+        return jsonify(
+            services=[service.serialize() for service in items],
+            links=dict()
+        )
 
     services = services.paginate(
         page=page,

--- a/app/models.py
+++ b/app/models.py
@@ -211,6 +211,7 @@ class Service(db.Model):
             'supplierId': self.supplier.supplier_id,
             'supplierName': self.supplier.name,
             'frameworkName': self.framework.name,
+            'updatedAt': self.updated_at.strftime("%Y-%m-%dT%H:%M:%S%Z"),
             'status': self.status
         })
 

--- a/app/models.py
+++ b/app/models.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from sqlalchemy.dialects.postgresql import JSON
 
 from . import db
+from . import formats
 from .utils import link, url_for
 
 
@@ -155,8 +156,8 @@ class User(db.Model):
             'role': self.role,
             'active': self.active,
             'locked': self.locked,
-            'createdAt': self.created_at,
-            'updatedAt': self.updated_at,
+            'createdAt': self.created_at.strftime(formats.DATE_FORMAT),
+            'updatedAt': self.updated_at.strftime(formats.DATE_FORMAT),
             'passwordChangedAt': self.password_changed_at
         }
 
@@ -211,7 +212,7 @@ class Service(db.Model):
             'supplierId': self.supplier.supplier_id,
             'supplierName': self.supplier.name,
             'frameworkName': self.framework.name,
-            'updatedAt': self.updated_at.strftime("%Y-%m-%dT%H:%M:%S%Z"),
+            'updatedAt': self.updated_at.strftime(formats.DATE_FORMAT),
             'status': self.status
         })
 

--- a/app/service_utils.py
+++ b/app/service_utils.py
@@ -29,7 +29,7 @@ def update_and_validate_service(service, service_payload, updater_payload):
 
     data = drop_foreign_fields(
         data,
-        ['service_id', 'supplierName', 'links', 'frameworkName'])
+        ['service_id', 'supplierName', 'links', 'frameworkName', 'updatedAt'])
 
     detect_framework_or_400(data)
     return service

--- a/tests/app/test_users.py
+++ b/tests/app/test_users.py
@@ -1,6 +1,6 @@
 from flask import json
 from nose.tools import assert_equal, assert_not_equal, assert_in
-from app import db, encryption
+from app import db, encryption, formats
 from app.models import User, Supplier
 from datetime import datetime
 from .helpers import BaseApplicationTest, JSONUpdateTestMixin
@@ -471,7 +471,7 @@ class TestUsersUpdate(BaseApplicationTest):
 
 class TestUsersGet(BaseApplicationTest):
     def setup(self):
-        now = datetime.now()
+        self.now = datetime.now()
         super(TestUsersGet, self).setup()
         with self.app.app_context():
             user = User(
@@ -482,15 +482,16 @@ class TestUsersGet(BaseApplicationTest):
                 active=True,
                 locked=False,
                 role='buyer',
-                created_at=now,
-                updated_at=now,
-                password_changed_at=now
+                created_at=self.now,
+                updated_at=self.now,
+                password_changed_at=self.now
             )
             db.session.add(user)
             db.session.commit()
 
     def test_can_get_a_user_by_id(self):
         with self.app.app_context():
+            now_as_text = self.now.strftime("%Y-%m-%dT%H:%M:%S%Z")
             response = self.client.get("/users/123")
             data = json.loads(response.get_data())["users"]
             assert_equal(data['emailAddress'], "test@test.com")
@@ -498,6 +499,8 @@ class TestUsersGet(BaseApplicationTest):
             assert_equal(data['role'], "buyer")
             assert_equal(data['active'], True)
             assert_equal(data['locked'], False)
+            assert_equal(data['createdAt'], now_as_text)
+            assert_equal(data['updatedAt'], now_as_text)
             assert_equal('password' in data, False)
             assert_equal(response.status_code, 200)
 

--- a/tests/app/views/test_services.py
+++ b/tests/app/views/test_services.py
@@ -91,6 +91,20 @@ class TestListServices(BaseApplicationTest):
         assert_equal(response.status_code, 200)
         assert_equal(len(data['services']), 3)
 
+    def test_list_services_returns_updated_date(self):
+        self.setup_dummy_services_including_unpublished(1)
+        response = self.client.get('/services')
+        data = json.loads(response.get_data())
+
+        assert_equal(response.status_code, 200)
+        try:
+            datetime.strptime(
+                data['services'][0]['updatedAt'],
+                "%Y-%m-%dT%H:%M:%S")
+            assert True, "Parsed date"
+        except ValueError:
+            assert False, "Should be able to parse date"
+
     def test_list_services_gets_only_active_frameworks(self):
         with self.app.app_context():
             now = datetime.now()
@@ -276,27 +290,13 @@ class TestListServices(BaseApplicationTest):
             data['services']
         )
 
-    def test_supplier_id_filter_pagination(self):
+    def test_supplier_should_get_all_service_on_one_page(self):
         self.setup_dummy_services_including_unpublished(21)
 
-        response = self.client.get('/services?supplier_id=1&page=2')
+        response = self.client.get('/services?supplier_id=1')
         data = json.loads(response.get_data())
-
-        assert_equal(response.status_code, 200)
-        assert_equal(len(data['services']), 2)
-        assert_equal(
-            list(filter(lambda s: s['supplierId'] == 1, data['services'])),
-            data['services']
-        )
-
-    def test_supplier_id_filter_pagination_links(self):
-        self.setup_dummy_services_including_unpublished(21)
-
-        response = self.client.get('/services?supplier_id=1&page=1')
-        data = json.loads(response.get_data())
-        next_link = data['links']['next']
-        assert_in('page=2', next_link)
-        assert_in('supplier_id=1', next_link)
+        assert_not_in('next', data['links'])
+        assert_equal(len(data['services']), 7)
 
     def test_unknown_supplier_id(self):
         self.setup_dummy_services_including_unpublished(15)


### PR DESCRIPTION
- Add updated at field to JSON response for a service. Format is as input - YYYY-MM-DDTHH:MM:SS
- Note timezone is curious here - we use utcnow() to create dates but this doesn't set timezone - so the test asserts the above, even though allowed input formats include the timezone
- In terms of format strings:
	- %Y-%m-%dT%H:%M:%S%Z (prefered JSON Schema)
	- %Y-%m-%dT%H:%M:%S (whats returned from API)

Also removed page size / pagination from API calls to get services by supplier. Supplier API calls now return ALL services.