### PR TITLE
Update with standardized date format.

### DIFF
--- a/app/formats.py
+++ b/app/formats.py
@@ -1,1 +1,0 @@
-DATE_FORMAT = "%Y-%m-%dT%H:%M:%S%Z"

--- a/app/models.py
+++ b/app/models.py
@@ -3,9 +3,9 @@ from datetime import datetime
 from sqlalchemy.dialects.postgresql import JSON
 from sqlalchemy_utils import generic_relationship
 from dmutils.audit import AuditTypes
+from dmutils.formats import DATETIME_FORMAT
 
 from . import db
-from . import formats
 from .utils import link, url_for
 
 
@@ -186,9 +186,10 @@ class User(db.Model):
             'role': self.role,
             'active': self.active,
             'locked': self.locked,
-            'createdAt': self.created_at.strftime(formats.DATE_FORMAT),
-            'updatedAt': self.updated_at.strftime(formats.DATE_FORMAT),
-            'passwordChangedAt': self.password_changed_at
+            'createdAt': self.created_at.strftime(DATETIME_FORMAT),
+            'updatedAt': self.updated_at.strftime(DATETIME_FORMAT),
+            'passwordChangedAt':
+                self.password_changed_at.strftime(DATETIME_FORMAT)
         }
 
         if self.role == 'supplier':
@@ -238,7 +239,7 @@ class Service(db.Model):
             'supplierId': self.supplier.supplier_id,
             'supplierName': self.supplier.name,
             'frameworkName': self.framework.name,
-            'updatedAt': self.updated_at.strftime(formats.DATE_FORMAT),
+            'updatedAt': self.updated_at.strftime(DATETIME_FORMAT),
             'status': self.status
         })
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,8 +7,7 @@ Flask-SQLAlchemy==2.0
 SQLAlchemy-Utils==0.30.5
 psycopg2==2.5.4
 jsonschema==2.3.0
-git+https://github.com/pcraig3/Flask-FeatureFlags.git@master#egg=Flask-FeatureFlags==0.6-dev
-git+https://github.com/alphagov/digitalmarketplace-utils.git@0.22.0#egg=digitalmarketplace-utils==0.22.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@1.0.0#egg=digitalmarketplace-utils==1.0.0
 # For the import script
 requests==2.5.1
 docopt==0.6.2

--- a/tests/app/test_users.py
+++ b/tests/app/test_users.py
@@ -1,6 +1,6 @@
 from flask import json
 from nose.tools import assert_equal, assert_not_equal, assert_in
-from app import db, encryption, formats
+from app import db, encryption
 from app.models import User, Supplier
 from datetime import datetime
 from .helpers import BaseApplicationTest, JSONUpdateTestMixin


### PR DESCRIPTION
New version of digitalmarketplace-utils contains our `DATETIME_FORMAT` variable so that we can standardise changes across all apps.
Breaking change to `content_loader` ([as mentioned here](https://github.com/alphagov/digitalmarketplace-utils/pull/64)) doesn't affect this app.