### PR TITLE
Add a route to list users (optionally by `supplier_id`)

### DIFF
--- a/app/main/views/audits.py
+++ b/app/main/views/audits.py
@@ -4,7 +4,7 @@ from ...models import AuditEvent
 from sqlalchemy import asc, Date, cast
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.sql.expression import true, false
-from ...utils import pagination_links
+from ...utils import pagination_links, get_valid_page_or_1
 from .. import main
 from ... import db
 from dmutils.audit import AuditTypes
@@ -15,10 +15,7 @@ from ...service_utils import validate_and_return_updater_request
 
 @main.route('/audit-events', methods=['GET'])
 def list_audits():
-    try:
-        page = int(request.args.get('page', 1))
-    except ValueError:
-        abort(400, "Invalid page argument")
+    page = get_valid_page_or_1()
 
     audits = AuditEvent.query.order_by(
         asc(AuditEvent.created_at)

--- a/app/main/views/drafts.py
+++ b/app/main/views/drafts.py
@@ -10,11 +10,9 @@ from ... import db
 from ...utils import drop_foreign_fields, json_has_required_keys
 from ...validation import is_valid_service_id_or_400
 from ...models import Service, DraftService, Supplier, AuditEvent, Framework
-from ...service_utils import validate_and_return_updater_request, \
-    update_and_validate_service, index_service, validate_service, \
-    commit_and_archive_service, create_service_from_draft
-from ...draft_utils import validate_and_return_draft_request, \
-    get_draft_validation_errors
+from ...service_utils import validate_and_return_updater_request, update_and_validate_service, index_service, \
+    validate_service, commit_and_archive_service, create_service_from_draft
+from ...draft_utils import validate_and_return_draft_request, get_draft_validation_errors
 
 
 @main.route('/draft-services/copy-from/<string:service_id>', methods=['PUT'])
@@ -120,8 +118,7 @@ def list_draft_services():
     except ValueError:
         abort(400, "Invalid supplier_id: %s" % supplier_id)
 
-    supplier = Supplier.query.filter(Supplier.supplier_id == supplier_id) \
-        .all()
+    supplier = Supplier.query.filter(Supplier.supplier_id == supplier_id).all()
     if not supplier:
         abort(404, "supplier_id '%d' not found" % supplier_id)
 

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -8,7 +8,8 @@ from ...models import ArchivedService, Service, Supplier, Framework
 
 from sqlalchemy import asc
 from ...validation import detect_framework_or_400, is_valid_service_id_or_400
-from ...utils import url_for, pagination_links, drop_foreign_fields, display_list, strip_whitespace_from_data
+from ...utils import url_for, pagination_links, drop_foreign_fields, display_list, strip_whitespace_from_data, \
+    get_valid_page_or_1
 
 from ...service_utils import (
     validate_and_return_service_request,
@@ -34,10 +35,7 @@ def index():
 
 @main.route('/services', methods=['GET'])
 def list_services():
-    try:
-        page = int(request.args.get('page', 1))
-    except ValueError:
-        abort(400, "Invalid page argument")
+    page = get_valid_page_or_1()
 
     supplier_id = request.args.get('supplier_id')
 
@@ -91,10 +89,7 @@ def list_archived_services_by_service_id():
     is_valid_service_id_or_400(request.args.get("service-id", "no service id"))
     service_id = request.args.get("service-id", "no service id")
 
-    try:
-        page = int(request.args.get('page', 1))
-    except ValueError:
-        abort(400, "Invalid page argument")
+    page = get_valid_page_or_1()
 
     services = ArchivedService.query.filter(
         ArchivedService.service_id == service_id

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -8,8 +8,7 @@ from ...models import ArchivedService, Service, Supplier, Framework
 
 from sqlalchemy import asc
 from ...validation import detect_framework_or_400, is_valid_service_id_or_400
-from ...utils import url_for, pagination_links, \
-    drop_foreign_fields, display_list, strip_whitespace_from_data
+from ...utils import url_for, pagination_links, drop_foreign_fields, display_list, strip_whitespace_from_data
 
 from ...service_utils import (
     validate_and_return_service_request,
@@ -53,8 +52,7 @@ def list_services():
         except ValueError:
             abort(400, "Invalid supplier_id: %s" % supplier_id)
 
-        supplier = Supplier.query.filter(Supplier.supplier_id == supplier_id) \
-            .all()
+        supplier = Supplier.query.filter(Supplier.supplier_id == supplier_id).all()
         if not supplier:
             abort(404, "supplier_id '%d' not found" % supplier_id)
 
@@ -99,8 +97,8 @@ def list_archived_services_by_service_id():
         abort(400, "Invalid page argument")
 
     services = ArchivedService.query.filter(
-        ArchivedService.service_id == service_id) \
-        .order_by(asc(ArchivedService.id))
+        ArchivedService.service_id == service_id
+    ).order_by(asc(ArchivedService.id))
 
     services = services.paginate(
         page=page,

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -2,8 +2,7 @@ from flask import jsonify, abort, request, current_app
 from sqlalchemy.exc import IntegrityError, DataError
 from .. import main
 from ... import db
-from ...models import Supplier, ContactInformation, AuditEvent, Service, \
-    SelectionAnswers, Framework
+from ...models import Supplier, ContactInformation, AuditEvent, Service, SelectionAnswers, Framework
 from ...validation import (
     validate_supplier_json_or_400,
     validate_contact_information_json_or_400,
@@ -82,7 +81,6 @@ def get_supplier(supplier_id):
     }))
 
 
-# Route to insert new Suppliers, not update existing ones
 @main.route('/suppliers/<int:supplier_id>', methods=['PUT'])
 def import_supplier(supplier_id):
     supplier_data = get_json_from_request()
@@ -140,24 +138,15 @@ def import_supplier(supplier_id):
     for contact_information_data in contact_informations_data:
         contact_information = ContactInformation()
 
-        contact_information.contact_name = \
-            contact_information_data.get('contactName', None)
-        contact_information.phone_number = \
-            contact_information_data.get('phoneNumber', None)
-        contact_information.email = \
-            contact_information_data.get('email', None)
-        contact_information.website = \
-            contact_information_data.get('website', None)
-        contact_information.address1 = \
-            contact_information_data.get('address1', None)
-        contact_information.address2 = \
-            contact_information_data.get('address2', None)
-        contact_information.city = \
-            contact_information_data.get('city', None)
-        contact_information.country = \
-            contact_information_data.get('country', None)
-        contact_information.postcode = \
-            contact_information_data.get('postcode', None)
+        contact_information.contact_name = contact_information_data.get('contactName')
+        contact_information.phone_number = contact_information_data.get('phoneNumber')
+        contact_information.email = contact_information_data.get('email')
+        contact_information.website = contact_information_data.get('website')
+        contact_information.address1 = contact_information_data.get('address1')
+        contact_information.address2 = contact_information_data.get('address2')
+        contact_information.city = contact_information_data.get('city')
+        contact_information.country = contact_information_data.get('country')
+        contact_information.postcode = contact_information_data.get('postcode')
 
         supplier.contact_information.append(contact_information)
 

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -8,17 +8,14 @@ from ...validation import (
     validate_contact_information_json_or_400,
     is_valid_string_or_400
 )
-from ...utils import pagination_links, drop_foreign_fields, \
-    get_json_from_request, json_has_required_keys, json_has_matching_id
+from ...utils import pagination_links, drop_foreign_fields, get_json_from_request, \
+    json_has_required_keys, json_has_matching_id, get_valid_page_or_1
 from dmutils.audit import AuditTypes
 
 
 @main.route('/suppliers', methods=['GET'])
 def list_suppliers():
-    try:
-        page = int(request.args.get('page', 1))
-    except ValueError:
-        abort(400, "Invalid page argument")
+    page = get_valid_page_or_1()
 
     prefix = request.args.get('prefix', '')
 

--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -5,11 +5,9 @@ from flask import jsonify, abort, request, current_app
 
 from .. import main
 from ... import db, encryption
-from ...models import User, AuditEvent
-from ...utils import get_json_from_request, json_has_required_keys, \
-    json_has_matching_id
-from ...validation import validate_user_json_or_400, \
-    validate_user_auth_json_or_400
+from ...models import User, AuditEvent, Supplier
+from ...utils import get_json_from_request, json_has_required_keys, json_has_matching_id, pagination_links
+from ...validation import validate_user_json_or_400, validate_user_auth_json_or_400
 
 
 @main.route('/users/auth', methods=['POST'])
@@ -47,6 +45,47 @@ def get_user_by_id(user_id):
 
 
 @main.route('/users', methods=['GET'])
+def list_users():
+    try:
+        page = int(request.args.get('page', 1))
+    except ValueError:
+        abort(400, "Invalid page argument")
+
+    supplier_id = request.args.get('supplier_id')
+
+    if supplier_id is not None:
+        try:
+            supplier_id = int(supplier_id)
+        except ValueError:
+            abort(400, "Invalid supplier_id: %s" % supplier_id)
+
+        supplier = Supplier.query.filter(Supplier.supplier_id == supplier_id).all()
+        if not supplier:
+            abort(404, "supplier_id '%d' not found" % supplier_id)
+
+        users = User.query.filter(User.supplier_id == supplier_id).paginate(
+            page=page,
+            per_page=current_app.config['DM_API_SERVICES_PAGE_SIZE'],
+        )
+
+    # No query parameters, so list all users
+    else:
+        users = User.query.paginate(
+            page=page,
+            per_page=current_app.config['DM_API_SERVICES_PAGE_SIZE'],
+        )
+
+    return jsonify(
+        users=[user.serialize() for user in users.items],
+        links=pagination_links(
+            users,
+            '.list_users',
+            request.args
+        )
+    )
+
+
+@main.route('/users/email-address', methods=['GET'])
 def get_user_by_email():
     email_address = request.args.get('email')
     if email_address is None:

--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -6,7 +6,8 @@ from flask import jsonify, abort, request, current_app
 from .. import main
 from ... import db, encryption
 from ...models import User, AuditEvent, Supplier
-from ...utils import get_json_from_request, json_has_required_keys, json_has_matching_id, pagination_links
+from ...utils import get_json_from_request, json_has_required_keys, \
+    json_has_matching_id, pagination_links, get_valid_page_or_1
 from ...validation import validate_user_json_or_400, validate_user_auth_json_or_400
 
 
@@ -46,10 +47,7 @@ def get_user_by_id(user_id):
 
 @main.route('/users', methods=['GET'])
 def list_users():
-    try:
-        page = int(request.args.get('page', 1))
-    except ValueError:
-        abort(400, "Invalid page argument")
+    page = get_valid_page_or_1()
 
     supplier_id = request.args.get('supplier_id')
 
@@ -150,7 +148,7 @@ def create_user():
         db.session.rollback()
         abort(400, "Invalid supplier id")
 
-    return jsonify(users=user.serialize()), 200
+    return jsonify(users=user.serialize()), 201
 
 
 @main.route('/users/<int:user_id>', methods=['POST'])

--- a/app/utils.py
+++ b/app/utils.py
@@ -13,6 +13,13 @@ def url_for(*args, **kwargs):
     return base_url_for(*args, **kwargs)
 
 
+def get_valid_page_or_1():
+    try:
+        return int(request.args.get('page', 1))
+    except ValueError:
+        abort(400, "Invalid page argument")
+
+
 def pagination_links(pagination, endpoint, args):
     links = dict()
     if pagination.has_prev:

--- a/tests/app/test_users.py
+++ b/tests/app/test_users.py
@@ -627,9 +627,9 @@ class TestUsersGet(BaseApplicationTest):
 
     def test_can_get_a_user_by_email(self):
         with self.app.app_context():
-            response = self.client.get("/users/email-address?email=j@examplecompany.biz")
+            response = self.client.get("/users?email_address=j@examplecompany.biz")
             assert_equal(response.status_code, 200)
-            data = json.loads(response.get_data())["users"]
+            data = json.loads(response.get_data())["users"][0]
             assert_equal(data['emailAddress'], self.users[0]['emailAddress'])
             assert_equal(data['name'], self.users[0]['name'])
             assert_equal(data['role'], self.users[0]['role'])
@@ -667,11 +667,15 @@ class TestUsersGet(BaseApplicationTest):
         response = self.client.get("/users/bogus")
         assert_equal(response.status_code, 404)
 
-    def test_returns_404_for_no_email_supplied(self):
-        response = self.client.get("/users/email-address?notemail=j@examplecompany.biz")
+    def test_returns_404_for_nonexistent_email_address(self):
+        non_existent_email = "jbond@mi6.biz"
+        response = self.client.get("/users?email_address={}".format(non_existent_email))
         data = json.loads(response.get_data())["error"]
         assert_equal(response.status_code, 404)
-        assert_equal(data, "'email' is a required parameter")
+        assert_equal(
+            data,
+            "No user with email_address 'jbond@mi6.biz'".format(non_existent_email)
+        )
 
     def test_returns_400_for_non_int_supplier_id(self):
         bad_supplier_id = 'not_an_integer'


### PR DESCRIPTION
### The thing I'm actively working on

As part of the [user dashboard](https://www.pivotaltracker.com/story/show/98628954) story on Pivotal, we need an API route that can return users associated with a certain supplier.

This pull request creates a `list_users` route to get back all users, optionally filterable by a `supplier_id` or an `email_address`. If an email address is specified that doesn't exist, a 404 is returned.
<del>It also changes the existing url path for the `get_user_by_email` route because it was in conflict with the `list_users` route.</del> 
The `get_user_by_email` route has been removed entirely.

For example:

```python

# /users?supplier_id=123456
# /users?email_address=liz@royal.gov.uk
@main.route('/users', methods=['GET'])
def list_users():

```

*** 
#### Housekeeping

* I changed the pep8 line number thing to 120 like we've done in a few of the other apps
* Put the page-getting logic into the `utils.py` file and replaced the page-number-getting try/except block everywhere I found it being used 