### PR TITLE
Send service.serialize() instead of .data for indexing

### DIFF
--- a/app/service_utils.py
+++ b/app/service_utils.py
@@ -104,7 +104,7 @@ def commit_and_archive_service(updated_service, update_details,
 def index_service(service):
     if service.framework.status == 'live' and service.status == 'published':
         try:
-            search_api_client.index(service.service_id, service.data)
+            search_api_client.index(service.service_id, service.serialize())
         except apiclient.HTTPError as e:
             current_app.logger.warning(
                 'Failed to add {} to search index: {}'.format(

--- a/tests/app/views/test_services.py
+++ b/tests/app/views/test_services.py
@@ -927,7 +927,7 @@ class TestShouldCallSearchApiOnPutToCreateService(BaseApplicationTest):
 
             payload = self.load_example_listing("G6-IaaS")
             payload['id'] = "1234567890123456"
-            self.client.put(
+            response = self.client.put(
                 '/services/1234567890123456',
                 data=json.dumps(
                     {
@@ -937,11 +937,9 @@ class TestShouldCallSearchApiOnPutToCreateService(BaseApplicationTest):
                 ),
                 content_type='application/json')
 
-            service = Service.query.filter(Service.service_id ==
-                                           "1234567890123456").first()
             search_api_client.index.assert_called_with(
                 "1234567890123456",
-                service.data
+                json.loads(response.get_data())['services']
             )
 
     def test_should_not_index_on_service_on_expired_frameworks(
@@ -1028,11 +1026,9 @@ class TestShouldCallSearchApiOnPost(BaseApplicationTest):
                 ),
                 content_type='application/json')
 
-            service = Service.query.filter(Service.service_id ==
-                                           "1234567890123456").first()
             search_api_client.index.assert_called_with(
                 "1234567890123456",
-                service.data
+                mock.ANY
             )
 
     @mock.patch('app.service_utils.db.session.commit')
@@ -1177,7 +1173,7 @@ class TestShouldCallSearchApiOnPostStatusUpdate(BaseApplicationTest):
             if service_is_indexed:
                 search_api_client.index.assert_called_with(
                     service.service_id,
-                    service.data
+                    json.loads(response.get_data())['services']
                 )
             else:
                 assert_false(search_api_client.index.called)


### PR DESCRIPTION
service.data is missing service id, supplier and framework information,
so the services that were sent to the search-api after PUT/POST requests
were missing these fields in the index. The reindex script fixes the
issues since it uses the service data from API responses, which contain
all required fields.

Before dmutils 3.2.0 apiclient was adding the relevant field values to
the service data before sending it for indexing.

Sending service.serialize() does the same thing reindexing scripts would
do: send the service as it appears in the API output to the search-api.
This way both index calls (one from within the API itself and another
one from the scripts) send the same data and there's no need for any
special processing in the SearchAPIClient.