### PR TITLE
Use a custom access log for CloudWatch logs

### DIFF
--- a/.ebextensions/apache_log.config
+++ b/.ebextensions/apache_log.config
@@ -4,4 +4,5 @@ files:
     owner: root
     group: root
     content: |
-      LogFormat "apache-access api \"%{DM-Request-ID}i\" %h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
+      LogFormat "apache-access api \"%{DM-Request-ID}i\" %h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" cloudwatchlogs
+      CustomLog logs/cwl_access_log cloudwatchlogs

--- a/.ebextensions/cwl-logs-apache-access.config
+++ b/.ebextensions/cwl-logs-apache-access.config
@@ -28,7 +28,7 @@
 Mappings:
   CWLogs:
     AccessLogs:
-      LogFile: "/var/log/httpd/access_log"
+      LogFile: "/var/log/httpd/cwl_access_log"
       TimestampFormat: "%d/%b/%Y:%H:%M:%S %z"
       LogGroupName: {"Fn::GetOptionSetting": {"OptionName": "LogGroupName"}}
       ApplicationName: {"Fn::GetOptionSetting": {"OptionName": "ApplicationName"}}


### PR DESCRIPTION
Beanstalk sets the LogFormat in it's wsgi.conf that gets loaded after
our config file. We are also not sure that Beanstalk does not depend on
the custom log format. This change puts it in a separate log file
specific to our CloudWatch logs stuff.