### PR TITLE
[#98556000] Fix service import errors

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -9,7 +9,7 @@ from ...models import ArchivedService, Service, Supplier, Framework
 from sqlalchemy import asc
 from ...validation import detect_framework_or_400, is_valid_service_id_or_400
 from ...utils import url_for, pagination_links, \
-    drop_foreign_fields, display_list
+    drop_foreign_fields, display_list, strip_whitespace_from_data
 
 from ...service_utils import (
     validate_and_return_service_request,
@@ -164,7 +164,7 @@ def import_service(service_id):
         service_json,
         ['supplierName', 'links', 'frameworkName']
     )
-
+    service_data = strip_whitespace_from_data(service_data)
     framework = detect_framework_or_400(service_data)
     service_data = drop_foreign_fields(service_data, ['id'])
 

--- a/app/models.py
+++ b/app/models.py
@@ -13,7 +13,7 @@ from sqlalchemy_utils import generic_relationship
 from dmutils.formats import DATETIME_FORMAT
 
 from . import db
-from .utils import link, url_for
+from .utils import link, url_for, strip_whitespace_from_data
 
 
 class Framework(db.Model):
@@ -356,10 +356,7 @@ class ServiceTableMixin(object):
         data.pop('frameworkName', None)
         data.pop('status', None)
         data.pop('links', None)
-        for key, value in data.items():
-            if isinstance(value, list):
-                # Remove empty items from lists
-                data[key] = list(filter(None, value))
+        data = strip_whitespace_from_data(data)
         current_data = dict(self.data.items())
         current_data.update(data)
         self.data = current_data

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,5 +1,6 @@
 from flask import url_for as base_url_for
 from flask import abort, request
+from six import string_types
 
 
 def link(rel, href):
@@ -65,3 +66,16 @@ def display_list(l):
     else:
         # oxford comma
         return ", ".join(l[:-1]) + ", and " + l[-1]
+
+
+def strip_whitespace_from_data(data):
+    for key, value in data.items():
+        if isinstance(value, list):
+            # Strip whitespace and remove empty items from lists
+            data[key] = list(
+                filter(None, map((lambda x: x.strip()), value))
+            )
+        elif isinstance(value, string_types):
+            # Strip whitespace from strings
+            data[key] = value.strip()
+    return data

--- a/json_schemas/services-g-cloud-5.json
+++ b/json_schemas/services-g-cloud-5.json
@@ -36,7 +36,7 @@
       "items":{
         "type":"string",
         "maxLength":100,
-        "pattern":"^\\s*(?:\\S+\\s+){0,9}\\S+\\s*$"
+        "pattern":"^(?:\\S+\\s+){0,9}\\S+$"
       }
     },
     "serviceFeatures":{
@@ -46,7 +46,7 @@
       "items":{
         "type":"string",
         "maxLength":100,
-        "pattern":"^\\s*(?:\\S+\\s+){0,9}\\S+\\s*$"
+        "pattern":"^(?:\\S+\\s+){0,9}\\S+$"
       }
     },
     "serviceDefinitionDocumentURL": {

--- a/json_schemas/services-g-cloud-5.json
+++ b/json_schemas/services-g-cloud-5.json
@@ -35,7 +35,7 @@
       "maxItems":10,
       "items":{
         "type":"string",
-        "maxLength":100,
+        "maxLength":120,
         "pattern":"^(?:\\S+\\s+){0,9}\\S+$"
       }
     },
@@ -45,7 +45,7 @@
       "maxItems":10,
       "items":{
         "type":"string",
-        "maxLength":100,
+        "maxLength":120,
         "pattern":"^(?:\\S+\\s+){0,9}\\S+$"
       }
     },

--- a/json_schemas/services-g-cloud-6-iaas.json
+++ b/json_schemas/services-g-cloud-6-iaas.json
@@ -48,7 +48,7 @@
       "maxItems":10,
       "items":{
         "type":"string",
-        "maxLength":100,
+        "maxLength":120,
         "pattern":"^(?:\\S+\\s+){0,9}\\S+$"
       }
     },
@@ -58,7 +58,7 @@
       "maxItems":10,
       "items":{
         "type":"string",
-        "maxLength":100,
+        "maxLength":120,
         "pattern":"^(?:\\S+\\s+){0,9}\\S+$"
       }
     },

