### PR TITLE
[#96549780] Add framework status

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -105,7 +105,8 @@ def list_archived_services_by_service_id():
     except ValueError:
         abort(400, "Invalid page argument")
 
-    services = ArchivedService.query.filter(Service.service_id == service_id)
+    services = ArchivedService.query.filter(Service.service_id == service_id) \
+                                    .order_by(asc(ArchivedService.id))
 
     services = services.paginate(
         page=page,

--- a/app/models.py
+++ b/app/models.py
@@ -13,8 +13,17 @@ from .utils import link, url_for
 class Framework(db.Model):
     __tablename__ = 'frameworks'
 
+    STATUSES = [
+        'pending', 'live', 'expired'
+    ]
+
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(255), nullable=False)
+    framework = db.Column(db.Enum('gcloud', name='frameworks_enum'),
+                          index=True, nullable=False)
+    status = db.Column(db.Enum(STATUSES, name='framework_status_enum'),
+                       index=True, nullable=False,
+                       server_default='pending')
     expired = db.Column(db.Boolean, index=False, unique=False,
                         nullable=False)
 

--- a/migrations/versions/70_add_framework_and_status.py
+++ b/migrations/versions/70_add_framework_and_status.py
@@ -1,0 +1,41 @@
+"""Add framework and framework status fields
+
+Revision ID: 70_add_framework_status
+Revises: 60_archive_current_services
+Create Date: 2015-06-16 09:18:05.389816
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '70_add_framework_status'
+down_revision = '60_archive_current_services'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    # add framework field
+    framework_enum = sa.Enum('gcloud', name='framework_enum')
+    framework_enum.create(op.get_bind())
+    framework_column = sa.Column('framework', framework_enum,
+                                 nullable=False, index=True, server_default='gcloud')
+    op.add_column('frameworks', framework_column)
+    # remove framework default
+    op.alter_column('frameworks', 'framework', server_default=None)
+
+    # add status column
+    status_enum = sa.Enum(
+        'pending', 'live', 'expired',
+        name='framework_status_enum')
+    status_enum.create(op.get_bind())
+    status_column = sa.Column('status', status_enum,
+                              nullable=False, index=True, server_default='pending')
+    op.add_column('frameworks', status_column)
+    op.execute("UPDATE frameworks SET status = 'expired' WHERE expired = TRUE;")
+    op.execute("UPDATE frameworks SET status = 'live' WHERE expired = FALSE;")
+
+
+def downgrade():
+    op.drop_column('frameworks', 'framework')
+    op.drop_column('frameworks', 'status')

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ Flask-Bootstrap==3.3.0.1
 Flask-Migrate==1.3.1
 Flask-Script==2.0.5
 Flask-SQLAlchemy==2.0
+SQLAlchemy==1.0.5
 SQLAlchemy-Utils==0.30.5
 psycopg2==2.5.4
 jsonschema==2.3.0

--- a/scripts/reset-db.sh
+++ b/scripts/reset-db.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+dropdb digitalmarketplace
+dropdb digitalmarketplace_test
+
+createdb digitalmarketplace
+createdb digitalmarketplace_test

--- a/tests/app/__init__.py
+++ b/tests/app/__init__.py
@@ -4,6 +4,7 @@ from flask.ext.migrate import Migrate, MigrateCommand
 from flask.ext.script import Manager
 from alembic.command import upgrade
 from alembic.config import Config
+from sqlalchemy import inspect
 
 
 def setup():
@@ -29,4 +30,7 @@ def teardown():
         db.session.remove()
         db.drop_all()
         db.engine.execute("drop table alembic_version")
+        insp = inspect(db.engine)
+        for enum in insp.get_enums():
+            db.Enum(name=enum['name']).drop(db.engine)
         db.get_engine(app).dispose()

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -81,7 +81,10 @@ class BaseApplicationTest(object):
                                        updated_at=now,
                                        status='published',
                                        created_at=now,
-                                       data={'foo': 'bar'},
+                                       data={
+                                           'serviceName': 'Service {}'.
+                                                          format(i),
+                                       },
                                        framework_id=1))
             # Add extra 'enabled' and 'disabled' services
             db.session.add(Service(service_id=n + 1,
@@ -89,14 +92,18 @@ class BaseApplicationTest(object):
                                    updated_at=now,
                                    status='disabled',
                                    created_at=now,
-                                   data={'foo': 'bar'},
+                                   data={
+                                       'serviceName': 'Service {}'.format(n),
+                                   },
                                    framework_id=1))
             db.session.add(Service(service_id=n + 2,
                                    supplier_id=n % TEST_SUPPLIERS_COUNT,
                                    updated_at=now,
                                    status='enabled',
                                    created_at=now,
-                                   data={'foo': 'bar'},
+                                   data={
+                                       'serviceName': 'Service {}'.format(n),
+                                   },
                                    framework_id=1))
             # Add an extra supplier that will have no services
             db.session.add(

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -1,7 +1,10 @@
-from dmutils.audit import AuditTypes
-from nose.tools import assert_equal, assert_raises
-from app.models import User, AuditEvent
 from datetime import datetime
+
+from nose.tools import assert_equal, assert_raises
+from sqlalchemy.exc import DataError
+
+from app import db, create_app
+from app.models import User, Framework
 
 
 def test_should_not_return_password_on_user():
@@ -22,3 +25,30 @@ def test_should_not_return_password_on_user():
     assert_equal(user.serialize()['name'], "name")
     assert_equal(user.serialize()['role'], "buyer")
     assert_equal('password' in user.serialize(), False)
+
+
+def test_framework_should_not_accept_invalid_status():
+    app = create_app('test')
+    with app.app_context(), assert_raises(DataError):
+        f = Framework(
+            name='foo',
+            framework='gcloud',
+            status='invalid',
+            expired=False,
+        )
+        db.session.add(f)
+        db.session.commit()
+
+
+def test_framework_should_accept_valid_statuses():
+    app = create_app('test')
+    with app.app_context():
+        for i, status in enumerate(Framework.STATUSES):
+            f = Framework(
+                name='foo',
+                framework='gcloud',
+                status=status,
+                expired=False,
+            )
+            db.session.add(f)
+            db.session.commit()

--- a/tests/app/views/test_services.py
+++ b/tests/app/views/test_services.py
@@ -608,10 +608,32 @@ class TestPostService(BaseApplicationTest):
             archived_state = self.client.get(
                 '/archived-services?service-id=' +
                 self.service_id).get_data()
-            archived_service_json = json.loads(archived_state)['services'][0]
+            archived_service_json = json.loads(archived_state)['services'][-1]
 
             assert_equal(archived_service_json['serviceName'],
-                         "new service name")
+                         'new service name')
+
+    def test_updated_service_archive_is_listed_in_chronological_order(self):
+        with self.app.app_context():
+            response = self.client.post(
+                '/services/%s' % self.service_id,
+                data=json.dumps(
+                    {'update_details': {
+                        'updated_by': 'joeblogs'},
+                     'services': {
+                         'serviceName': 'new service name'}}),
+                content_type='application/json')
+
+            assert_equal(response.status_code, 200)
+
+            archived_state = self.client.get(
+                '/archived-services?service-id=' +
+                self.service_id).get_data()
+            archived_service_json = json.loads(archived_state)['services']
+
+            assert_equal(
+                [s['serviceName'] for s in archived_service_json],
+                ['My Iaas Service', 'new service name'])
 
     def test_updated_service_should_be_archived_on_each_update(self):
         with self.app.app_context():

--- a/tests/app/views/test_services.py
+++ b/tests/app/views/test_services.py
@@ -109,6 +109,8 @@ class TestListServices(BaseApplicationTest):
             db.session.add(Framework(
                 id=123,
                 name="expired",
+                framework="gcloud",
+                status="expired",
                 expired=True
             ))
 
@@ -161,8 +163,8 @@ class TestListServices(BaseApplicationTest):
 
         assert_equal(response.status_code, 200)
         assert_equal(len(data['services']), 2)
-        assert_equal(data['services'][0]['id'], '3')
-        assert_equal(data['services'][1]['id'], '2')
+        assert_equal(data['services'][0]['id'], '2')
+        assert_equal(data['services'][1]['id'], '3')
 
     def test_list_services_gets_combination_of_enabled_and_published(self):
         self.setup_dummy_services_including_unpublished(1)
@@ -1476,7 +1478,9 @@ class TestGetService(BaseApplicationTest):
             db.session.add(Framework(
                 id=123,
                 name="expired",
-                expired=True
+                framework="gcloud",
+                status="expired",
+                expired=True,
             ))
             db.session.add(
                 Supplier(supplier_id=1, name=u"Supplier 1")


### PR DESCRIPTION
Add two fields to the `Framework` model:
- `framework`: an enum identifying the framework this is associated with
             eg. for 'G-Cloud 7' framework would be 'gcloud'
- `status`: an enum identifying the current status of the framework
          iteration.

This change does not make use of these fields yet. The status field will replace the expired flag but the code change will go through in a separate pull request.

This uses native Enums for the framework and status fields. They are well supported in SQLAlchemy now and are cleaner than a manual constraint based solution.

One of the tests has started failing because of switched order. On investigation the order was not deterministic. I've added serviceName to the dummy services to make ordering deterministic.

This pull request pins SQLAlchemy to 1.0.5 to get some new enum related features.