### PR TITLE
Add json logs

### DIFF
--- a/.ebextensions/apache_log.config
+++ b/.ebextensions/apache_log.config
@@ -6,3 +6,6 @@ files:
     content: |
       LogFormat "apache-access api \"%{DM-Request-ID}i\" %h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" cloudwatchlogs
       CustomLog logs/cwl_access_log cloudwatchlogs
+
+      LogFormat "{ \"application\": \"api\", \"logType\": \"apache-access\", \"requestId\": \"%{DM-Request-ID}i\", \"remoteHost\": \"%h\", \"remoteLogname\": \"%l\", \"user\": \"%u\", \"time\": \"%t\", \"request\": \"%r\", \"status\": %>s, \"size\": %b, \"referer\": \"%{Referer}i\", \"userAgent\": \"%{User-Agent}i\"}" cloudwatchjsonlogs
+      CustomLog logs/cwl_access_log.json cloudwatchjsonlogs

--- a/.ebextensions/cwl-logs-apache-access.config
+++ b/.ebextensions/cwl-logs-apache-access.config
@@ -32,10 +32,11 @@ Mappings:
       JSONLogFile: "/var/log/httpd/cwl_access_log.json"
       TimestampFormat: "%d/%b/%Y:%H:%M:%S %z"
       LogGroupName: {"Fn::GetOptionSetting": {"OptionName": "LogGroupName"}}
+      JSONLogGroupName: {"Fn::Join": ["", [{"Fn::GetOptionSetting": {"OptionName": "LogGroupName"}}, "-json"]]}
       ApplicationName: {"Fn::GetOptionSetting": {"OptionName": "ApplicationName"}}
     FilterPatterns:
-      Http400To403MetricFilter: "[type=apache-access, app=api, ..., status < 404, size, referer, agent]"
-      Http404UpMetricFilter: "[type=apache-access, app=api, ..., status >= 404, size, referer, agent]"
+      Http400To403MetricFilter: "{ $.logType = apache-access && $.application = api && $.status >= 400 && $.status <= 403 }"
+      HttpNon400To403MetricFilter: "{ $.logType = apache-access && $.application = api && ($.status < 400 || $.status > 403) }"
       Http4xxMetricFilter: "[type=apache-access, app=api, ..., status=4*, size, referer, agent]"
       HttpNon4xxMetricFilter: "[type=apache-access, app=api, ..., status!=4*, size, referer, agent]"
       Http5xxMetricFilter: "[type=apache-access, app=api, ..., status=5*, size, referer, agent]"
@@ -65,7 +66,7 @@ Resources :
                 datetime_format = `{"Fn::FindInMap":["CWLogs", "AccessLogs", "TimestampFormat"]}`
                 [apache-access_log-json]
                 file = `{"Fn::FindInMap":["CWLogs", "AccessLogs", "JSONLogFile"]}`
-                log_group_name = `{"Fn::Join": ["", [{"Fn::FindInMap":["CWLogs", "AccessLogs", "LogGroupName"]}, "-json"]]}`
+                log_group_name = `{"Fn::FindInMap":["CWLogs", "AccessLogs", "JSONLogGroupName"]}`
                 log_stream_name = `{"Fn::Join": ["-", ["apache-access", {"Fn::FindInMap":["CWLogs", "ApplicationLogs", "ApplicationName"]}]]}`
                 datetime_format = `{"Fn::FindInMap":["CWLogs", "AccessLogs", "TimestampFormat"]}`
                 [apache-access_log-combined]
@@ -82,26 +83,25 @@ Resources :
 
   ###########################
   ## Apache access log metric filters
-  AWSEBCWLHttp400To403MetricFilter :
-    Type : "AWS::Logs::MetricFilter"
-    Properties :
-      LogGroupName: {"Fn::FindInMap":["CWLogs", "AccessLogs", "LogGroupName"]}
-      FilterPattern : {"Fn::FindInMap":["CWLogs", "FilterPatterns", "Http400To403MetricFilter"]}
-      MetricTransformations :
-        - MetricValue : 1
-          MetricNamespace: {"Fn::Join":["/", ["ElasticBeanstalk", {"Ref":"AWSEBEnvironmentName"}]]}
-          MetricName : CWLHttp400To403
+  AWSEBCWLHttp400To403MetricFilter:
+    Type: "AWS::Logs::MetricFilter"
+    Properties:
+      LogGroupName: {"Fn::FindInMap": ["CWLogs", "AccessLogs", "JSONLogGroupName"]}
+      FilterPattern: {"Fn::FindInMap": ["CWLogs", "FilterPatterns", "Http400To403MetricFilter"]}
+      MetricTransformations:
+        - MetricValue: 1
+          MetricNamespace: {"Fn::Join": ["/", ["ElasticBeanstalk", {"Ref": "AWSEBEnvironmentName"}]]}
+          MetricName: CWLHttp400To403
 
