### PR TITLE
Make Apache logs more specific

### DIFF
--- a/.ebextensions/apache_log.config
+++ b/.ebextensions/apache_log.config
@@ -1,0 +1,7 @@
+files:
+  "/etc/httpd/conf.d/custom_log.conf":
+    mode: "000644"
+    owner: root
+    group: root
+    content: |
+      LogFormat "apache-access api \"%{DM-Request-ID}i\" %h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"

--- a/.ebextensions/cwl-logs-apache-access.config
+++ b/.ebextensions/cwl-logs-apache-access.config
@@ -33,10 +33,10 @@ Mappings:
       LogGroupName: {"Fn::GetOptionSetting": {"OptionName": "LogGroupName"}}
       ApplicationName: {"Fn::GetOptionSetting": {"OptionName": "ApplicationName"}}
     FilterPatterns:
-      Http4xxMetricFilter: "[..., status=4*, size, referer, agent]"  
-      HttpNon4xxMetricFilter: "[..., status!=4*, size, referer, agent]"
-      Http5xxMetricFilter: "[..., status=5*, size, referer, agent]"  
-      HttpNon5xxMetricFilter: "[..., status!=5*, size, referer, agent]"  
+      Http4xxMetricFilter: "[type=apache-access, app=api, ..., status=4*, size, referer, agent]"
+      HttpNon4xxMetricFilter: "[type=apache-access, app=api, ..., status!=4*, size, referer, agent]"
+      Http5xxMetricFilter: "[type=apache-access, app=api, ..., status=5*, size, referer, agent]"
+      HttpNon5xxMetricFilter: "[type=apache-access, app=api, ..., status!=5*, size, referer, agent]"
 
 
 Outputs:


### PR DESCRIPTION
This makes the Apache log line format more specific by adding the type
(apache), application (api) and the DM-Request-ID header value. It also
updates the metric filters to only match apache log lines for this
application.

This was motivated by the realisation that metric filters are applied to a
whole log group rather than individual log streams.