### PR TITLE
Bug in the logic around fetching all audit events

### DIFF
--- a/app/main/views/audits.py
+++ b/app/main/views/audits.py
@@ -42,7 +42,7 @@ def list_audits():
             abort(400, "Invalid audit type")
 
     acknowledged = request.args.get('acknowledged', None)
-    if acknowledged:
+    if acknowledged and acknowledged != 'all':
         if is_valid_acknowledged_state(acknowledged):
             if convert_to_boolean(acknowledged):
                 audits = audits.filter(

--- a/tests/app/views/test_audits.py
+++ b/tests/app/views/test_audits.py
@@ -198,6 +198,12 @@ class TestAudits(BaseApplicationTest):
         assert_equal(res.status_code, 200)
         assert_equal(len(new_data['auditEvents']), 2)
 
+        # all should return both
+        new_response = self.client.get('/audit-events?acknowledged=all')
+        new_data = json.loads(new_response.get_data())
+        assert_equal(res.status_code, 200)
+        assert_equal(len(new_data['auditEvents']), 2)
+
     def test_should_get_only_acknowledged_audit_events(self):
         self.add_audit_events(2)
         response = self.client.get('/audit-events')


### PR DESCRIPTION
'all' is truthy so fetched only ack'd events when all is requests