### PR TITLE
Require new version of digitalmarketplace-utils

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,8 +7,7 @@ Flask-SQLAlchemy==2.0
 SQLAlchemy-Utils==0.30.5
 psycopg2==2.5.4
 jsonschema==2.3.0
-git+https://github.com/pcraig3/Flask-FeatureFlags.git@master#egg=Flask-FeatureFlags==0.6-dev
-git+https://github.com/alphagov/digitalmarketplace-utils.git@0.20.0#egg=digitalmarketplace-utils==0.20.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@0.21.0#egg=digitalmarketplace-utils==0.21.0
 # For the import script
 requests==2.5.1
 docopt==0.6.2


### PR DESCRIPTION
New version of digitalmarketplace-utils requires FeatureFlags in a more normal fashion and so we can lose the dependency on a custom forked FeatureFlags repo.