### PR TITLE
Do not allow "missing" lot

### DIFF
--- a/json_schemas/services-g-cloud-4.json
+++ b/json_schemas/services-g-cloud-4.json
@@ -15,7 +15,7 @@
       "type": "integer"
     },
     "lot": {
-      "enum": ["SaaS", "PaaS", "IaaS", "SCS", "missing"]
+      "enum": ["SaaS", "PaaS", "IaaS", "SCS"]
     },
     "title": {
       "type": "string"

--- a/json_schemas/services-g-cloud-5.json
+++ b/json_schemas/services-g-cloud-5.json
@@ -15,7 +15,7 @@
       "type": "integer"
     },
     "lot": {
-      "enum": ["SaaS", "PaaS", "IaaS", "SCS", "missing"]
+      "enum": ["SaaS", "PaaS", "IaaS", "SCS"]
     },
     "title": {
       "type": "string"


### PR DESCRIPTION
Services missing 'lot' are SCS, so we will fix the data before import - so no more missing lots.