--- a/json_schemas/services-g-cloud-6-iaas.json
+++ b/json_schemas/services-g-cloud-6-iaas.json
@@ -40,7 +40,7 @@
     "serviceSummary":{
       "type":"string",
       "maxLength":500,
-      "pattern":"^\\s*(?:\\S+\\s+){0,49}\\S+\\s*$"
+      "pattern":"^(?:\\S+\\s+){0,49}\\S+$"
     },
     "serviceBenefits":{
       "type":"array",
@@ -49,7 +49,7 @@
       "items":{
         "type":"string",
         "maxLength":100,
-        "pattern":"^\\s*(?:\\S+\\s+){0,9}\\S+\\s*$"
+        "pattern":"^(?:\\S+\\s+){0,9}\\S+$"
       }
     },
     "serviceFeatures":{
@@ -59,7 +59,7 @@
       "items":{
         "type":"string",
         "maxLength":100,
-        "pattern":"^\\s*(?:\\S+\\s+){0,9}\\S+\\s*$"
+        "pattern":"^(?:\\S+\\s+){0,9}\\S+$"
       }
     },
     "serviceDefinitionDocument": {

--- a/json_schemas/services-g-cloud-6-paas.json
+++ b/json_schemas/services-g-cloud-6-paas.json
@@ -40,7 +40,7 @@
       "maxItems":10,
       "items":{
         "type":"string",
-        "maxLength":100,
+        "maxLength":120,
         "pattern":"^(?:\\S+\\s+){0,9}\\S+$"
       }
     },
@@ -50,7 +50,7 @@
       "maxItems":10,
       "items":{
         "type":"string",
-        "maxLength":100,
+        "maxLength":120,
         "pattern":"^(?:\\S+\\s+){0,9}\\S+$"
       }
     },

--- a/json_schemas/services-g-cloud-6-paas.json
+++ b/json_schemas/services-g-cloud-6-paas.json
@@ -32,7 +32,7 @@
     "serviceSummary":{
       "type":"string",
       "maxLength":500,
-      "pattern":"^\\s*(?:\\S+\\s+){0,49}\\S+\\s*$"
+      "pattern":"^(?:\\S+\\s+){0,49}\\S+$"
     },
     "serviceBenefits":{
       "type":"array",
@@ -41,7 +41,7 @@
       "items":{
         "type":"string",
         "maxLength":100,
-        "pattern":"^\\s*(?:\\S+\\s+){0,9}\\S+\\s*$"
+        "pattern":"^(?:\\S+\\s+){0,9}\\S+$"
       }
     },
     "serviceFeatures":{
@@ -51,7 +51,7 @@
       "items":{
         "type":"string",
         "maxLength":100,
-        "pattern":"^\\s*(?:\\S+\\s+){0,9}\\S+\\s*$"
+        "pattern":"^(?:\\S+\\s+){0,9}\\S+$"
       }
     },
     "serviceDefinitionDocument": {

--- a/json_schemas/services-g-cloud-6-saas.json
+++ b/json_schemas/services-g-cloud-6-saas.json
@@ -48,7 +48,7 @@
       "maxItems":10,
       "items":{
         "type":"string",
-        "maxLength":100,
+        "maxLength":120,
         "pattern":"^(?:\\S+\\s+){0,9}\\S+$"
       }
     },
@@ -58,7 +58,7 @@
       "maxItems":10,
       "items":{
         "type":"string",
-        "maxLength":100,
+        "maxLength":120,
         "pattern":"^(?:\\S+\\s+){0,9}\\S+$"
       }
     },

--- a/json_schemas/services-g-cloud-6-saas.json
+++ b/json_schemas/services-g-cloud-6-saas.json
@@ -40,7 +40,7 @@
     "serviceSummary":{
       "type":"string",
       "maxLength":500,
-      "pattern":"^\\s*(?:\\S+\\s+){0,49}\\S+\\s*$"
+      "pattern":"^(?:\\S+\\s+){0,49}\\S+$"
     },
     "serviceBenefits":{
       "type":"array",
@@ -49,7 +49,7 @@
       "items":{
         "type":"string",
         "maxLength":100,
-        "pattern":"^\\s*(?:\\S+\\s+){0,9}\\S+\\s*$"
+        "pattern":"^(?:\\S+\\s+){0,9}\\S+$"
       }
     },
     "serviceFeatures":{
@@ -59,7 +59,7 @@
       "items":{
         "type":"string",
         "maxLength":100,
-        "pattern":"^\\s*(?:\\S+\\s+){0,9}\\S+\\s*$"
+        "pattern":"^(?:\\S+\\s+){0,9}\\S+$"
       }
     },
     "serviceDefinitionDocument": {

--- a/json_schemas/services-g-cloud-6-scs.json
+++ b/json_schemas/services-g-cloud-6-scs.json
@@ -48,7 +48,7 @@
         "maxItems":10,
         "items":{
           "type":"string",
-          "maxLength":100,
+          "maxLength":120,
           "pattern":"^(?:\\S+\\s+){0,9}\\S+$"
         }
       },
