### PR TITLE
Split out 400 to 403 metric transformation

### DIFF
--- a/.ebextensions/cwl-logs-apache-access.config
+++ b/.ebextensions/cwl-logs-apache-access.config
@@ -117,6 +117,14 @@ Resources :
         - MetricValue : 0
           MetricNamespace: {"Fn::Join":["/", ["ElasticBeanstalk", {"Ref":"AWSEBEnvironmentName"}]]}
           MetricName : CWLHttp4xx
+
+  AWSEBCWLHttpNon4xxFor400To403MetricFilter :
+    Type : "AWS::Logs::MetricFilter"
+    DependsOn : AWSEBCWLHttp4xxMetricFilter
+    Properties :
+      LogGroupName: {"Fn::FindInMap":["CWLogs", "AccessLogs", "LogGroupName"]}
+      FilterPattern : {"Fn::FindInMap":["CWLogs", "FilterPatterns", "HttpNon4xxMetricFilter"]}
+      MetricTransformations :
         - MetricValue : 0
           MetricNamespace: {"Fn::Join":["/", ["ElasticBeanstalk", {"Ref":"AWSEBEnvironmentName"}]]}
           MetricName : CWLHttp400To403


### PR DESCRIPTION
The previous build failed to deploy. It looks like MetricTransformations can only contain one transformation. Which begs the question, "why make it an array?".