### PR TITLE
Fix JSON logs configuration

### DIFF
--- a/.ebextensions/cwl-logs-apache-access.config
+++ b/.ebextensions/cwl-logs-apache-access.config
@@ -32,11 +32,10 @@ Mappings:
       JSONLogFile: "/var/log/httpd/cwl_access_log.json"
       TimestampFormat: "%d/%b/%Y:%H:%M:%S %z"
       LogGroupName: {"Fn::GetOptionSetting": {"OptionName": "LogGroupName"}}
-      JSONLogGroupName: {"Fn::Join": ["", [{"Fn::GetOptionSetting": {"OptionName": "LogGroupName"}}, "-json"]]}
       ApplicationName: {"Fn::GetOptionSetting": {"OptionName": "ApplicationName"}}
     FilterPatterns:
-#      Http400To403MetricFilter: "{ $.logType = apache-access && $.application = api && $.status >= 400 && $.status <= 403 }"
-#      HttpNon400To403MetricFilter: "{ $.logType = apache-access && $.application = api && ($.status < 400 || $.status > 403) }"
+      Http400To403MetricFilter: "{ $.logType = apache-access && $.application = api && $.status >= 400 && $.status <= 403 }"
+      HttpNon400To403MetricFilter: "{ $.logType = apache-access && $.application = api && ($.status < 400 || $.status > 403) }"
       Http4xxMetricFilter: "[type=apache-access, app=api, ..., status=4*, size, referer, agent]"
       HttpNon4xxMetricFilter: "[type=apache-access, app=api, ..., status!=4*, size, referer, agent]"
       Http5xxMetricFilter: "[type=apache-access, app=api, ..., status=5*, size, referer, agent]"
@@ -66,7 +65,7 @@ Resources :
                 datetime_format = `{"Fn::FindInMap":["CWLogs", "AccessLogs", "TimestampFormat"]}`
                 [apache-access_log-json]
                 file = `{"Fn::FindInMap":["CWLogs", "AccessLogs", "JSONLogFile"]}`
-                log_group_name = `{"Fn::FindInMap":["CWLogs", "AccessLogs", "JSONLogGroupName"]}`
+                log_group_name = `{"Fn::Join": ["", [{"Fn::FindInMap":["CWLogs", "AccessLogs", "LogGroupName"]}, "-json"]]}`
                 log_stream_name = `{"Fn::Join": ["-", ["apache-access", {"Fn::FindInMap":["CWLogs", "ApplicationLogs", "ApplicationName"]}]]}`
                 datetime_format = `{"Fn::FindInMap":["CWLogs", "AccessLogs", "TimestampFormat"]}`
                 [apache-access_log-combined]
@@ -83,25 +82,25 @@ Resources :
 
   ###########################
   ## Apache access log metric filters
-  #AWSEBCWLHttp400To403MetricFilter:
-  #  Type: "AWS::Logs::MetricFilter"
-  #  Properties:
-  #    LogGroupName: {"Fn::FindInMap": ["CWLogs", "AccessLogs", "JSONLogGroupName"]}
-  #    FilterPattern: {"Fn::FindInMap": ["CWLogs", "FilterPatterns", "Http400To403MetricFilter"]}
-  #    MetricTransformations:
-  #      - MetricValue: 1
-  #        MetricNamespace: {"Fn::Join": ["/", ["ElasticBeanstalk", {"Ref": "AWSEBEnvironmentName"}]]}
-  #        MetricName: CWLHttp400To403
+  AWSEBCWLHttp400To403MetricFilter:
+    Type: "AWS::Logs::MetricFilter"
+    Properties:
+      LogGroupName: {"Fn::Join": ["", [{"Fn::FindInMap":["CWLogs", "AccessLogs", "LogGroupName"]}, "-json"]]}
+      FilterPattern: {"Fn::FindInMap": ["CWLogs", "FilterPatterns", "Http400To403MetricFilter"]}
+      MetricTransformations:
+        - MetricValue: 1
+          MetricNamespace: {"Fn::Join": ["/", ["ElasticBeanstalk", {"Ref": "AWSEBEnvironmentName"}]]}
+          MetricName: CWLHttp400To403
 
