### PR TITLE
Generate new service ids

### DIFF
--- a/app/main/views/drafts.py
+++ b/app/main/views/drafts.py
@@ -12,7 +12,7 @@ from ...validation import is_valid_service_id_or_400
 from ...models import Service, DraftService, Supplier, AuditEvent, Framework
 from ...service_utils import validate_and_return_updater_request, \
     update_and_validate_service, index_service, validate_service, \
-    commit_and_archive_service
+    commit_and_archive_service, create_service_from_draft
 from ...draft_utils import validate_and_return_draft_request, \
     get_draft_validation_errors
 
@@ -223,8 +223,7 @@ def publish_draft_service(draft_id):
             draft.data)
 
     else:
-        service_from_draft = Service.create_from_draft(draft, "enabled")
-        validate_service(service_from_draft)
+        service_from_draft = create_service_from_draft(draft, "enabled")
 
     commit_and_archive_service(service_from_draft, update_details,
                                AuditTypes.publish_draft_service,

--- a/app/models.py
+++ b/app/models.py
@@ -1,4 +1,4 @@
-import uuid
+import random
 from datetime import datetime
 from flask_sqlalchemy import BaseQuery
 
@@ -526,7 +526,4 @@ def filter_null_value_fields(obj):
 
 
 def generate_new_service_id():
-    # TODO: Decide what we want G7 service IDs to look like and implement
-    u = uuid.uuid4()
-    id = str(u.int)[-16:]
-    return id
+    return str(random.randint(7e15, 8e15-1))


### PR DESCRIPTION
When 'publishing' a draft service we have to generate a service ID. This commit handles collisions by attempting to add the service in a nested transaction and then trying again, with a new generated service ID.

See:
http://docs.sqlalchemy.org/en/rel_1_0/orm/session_transaction.html#using-savepoint

After 5 attempts the IntegrityError is just raised and will result in a 500.

New service IDs for G7 are now generated as a random 16 digit number between 7e15 and 8e15. Collisions are handled and retries made.
