### PR TITLE
Update draft before validating

### DIFF
--- a/app/main/views/drafts.py
+++ b/app/main/views/drafts.py
@@ -77,13 +77,12 @@ def edit_draft_service(draft_id):
         DraftService.id == draft_id
     ).first_or_404()
 
-    errs = get_draft_validation_errors(update_json,
+    draft.update_from_json(update_json)
+    errs = get_draft_validation_errors(draft.data,
                                        draft.data['lot'],
                                        framework_id=draft.framework_id)
     if errs:
-        return jsonify(errors=errs), 400
-
-    draft.update_from_json(update_json)
+        abort(400, errs)
 
     audit = AuditEvent(
         audit_type=AuditTypes.update_draft_service,

--- a/tests/app/views/test_drafts.py
+++ b/tests/app/views/test_drafts.py
@@ -340,8 +340,7 @@ class TestDraftServices(BaseApplicationTest):
             content_type='application/json')
         data2 = json.loads(res2.get_data())
         assert_equal(res2.status_code, 400)
-        assert_in("'Bad Type' is not one of", data2['errors']['serviceTypes'])
-        # 'Invalid value' is not one of
+        assert_in("'Bad Type' is not one of", data2['error']['serviceTypes'])
 
     def test_validation_errors_returned_for_invalid_update_of_copy(self):
         res = self.client.put(
@@ -362,8 +361,8 @@ class TestDraftServices(BaseApplicationTest):
             content_type='application/json')
         data = json.loads(res.get_data())
         assert_equal(res.status_code, 400)
-        assert_in("'badField' was unexpected", str(data['errors']['_form']))
-        assert_in("'chickens' is not one of", data['errors']['priceUnit'])
+        assert_in("'badField' was unexpected", str(data['error']['_form']))
+        assert_in("'chickens' is not one of", data['error']['priceUnit'])
 
     def test_should_create_draft_from_existing_service(self):
         res = self.client.put(


### PR DESCRIPTION
The logic for validation of drafts was the wrong way round - need to update the existing draft before validating, so this swaps the order of two methods.

Also changes the way the errors are returned to match the way validation errors for live servcie updates are returned.