### PR TITLE
Add supplier service counts

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -56,7 +56,11 @@ def get_supplier(supplier_id):
         Supplier.supplier_id == supplier_id
     ).first_or_404()
 
-    return jsonify(suppliers=supplier.serialize())
+    service_counts = supplier.get_service_counts()
+
+    return jsonify(suppliers=supplier.serialize({
+        'service_counts': service_counts
+    }))
 
 
 # Route to insert new Suppliers, not update existing ones

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -85,13 +85,22 @@ class BaseApplicationTest(object):
                                created_at=now,
                                updated_at=now))
 
-    def setup_dummy_services_including_unpublished(self, n):
+    def setup_dummy_services(self, n, supplier_id=None, framework_id=None,
+                             start_id=0):
         with self.app.app_context():
-            self.setup_dummy_suppliers(TEST_SUPPLIERS_COUNT)
-            for i in range(n):
+            for i in range(start_id, start_id + n):
                 self.setup_dummy_service(
                     service_id=i,
-                    supplier_id=i % TEST_SUPPLIERS_COUNT)
+                    supplier_id=supplier_id or (i % TEST_SUPPLIERS_COUNT),
+                    framework_id=framework_id or 1
+                )
+
+            db.session.commit()
+
+    def setup_dummy_services_including_unpublished(self, n):
+        self.setup_dummy_suppliers(TEST_SUPPLIERS_COUNT)
+        self.setup_dummy_services(n)
+        with self.app.app_context():
             # Add extra 'enabled' and 'disabled' services
             self.setup_dummy_service(
                 service_id=n + 1,
@@ -109,8 +118,9 @@ class BaseApplicationTest(object):
             db.session.add(
                 ContactInformation(
                     supplier_id=TEST_SUPPLIERS_COUNT,
-                    contact_name=u"Contact for Supplier {}".format(i),
-                    email=u"{}@contact.com".format(i),
+                    contact_name=u"Contact for Supplier {}".format(
+                        TEST_SUPPLIERS_COUNT),
+                    email=u"{}@contact.com".format(TEST_SUPPLIERS_COUNT),
                     postcode=u"SW1A 1AA"
                 )
             )

--- a/tests/app/views/test_suppliers.py
+++ b/tests/app/views/test_suppliers.py
@@ -69,6 +69,25 @@ class TestGetSupplier(BaseApplicationTest):
         assert_in('clients', data['suppliers'].keys())
         assert_equal(0, len(data['suppliers']['clients']))
 
+    def test_get_supplier_returns_service_counts(self):
+        self.setup_dummy_services(
+            5, supplier_id=self.supplier_id, framework_id=1
+        )
+        self.setup_dummy_services(
+            10, start_id=5, supplier_id=self.supplier_id, framework_id=2
+        )
+        self.setup_dummy_services(
+            15, start_id=15, supplier_id=self.supplier_id, framework_id=3
+        )
+
+        response = self.client.get('/suppliers/{}'.format(self.supplier_id))
+
+        data = json.loads(response.get_data())
+        assert_equal(data['suppliers']['service_counts'], {
+            u'G-Cloud 5': 15,
+            u'G-Cloud 6': 5
+        })
+
 
 class TestListSuppliers(BaseApplicationTest):
     def setup(self):


### PR DESCRIPTION
[#97275278](https://www.pivotaltracker.com/story/show/97275278)

Adds 'service_counts' key to the supplier response with service
counts for each framework:

```json
{
  ...
  "service_counts": {
    "G-Cloud 5": 10,
    "G-Cloud 6": 5,
  }
}
```

Only published services for "live" frameworks are counted.