### PR TITLE
Improve status code alarm descriptions

### DIFF
--- a/.ebextensions/cwl-logs-apache-access.config
+++ b/.ebextensions/cwl-logs-apache-access.config
@@ -128,7 +128,15 @@ Resources :
     Type : "AWS::CloudWatch::Alarm"
     DependsOn : AWSEBCWLHttpNon5xxMetricFilter
     Properties :
-      AlarmDescription: "Application is returning too many 5xx responses (count too high)."
+      AlarmDescription:
+        "Fn::Join":
+          - ""
+          -
+            - "The data API is returning too many 5xx responses.\n"
+            - "Stage and environment: "
+            - {"Fn::FindInMap": ["CWLogs", "AccessLogs", "LogGroupName"]}
+            - "\n"
+            - "Manual link: https://github.gds/pages/gds/digitalmarketplace-manual/alerts.html#5xx-error-rate"
       MetricName: CWLHttp5xx
       Namespace: {"Fn::Join":["/", ["ElasticBeanstalk", {"Ref":"AWSEBEnvironmentName"}]]}
       Statistic: Sum
@@ -149,7 +157,15 @@ Resources :
     Type : "AWS::CloudWatch::Alarm"
     DependsOn : AWSEBCWLHttpNon4xxMetricFilter
     Properties :
-      AlarmDescription: "Application is returning too many 4xx responses (percentage too high)."
+      AlarmDescription:
+        "Fn::Join":
+          - ""
+          -
+            - "The data API is returning too high a proportion of 4xx responses.\n"
+            - "Stage and environment: "
+            - {"Fn::FindInMap": ["CWLogs", "AccessLogs", "LogGroupName"]}
+            - "\n"
+            - "Manual link: https://github.gds/pages/gds/digitalmarketplace-manual/alerts.html#4xx-error-rate"
       MetricName: CWLHttp4xx
       Namespace: {"Fn::Join":["/", ["ElasticBeanstalk", {"Ref":"AWSEBEnvironmentName"}]]}
       Statistic: Average


### PR DESCRIPTION
Improve the descriptions that go along with the HTTP status code
CloudWatch alarms. This is not ideal. When we come to sending these
alarms to Slack we will revisit it.