-  #AWSEBCWLHttpNon400To403MetricFilter:
-  #  Type: "AWS::Logs::MetricFilter"
-  #  Properties:
-  #    LogGroupName: {"Fn::FindInMap": ["CWLogs", "AccessLogs", "JSONLogGroupName"]}
-  #    FilterPattern: {"Fn::FindInMap": ["CWLogs", "FilterPatterns", "HttpNon400To403MetricFilter"]}
-  #    MetricTransformations:
-  #      - MetricValue: 0
-  #        MetricNamespace: {"Fn::Join": ["/", ["ElasticBeanstalk", {"Ref": "AWSEBEnvironmentName"}]]}
-  #        MetricName: CWLHttp400To403
+  AWSEBCWLHttpNon400To403MetricFilter:
+    Type: "AWS::Logs::MetricFilter"
+    Properties:
+      LogGroupName: {"Fn::Join": ["", [{"Fn::FindInMap":["CWLogs", "AccessLogs", "LogGroupName"]}, "-json"]]}
+      FilterPattern: {"Fn::FindInMap": ["CWLogs", "FilterPatterns", "HttpNon400To403MetricFilter"]}
+      MetricTransformations:
+        - MetricValue: 0
+          MetricNamespace: {"Fn::Join": ["/", ["ElasticBeanstalk", {"Ref": "AWSEBEnvironmentName"}]]}
+          MetricName: CWLHttp400To403
 
   AWSEBCWLHttp4xxMetricFilter :
     Type : "AWS::Logs::MetricFilter"
@@ -181,31 +180,31 @@ Resources :
                 - EBSNSTopicArn
             - { "Ref" : "AWS::NoValue" }
 
-  #AWSEBCWLHttp4xxPercentAlarm :
-  #  Type : "AWS::CloudWatch::Alarm"
-  #  DependsOn : AWSEBCWLHttpNon4xxMetricFilter
-  #  Properties :
-  #    AlarmDescription:
-  #      "Fn::Join":
-  #        - ""
-  #        -
-  #          - "The data API is returning too high a proportion of 400, 401, 402 or 403 responses.\n"
-  #          - "Stage and environment: "
-  #          - {"Fn::FindInMap": ["CWLogs", "AccessLogs", "LogGroupName"]}
-  #          - "\n"
-  #          - "Manual link: https://github.gds/pages/gds/digitalmarketplace-manual/alerts.html#4xx-error-rate"
-  #    MetricName: CWLHttp400To403
-  #    Namespace: {"Fn::Join":["/", ["ElasticBeanstalk", {"Ref":"AWSEBEnvironmentName"}]]}
-  #    Statistic: Average
-  #    Period: 60
-  #    EvaluationPeriods: 1
-  #    Threshold: 0.10    
-  #    ComparisonOperator: GreaterThanThreshold
-  #    AlarmActions:
-  #      - "Fn::If":
-  #          - SNSTopicExists
-  #          - "Fn::FindInMap":
-  #              - AWSEBOptions
-  #              - options
-  #              - EBSNSTopicArn
-  #          - { "Ref" : "AWS::NoValue" }
+  AWSEBCWLHttp4xxPercentAlarm :
+    Type : "AWS::CloudWatch::Alarm"
+    DependsOn : AWSEBCWLHttpNon4xxMetricFilter
+    Properties :
+      AlarmDescription:
+        "Fn::Join":
+          - ""
+          -
+            - "The data API is returning too high a proportion of 400, 401, 402 or 403 responses.\n"
+            - "Stage and environment: "
+            - {"Fn::FindInMap": ["CWLogs", "AccessLogs", "LogGroupName"]}
+            - "\n"
+            - "Manual link: https://github.gds/pages/gds/digitalmarketplace-manual/alerts.html#4xx-error-rate"
+      MetricName: CWLHttp400To403
+      Namespace: {"Fn::Join":["/", ["ElasticBeanstalk", {"Ref":"AWSEBEnvironmentName"}]]}
+      Statistic: Average
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 0.10    
+      ComparisonOperator: GreaterThanThreshold
+      AlarmActions:
+        - "Fn::If":
+            - SNSTopicExists
+            - "Fn::FindInMap":
+                - AWSEBOptions
+                - options
+                - EBSNSTopicArn
+            - { "Ref" : "AWS::NoValue" }

