### PR TITLE
Set Postgres client encoding to UTF8 in config.py.

### DIFF
--- a/config.py
+++ b/config.py
@@ -27,7 +27,7 @@ class Config:
     DM_API_SUPPLIERS_PAGE_SIZE = 100
     SQLALCHEMY_COMMIT_ON_TEARDOWN = False
     SQLALCHEMY_RECORD_QUERIES = True
-    SQLALCHEMY_DATABASE_URI = 'postgresql://localhost/digitalmarketplace'
+    SQLALCHEMY_DATABASE_URI = 'postgresql://localhost/digitalmarketplace?client_encoding=utf8'
 
     DM_FAILED_LOGIN_LIMIT = 5
 


### PR DESCRIPTION
We found out there was an issue with import scripts
not working properly, we had to set client encoding
in the Postgres connection string in the config file.