### PR TITLE
Fix add audit event migration revision

### DIFF
--- a/migrations/VERSION-HISTORY.txt
+++ b/migrations/VERSION-HISTORY.txt
@@ -22,4 +22,5 @@ c8bce0740af   -  add 'supplier_id', 'created_at' and 'updated_at'
 10_adding_supplier_to_user_table - add 'supplier_id' to users table
 20_adding_json_index_to_services - add JSON index for services order_by
 40_add_draft_services
-50_add_audit_events - add 'AuditEvent' table
+30_add_audit_events - add 'AuditEvent' table
+50_remove_updated_details

--- a/migrations/versions/30_add_audit_events.py
+++ b/migrations/versions/30_add_audit_events.py
@@ -1,13 +1,13 @@
 """Add audit events
 
 Revision ID: 30_add_audit_events
-Revises: 20_adding_json_index_to_services
+Revises: 40_add_draft_services
 Create Date: 2015-06-05 11:30:26.425563
 
 """
 
 # revision identifiers, used by Alembic.
-revision = '50_add_audit_events'
+revision = '30_add_audit_events'
 down_revision = '40_add_draft_services'
 
 from alembic import op

--- a/migrations/versions/50_remove_updated_details.py
+++ b/migrations/versions/50_remove_updated_details.py
@@ -8,7 +8,7 @@ Create Date: 2015-06-10 08:04:00.175499
 
 # revision identifiers, used by Alembic.
 revision = '50_remove_updated_details'
-down_revision = '50_add_audit_events'
+down_revision = '30_add_audit_events'
 
 from alembic import op
 import sqlalchemy as sa


### PR DESCRIPTION
The revision label has been deployed as 30_... so it will be easier to
just update this.