### PR TITLE
Add copy g-cloud-7 draft API endpoint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+sudo: false
 python:
   - "2.7"
   - "3.4"

--- a/app/main/views/drafts.py
+++ b/app/main/views/drafts.py
@@ -10,8 +10,9 @@ from ... import db
 from ...utils import drop_foreign_fields, json_has_required_keys
 from ...validation import is_valid_service_id_or_400
 from ...models import Service, DraftService, Supplier, AuditEvent, Framework
-from ...service_utils import validate_and_return_updater_request, update_and_validate_service, index_service, \
-    validate_service, commit_and_archive_service, create_service_from_draft
+from ...service_utils import validate_and_return_updater_request, \
+    update_and_validate_service, index_service, \
+    commit_and_archive_service, create_service_from_draft
 from ...draft_utils import validate_and_return_draft_request, get_draft_validation_errors
 
 
@@ -125,8 +126,7 @@ def list_draft_services():
     services = DraftService.query.order_by(
         asc(DraftService.framework_id),
         asc(DraftService.data['lot'].cast(String).label('data_lot')),
-        asc(DraftService.data['serviceName'].
-            cast(String).label('data_servicename'))
+        asc(DraftService.id)
     )
 
     if service_id:

--- a/app/models.py
+++ b/app/models.py
@@ -451,6 +451,14 @@ class DraftService(db.Model, ServiceTableMixin):
             status=service.status
         )
 
+    def copy(self):
+        return DraftService(
+            framework_id=self.framework_id,
+            supplier_id=self.supplier_id,
+            data=self.data,
+            status=self.status
+        )
+
     def serialize(self):
         data = super(DraftService, self).serialize()
         data['id'] = self.id

--- a/tests/app/views/test_drafts.py
+++ b/tests/app/views/test_drafts.py
@@ -802,3 +802,86 @@ class TestDraftServices(BaseApplicationTest):
             db.session.rollback()
             assert_equal(Service.query.count(), 2)
             assert_equal(DraftService.query.count(), 1)
+
+
+class TestCopyDraft(BaseApplicationTest):
+    def setup(self):
+        super(TestCopyDraft, self).setup()
+
+        with self.app.app_context():
+            db.session.add(
+                Supplier(supplier_id=1, name=u"Supplier 1")
+            )
+            db.session.add(
+                ContactInformation(
+                    supplier_id=1,
+                    contact_name=u"Liz",
+                    email=u"liz@royal.gov.uk",
+                    postcode=u"SW1A 1AA"
+                )
+            )
+            Framework.query.filter_by(slug='g-cloud-5') \
+                .update(dict(status='live'))
+            Framework.query.filter_by(slug='g-cloud-7') \
+                .update(dict(status='open'))
+            db.session.commit()
+
+        create_draft_json = {
+            'update_details': {
+                'updated_by': 'joeblogs'
+            },
+            'services': {
+                'lot': 'SCS',
+                'supplierId': 1
+            }
+        }
+
+        draft = self.client.post(
+            '/draft-services/g-cloud-7/create',
+            data=json.dumps(create_draft_json),
+            content_type='application/json')
+
+        self.draft = json.loads(draft.get_data())['services']
+        self.draft_id = self.draft['id']
+
+    def test_copy_draft(self):
+        res = self.client.post(
+            '/draft-services/%s/copy' % self.draft_id,
+            data=json.dumps({'update_details': {'updated_by': 'joeblogs'}}),
+            content_type='application/json')
+
+        data = json.loads(res.get_data())
+        assert_equal(res.status_code, 201)
+        assert_equal(data['services']['lot'], 'SCS')
+        assert_equal(data['services']['supplierId'], 1)
+        assert_equal(data['services']['frameworkName'],
+                     self.draft['frameworkName'])
+
+    def test_copy_draft_should_create_audit_event(self):
+        res = self.client.post(
+            '/draft-services/%s/copy' % self.draft_id,
+            data=json.dumps({'update_details': {'updated_by': 'joeblogs'}}),
+            content_type='application/json')
+
+        assert_equal(res.status_code, 201)
+        data = json.loads(res.get_data())
+        draft_id = data['services']['id']
+
+        audit_response = self.client.get('/audit-events')
+        assert_equal(audit_response.status_code, 200)
+        data = json.loads(audit_response.get_data())
+        assert_equal(len(data['auditEvents']), 2)
+        assert_equal(data['auditEvents'][1]['user'], 'joeblogs')
+        assert_equal(data['auditEvents'][1]['type'], 'create_draft_service')
+        assert_equal(data['auditEvents'][1]['data'], {
+            'draftId': draft_id,
+            'originalDraftId': self.draft_id
+        })
+
+    def test_should_not_create_draft_with_invalid_data(self):
+        res = self.client.post(
+            '/draft-services/1000/copy',
+            data=json.dumps({'update_details': {'updated_by': 'joeblogs'}}),
+            content_type='application/json')
+
+        assert_equal(res.status_code, 404)


### PR DESCRIPTION
[#97536644](https://www.pivotaltracker.com/story/show/97536644)

POST /draft-services/<draft_id>/copy creates a copy of the draft
service. List of copied fields is the same as when creating a draft
from existing service, except the service_id is not copied from the
original draft.

Required for the "Make a copy" supplier-frontend button. Instead of
an additional API endpoint it'd be possible to add a new apiclient
method that would GET the original draft from the API and then POST
it to the create draft URL. But in order to do this apiclient would
have to filter all non-data fields from the draft: service id, links,
timestamps etc. API endpoint avoids this by only copying the relevant
model fields from one object to another.

**Note:** similar to the "make a draft from service" endpoint there's no validation that the supplier that triggered the request is the owner of the original service or draft.

I've left it out for now. It's better to do this the same way for all similar drafts endpoints so it should be a separate change/story.