### PR TITLE
[#97275564] DB migration: service IDs are not required for draft services

### DIFF
--- a/app/main/views/drafts.py
+++ b/app/main/views/drafts.py
@@ -29,6 +29,10 @@ def create_draft_service(service_id):
         Service.service_id == service_id
     ).first_or_404()
 
+    if DraftService.query.filter(
+        DraftService.service_id == service_id
+    ).first():
+        abort(400, "Draft already exists for service {}".format(service_id))
     draft = DraftService.from_service(service)
     audit = AuditEvent(
         audit_type=AuditTypes.create_draft_service,

--- a/app/main/views/drafts.py
+++ b/app/main/views/drafts.py
@@ -29,10 +29,12 @@ def create_draft_service(service_id):
         Service.service_id == service_id
     ).first_or_404()
 
-    if DraftService.query.filter(
+    draft_service = DraftService.query.filter(
         DraftService.service_id == service_id
-    ).first():
+    ).first()
+    if draft_service:
         abort(400, "Draft already exists for service {}".format(service_id))
+
     draft = DraftService.from_service(service)
     audit = AuditEvent(
         audit_type=AuditTypes.create_draft_service,

--- a/app/models.py
+++ b/app/models.py
@@ -372,6 +372,9 @@ class ArchivedService(db.Model, ServiceTableMixin):
 class DraftService(db.Model, ServiceTableMixin):
     __tablename__ = 'draft_services'
 
+    # Overwrites service_id column to remove uniqueness and nullable constraint
+    service_id = db.Column(db.String, index=True, unique=False, nullable=True)
+
     @staticmethod
     def from_service(service):
         now = datetime.utcnow(),

--- a/migrations/VERSION-HISTORY.txt
+++ b/migrations/VERSION-HISTORY.txt
@@ -24,3 +24,12 @@ c8bce0740af   -  add 'supplier_id', 'created_at' and 'updated_at'
 40_add_draft_services
 30_add_audit_events - add 'AuditEvent' table
 50_remove_updated_details
+60_archive_current_services
+70_add_framework_status
+80_remove_framework_expired
+90_add_gcloud_7
+100_add_open_status
+110_add_acknowledged_column
+120_acknowledged_not_null
+130_acknowledged_at_column
+140_service_id_null_for_drafts

--- a/migrations/versions/140_service_id_null_for_drafts.py
+++ b/migrations/versions/140_service_id_null_for_drafts.py
@@ -1,0 +1,30 @@
+"""empty message
+
+Revision ID: 140_service_id_null_for_drafts
+Revises: 130_acknowledged_at_column
+Create Date: 2015-06-22 10:42:37.274484
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '140_service_id_null_for_drafts'
+down_revision = '130_acknowledged_at_column'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.alter_column('draft_services', 'service_id',
+               existing_type=sa.VARCHAR(),
+               nullable=True)
+    op.drop_index('ix_draft_services_service_id', table_name='draft_services')
+    op.create_index(op.f('ix_draft_services_service_id'), 'draft_services', ['service_id'], unique=False)
+
+
+def downgrade():
+    op.drop_index(op.f('ix_draft_services_service_id'), table_name='draft_services')
+    op.create_index('ix_draft_services_service_id', 'draft_services', ['service_id'], unique=True)
+    op.alter_column('draft_services', 'service_id',
+               existing_type=sa.VARCHAR(),
+               nullable=False)

--- a/tests/app/views/test_drafts.py
+++ b/tests/app/views/test_drafts.py
@@ -232,7 +232,7 @@ class TestDraftServices(BaseApplicationTest):
 
         assert_equal(res.status_code, 400)
         assert_in(
-            'duplicate key value violates unique constraint "ix_draft_services_service_id"\nDETAIL:  Key (service_id)=(1234567890123456) already exists.',  # noqa
+            'Draft already exists for service {}'.format(self.service_id),
             data['error'])
 
     def test_should_fetch_a_draft(self):


### PR DESCRIPTION
Newly created drafts for service submissions will not have a related service ID
- service IDs will only be generated when a draft service is published, so should
be able to be null in the draft services table.