### PR TITLE
Store archive id instead of a link in audit event data

### DIFF
--- a/app/service_utils.py
+++ b/app/service_utils.py
@@ -44,7 +44,7 @@ def commit_and_archive_service(updated_service, update_details,
         ArchivedService.service_id == updated_service.service_id
     ).order_by(ArchivedService.id.desc()).first()
 
-    last_archive_link = last_archive.get_link() if last_archive else None
+    last_archive = last_archive.id if last_archive else None
 
     if audit_data is None:
         audit_data = {}
@@ -57,8 +57,8 @@ def commit_and_archive_service(updated_service, update_details,
 
         audit_data.update({
             'service_id': updated_service.service_id,
-            'old_archived_service': last_archive_link,
-            'new_archived_service': service_to_archive.get_link(),
+            'old_archived_service_id': last_archive,
+            'new_archived_service_id': service_to_archive.id,
         })
 
         audit = AuditEvent(

--- a/tests/app/views/test_services.py
+++ b/tests/app/views/test_services.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta
 import os
 
 from flask import json
-from nose.tools import assert_equal, assert_in, \
+from nose.tools import assert_equal, assert_in, assert_true, \
     assert_almost_equal, assert_false, assert_is_not_none, assert_not_in
 
 from app.models import Service, Supplier, ContactInformation, Framework
@@ -474,8 +474,8 @@ class TestPostService(BaseApplicationTest):
             assert_equal(len(data['auditEvents']), 3)
             update_event = data['auditEvents'][2]
 
-            old_version = update_event['data']['old_archived_service']
-            new_version = update_event['data']['new_archived_service']
+            old_version = update_event['links']['old_archived_service']
+            new_version = update_event['links']['new_archived_service']
 
             assert_in('/archived-services/', old_version)
             assert_in('/archived-services/', new_version)
@@ -781,9 +781,9 @@ class TestPostService(BaseApplicationTest):
         assert_equal(data['auditEvents'][1]['data']['new_status'], 'disabled')
         assert_equal(data['auditEvents'][1]['data']['old_status'], 'published')
         assert_in('/archived-services/',
-                  data['auditEvents'][1]['data']['old_archived_service'])
+                  data['auditEvents'][1]['links']['old_archived_service'])
         assert_in('/archived-services/',
-                  data['auditEvents'][1]['data']['new_archived_service'])
+                  data['auditEvents'][1]['links']['new_archived_service'])
 
     def test_should_400_with_invalid_statuses(self):
         invalid_statuses = [
@@ -1364,10 +1364,15 @@ class TestPutService(BaseApplicationTest, JSONUpdateTestMixin):
             assert_equal(data['auditEvents'][0]['data']['service_id'],
                          "1234567890123456")
             assert_equal(
-                data['auditEvents'][0]['data']['old_archived_service'], None
+                data['auditEvents'][0]['data']['old_archived_service_id'], None
             )
-            assert_in('/archived-services/',
-                      data['auditEvents'][0]['data']['new_archived_service'])
+            assert_not_in('old_archived_service',
+                          data['auditEvents'][0]['links'])
+
+            assert_true(isinstance(
+                data['auditEvents'][0]['data']['new_archived_service_id'], int
+            ))
+            assert_in('new_archived_service', data['auditEvents'][0]['links'])
 
     def test_add_a_new_service_with_status_disabled(self):
         with self.app.app_context():


### PR DESCRIPTION
Since url_for is using the Host header to build the link, when API
is called from another app the URL is generated using internal DNS
name. Storing links instead of ids would also make it harder to
change the archived-services route.

Instead, only archived-services ids are stored in the audit event
data. When the audit event is serialized to JSON the ids are used
to add [old|new]_archived_service to the list of links.