### PR TITLE
Fix index script so that handles new JSON format

### DIFF
--- a/scripts/process-g6-into-elastic-search.py
+++ b/scripts/process-g6-into-elastic-search.py
@@ -389,6 +389,7 @@ def request_services(endpoint, token):
                 if link['rel'] == 'next':
                     page_url = link['href']
 
+
 def process_json_files_in_directory(dirname):
     for filename in os.listdir(dirname):
         with open(os.path.join(dirname, filename)) as f:

--- a/scripts/process-g6-into-elastic-search.py
+++ b/scripts/process-g6-into-elastic-search.py
@@ -384,8 +384,10 @@ def request_services(endpoint, token):
         for service in data["services"]:
             yield service
 
-            page_url = data['links'].get('next')
-
+            page_url = None
+            for link in data['links']:
+                if link['rel'] == 'next':
+                    page_url = link['href']
 
 def process_json_files_in_directory(dirname):
     for filename in os.listdir(dirname):


### PR DESCRIPTION
Fixes issue where index G6 into grails had fallen behind in some JSON formats.

- Links block is now a list of objects, and this wasn't how it was expected.