### PR TITLE
[#97502388] Validation errors for service updates

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -339,7 +339,10 @@ class ServiceTableMixin(object):
         data.pop('frameworkName', None)
         data.pop('status', None)
         data.pop('links', None)
-
+        for key, value in data.items():
+            if isinstance(value, list):
+                # Remove empty items from lists
+                data[key] = filter(None, value)
         current_data = dict(self.data.items())
         current_data.update(data)
         self.data = current_data

--- a/app/models.py
+++ b/app/models.py
@@ -342,7 +342,7 @@ class ServiceTableMixin(object):
         for key, value in data.items():
             if isinstance(value, list):
                 # Remove empty items from lists
-                data[key] = filter(None, value)
+                data[key] = list(filter(None, value))
         current_data = dict(self.data.items())
         current_data.update(data)
         self.data = current_data

--- a/app/service_utils.py
+++ b/app/service_utils.py
@@ -3,8 +3,7 @@ from sqlalchemy.exc import IntegrityError
 
 from .utils import get_json_from_request, \
     json_has_matching_id, json_has_required_keys, drop_foreign_fields
-from .validation import validate_updater_json_or_400, detect_framework_or_400, \
-    get_validation_errors
+from .validation import validate_updater_json_or_400, get_validation_errors
 from . import search_api_client, apiclient
 from . import db
 from .models import ArchivedService, AuditEvent
@@ -62,7 +61,6 @@ def validate_service(service):
     errs = get_validation_errors(validator_name, data, enforce_required=True)
     if errs:
         abort(400, errs)
-    # detect_framework_or_400(data)
     return
 
 

--- a/app/service_utils.py
+++ b/app/service_utils.py
@@ -3,7 +3,8 @@ from sqlalchemy.exc import IntegrityError
 
 from .utils import get_json_from_request, \
     json_has_matching_id, json_has_required_keys, drop_foreign_fields
-from .validation import validate_updater_json_or_400, detect_framework_or_400
+from .validation import validate_updater_json_or_400, detect_framework_or_400, \
+    get_validation_errors
 from . import search_api_client, apiclient
 from . import db
 from .models import ArchivedService, AuditEvent
@@ -30,6 +31,24 @@ def update_and_validate_service(service, service_payload):
 
 
 def validate_service(service):
+
+    # TODO: Get framework slug from Framework table once it exists.
+    # framework = Framework.query.filter(
+    #     Framework.id == service.framework_id
+    # ).first()
+    # slug = framework.slug
+
+    if service.framework_id == 1:
+        validator_name = "services-g-cloud-6-{}".format(
+            service.data['lot'].lower())
+    elif service.framework_id == 2:
+        validator_name = "services-g-cloud-4"
+    elif service.framework_id == 3:
+        validator_name = "services-g-cloud-5"
+    else:
+        validator_name = "services-g-cloud-7-{}".format(
+            service.data['lot'].lower())
+
     data = dict(service.data.items())
     data.update({
         'id': service.service_id,
@@ -40,7 +59,10 @@ def validate_service(service):
     data = drop_foreign_fields(
         data,
         ['service_id', 'supplierName', 'links', 'frameworkName', 'updatedAt'])
-    detect_framework_or_400(data)
+    errs = get_validation_errors(validator_name, data, enforce_required=True)
+    if errs:
+        abort(400, errs)
+    # detect_framework_or_400(data)
     return
 
 

--- a/json_schemas/services-g-cloud-5.json
+++ b/json_schemas/services-g-cloud-5.json
@@ -20,24 +20,33 @@
     "title": {
       "type": "string"
     },
-    "serviceName": {
-      "type": "string"
+    "serviceName":{
+      "type":"string",
+      "minLength":1,
+      "maxLength":200
     },
-    "serviceSummary": {
-      "type": "string"
+    "serviceSummary":{
+      "type":"string",
+      "maxLength":10000
     },
-    "serviceBenefits": {
-      "type": "array",
-      "maxItems": 10,
-      "items": {
-        "type": "string"
+    "serviceBenefits":{
+      "type":"array",
+      "minItems":1,
+      "maxItems":10,
+      "items":{
+        "type":"string",
+        "maxLength":100,
+        "pattern":"^\\s?(\\S*\\s*){1,10}$"
       }
     },
-    "serviceFeatures": {
-      "type": "array",
-      "maxItems": 10,
-      "items": {
-        "type": "string"
+    "serviceFeatures":{
+      "type":"array",
+      "minItems":1,
+      "maxItems":10,
+      "items":{
+        "type":"string",
+        "maxLength":100,
+        "pattern":"^\\s?(\\S*\\s*){1,10}$"
       }
     },
     "serviceDefinitionDocumentURL": {

--- a/json_schemas/services-g-cloud-5.json
+++ b/json_schemas/services-g-cloud-5.json
@@ -36,7 +36,7 @@
       "items":{
         "type":"string",
         "maxLength":100,
-        "pattern":"^\\s?(\\S*\\s*){1,10}$"
+        "pattern":"^\\s?(?:\\S+\\s+){0,9}\\S+\\s?$"
       }
     },
     "serviceFeatures":{
@@ -46,7 +46,7 @@
       "items":{
         "type":"string",
         "maxLength":100,
-        "pattern":"^\\s?(\\S*\\s*){1,10}$"
+        "pattern":"^\\s?(?:\\S+\\s+){0,9}\\S+\\s?$"
       }
     },
     "serviceDefinitionDocumentURL": {

--- a/json_schemas/services-g-cloud-5.json
+++ b/json_schemas/services-g-cloud-5.json
@@ -36,7 +36,7 @@
       "items":{
         "type":"string",
         "maxLength":100,
-        "pattern":"^\\s?(?:\\S+\\s+){0,9}\\S+\\s?$"
+        "pattern":"^\\s*(?:\\S+\\s+){0,9}\\S+\\s*$"
       }
     },
     "serviceFeatures":{
@@ -46,7 +46,7 @@
       "items":{
         "type":"string",
         "maxLength":100,
-        "pattern":"^\\s?(?:\\S+\\s+){0,9}\\S+\\s?$"
+        "pattern":"^\\s*(?:\\S+\\s+){0,9}\\S+\\s*$"
       }
     },
     "serviceDefinitionDocumentURL": {

--- a/json_schemas/services-g-cloud-6-iaas.json
+++ b/json_schemas/services-g-cloud-6-iaas.json
@@ -50,7 +50,7 @@
     "serviceSummary":{
       "type":"string",
       "maxLength":500,
-      "pattern":"^\\s?(?:\\S+\\s+){0,49}\\S+\\s?$"
+      "pattern":"^\\s*(?:\\S+\\s+){0,49}\\S+\\s*$"
     },
     "serviceBenefits":{
       "type":"array",
@@ -59,7 +59,7 @@
       "items":{
         "type":"string",
         "maxLength":100,
-        "pattern":"^\\s?(?:\\S+\\s+){0,9}\\S+\\s?$"
+        "pattern":"^\\s*(?:\\S+\\s+){0,9}\\S+\\s*$"
       }
     },
     "serviceFeatures":{
@@ -69,7 +69,7 @@
       "items":{
         "type":"string",
         "maxLength":100,
-        "pattern":"^\\s?(?:\\S+\\s+){0,9}\\S+\\s?$"
+        "pattern":"^\\s*(?:\\S+\\s+){0,9}\\S+\\s*$"
       }
     },
     "serviceDefinitionDocument": {

--- a/json_schemas/services-g-cloud-6-iaas.json
+++ b/json_schemas/services-g-cloud-6-iaas.json
@@ -50,7 +50,7 @@
     "serviceSummary":{
       "type":"string",
       "maxLength":500,
-      "pattern":"^\\s?(\\S*\\s*){1,50}$"
+      "pattern":"^\\s?(?:\\S+\\s+){0,49}\\S+\\s?$"
     },
     "serviceBenefits":{
       "type":"array",
@@ -59,7 +59,7 @@
       "items":{
         "type":"string",
         "maxLength":100,
-        "pattern":"^\\s?(\\S*\\s*){1,10}$"
+        "pattern":"^\\s?(?:\\S+\\s+){0,9}\\S+\\s?$"
       }
     },
     "serviceFeatures":{
@@ -69,7 +69,7 @@
       "items":{
         "type":"string",
         "maxLength":100,
-        "pattern":"^\\s?(\\S*\\s*){1,10}$"
+        "pattern":"^\\s?(?:\\S+\\s+){0,9}\\S+\\s?$"
       }
     },
     "serviceDefinitionDocument": {

--- a/json_schemas/services-g-cloud-6-iaas.json
+++ b/json_schemas/services-g-cloud-6-iaas.json
@@ -42,24 +42,34 @@
         "enum": ["Compute", "Storage"]
       }
     },
-    "serviceName": {
-      "type": "string"
+    "serviceName":{
+      "type":"string",
+      "minLength":1,
+      "maxLength":100
     },
-    "serviceSummary": {
-      "type": "string"
+    "serviceSummary":{
+      "type":"string",
+      "maxLength":500,
+      "pattern":"^\\s?(\\S*\\s*){1,50}$"
     },
-    "serviceBenefits": {
-      "type": "array",
-      "maxItems": 10,
-      "items": {
-        "type": "string"
+    "serviceBenefits":{
+      "type":"array",
+      "minItems":1,
+      "maxItems":10,
+      "items":{
+        "type":"string",
+        "maxLength":100,
+        "pattern":"^\\s?(\\S*\\s*){1,10}$"
       }
     },
-    "serviceFeatures": {
-      "type": "array",
-      "maxItems": 10,
-      "items": {
-        "type": "string"
+    "serviceFeatures":{
+      "type":"array",
+      "minItems":1,
+      "maxItems":10,
+      "items":{
+        "type":"string",
+        "maxLength":100,
+        "pattern":"^\\s?(\\S*\\s*){1,10}$"
       }
     },
     "serviceDefinitionDocument": {

--- a/json_schemas/services-g-cloud-6-paas.json
+++ b/json_schemas/services-g-cloud-6-paas.json
@@ -42,7 +42,7 @@
     "serviceSummary":{
       "type":"string",
       "maxLength":500,
-      "pattern":"^\\s?(\\S*\\s*){1,50}$"
+      "pattern":"^\\s?(?:\\S+\\s+){0,49}\\S+\\s?$"
     },
     "serviceBenefits":{
       "type":"array",
@@ -51,7 +51,7 @@
       "items":{
         "type":"string",
         "maxLength":100,
-        "pattern":"^\\s?(\\S*\\s*){1,10}$"
+        "pattern":"^\\s?(?:\\S+\\s+){0,9}\\S+\\s?$"
       }
     },
     "serviceFeatures":{
@@ -61,7 +61,7 @@
       "items":{
         "type":"string",
         "maxLength":100,
-        "pattern":"^\\s?(\\S*\\s*){1,10}$"
+        "pattern":"^\\s?(?:\\S+\\s+){0,9}\\S+\\s?$"
       }
     },
     "serviceDefinitionDocument": {

--- a/json_schemas/services-g-cloud-6-paas.json
+++ b/json_schemas/services-g-cloud-6-paas.json
@@ -34,24 +34,34 @@
     "lastCompletedByEmail": {
       "type": "string"
     },
-    "serviceName": {
-      "type": "string"
+    "serviceName":{
+      "type":"string",
+      "minLength":1,
+      "maxLength":100
     },
-    "serviceSummary": {
-      "type": "string"
+    "serviceSummary":{
+      "type":"string",
+      "maxLength":500,
+      "pattern":"^\\s?(\\S*\\s*){1,50}$"
     },
-    "serviceBenefits": {
-      "type": "array",
-      "maxItems": 10,
-      "items": {
-        "type": "string"
+    "serviceBenefits":{
+      "type":"array",
+      "minItems":1,
+      "maxItems":10,
+      "items":{
+        "type":"string",
+        "maxLength":100,
+        "pattern":"^\\s?(\\S*\\s*){1,10}$"
       }
     },
-    "serviceFeatures": {
-      "type": "array",
-      "maxItems": 10,
-      "items": {
-        "type": "string"
+    "serviceFeatures":{
+      "type":"array",
+      "minItems":1,
+      "maxItems":10,
+      "items":{
+        "type":"string",
+        "maxLength":100,
+        "pattern":"^\\s?(\\S*\\s*){1,10}$"
       }
     },
     "serviceDefinitionDocument": {

--- a/json_schemas/services-g-cloud-6-paas.json
+++ b/json_schemas/services-g-cloud-6-paas.json
@@ -42,7 +42,7 @@
     "serviceSummary":{
       "type":"string",
       "maxLength":500,
-      "pattern":"^\\s?(?:\\S+\\s+){0,49}\\S+\\s?$"
+      "pattern":"^\\s*(?:\\S+\\s+){0,49}\\S+\\s*$"
     },
     "serviceBenefits":{
       "type":"array",
@@ -51,7 +51,7 @@
       "items":{
         "type":"string",
         "maxLength":100,
-        "pattern":"^\\s?(?:\\S+\\s+){0,9}\\S+\\s?$"
+        "pattern":"^\\s*(?:\\S+\\s+){0,9}\\S+\\s*$"
       }
     },
     "serviceFeatures":{
@@ -61,7 +61,7 @@
       "items":{
         "type":"string",
         "maxLength":100,
-        "pattern":"^\\s?(?:\\S+\\s+){0,9}\\S+\\s?$"
+        "pattern":"^\\s*(?:\\S+\\s+){0,9}\\S+\\s*$"
       }
     },
     "serviceDefinitionDocument": {

--- a/json_schemas/services-g-cloud-6-saas.json
+++ b/json_schemas/services-g-cloud-6-saas.json
@@ -50,7 +50,7 @@
     "serviceSummary":{
       "type":"string",
       "maxLength":500,
-      "pattern":"^\\s?(?:\\S+\\s+){0,49}\\S+\\s?$"
+      "pattern":"^\\s*(?:\\S+\\s+){0,49}\\S+\\s*$"
     },
     "serviceBenefits":{
       "type":"array",
@@ -59,7 +59,7 @@
       "items":{
         "type":"string",
         "maxLength":100,
-        "pattern":"^\\s?(?:\\S+\\s+){0,9}\\S+\\s?$"
+        "pattern":"^\\s*(?:\\S+\\s+){0,9}\\S+\\s*$"
       }
     },
     "serviceFeatures":{
@@ -69,7 +69,7 @@
       "items":{
         "type":"string",
         "maxLength":100,
-        "pattern":"^\\s?(?:\\S+\\s+){0,9}\\S+\\s?$"
+        "pattern":"^\\s*(?:\\S+\\s+){0,9}\\S+\\s*$"
       }
     },
     "serviceDefinitionDocument": {

--- a/json_schemas/services-g-cloud-6-saas.json
+++ b/json_schemas/services-g-cloud-6-saas.json
@@ -42,24 +42,34 @@
         "enum": ["Accounting and finance", "Business intelligence and analytics", "Collaboration", "Creative and design", "Customer relationship management (CRM)", "Data management", "Electronic document and records management (EDRM)", "Energy and environment", "Healthcare", "Human resources and employee management", "IT management", "Legal", "Libraries", "Marketing", "Operations management", "Project management and planning", "Sales", "Schools and education", "Security", "Software development tools", "Telecoms", "Transport and logistics"]
       }
     },
-    "serviceName": {
-      "type": "string"
+    "serviceName":{
+      "type":"string",
+      "minLength":1,
+      "maxLength":100
     },
-    "serviceSummary": {
-      "type": "string"
+    "serviceSummary":{
+      "type":"string",
+      "maxLength":500,
+      "pattern":"^\\s?(\\S*\\s*){1,50}$"
     },
-    "serviceBenefits": {
-      "type": "array",
-      "maxItems": 10,
-      "items": {
-        "type": "string"
+    "serviceBenefits":{
+      "type":"array",
+      "minItems":1,
+      "maxItems":10,
+      "items":{
+        "type":"string",
+        "maxLength":100,
+        "pattern":"^\\s?(\\S*\\s*){1,10}$"
       }
     },
-    "serviceFeatures": {
-      "type": "array",
-      "maxItems": 10,
-      "items": {
-        "type": "string"
+    "serviceFeatures":{
+      "type":"array",
+      "minItems":1,
+      "maxItems":10,
+      "items":{
+        "type":"string",
+        "maxLength":100,
+        "pattern":"^\\s?(\\S*\\s*){1,10}$"
       }
     },
     "serviceDefinitionDocument": {

--- a/json_schemas/services-g-cloud-6-saas.json
+++ b/json_schemas/services-g-cloud-6-saas.json
@@ -50,7 +50,7 @@
     "serviceSummary":{
       "type":"string",
       "maxLength":500,
-      "pattern":"^\\s?(\\S*\\s*){1,50}$"
+      "pattern":"^\\s?(?:\\S+\\s+){0,49}\\S+\\s?$"
     },
     "serviceBenefits":{
       "type":"array",
@@ -59,7 +59,7 @@
       "items":{
         "type":"string",
         "maxLength":100,
-        "pattern":"^\\s?(\\S*\\s*){1,10}$"
+        "pattern":"^\\s?(?:\\S+\\s+){0,9}\\S+\\s?$"
       }
     },
     "serviceFeatures":{
@@ -69,7 +69,7 @@
       "items":{
         "type":"string",
         "maxLength":100,
-        "pattern":"^\\s?(\\S*\\s*){1,10}$"
+        "pattern":"^\\s?(?:\\S+\\s+){0,9}\\S+\\s?$"
       }
     },
     "serviceDefinitionDocument": {

--- a/json_schemas/services-g-cloud-6-scs.json
+++ b/json_schemas/services-g-cloud-6-scs.json
@@ -50,7 +50,7 @@
       "serviceSummary":{
         "type":"string",
         "maxLength":500,
-        "pattern":"^\\s?(\\S*\\s*){1,50}$"
+        "pattern":"^\\s?(?:\\S+\\s+){0,49}\\S+\\s?$"
       },
       "serviceBenefits":{
         "type":"array",
@@ -59,7 +59,7 @@
         "items":{
           "type":"string",
           "maxLength":100,
-          "pattern":"^\\s?(\\S*\\s*){1,10}$"
+          "pattern":"^\\s?(?:\\S+\\s+){0,9}\\S+\\s?$"
         }
       },
       "serviceFeatures":{
@@ -69,7 +69,7 @@
         "items":{
           "type":"string",
           "maxLength":100,
-          "pattern":"^\\s?(\\S*\\s*){1,10}$"
+          "pattern":"^\\s?(?:\\S+\\s+){0,9}\\S+\\s?$"
         }
       },
       "serviceDefinitionDocument": {

--- a/json_schemas/services-g-cloud-6-scs.json
+++ b/json_schemas/services-g-cloud-6-scs.json
@@ -42,25 +42,35 @@
             "enum": ["Implementation", "Ongoing support", "Planning", "Testing", "Training"]
          }
       },
-      "serviceName": {
-         "type": "string"
+      "serviceName":{
+        "type":"string",
+        "minLength":1,
+        "maxLength":100
       },
-      "serviceSummary": {
-         "type": "string"
+      "serviceSummary":{
+        "type":"string",
+        "maxLength":500,
+        "pattern":"^\\s?(\\S*\\s*){1,50}$"
       },
-      "serviceBenefits": {
-         "type": "array",
-         "maxItems": 10,
-         "items": {
-            "type": "string"
-         }
+      "serviceBenefits":{
+        "type":"array",
+        "minItems":1,
+        "maxItems":10,
+        "items":{
+          "type":"string",
+          "maxLength":100,
+          "pattern":"^\\s?(\\S*\\s*){1,10}$"
+        }
       },
-      "serviceFeatures": {
-         "type": "array",
-         "maxItems": 10,
-         "items": {
-            "type": "string"
-         }
+      "serviceFeatures":{
+        "type":"array",
+        "minItems":1,
+        "maxItems":10,
+        "items":{
+          "type":"string",
+          "maxLength":100,
+          "pattern":"^\\s?(\\S*\\s*){1,10}$"
+        }
       },
       "serviceDefinitionDocument": {
          "type": "string"

--- a/json_schemas/services-g-cloud-6-scs.json
+++ b/json_schemas/services-g-cloud-6-scs.json
@@ -50,7 +50,7 @@
       "serviceSummary":{
         "type":"string",
         "maxLength":500,
-        "pattern":"^\\s?(?:\\S+\\s+){0,49}\\S+\\s?$"
+        "pattern":"^\\s*(?:\\S+\\s+){0,49}\\S+\\s*$"
       },
       "serviceBenefits":{
         "type":"array",
@@ -59,7 +59,7 @@
         "items":{
           "type":"string",
           "maxLength":100,
-          "pattern":"^\\s?(?:\\S+\\s+){0,9}\\S+\\s?$"
+          "pattern":"^\\s*(?:\\S+\\s+){0,9}\\S+\\s*$"
         }
       },
       "serviceFeatures":{
@@ -69,7 +69,7 @@
         "items":{
           "type":"string",
           "maxLength":100,
-          "pattern":"^\\s?(?:\\S+\\s+){0,9}\\S+\\s?$"
+          "pattern":"^\\s*(?:\\S+\\s+){0,9}\\S+\\s*$"
         }
       },
       "serviceDefinitionDocument": {

--- a/json_schemas/services-g-cloud-7-scs.json
+++ b/json_schemas/services-g-cloud-7-scs.json
@@ -57,7 +57,7 @@
     "serviceSummary":{
       "type":"string",
       "maxLength":500,
-      "pattern":"^\\s?(\\S*\\s*){1,50}$"
+      "pattern":"^\\s?(?:\\S+\\s+){0,49}\\S+\\s?$"
     },
     "serviceBenefits":{
       "type":"array",
@@ -66,7 +66,7 @@
       "items":{
         "type":"string",
         "maxLength":100,
-        "pattern":"^\\s?(\\S*\\s*){1,10}$"
+        "pattern":"^\\s?(?:\\S+\\s+){0,9}\\S+\\s?$"
       }
     },
     "serviceFeatures":{
@@ -76,7 +76,7 @@
       "items":{
         "type":"string",
         "maxLength":100,
-        "pattern":"^\\s?(\\S*\\s*){1,10}$"
+        "pattern":"^\\s?(?:\\S+\\s+){0,9}\\S+\\s?$"
       }
     },
     "minimumContractPeriod":{
@@ -146,12 +146,12 @@
     "supportAvailability":{
       "type":"string",
       "maxLength":200,
-      "pattern":"^\\s?(\\S*\\s*){1,20}$"
+      "pattern":"^\\s?(?:\\S+\\s+){0,19}\\S+\\s?$"
     },
     "supportResponseTime":{
       "type":"string",
       "maxLength":200,
-      "pattern":"^\\s?(\\S*\\s*){1,20}$"
+      "pattern":"^\\s?(?:\\S+\\s+){0,19}\\S+\\s?$"
     },
     "incidentEscalation":{
       "type":"boolean"
@@ -177,7 +177,7 @@
       "items":{
         "type":"string",
         "maxLength":100,
-        "pattern":"^\\s?(\\S*\\s*){1,10}$"
+        "pattern":"^\\s?(?:\\S+\\s+){0,9}\\S+\\s?$"
       }
     }
   },

--- a/json_schemas/services-g-cloud-7-scs.json
+++ b/json_schemas/services-g-cloud-7-scs.json
@@ -57,7 +57,7 @@
     "serviceSummary":{
       "type":"string",
       "maxLength":500,
-      "pattern":"^\\s?(?:\\S+\\s+){0,49}\\S+\\s?$"
+      "pattern":"^\\s*(?:\\S+\\s+){0,49}\\S+\\s*$"
     },
     "serviceBenefits":{
       "type":"array",
@@ -66,7 +66,7 @@
       "items":{
         "type":"string",
         "maxLength":100,
-        "pattern":"^\\s?(?:\\S+\\s+){0,9}\\S+\\s?$"
+        "pattern":"^\\s*(?:\\S+\\s+){0,9}\\S+\\s*$"
       }
     },
     "serviceFeatures":{
@@ -76,7 +76,7 @@
       "items":{
         "type":"string",
         "maxLength":100,
-        "pattern":"^\\s?(?:\\S+\\s+){0,9}\\S+\\s?$"
+        "pattern":"^\\s*(?:\\S+\\s+){0,9}\\S+\\s*$"
       }
     },
     "minimumContractPeriod":{
@@ -146,12 +146,12 @@
     "supportAvailability":{
       "type":"string",
       "maxLength":200,
-      "pattern":"^\\s?(?:\\S+\\s+){0,19}\\S+\\s?$"
+      "pattern":"^\\s*(?:\\S+\\s+){0,19}\\S+\\s*$"
     },
     "supportResponseTime":{
       "type":"string",
       "maxLength":200,
-      "pattern":"^\\s?(?:\\S+\\s+){0,19}\\S+\\s?$"
+      "pattern":"^\\s*(?:\\S+\\s+){0,19}\\S+\\s*$"
     },
     "incidentEscalation":{
       "type":"boolean"
@@ -177,7 +177,7 @@
       "items":{
         "type":"string",
         "maxLength":100,
-        "pattern":"^\\s?(?:\\S+\\s+){0,9}\\S+\\s?$"
+        "pattern":"^\\s*(?:\\S+\\s+){0,9}\\S+\\s*$"
       }
     }
   },

--- a/tests/app/views/test_services.py
+++ b/tests/app/views/test_services.py
@@ -584,8 +584,9 @@ class TestPostService(BaseApplicationTest):
                 content_type='application/json')
 
             assert_equal(response.status_code, 400)
-            assert_in('JSON was not a valid format',
-                      json.loads(response.get_data())['error'])
+            assert_in('Additional properties are not allowed',
+                      "{}".format(
+                          json.loads(response.get_data())['error']['_form']))
 
     def test_invalid_field_value_not_accepted_on_update(self):
         with self.app.app_context():
@@ -599,8 +600,8 @@ class TestPostService(BaseApplicationTest):
                 content_type='application/json')
 
             assert_equal(response.status_code, 400)
-            assert_in('JSON was not a valid format',
-                      json.loads(response.get_data())['error'])
+            assert_in("'per Truth' is not one of",
+                      json.loads(response.get_data())['error']['priceUnit'])
 
     def test_updated_service_is_archived_right_away(self):
         with self.app.app_context():

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -308,6 +308,15 @@ def test_invalid_url_field_has_validation_error():
     assert "'not_a_url' is not" in errs['serviceDefinitionDocumentURL']
 
 
+def test_too_many_words_causes_validation_error():
+    data = load_example_listing("G7-SCS")
+    data.update({'serviceBenefits': ['more than ten words 5 6 7 8 9 10 11']})
+    errs = get_validation_errors("services-g-cloud-7-scs", data)
+    print("{}".format(errs['serviceBenefits']))
+    assert "'more than ten words 5 6 7 8 9 10 11' does not match" \
+           in errs['serviceBenefits']
+
+
 def assert_example(name, result, expected):
     assert_equal(result, expected)
 


### PR DESCRIPTION
~~NOTE: This PR is branched from the following (to preserve schema filename changes), which should be reviewed and merged before this one (only the final two three commits on this branch are new to this PR): https://github.com/alphagov/digitalmarketplace-api/pull/156~~

 This is the API end of the following story: https://www.pivotaltracker.com/story/show/97502388

In order to display validation errors on the supplier frontend the API needs to return per-field validation errors. The validation rules added to the schemas in this PR are on the supplier-editable fields only.

I have tested the import of G4 and G5 services against this branch with the latest dump data and the import runs fine with the additional validation rules in the G5 schema here.