### PR TITLE
[#96549780] Add G-Cloud 7 and Framework list

### DIFF
--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -13,5 +13,5 @@ def add_cache_control(response):
     return response
 
 
-from .views import suppliers, services, users, drafts, audits
+from .views import suppliers, services, users, drafts, audits, frameworks
 from . import errors

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -1,0 +1,13 @@
+from flask import jsonify
+
+from .. import main
+from ...models import Framework
+
+
+@main.route('/frameworks', methods=['GET'])
+def list_frameworks():
+    frameworks = Framework.query.all()
+
+    return jsonify(
+        frameworks=[f.serialize() for f in frameworks]
+    )

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -27,7 +27,8 @@ def index():
     return jsonify(links={
         "audits.list": url_for('.list_audits', _external=True),
         "services.list": url_for('.list_services', _external=True),
-        "suppliers.list": url_for('.list_suppliers', _external=True)
+        "suppliers.list": url_for('.list_suppliers', _external=True),
+        "frameworks.list": url_for('.list_frameworks', _external=True),
     }
     ), 200
 

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -44,7 +44,7 @@ def list_services():
     supplier_id = request.args.get('supplier_id')
 
     services = Service.query.filter(
-        Service.framework.has(Framework.expired == false())
+        Service.framework.has(Framework.status == 'live')
     ).order_by(
         asc(Service.framework_id),
         asc(Service.data['lot'].cast(String).label('data_lot')),
@@ -213,7 +213,7 @@ def get_service(service_id):
 
     service = Service.query.filter(
         Service.service_id == service_id) \
-        .filter(Service.framework.has(Framework.expired == false())) \
+        .filter(Service.framework.has(Framework.status == 'live')) \
         .first_or_404()
 
     return jsonify(services=service.serialize())

--- a/app/models.py
+++ b/app/models.py
@@ -24,8 +24,6 @@ class Framework(db.Model):
     status = db.Column(db.Enum(STATUSES, name='framework_status_enum'),
                        index=True, nullable=False,
                        server_default='pending')
-    expired = db.Column(db.Boolean, index=False, unique=False,
-                        nullable=False)
 
 
 class ContactInformation(db.Model):

--- a/app/models.py
+++ b/app/models.py
@@ -28,6 +28,14 @@ class Framework(db.Model):
                        index=True, nullable=False,
                        server_default='pending')
 
+    def serialize(self):
+        return {
+            'id': self.id,
+            'name': self.name,
+            'framework': self.framework,
+            'status': self.status,
+        }
+
 
 class ContactInformation(db.Model):
     __tablename__ = 'contact_information'

--- a/app/models.py
+++ b/app/models.py
@@ -17,7 +17,7 @@ class Framework(db.Model):
     __tablename__ = 'frameworks'
 
     STATUSES = [
-        'pending', 'live', 'expired'
+        'pending', 'open', 'live', 'expired'
     ]
 
     id = db.Column(db.Integer, primary_key=True)

--- a/app/models.py
+++ b/app/models.py
@@ -1,7 +1,10 @@
 from datetime import datetime
+from flask_sqlalchemy import BaseQuery
 
+from sqlalchemy import asc
 from sqlalchemy.dialects.postgresql import JSON
 from sqlalchemy.ext.declarative import declared_attr
+from sqlalchemy.types import String
 from sqlalchemy_utils import generic_relationship
 from dmutils.audit import AuditTypes
 from dmutils.formats import DATETIME_FORMAT
@@ -288,6 +291,26 @@ class ServiceTableMixin(object):
 
 class Service(db.Model, ServiceTableMixin):
     __tablename__ = 'services'
+
+    class query_class(BaseQuery):
+        def framework_is_live(self):
+            return self.filter(
+                Service.framework.has(Framework.status == 'live'))
+
+        def default_order(self):
+            lot = Service.data['lot'] \
+                         .cast(String) \
+                         .label('data_lot')
+            service_name = Service.data['serviceName'] \
+                                  .cast(String) \
+                                  .label('data_servicename')
+            return self.order_by(
+                asc(Service.framework_id),
+                asc(lot),
+                asc(service_name))
+
+        def has_statuses(self, *statuses):
+            return self.filter(Service.status.in_(statuses))
 
     def get_link(self):
         return url_for(".get_service", service_id=self.service_id)

--- a/app/service_utils.py
+++ b/app/service_utils.py
@@ -76,7 +76,7 @@ def commit_and_archive_service(updated_service, update_details,
 
 
 def index_service(service):
-    if not service.framework.expired and service.status == 'published':
+    if service.framework.status == 'live' and service.status == 'published':
         try:
             search_api_client.index(
                 service.service_id,

--- a/migrations/versions/100_add_open_stauts.py
+++ b/migrations/versions/100_add_open_stauts.py
@@ -1,0 +1,23 @@
+"""Add open status to framework table
+
+Revision ID: 100_add_open_status
+Revises: 90_add_gcloud_7
+Create Date: 2015-06-18 08:43:33.427050
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '100_add_open_status'
+down_revision = '90_add_gcloud_7'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.execute("COMMIT") # See: http://stackoverflow.com/a/30910417/15720
+    op.execute("ALTER TYPE framework_status_enum ADD VALUE 'open' AFTER 'pending';")
+
+
+def downgrade():
+    raise NotImplemented("Cannot remove framework value")

--- a/migrations/versions/80_remove_framework_expired.py
+++ b/migrations/versions/80_remove_framework_expired.py
@@ -1,0 +1,27 @@
+"""Remove framework expired column
+
+Revision ID: 80_remove_framework_expired
+Revises: 70_add_framework_status
+Create Date: 2015-06-16 15:44:21.263411
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '80_remove_framework_expired'
+down_revision = '70_add_framework_status'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.drop_column('frameworks', 'expired')
+
+
+def downgrade():
+    op.add_column('frameworks',
+                  sa.Column('expired', sa.BOOLEAN(),
+                            autoincrement=False, nullable=False, default=True))
+    op.execute("UPDATE frameworks SET expired = TRUE WHERE status != 'live';")
+    op.execute("UPDATE frameworks SET expired = FALSE WHERE status = 'live';")
+    op.alter_column('frameworks', 'framework', server_default=None)

--- a/migrations/versions/90_add_gcloud_7.py
+++ b/migrations/versions/90_add_gcloud_7.py
@@ -1,0 +1,35 @@
+"""Add G-Cloud 7
+
+Revision ID: 90_add_gcloud_7
+Revises: 80_remove_framework_expired
+Create Date: 2015-06-17 14:44:08.138355
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '90_add_gcloud_7'
+down_revision = '80_remove_framework_expired'
+
+from alembic import op
+from sqlalchemy.sql import table, column
+from sqlalchemy import String
+
+
+frameworks = table('frameworks',
+    column('name', String),
+    column('framework', String),
+    column('status', String),
+)
+
+
+def upgrade():
+    op.execute(
+        frameworks.insert().
+        values({'name': op.inline_literal('G-Cloud 7'),
+                'framework': op.inline_literal('gcloud'),
+                'status': op.inline_literal('pending')}))
+
+
+def downgrade():
+    op.execute(
+        frameworks.delete().where(frameworks.c.name == 'G-Cloud 7'))

--- a/scripts/migrations-list.py
+++ b/scripts/migrations-list.py
@@ -15,4 +15,4 @@ def version_history(migrations_path):
 
 if __name__ == '__main__':
     for version in version_history(sys.argv[1]):
-        print version
+        print(version)

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -71,40 +71,46 @@ class BaseApplicationTest(object):
                 )
             db.session.commit()
 
-    def setup_dummy_services_including_unpublished(self, n):
+    def setup_dummy_framework(self, id=123, name='expired', framework='gcloud',
+                              status='expired'):
+        db.session.add(Framework(
+            id=id,
+            name=name,
+            framework=framework,
+            status=status))
+
+        return id
+
+    def setup_dummy_service(self, service_id, supplier_id=1, data=None,
+                            status='published', framework_id=1):
         now = datetime.utcnow()
+        db.session.add(Service(service_id=service_id,
+                               supplier_id=supplier_id,
+                               status=status,
+                               data=data or {
+                                   'serviceName': 'Service {}'.
+                                                  format(service_id)
+                               },
+                               framework_id=framework_id,
+                               created_at=now,
+                               updated_at=now))
+
+    def setup_dummy_services_including_unpublished(self, n):
         with self.app.app_context():
             self.setup_dummy_suppliers(TEST_SUPPLIERS_COUNT)
             for i in range(n):
-                db.session.add(Service(service_id=i,
-                                       supplier_id=i % TEST_SUPPLIERS_COUNT,
-                                       updated_at=now,
-                                       status='published',
-                                       created_at=now,
-                                       data={
-                                           'serviceName': 'Service {}'.
-                                                          format(i),
-                                       },
-                                       framework_id=1))
+                self.setup_dummy_service(
+                    service_id=i,
+                    supplier_id=i % TEST_SUPPLIERS_COUNT)
             # Add extra 'enabled' and 'disabled' services
-            db.session.add(Service(service_id=n + 1,
-                                   supplier_id=n % TEST_SUPPLIERS_COUNT,
-                                   updated_at=now,
-                                   status='disabled',
-                                   created_at=now,
-                                   data={
-                                       'serviceName': 'Service {}'.format(n),
-                                   },
-                                   framework_id=1))
-            db.session.add(Service(service_id=n + 2,
-                                   supplier_id=n % TEST_SUPPLIERS_COUNT,
-                                   updated_at=now,
-                                   status='enabled',
-                                   created_at=now,
-                                   data={
-                                       'serviceName': 'Service {}'.format(n),
-                                   },
-                                   framework_id=1))
+            self.setup_dummy_service(
+                service_id=n + 1,
+                supplier_id=n % TEST_SUPPLIERS_COUNT,
+                status='disabled')
+            self.setup_dummy_service(
+                service_id=n + 2,
+                supplier_id=n % TEST_SUPPLIERS_COUNT,
+                status='enabled')
             # Add an extra supplier that will have no services
             db.session.add(
                 Supplier(supplier_id=TEST_SUPPLIERS_COUNT, name=u"Supplier {}"

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -71,16 +71,6 @@ class BaseApplicationTest(object):
                 )
             db.session.commit()
 
-    def setup_dummy_framework(self, id=123, name='expired', framework='gcloud',
-                              status='expired'):
-        db.session.add(Framework(
-            id=id,
-            name=name,
-            framework=framework,
-            status=status))
-
-        return id
-
     def setup_dummy_service(self, service_id, supplier_id=1, data=None,
                             status='published', framework_id=1):
         now = datetime.utcnow()

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -4,7 +4,8 @@ from nose.tools import assert_equal, assert_raises
 from sqlalchemy.exc import DataError
 
 from app import db, create_app
-from app.models import User, Framework
+from app.models import User, Framework, Service
+from .helpers import BaseApplicationTest
 
 
 def test_should_not_return_password_on_user():
@@ -50,3 +51,57 @@ def test_framework_should_accept_valid_statuses():
             )
             db.session.add(f)
             db.session.commit()
+
+
+class TestServices(BaseApplicationTest):
+    def test_framework_is_live_only_returns_live_frameworks(self):
+        with self.app.app_context():
+            self.setup_dummy_service(
+                service_id='999',
+                status='published',
+                framework_id=self.setup_dummy_framework())
+            self.setup_dummy_services_including_unpublished(1)
+
+            services = Service.query.framework_is_live()
+
+            assert_equal(Service.query.count(), 4)
+            assert_equal(services.count(), 3)
+            assert(all(s.framework.status == 'live' for s in services))
+
+    def test_default_ordering(self):
+        def add_service(service_id, framework_id, lot, service_name):
+            self.setup_dummy_service(
+                service_id=service_id,
+                supplier_id=0,
+                framework_id=framework_id,
+                data={'lot': lot, 'serviceName': service_name})
+
+        with self.app.app_context():
+            self.setup_dummy_suppliers(1)
+            add_service('990', 3, 'zzz', 'zzz')
+            add_service('991', 3, 'zzz', 'aaa')
+            add_service('992', 3, 'aaa', 'zzz')
+            add_service('993', 1, 'zzz', 'zzz')
+            db.session.commit()
+
+            services = Service.query.default_order()
+
+            assert_equal(
+                [s.service_id for s in services],
+                ['993', '992', '991', '990'])
+
+    def test_has_statuses(self):
+        with self.app.app_context():
+            self.setup_dummy_services_including_unpublished(1)
+
+            services = Service.query.has_statuses('published')
+
+            assert_equal(services.count(), 1)
+
+    def test_has_statuses_should_accept_multiple_statuses(self):
+        with self.app.app_context():
+            self.setup_dummy_services_including_unpublished(1)
+
+            services = Service.query.has_statuses('published', 'disabled')
+
+            assert_equal(services.count(), 2)

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -34,7 +34,6 @@ def test_framework_should_not_accept_invalid_status():
             name='foo',
             framework='gcloud',
             status='invalid',
-            expired=False,
         )
         db.session.add(f)
         db.session.commit()
@@ -48,7 +47,6 @@ def test_framework_should_accept_valid_statuses():
                 name='foo',
                 framework='gcloud',
                 status=status,
-                expired=False,
             )
             db.session.add(f)
             db.session.commit()

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -59,7 +59,7 @@ class TestServices(BaseApplicationTest):
             self.setup_dummy_service(
                 service_id='999',
                 status='published',
-                framework_id=self.setup_dummy_framework())
+                framework_id=2)
             self.setup_dummy_services_including_unpublished(1)
 
             services = Service.query.framework_is_live()

--- a/tests/app/views/test_frameworks.py
+++ b/tests/app/views/test_frameworks.py
@@ -1,0 +1,16 @@
+from __future__ import absolute_import
+
+from flask import json
+from nose.tools import assert_equal
+
+from ..helpers import BaseApplicationTest
+
+
+class TestListFrameworks(BaseApplicationTest):
+    def test_all_frameworks_are_returned(self):
+        with self.app.app_context():
+            response = self.client.get('/frameworks')
+            data = json.loads(response.get_data())
+
+            assert_equal(response.status_code, 200)
+            assert_equal(len(data['frameworks']), 3)

--- a/tests/app/views/test_frameworks.py
+++ b/tests/app/views/test_frameworks.py
@@ -4,6 +4,7 @@ from flask import json
 from nose.tools import assert_equal
 
 from ..helpers import BaseApplicationTest
+from app.models import Framework
 
 
 class TestListFrameworks(BaseApplicationTest):
@@ -13,4 +14,5 @@ class TestListFrameworks(BaseApplicationTest):
             data = json.loads(response.get_data())
 
             assert_equal(response.status_code, 200)
-            assert_equal(len(data['frameworks']), 3)
+            assert_equal(len(data['frameworks']),
+                         len(Framework.query.all()))

--- a/tests/app/views/test_services.py
+++ b/tests/app/views/test_services.py
@@ -108,7 +108,7 @@ class TestListServices(BaseApplicationTest):
             self.setup_dummy_service(
                 service_id='999',
                 status='published',
-                framework_id=self.setup_dummy_framework())
+                framework_id=2)
             self.setup_dummy_services_including_unpublished(1)
 
             response = self.client.get('/services')
@@ -122,7 +122,7 @@ class TestListServices(BaseApplicationTest):
             self.setup_dummy_service(
                 service_id='999',
                 status='published',
-                framework_id=self.setup_dummy_framework())
+                framework_id=2)
             self.setup_dummy_services_including_unpublished(1)
 
             response = self.client.get('/services?status=published')

--- a/tests/app/views/test_services.py
+++ b/tests/app/views/test_services.py
@@ -111,7 +111,6 @@ class TestListServices(BaseApplicationTest):
                 name="expired",
                 framework="gcloud",
                 status="expired",
-                expired=True
             ))
 
             db.session.add(Service(service_id="999",
@@ -1502,7 +1501,6 @@ class TestGetService(BaseApplicationTest):
                 name="expired",
                 framework="gcloud",
                 status="expired",
-                expired=True,
             ))
             db.session.add(
                 Supplier(supplier_id=1, name=u"Supplier 1")


### PR DESCRIPTION
This builds on #142 to actually add new G-Cloud 7 framework with a 'pending' status.

This change removes the now redundant 'expired' flag as it is covered by the 'status' field.

This change also fixes a bug in the list services view where the Framework status filter was not being applied when filtering by status. Some of the querying logic has been moved into the Service model so that it can be tested in isolation and shared between multiple places. This logic has been added to the Service rather than the mixin because the logic is only needed on the Service right now.