@@ -58,7 +58,7 @@
         "maxItems":10,
         "items":{
           "type":"string",
-          "maxLength":100,
+          "maxLength":120,
           "pattern":"^(?:\\S+\\s+){0,9}\\S+$"
         }
       },

--- a/json_schemas/services-g-cloud-6-scs.json
+++ b/json_schemas/services-g-cloud-6-scs.json
@@ -40,7 +40,7 @@
       "serviceSummary":{
         "type":"string",
         "maxLength":500,
-        "pattern":"^\\s*(?:\\S+\\s+){0,49}\\S+\\s*$"
+        "pattern":"^(?:\\S+\\s+){0,49}\\S+$"
       },
       "serviceBenefits":{
         "type":"array",
@@ -49,7 +49,7 @@
         "items":{
           "type":"string",
           "maxLength":100,
-          "pattern":"^\\s*(?:\\S+\\s+){0,9}\\S+\\s*$"
+          "pattern":"^(?:\\S+\\s+){0,9}\\S+$"
         }
       },
       "serviceFeatures":{
@@ -59,7 +59,7 @@
         "items":{
           "type":"string",
           "maxLength":100,
-          "pattern":"^\\s*(?:\\S+\\s+){0,9}\\S+\\s*$"
+          "pattern":"^(?:\\S+\\s+){0,9}\\S+$"
         }
       },
       "serviceDefinitionDocument": {

--- a/json_schemas/services-g-cloud-7-scs.json
+++ b/json_schemas/services-g-cloud-7-scs.json
@@ -57,7 +57,7 @@
     "serviceSummary":{
       "type":"string",
       "maxLength":500,
-      "pattern":"^\\s*(?:\\S+\\s+){0,49}\\S+\\s*$"
+      "pattern":"^(?:\\S+\\s+){0,49}\\S+$"
     },
     "serviceBenefits":{
       "type":"array",
@@ -66,7 +66,7 @@
       "items":{
         "type":"string",
         "maxLength":100,
-        "pattern":"^\\s*(?:\\S+\\s+){0,9}\\S+\\s*$"
+        "pattern":"^(?:\\S+\\s+){0,9}\\S+$"
       }
     },
     "serviceFeatures":{
@@ -76,7 +76,7 @@
       "items":{
         "type":"string",
         "maxLength":100,
-        "pattern":"^\\s*(?:\\S+\\s+){0,9}\\S+\\s*$"
+        "pattern":"^(?:\\S+\\s+){0,9}\\S+$"
       }
     },
     "minimumContractPeriod":{
@@ -146,12 +146,12 @@
     "supportAvailability":{
       "type":"string",
       "maxLength":200,
-      "pattern":"^\\s*(?:\\S+\\s+){0,19}\\S+\\s*$"
+      "pattern":"^(?:\\S+\\s+){0,19}\\S+$"
     },
     "supportResponseTime":{
       "type":"string",
       "maxLength":200,
-      "pattern":"^\\s*(?:\\S+\\s+){0,19}\\S+\\s*$"
+      "pattern":"^(?:\\S+\\s+){0,19}\\S+$"
     },
     "incidentEscalation":{
       "type":"boolean"
@@ -177,7 +177,7 @@
       "items":{
         "type":"string",
         "maxLength":100,
-        "pattern":"^\\s*(?:\\S+\\s+){0,9}\\S+\\s*$"
+        "pattern":"^(?:\\S+\\s+){0,9}\\S+$"
       }
     }
   },


### PR DESCRIPTION
Addresses this bug: https://www.pivotaltracker.com/story/show/98556000

By stripping whitespace and removing empty items from lists we avoid validation errors for list items.
By stripping whitespace from string values we make the word-count regular expressions nicer, and don't have superfluous whitespace around stuff.
By allowing features and benefits to be over 100 characters (I have made the limit 120, which should be more than plenty) we avoid import errors for the existing services that somehow managed to get more than 100 characters into their features.