### PR TITLE
Improve 4xx alarm

### DIFF
--- a/.ebextensions/cwl-logs-apache-access.config
+++ b/.ebextensions/cwl-logs-apache-access.config
@@ -33,6 +33,8 @@ Mappings:
       LogGroupName: {"Fn::GetOptionSetting": {"OptionName": "LogGroupName"}}
       ApplicationName: {"Fn::GetOptionSetting": {"OptionName": "ApplicationName"}}
     FilterPatterns:
+      Http400To403MetricFilter: "[type=apache-access, app=api, ..., status < 404, size, referer, agent]"
+      Http404UpMetricFilter: "[type=apache-access, app=api, ..., status >= 404, size, referer, agent]"
       Http4xxMetricFilter: "[type=apache-access, app=api, ..., status=4*, size, referer, agent]"
       HttpNon4xxMetricFilter: "[type=apache-access, app=api, ..., status!=4*, size, referer, agent]"
       Http5xxMetricFilter: "[type=apache-access, app=api, ..., status=5*, size, referer, agent]"
@@ -74,6 +76,26 @@ Resources :
 
   ###########################
   ## Apache access log metric filters
+  AWSEBCWLHttp400To403MetricFilter :
+    Type : "AWS::Logs::MetricFilter"
+    Properties :
+      LogGroupName: {"Fn::FindInMap":["CWLogs", "AccessLogs", "LogGroupName"]}
+      FilterPattern : {"Fn::FindInMap":["CWLogs", "FilterPatterns", "Http400To403MetricFilter"]}
+      MetricTransformations :
+        - MetricValue : 1
+          MetricNamespace: {"Fn::Join":["/", ["ElasticBeanstalk", {"Ref":"AWSEBEnvironmentName"}]]}
+          MetricName : CWLHttp400To403
+
+  AWSEBCWLHttp404UpMetricFilter:
+    Type : "AWS::Logs::MetricFilter"
+    Properties :
+      LogGroupName: {"Fn::FindInMap":["CWLogs", "AccessLogs", "LogGroupName"]}
+      FilterPattern : {"Fn::FindInMap":["CWLogs", "FilterPatterns", "Http404UpMetricFilter"]}
+      MetricTransformations :
+        - MetricValue : 0
+          MetricNamespace: {"Fn::Join":["/", ["ElasticBeanstalk", {"Ref":"AWSEBEnvironmentName"}]]}
+          MetricName : CWLHttp400To403
+
 
   AWSEBCWLHttp4xxMetricFilter :
     Type : "AWS::Logs::MetricFilter"
@@ -95,6 +117,9 @@ Resources :
         - MetricValue : 0
           MetricNamespace: {"Fn::Join":["/", ["ElasticBeanstalk", {"Ref":"AWSEBEnvironmentName"}]]}
           MetricName : CWLHttp4xx
+        - MetricValue : 0
+          MetricNamespace: {"Fn::Join":["/", ["ElasticBeanstalk", {"Ref":"AWSEBEnvironmentName"}]]}
+          MetricName : CWLHttp400To403
 
   AWSEBCWLHttp5xxMetricFilter :
     Type : "AWS::Logs::MetricFilter"
@@ -161,12 +186,12 @@ Resources :
         "Fn::Join":
           - ""
           -
-            - "The data API is returning too high a proportion of 4xx responses.\n"
+            - "The data API is returning too high a proportion of 400, 401, 402 or 403 responses.\n"
             - "Stage and environment: "
             - {"Fn::FindInMap": ["CWLogs", "AccessLogs", "LogGroupName"]}
             - "\n"
             - "Manual link: https://github.gds/pages/gds/digitalmarketplace-manual/alerts.html#4xx-error-rate"
-      MetricName: CWLHttp4xx
+      MetricName: CWLHttp400To403
       Namespace: {"Fn::Join":["/", ["ElasticBeanstalk", {"Ref":"AWSEBEnvironmentName"}]]}
       Statistic: Average
       Period: 60


### PR DESCRIPTION
Only alarm on 400 - 403 errors. We get a lot of 404s but they're ok on
the API.