### PR TITLE
Order services by id when listing all services

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -42,7 +42,7 @@ def list_services():
 
     supplier_id = request.args.get('supplier_id')
 
-    services = Service.query.framework_is_live().default_order()
+    services = Service.query.framework_is_live()
 
     if request.args.get('status'):
         services = services.has_statuses(*request.values.getlist('status'))
@@ -58,11 +58,13 @@ def list_services():
         if not supplier:
             abort(404, "supplier_id '%d' not found" % supplier_id)
 
-        items = services.filter(Service.supplier_id == supplier_id).all()
+        items = services.default_order().filter(Service.supplier_id == supplier_id).all()
         return jsonify(
             services=[service.serialize() for service in items],
             links=dict()
         )
+    else:
+        services = services.order_by(asc(Service.id))
 
     services = services.paginate(
         page=page,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,3 @@
 [pep8]
 exclude = ./migrations,./venv,./venv3
+max-line-length = 120


### PR DESCRIPTION
Service lists from the API are used by import and index scripts and
service order affects pagination. Using an editable field like service
name means that the service order might change during the script run,
skipping or duplicating the services in pagination results.

Using id instead (none of which are editable by users or admins) means
that service order is always the same even if services are edited or
added in the process.

Service lists filtered by supplier_id are still ordered using the
Service.default_order.