### PR TITLE
Change import to respect original dates

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -320,6 +320,7 @@ class ServiceTableMixin(object):
             'supplierName': self.supplier.name,
             'frameworkName': self.framework.name,
             'updatedAt': self.updated_at.strftime(DATETIME_FORMAT),
+            'createdAt': self.created_at.strftime(DATETIME_FORMAT),
             'status': self.status
         })
 

--- a/example_listings/G6-IaaS.json
+++ b/example_listings/G6-IaaS.json
@@ -3,10 +3,7 @@
    "supplierId": 1,
    "lot": "IaaS",
    "title": "My Iaas Service",
-   "lastUpdated": "2014-12-23T14:46:17Z",
-   "lastUpdatedByEmail": "supplier@digital.cabinet-office.gov.uk",
-   "lastCompleted": "2014-12-23T14:46:22Z",
-   "lastCompletedByEmail": "supplier@digital.cabinet-office.gov.uk",
+   "createdAt": "2014-12-23T14:46:22Z",
    "serviceTypes": [
       "Compute",
       "Storage"

--- a/example_listings/G6-PaaS.json
+++ b/example_listings/G6-PaaS.json
@@ -3,10 +3,7 @@
    "supplierId": 1,
    "lot": "PaaS",
    "title": "\"My new PaaS\" Service with \"Quotes\"",
-   "lastUpdated": "2014-12-22T17:32:31Z",
-   "lastUpdatedByEmail": "supplier@digital.cabinet-office.gov.uk",
-   "lastCompleted": "2014-12-22T17:32:37Z",
-   "lastCompletedByEmail": "supplier@digital.cabinet-office.gov.uk",
+   "createdAt": "2014-12-22T17:32:37Z",
    "serviceBenefits": [
       "Benefit 1"
    ],

--- a/example_listings/G6-SCS.json
+++ b/example_listings/G6-SCS.json
@@ -3,10 +3,7 @@
    "supplierId": 1,
    "lot": "SCS",
    "title": "Finally, an SCS \"Service\u0027: ]",
-   "lastUpdated": "2014-12-23T14:53:17Z",
-   "lastUpdatedByEmail": "supplier@digital.cabinet-office.gov.uk",
-   "lastCompleted": "2014-12-23T14:53:20Z",
-   "lastCompletedByEmail": "supplier@digital.cabinet-office.gov.uk",
+   "createdAt": "2014-12-23T14:53:20Z",
    "serviceTypes": [
       "Implementation",
       "Ongoing support",

--- a/example_listings/G6-SaaS.json
+++ b/example_listings/G6-SaaS.json
@@ -3,10 +3,7 @@
    "supplierId": 1,
    "lot": "SaaS",
    "title": "A SaaS with lots of options",
-   "lastUpdated": "2014-12-23T14:51:15Z",
-   "lastUpdatedByEmail": "supplier@digital.cabinet-office.gov.uk",
-   "lastCompleted": "2014-12-23T14:51:19Z",
-   "lastCompletedByEmail": "supplier@digital.cabinet-office.gov.uk",
+   "createdAt": "2014-12-23T14:51:19Z",
    "serviceTypes": [
       "Accounting and finance",
       "Business intelligence and analytics",

--- a/json_schemas/services-g-cloud-6-iaas.json
+++ b/json_schemas/services-g-cloud-6-iaas.json
@@ -20,19 +20,9 @@
     "title": {
       "type": "string"
     },
-    "lastUpdated": {
+    "createdAt": {
       "type": "string",
       "format": "date-time"
-    },
-    "lastUpdatedByEmail": {
-      "type": "string"
-    },
-    "lastCompleted": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "lastCompletedByEmail": {
-      "type": "string"
     },
     "serviceTypes": {
       "type": "array",
@@ -853,10 +843,6 @@
     "supplierId",
     "lot",
     "title",
-    "lastUpdated",
-    "lastUpdatedByEmail",
-    "lastCompleted",
-    "lastCompletedByEmail",
     "serviceTypes",
     "serviceName",
     "serviceSummary",

--- a/json_schemas/services-g-cloud-6-paas.json
+++ b/json_schemas/services-g-cloud-6-paas.json
@@ -20,19 +20,9 @@
     "title": {
       "type": "string"
     },
-    "lastUpdated": {
+    "createdAt": {
       "type": "string",
       "format": "date-time"
-    },
-    "lastUpdatedByEmail": {
-      "type": "string"
-    },
-    "lastCompleted": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "lastCompletedByEmail": {
-      "type": "string"
     },
     "serviceName": {
       "type": "string"
@@ -845,10 +835,6 @@
     "supplierId",
     "lot",
     "title",
-    "lastUpdated",
-    "lastUpdatedByEmail",
-    "lastCompleted",
-    "lastCompletedByEmail",
     "serviceName",
     "serviceSummary",
     "serviceBenefits",

--- a/json_schemas/services-g-cloud-6-saas.json
+++ b/json_schemas/services-g-cloud-6-saas.json
@@ -20,19 +20,9 @@
     "title": {
       "type": "string"
     },
-    "lastUpdated": {
+    "createdAt": {
       "type": "string",
       "format": "date-time"
-    },
-    "lastUpdatedByEmail": {
-      "type": "string"
-    },
-    "lastCompleted": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "lastCompletedByEmail": {
-      "type": "string"
     },
     "serviceTypes": {
       "type": "array",
@@ -728,10 +718,6 @@
     "supplierId",
     "lot",
     "title",
-    "lastUpdated",
-    "lastUpdatedByEmail",
-    "lastCompleted",
-    "lastCompletedByEmail",
     "serviceTypes",
     "serviceName",
     "serviceSummary",

--- a/json_schemas/services-g-cloud-6-scs.json
+++ b/json_schemas/services-g-cloud-6-scs.json
@@ -20,19 +20,9 @@
       "title": {
          "type": "string"
       },
-      "lastUpdated": {
+      "createdAt": {
          "type": "string",
          "format": "date-time"
-      },
-      "lastUpdatedByEmail": {
-         "type": "string"
-      },
-      "lastCompleted": {
-         "type": "string",
-         "format": "date-time"
-      },
-      "lastCompletedByEmail": {
-         "type": "string"
       },
       "serviceTypes": {
          "type": "array",
@@ -150,10 +140,6 @@
       "supplierId",
       "lot",
       "title",
-      "lastUpdated",
-      "lastUpdatedByEmail",
-      "lastCompleted",
-      "lastCompletedByEmail",
       "serviceTypes",
       "serviceName",
       "serviceSummary",

--- a/scripts/import-g4-g5.py
+++ b/scripts/import-g4-g5.py
@@ -43,8 +43,7 @@ class ServicePutter(object):
         except ValueError:
             print("Skipping {}: could not get ID".format(service_json))
             return service_id, None
-        data = {'update_details': {'updated_by': getpass.getuser(),
-                                   'update_reason': 'service import'},
+        data = {'update_details': {'updated_by': getpass.getuser()},
                 'services': service_json}
         url = '{}/{}'.format(self.endpoint, data['services']['id'])
         response = requests.put(

--- a/scripts/import.py
+++ b/scripts/import.py
@@ -56,9 +56,22 @@ class ServicePutter(object):
             except ValueError:
                 print("Skipping {}: not a valid JSON file".format(file_path))
                 return file_path, None
-        data = {'update_details': {'updated_by': getpass.getuser(),
-                                   'update_reason': 'service import'},
-                'services': data}
+
+        # set the createdAt date from the lastcompleted field
+        data['createdAt'] = data['lastCompleted']
+        # updated by user who last completed the service
+        updater_json = {'updated_by': data['lastCompletedByEmail']}
+
+        # clean out unused metadata
+        del data['lastCompleted']
+        del data['lastCompletedByEmail']
+        del data['lastUpdated']
+        del data['lastUpdatedByEmail']
+
+        data = {
+            'update_details': updater_json,
+            'services': data
+        }
         url = '{}/{}'.format(self.endpoint, data['services']['id'])
         response = requests.put(
             url,

--- a/scripts/import_services_from_api.py
+++ b/scripts/import_services_from_api.py
@@ -111,9 +111,9 @@ def do_index(api_url, api_access_token, source_api_url,
             status = status and result
             print_progress(counter, start_time)
 
+    print_progress(counter, start_time)
     return status
 
-    print_progress(counter, start_time)
 
 if __name__ == "__main__":
     arguments = docopt(__doc__)

--- a/scripts/import_services_from_api.py
+++ b/scripts/import_services_from_api.py
@@ -41,11 +41,27 @@ def request_services(api_url, api_access_token, page=1):
         for service in services_page['services']:
             yield service
 
-        if services_page['links'].get('next'):
-            page += 1
+        if 'links' in services_page:
+            links = services_page['links']
+
+            if isinstance(links, list):
+                found = False
+                for link in links:
+                    if 'rel' in link:
+                        if link['rel'] == 'next':
+                            page += 1
+                            found = True
+
+                if not found:
+                    return
+
+            else:
+                if 'next' in links:
+                    page += 1
+                else:
+                    return
         else:
             return
-
 
 def print_progress(counter, start_time):
     if counter % 100 == 0:

--- a/scripts/import_services_from_api.py
+++ b/scripts/import_services_from_api.py
@@ -63,6 +63,7 @@ def request_services(api_url, api_access_token, page=1):
         else:
             return
 
+
 def print_progress(counter, start_time):
     if counter % 100 == 0:
         time_delta = datetime.utcnow() - start_time

--- a/scripts/import_services_from_api.py
+++ b/scripts/import_services_from_api.py
@@ -133,7 +133,6 @@ def do_index(api_url, api_access_token, source_api_url,
             counter += 1
             status = status and result
             print_progress(counter, start_time)
-        services = None
 
     print_progress(counter, start_time)
     return status

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -151,6 +151,14 @@ class BaseApplicationTest(object):
         with open(file_path) as f:
             return json.load(f)
 
+    def string_to_time_to_string(self, value, from_format, to_format):
+        return datetime.strptime(
+            value, from_format).strftime(to_format)
+
+    def string_to_time(self, value, from_format):
+        return datetime.strptime(
+            value, from_format)
+
 
 class JSONUpdateTestMixin(object):
     """

--- a/tests/app/views/test_services.py
+++ b/tests/app/views/test_services.py
@@ -1318,8 +1318,6 @@ class TestPutService(BaseApplicationTest, JSONUpdateTestMixin):
 
     @mock.patch('app.search_api_client')
     def test_add_a_new_service(self, search_api_client):
-        assert_equal.im_class.maxDiff = None
-
         with self.app.app_context():
             search_api_client.index.return_value = "bar"
 


### PR DESCRIPTION
Services no longer have dates in the JSON data column.

- createdAt can be set in submitted JSON to PUT endpoint
	- this is not  a required field
	- if present it is used as created_at data on the model
	- if not present we use utcnow instead
	- not persisted in the JSON data column

- Removed from the JSON Schemas for G6
	- lastUpdated
	- lastUpdatedByEmail
	- lastCompleted
	- lastCompletedByEmail

- Replaced with createdAt (See above)
- lastUpdated now set as utcnow() on the model in the last_updated column
- lastUpdatedByEmail - not used
- lastCompletedByEmail should be set as the updatedBy field in the importer - this will be used in the creation audit event