### PR TITLE
Update JSON schemas and PUT route with `updatedAt`

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -179,11 +179,8 @@ def import_service(service_id):
     service.framework_id = framework.id
     service.status = service_data.pop('status', 'published')
     now = datetime.utcnow()
-    if 'createdAt' in service_data:
-        service.created_at = service_data['createdAt']
-    else:
-        service.created_at = now
-    service.updated_at = now
+    service.created_at = service_data.get('createdAt', now)
+    service.updated_at = service_data.get('updatedAt', now)
 
     service_data = drop_foreign_fields(
         service_data,

--- a/json_schemas/services-g-cloud-4.json
+++ b/json_schemas/services-g-cloud-4.json
@@ -20,6 +20,14 @@
     "title": {
       "type": "string"
     },
+    "createdAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "updatedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
     "serviceName": {
       "type": "string"
     },

--- a/json_schemas/services-g-cloud-5.json
+++ b/json_schemas/services-g-cloud-5.json
@@ -20,6 +20,14 @@
     "title": {
       "type": "string"
     },
+    "createdAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "updatedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
     "serviceName":{
       "type":"string",
       "minLength":1,

--- a/json_schemas/services-g-cloud-6-iaas.json
+++ b/json_schemas/services-g-cloud-6-iaas.json
@@ -24,6 +24,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "updatedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
     "serviceTypes": {
       "type": "array",
       "uniqueItems": true,

--- a/json_schemas/services-g-cloud-6-paas.json
+++ b/json_schemas/services-g-cloud-6-paas.json
@@ -24,6 +24,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "updatedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
     "serviceName":{
       "type":"string",
       "minLength":1,

--- a/json_schemas/services-g-cloud-6-saas.json
+++ b/json_schemas/services-g-cloud-6-saas.json
@@ -24,6 +24,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "updatedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
     "serviceTypes": {
       "type": "array",
       "uniqueItems": true,

--- a/json_schemas/services-g-cloud-6-scs.json
+++ b/json_schemas/services-g-cloud-6-scs.json
@@ -24,6 +24,10 @@
          "type": "string",
          "format": "date-time"
       },
+      "updatedAt": {
+        "type": "string",
+        "format": "date-time"
+      },
       "serviceTypes": {
          "type": "array",
          "uniqueItems": true,


### PR DESCRIPTION
Migrating data from the preview API through my local API was failing because the schemas didn't accept the `updatedAt` key.
This change adds `updatedAt` to the schemas as well as includes some logic to preserve updated times when they are included.