--- a/.ebextensions/cwl-logs-apache-access.config
+++ b/.ebextensions/cwl-logs-apache-access.config
@@ -32,6 +32,7 @@ Mappings:
       JSONLogFile: "/var/log/httpd/cwl_access_log.json"
       TimestampFormat: "%d/%b/%Y:%H:%M:%S %z"
       LogGroupName: {"Fn::GetOptionSetting": {"OptionName": "LogGroupName"}}
+      JSONLogGroupName: {"Fn::GetOptionSetting": {"OptionName": "JSONLogGroupName"}}
       ApplicationName: {"Fn::GetOptionSetting": {"OptionName": "ApplicationName"}}
     FilterPatterns:
       Http400To403MetricFilter: "{ $.logType = apache-access && $.application = api && $.status >= 400 && $.status <= 403 }"
@@ -65,7 +66,7 @@ Resources :
                 datetime_format = `{"Fn::FindInMap":["CWLogs", "AccessLogs", "TimestampFormat"]}`
                 [apache-access_log-json]
                 file = `{"Fn::FindInMap":["CWLogs", "AccessLogs", "JSONLogFile"]}`
-                log_group_name = `{"Fn::Join": ["", [{"Fn::FindInMap":["CWLogs", "AccessLogs", "LogGroupName"]}, "-json"]]}`
+                log_group_name = `{"Fn::FindInMap": ["CWLogs", "AccessLogs", "JSONLogGroupName"]}`
                 log_stream_name = `{"Fn::Join": ["-", ["apache-access", {"Fn::FindInMap":["CWLogs", "ApplicationLogs", "ApplicationName"]}]]}`
                 datetime_format = `{"Fn::FindInMap":["CWLogs", "AccessLogs", "TimestampFormat"]}`
                 [apache-access_log-combined]
@@ -85,7 +86,7 @@ Resources :
   AWSEBCWLHttp400To403MetricFilter:
     Type: "AWS::Logs::MetricFilter"
     Properties:
-      LogGroupName: {"Fn::Join": ["", [{"Fn::FindInMap":["CWLogs", "AccessLogs", "LogGroupName"]}, "-json"]]}
+      LogGroupName: {"Fn::FindInMap": ["CWLogs", "AccessLogs", "JSONLogGroupName"]}
       FilterPattern: {"Fn::FindInMap": ["CWLogs", "FilterPatterns", "Http400To403MetricFilter"]}
       MetricTransformations:
         - MetricValue: 1
@@ -95,7 +96,7 @@ Resources :
   AWSEBCWLHttpNon400To403MetricFilter:
     Type: "AWS::Logs::MetricFilter"
     Properties:
-      LogGroupName: {"Fn::Join": ["", [{"Fn::FindInMap":["CWLogs", "AccessLogs", "LogGroupName"]}, "-json"]]}
+      LogGroupName: {"Fn::FindInMap": ["CWLogs", "AccessLogs", "JSONLogGroupName"]}
       FilterPattern: {"Fn::FindInMap": ["CWLogs", "FilterPatterns", "HttpNon400To403MetricFilter"]}
       MetricTransformations:
         - MetricValue: 0


### PR DESCRIPTION
For some reason CloudFormation does not like the call to Fn::Join in the mappings section at the top. It throws an error saying that all mapping values must be strings or lists. Which is strange because the result of the Fn::Join is a string.

This change just does the Fn::Join where it's needed rather than at the top. The duplication is minimal. Ultimately it may be useful to do this in dm-aws.