### PR TITLE
Remove the valid service id check on service GET

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -208,8 +208,6 @@ def import_service(service_id):
 
 @main.route('/services/<string:service_id>', methods=['GET'])
 def get_service(service_id):
-    is_valid_service_id_or_400(service_id)
-
     service = Service.query.filter(
         Service.service_id == service_id
     ).framework_is_live().first_or_404()

--- a/tests/app/views/test_drafts.py
+++ b/tests/app/views/test_drafts.py
@@ -58,11 +58,11 @@ class TestDraftServices(BaseApplicationTest):
             content_type='application/json')
 
     def test_reject_list_drafts_no_supplier_id(self):
-        res = self.client.get('/services/draft')
+        res = self.client.get('/draft-services')
         assert_equal(res.status_code, 400)
 
     def test_reject_list_drafts_invalid_supplier_id(self):
-        res = self.client.get('/services/draft?supplier_id=invalid')
+        res = self.client.get('/draft-services?supplier_id=invalid')
         assert_equal(res.status_code, 400)
 
     def test_reject_list_drafts_if_no_supplier_for_id(self):

--- a/tests/app/views/test_services.py
+++ b/tests/app/views/test_services.py
@@ -1674,8 +1674,7 @@ class TestGetService(BaseApplicationTest):
 
     def test_invalid_service_id(self):
         response = self.client.get('/services/abc123')
-        assert_equal(400, response.status_code)
-        assert_in(b'Invalid service ID supplied', response.get_data())
+        assert_equal(404, response.status_code)
 
     def test_get_published_service(self):
         response = self.client.get('/services/123-published-456')


### PR DESCRIPTION
If the service ID doesn't exist in the database we should return a 404.
This is the behaviour that is expected by the buyer frontend and it will
raise a 500 if it gets any other response.