### PR TITLE
Add README link to FeatureFlags docs (in utils)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,8 @@ e.g.:
 ```
 curl -i -H "Authorization: Bearer myToken" 127.0.0.1:5000/services/123456789
 ```
+
+### Using FeatureFlags
+
+To use feature flags, check out the documentation in (the README of)
+[digitalmarketplace-utils](https://github.com/alphagov/digitalmarketplace-utils#using-featureflags).


### PR DESCRIPTION
Figured a link to utils is probably enough of a nudge in the right direction.