-  AWSEBCWLHttp404UpMetricFilter:
-    Type : "AWS::Logs::MetricFilter"
-    Properties :
-      LogGroupName: {"Fn::FindInMap":["CWLogs", "AccessLogs", "LogGroupName"]}
-      FilterPattern : {"Fn::FindInMap":["CWLogs", "FilterPatterns", "Http404UpMetricFilter"]}
-      MetricTransformations :
-        - MetricValue : 0
-          MetricNamespace: {"Fn::Join":["/", ["ElasticBeanstalk", {"Ref":"AWSEBEnvironmentName"}]]}
-          MetricName : CWLHttp400To403
-
+  AWSEBCWLHttpNon400To403MetricFilter:
+    Type: "AWS::Logs::MetricFilter"
+    Properties:
+      LogGroupName: {"Fn::FindInMap": ["CWLogs", "AccessLogs", "JSONLogGroupName"]}
+      FilterPattern: {"Fn::FindInMap": ["CWLogs", "FilterPatterns", "HttpNon400To403MetricFilter"]}
+      MetricTransformations:
+        - MetricValue: 0
+          MetricNamespace: {"Fn::Join": ["/", ["ElasticBeanstalk", {"Ref": "AWSEBEnvironmentName"}]]}
+          MetricName: CWLHttp400To403
 
   AWSEBCWLHttp4xxMetricFilter :
     Type : "AWS::Logs::MetricFilter"
@@ -123,17 +123,6 @@ Resources :
         - MetricValue : 0
           MetricNamespace: {"Fn::Join":["/", ["ElasticBeanstalk", {"Ref":"AWSEBEnvironmentName"}]]}
           MetricName : CWLHttp4xx
-
-  AWSEBCWLHttpNon4xxFor400To403MetricFilter :
-    Type : "AWS::Logs::MetricFilter"
-    DependsOn : AWSEBCWLHttp4xxMetricFilter
-    Properties :
-      LogGroupName: {"Fn::FindInMap":["CWLogs", "AccessLogs", "LogGroupName"]}
-      FilterPattern : {"Fn::FindInMap":["CWLogs", "FilterPatterns", "HttpNon4xxMetricFilter"]}
-      MetricTransformations :
-        - MetricValue : 0
-          MetricNamespace: {"Fn::Join":["/", ["ElasticBeanstalk", {"Ref":"AWSEBEnvironmentName"}]]}
-          MetricName : CWLHttp400To403
 
   AWSEBCWLHttp5xxMetricFilter :
     Type : "AWS::Logs::MetricFilter"

--- a/.ebextensions/cwl-logs-apache-access.config
+++ b/.ebextensions/cwl-logs-apache-access.config
@@ -29,6 +29,7 @@ Mappings:
   CWLogs:
     AccessLogs:
       LogFile: "/var/log/httpd/cwl_access_log"
+      JSONLogFile: "/var/log/httpd/cwl_access_log.json"
       TimestampFormat: "%d/%b/%Y:%H:%M:%S %z"
       LogGroupName: {"Fn::GetOptionSetting": {"OptionName": "LogGroupName"}}
       ApplicationName: {"Fn::GetOptionSetting": {"OptionName": "ApplicationName"}}
@@ -60,6 +61,11 @@ Resources :
                 [apache-access_log]
                 file = `{"Fn::FindInMap":["CWLogs", "AccessLogs", "LogFile"]}`
                 log_group_name = `{"Fn::FindInMap":["CWLogs", "AccessLogs", "LogGroupName"]}`
+                log_stream_name = `{"Fn::Join": ["-", ["apache-access", {"Fn::FindInMap":["CWLogs", "ApplicationLogs", "ApplicationName"]}]]}`
+                datetime_format = `{"Fn::FindInMap":["CWLogs", "AccessLogs", "TimestampFormat"]}`
+                [apache-access_log-json]
+                file = `{"Fn::FindInMap":["CWLogs", "AccessLogs", "JSONLogFile"]}`
+                log_group_name = `{"Fn::Join": ["", [{"Fn::FindInMap":["CWLogs", "AccessLogs", "LogGroupName"]}, "-json"]]}`
                 log_stream_name = `{"Fn::Join": ["-", ["apache-access", {"Fn::FindInMap":["CWLogs", "ApplicationLogs", "ApplicationName"]}]]}`
                 datetime_format = `{"Fn::FindInMap":["CWLogs", "AccessLogs", "TimestampFormat"]}`
                 [apache-access_log-combined]


### PR DESCRIPTION
## Add JSON formatted apache logs

You can create much richer CloudWatch metric filters against JSON logs.

## Use JSON log for 400 - 403 metric filter

The JSON log allows us to group conditions together.