### PR TITLE
Adds old and new archived service links to audit events

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -187,7 +187,7 @@ def import_service(service_id):
 
     service_data = drop_foreign_fields(
         service_json,
-        ['supplierName', 'links', 'frameworkName']
+        ['supplierName', 'links', 'frameworkName', 'updatedAt']
     )
 
     framework = detect_framework_or_400(service_data)

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -183,7 +183,7 @@ def update_supplier(supplier_id):
             audit_type=AuditTypes.supplier_update,
             db_object=supplier,
             user=request_data['updated_by'],
-            data={'request': request_data})
+            data={'update': request_data['suppliers']})
     )
 
     try:
@@ -231,7 +231,7 @@ def update_contact_information(supplier_id, contact_id):
             audit_type=AuditTypes.contact_update,
             db_object=contact.supplier,
             user=request_data['updated_by'],
-            data={'request': request_data})
+            data={'update': request_data['contactInformation']})
     )
 
     try:

--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -144,7 +144,7 @@ def update_user(user_id):
     audit = AuditEvent(
         audit_type=AuditTypes.update_user,
         user=user.email_address,
-        data=user_update,
+        data={'update': user_update},
         db_object=user
     )
 

--- a/app/models.py
+++ b/app/models.py
@@ -66,11 +66,14 @@ class ContactInformation(db.Model):
 
         return self
 
+    def get_link(self):
+        return url_for(".update_contact_information",
+                       supplier_id=self.supplier_id,
+                       contact_id=self.id)
+
     def serialize(self):
         links = link(
-            "self", url_for(".update_contact_information",
-                            supplier_id=self.supplier_id,
-                            contact_id=self.id)
+            "self", self.get_link()
         )
 
         serialized = {
@@ -116,9 +119,12 @@ class Supplier(db.Model):
 
     clients = db.Column(JSON, default=list)
 
+    def get_link(self):
+        return url_for(".get_supplier", supplier_id=self.supplier_id)
+
     def serialize(self):
         links = link(
-            "self", url_for(".get_supplier", supplier_id=self.supplier_id)
+            "self", self.get_link()
         )
 
         contact_information_list = []
@@ -178,6 +184,9 @@ class User(db.Model):
 
     supplier = db.relationship(Supplier, lazy='joined', innerjoin=False)
 
+    def get_link(self):
+        return url_for('.get_user_by_id', user_id=self.id)
+
     def serialize(self):
         user = {
             'id': self.id,
@@ -226,6 +235,9 @@ class Service(db.Model):
 
     framework = db.relationship(Framework, lazy='joined', innerjoin=True)
 
+    def get_link(self):
+        return url_for(".get_service", service_id=self.service_id)
+
     def serialize(self):
         """
         :return: dictionary representation of a service
@@ -243,7 +255,7 @@ class Service(db.Model):
         })
 
         data['links'] = link(
-            "self", url_for(".get_service", service_id=data['id'])
+            "self", self.get_link()
         )
 
         return data
@@ -302,6 +314,10 @@ class ArchivedService(db.Model):
             status=service.status
         )
 
+    def get_link(self):
+        return url_for(".get_archived_service",
+                       archived_service_id=self.id)
+
     def serialize(self):
         """
         :return: dictionary representation of a service
@@ -316,7 +332,7 @@ class ArchivedService(db.Model):
         })
 
         data['links'] = link(
-            "self", url_for(".get_service", service_id=data['id'])
+            "self", self.get_link()
         )
 
         return data
@@ -360,6 +376,9 @@ class DraftService(db.Model):
             status=service.status
         )
 
+    def get_link(self):
+        return url_for(".fetch_draft_service", service_id=self.service_id)
+
     def serialize(self):
         """
         :return: dictionary representation of a draft service
@@ -375,7 +394,7 @@ class DraftService(db.Model):
         })
 
         data['links'] = link(
-            "self", url_for(".fetch_draft_service", service_id=self.service_id)
+            "self", self.get_link()
         )
 
         return data

--- a/migrations/versions/60_archive_current_services.py
+++ b/migrations/versions/60_archive_current_services.py
@@ -1,0 +1,42 @@
+"""Create archives for current service versions
+
+Revision ID: 60_archive_current_services
+Revises: 50_remove_updated_details
+Create Date: 2015-06-16 14:47:45.802476
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '60_archive_current_services'
+down_revision = '50_remove_updated_details'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.execute(
+        """
+        INSERT INTO archived_services (
+            framework_id,
+            service_id,
+            supplier_id,
+            created_at,
+            updated_at,
+            data,
+            status
+        ) SELECT
+            framework_id,
+            service_id,
+            supplier_id,
+            created_at,
+            updated_at,
+            data,
+            status
+        FROM services;
+        """
+    )
+
+
+def downgrade():
+    pass

--- a/tests/app/test_users.py
+++ b/tests/app/test_users.py
@@ -452,7 +452,8 @@ class TestUsersUpdate(BaseApplicationTest):
             assert_equal(len(data['auditEvents']), 1)
             assert_equal(data['auditEvents'][0]['type'], 'update_user')
             assert_equal(
-                data['auditEvents'][0]['data']['name'], 'I Just Got Married'
+                data['auditEvents'][0]['data']['update']['name'],
+                'I Just Got Married'
             )
 
     def test_can_update_role_and_suppler_id(self):

--- a/tests/app/views/test_suppliers.py
+++ b/tests/app/views/test_suppliers.py
@@ -397,10 +397,7 @@ class TestUpdateSupplier(BaseApplicationTest, JSONUpdateTestMixin):
             assert_equal(audit.type, "supplier_update")
             assert_equal(audit.user, "supplier@user.dmdev")
             assert_equal(audit.data, {
-                "request": {
-                    'suppliers': {'name': "Name"},
-                    'updated_by': 'supplier@user.dmdev',
-                },
+                'update': {'name': "Name"},
             })
 
     def test_update_response_matches_payload(self):
@@ -551,10 +548,7 @@ class TestUpdateContactInformation(BaseApplicationTest):
             assert_equal(audit.type, "contact_update")
             assert_equal(audit.user, "supplier@user.dmdev")
             assert_equal(audit.data, {
-                "request": {
-                    'contactInformation': {'city': "New City"},
-                    'updated_by': 'supplier@user.dmdev'
-                }
+                'update': {'city': "New City"},
             })
 
     def test_update_response_matches_payload(self):


### PR DESCRIPTION
Part of the diff services story: [#95431862](https://www.pivotaltracker.com/story/show/95431862)

Changes "service_update" audit events data to:
```json
 "data": {
    "new_archived_service": "http://localhost:5000/archived-services/12403",
    "old_archived_service": "http://localhost:5000/archived-services/12402",
    "service_id": "5769999037759488"
}
```

With links to the related archived services API client can request the archives and create a diff of the change.

### Add models.ServiceTableMixin for common service columns
Removes duplication between Service, ArchivedService and DraftService
models by creating a common base class.

Also updates ArchivedService and DraftsService .serialize method and
API responses using them with new fields that were added to Service
.serialize.

### Add a migration to archive current services
Since the new update endpoint creates an archive for the updated
service version and the existing code created version for services
before updates there are no corresponding archived_services rows
for current versions of services. So we copy all the services rows
to archived_services with a migration.

### Create archived service immediately after update
Instead of archiving the previous service version during update we
archive the new one right away. This way there's always an archive
version to reference from the audit event.

This also means that service import now creates a service archive.

### Drop updatedAt field when importing services
### Use 'update' as a common key for request data in audit event
Only store the request key that contains the data update instead
of all request data. Uses the same AuditEvent.data['update'] key
for all object types.