### PR TITLE
Api updates for supplier a to z

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -26,7 +26,7 @@ def list_suppliers():
     suppliers = Supplier.query.order_by(Supplier.name)
 
     if prefix:
-        if prefix == 'other':
+        if prefix == '123':
             suppliers = suppliers.filter(
                 Supplier.name.op('~')('^[^A-Za-z]'))
         else:

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -70,7 +70,6 @@ def list_suppliers():
         abort(400, 'invalid framework')
 
 
-
 @main.route('/suppliers/<int:supplier_id>', methods=['GET'])
 def get_supplier(supplier_id):
     supplier = Supplier.query.filter(

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -28,15 +28,14 @@ def list_suppliers():
     if framework:
         is_valid_string_or_400(framework)
 
-    active_services = Service.query.join(
-        Service.framework
-    ).filter(
-        Framework.status == 'live',
-        Framework.framework == framework,
-        Service.status == 'published'
-    ).distinct('supplier_id').subquery()
+        active_services = Service.query.join(
+            Service.framework
+        ).filter(
+            Framework.status == 'live',
+            Framework.framework == framework,
+            Service.status == 'published'
+        ).distinct('supplier_id').subquery()
 
-    if framework:
         suppliers = Supplier.query.join(
             active_services,
             Supplier.supplier_id == active_services.c.supplier_id

--- a/app/validation.py
+++ b/app/validation.py
@@ -198,15 +198,11 @@ def is_valid_service_id(service_id):
     :return True|False:
     """
 
-    regex_match_valid_service_id = r"^[A-z0-9-]{%s,%s}$" % (
+    return is_valid_string(
+        service_id,
         MINIMUM_SERVICE_ID_LENGTH,
         MAXIMUM_SERVICE_ID_LENGTH
     )
-
-    if re.search(regex_match_valid_service_id, service_id):
-        return True
-
-    return False
 
 
 def is_valid_service_id_or_400(service_id):
@@ -226,3 +222,20 @@ def is_valid_date(date, default_format=DATE_FORMAT):
 
 def is_valid_acknowledged_state(acknowledged):
     return acknowledged in ['all', 'true', 'false']
+
+
+def is_valid_string_or_400(string):
+    if not is_valid_string(string):
+        abort(400, "invalid value {}".format(string))
+
+
+def is_valid_string(string, minlength=1, maxlength=255):
+    regex_match_valid_service_id = r"^[A-z0-9-]{%s,%s}$" % (
+        minlength,
+        maxlength
+    )
+
+    if re.search(regex_match_valid_service_id, string):
+        return True
+
+    return False

--- a/config.py
+++ b/config.py
@@ -13,7 +13,6 @@ class Config:
     ALLOW_EXPLORER = True
     AUTH_REQUIRED = True
     DM_HTTP_PROTO = 'http'
-
     # Logging
     DM_LOG_LEVEL = 'DEBUG'
     DM_APP_NAME = 'api'

--- a/tests/app/views/test_suppliers.py
+++ b/tests/app/views/test_suppliers.py
@@ -128,7 +128,7 @@ class TestListSuppliers(BaseApplicationTest):
             )
             db.session.commit()
 
-            response = self.client.get('/suppliers?prefix=other')
+            response = self.client.get('/suppliers?prefix=123')
 
             data = json.loads(response.get_data())
             assert_equal(200, response.status_code)

--- a/tests/app/views/test_suppliers.py
+++ b/tests/app/views/test_suppliers.py
@@ -201,6 +201,10 @@ class TestListSuppliersOnFramework(BaseApplicationTest):
         assert_equal(1, len(data['suppliers']))
         assert_equal('Active', data['suppliers'][0]['name'])
 
+    def test_should_return_no_suppliers_no_framework(self):
+        response = self.client.get('/suppliers?framework=bad')
+        assert_equal(400, response.status_code)
+
     def test_should_return_all_suppliers_if_no_framework(self):
         response = self.client.get('/suppliers')
         assert_equal(200, response.status_code)

--- a/tests/app/views/test_suppliers.py
+++ b/tests/app/views/test_suppliers.py
@@ -107,25 +107,16 @@ class TestListSuppliers(BaseApplicationTest):
 
     def test_query_string_prefix_returns_none(self):
         response = self.client.get('/suppliers?prefix=canada')
-        assert_equal(404, response.status_code)
-
-    def test_query_string_prefix_returns_single(self):
-        response = self.client.get('/suppliers?prefix=supplier%201')
-
-        data = json.loads(response.get_data())
         assert_equal(200, response.status_code)
-        assert_equal(1, len(data['suppliers']))
-        assert_equal(1, data['suppliers'][0]['id'])
-        assert_equal(
-            u"Supplier 1",
-            data['suppliers'][0]['name']
-        )
+        data = json.loads(response.get_data())
+        assert_equal(0, len(data['suppliers']))
 
     def test_other_prefix_returns_non_alphanumeric_suppliers(self):
         with self.app.app_context():
             db.session.add(
                 Supplier(supplier_id=999, name=u"123 Supplier")
             )
+            self.setup_dummy_service(service_id=123, supplier_id=999)
             db.session.commit()
 
             response = self.client.get('/suppliers?prefix=123')
@@ -171,6 +162,50 @@ class TestListSuppliers(BaseApplicationTest):
         response = self.client.get('/suppliers?page=0')
 
         assert_equal(response.status_code, 404)
+
+
+class TestListSuppliersOnFramework(BaseApplicationTest):
+
+    def setup(self):
+        super(TestListSuppliersOnFramework, self).setup()
+
+        with self.app.app_context():
+            db.session.add(
+                Supplier(supplier_id=1, name=u"Active")
+            )
+            db.session.add(
+                Supplier(supplier_id=2, name=u"Inactive Framework")
+            )
+            db.session.add(
+                Supplier(supplier_id=3, name=u"Unpublished Service")
+            )
+            self.setup_dummy_service(
+                service_id=1, supplier_id=1
+            )
+            self.setup_dummy_service(
+                service_id=2, supplier_id=2, framework_id=2
+            )
+            self.setup_dummy_service(
+                service_id=3, supplier_id=3, status='enabled'
+            )
+            db.session.commit()
+
+    def test_invalid_framework_returns_400(self):
+        response = self.client.get('/suppliers?framework=invalid!')
+        assert_equal(400, response.status_code)
+
+    def test_should_return_suppliers_on_framework(self):
+        response = self.client.get('/suppliers?framework=gcloud')
+        assert_equal(200, response.status_code)
+        data = json.loads(response.get_data())
+        assert_equal(1, len(data['suppliers']))
+        assert_equal('Active', data['suppliers'][0]['name'])
+
+    def test_should_return_all_suppliers_if_no_framework(self):
+        response = self.client.get('/suppliers')
+        assert_equal(200, response.status_code)
+        data = json.loads(response.get_data())
+        assert_equal(3, len(data['suppliers']))
 
 
 class TestPutSupplier(BaseApplicationTest, JSONUpdateTestMixin):

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -8,7 +8,8 @@ from jsonschema import validate, SchemaError, ValidationError
 
 from app.validation import detect_framework, \
     validates_against_schema, is_valid_service_id, \
-    is_valid_date, is_valid_acknowledged_state, get_validation_errors
+    is_valid_date, is_valid_acknowledged_state, get_validation_errors, \
+    is_valid_string
 
 EXAMPLE_LISTING_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__),
                                                     '..', 'example_listings'))
@@ -55,6 +56,24 @@ def test_for_valid_service_id():
 
     for example, expected in cases:
         yield assert_equal, is_valid_service_id(example), expected, example
+
+
+def test_for_valid_string():
+    cases = [
+        ("valid-string", 1, 200, True),
+        ("tooshort", 100, 200, False),
+        ("toolong", 1, 1, False),
+        ("1234567890123456", 1, 200, True),
+        ("THIS-IS-VALID-id", 1, 200, True),
+        ("invalid%chars&here", 1, 200, False),
+        ("no spaces", 1, 200, False),
+        ("no\nnewlines", 1, 200, False),
+        ("123-and-strings", 1, 200, True),
+    ]
+
+    for example, min, max, expected in cases:
+        yield assert_equal, is_valid_string(
+            example, min, max), expected, example
 
 
 def test_all_schemas_are_valid():


### PR DESCRIPTION
Adds the ability to get suppliers on a specific framework

- fetch suppliers now has an additional param "framework"

- if supplied the query is restricted to only suppliers that have a published service on that framework

- additionally framework must be active

- Framework validates as a string

- Uses enum to check is a valid value before using the query

- Query is a subselect