### PR TITLE
Unlock and deactivate users

### DIFF
--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -22,7 +22,7 @@ def auth_user():
 
     if user is None:
         return jsonify(authorization=False), 404
-    elif encryption.authenticate_user(json_payload['password'], user):
+    elif encryption.authenticate_user(json_payload['password'], user) and user.active:
         user.logged_in_at = datetime.utcnow()
         user.failed_login_count = 0
         db.session.add(user)
@@ -183,6 +183,8 @@ def update_user(user_id):
         user.supplier_id = user_update['supplierId']
     if 'emailAddress' in user_update:
         user.email_address = user_update['emailAddress']
+    if 'locked' in user_update and not user_update['locked']:
+        user.failed_login_count = 0
 
     audit = AuditEvent(
         audit_type=AuditTypes.update_user,

--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -198,7 +198,7 @@ def update_user(user_id):
 
     try:
         db.session.commit()
-        return jsonify(message="done"), 200
+        return jsonify(users=user.serialize()), 200
     except IntegrityError as e:
         db.session.rollback()
         abort(400, "Could not update user with: {0}".format(user_update))

--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from dmutils.audit import AuditTypes
+from dmutils.config import convert_to_boolean
 from sqlalchemy.exc import IntegrityError
 from flask import jsonify, abort, request, current_app
 
@@ -47,12 +48,13 @@ def get_user_by_id(user_id):
 
 @main.route('/users', methods=['GET'])
 def list_users():
+    user_query = User.query.order_by(User.id)
     page = get_valid_page_or_1()
 
     # email_address is a primary key
     email_address = request.args.get('email_address')
     if email_address:
-        user = User.query.filter(
+        user = user_query.filter(
             User.email_address == email_address.lower()
         ).first()
 
@@ -65,7 +67,6 @@ def list_users():
         )
 
     supplier_id = request.args.get('supplier_id')
-
     if supplier_id is not None:
         try:
             supplier_id = int(supplier_id)
@@ -75,17 +76,17 @@ def list_users():
         supplier = Supplier.query.filter(Supplier.supplier_id == supplier_id).all()
         if not supplier:
             abort(404, "supplier_id '{}' not found".format(supplier_id))
-        users = User.query.filter(User.supplier_id == supplier_id).paginate(
-            page=page,
-            per_page=current_app.config['DM_API_SERVICES_PAGE_SIZE'],
-        )
 
-    # No query parameters, so list all users
-    else:
-        users = User.query.paginate(
-            page=page,
-            per_page=current_app.config['DM_API_SERVICES_PAGE_SIZE'],
-        )
+        user_query = user_query.filter(User.supplier_id == supplier_id)
+
+    active = convert_to_boolean(request.args.get('active'))
+    if isinstance(active, bool):
+        user_query = user_query.filter(User.active == active)
+
+    users = user_query.paginate(
+        page=page,
+        per_page=current_app.config['DM_API_SERVICES_PAGE_SIZE'],
+    )
 
     return jsonify(
         users=[user.serialize() for user in users.items],

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ psycopg2==2.5.4
 SQLAlchemy==1.0.5
 SQLAlchemy-Utils==0.30.5
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@3.2.0#egg=digitalmarketplace-utils==3.2.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@3.3.1#egg=digitalmarketplace-utils==3.3.1
 
 # For schema validation
 jsonschema==2.3.0

--- a/tests/app/test_users.py
+++ b/tests/app/test_users.py
@@ -424,6 +424,8 @@ class TestUsersUpdate(BaseApplicationTest):
                 content_type='application/json')
 
             assert_equal(response.status_code, 200)
+            data = json.loads(response.get_data())['users']
+            assert_equal(data['active'], False)
 
             response = self.client.post(
                 '/users/auth',
@@ -470,6 +472,8 @@ class TestUsersUpdate(BaseApplicationTest):
                 content_type='application/json')
 
             assert_equal(response.status_code, 200)
+            data = json.loads(response.get_data())['users']
+            assert_equal(data['locked'], False)
 
             response = self.client.get(
                 '/users/123',
@@ -501,6 +505,8 @@ class TestUsersUpdate(BaseApplicationTest):
                 content_type='application/json')
 
             assert_equal(response.status_code, 200)
+            data = json.loads(response.get_data())['users']
+            assert_equal(data['locked'], False)
 
             response = self.client.get(
                 '/users/123',
@@ -522,6 +528,8 @@ class TestUsersUpdate(BaseApplicationTest):
                 content_type='application/json')
 
             assert_equal(response.status_code, 200)
+            data = json.loads(response.get_data())['users']
+            assert_equal(data['name'], 'I Just Got Married')
 
             response = self.client.post(
                 '/users/auth',
@@ -570,6 +578,8 @@ class TestUsersUpdate(BaseApplicationTest):
                 content_type='application/json')
 
             assert_equal(response.status_code, 200)
+            data = json.loads(response.get_data())['users']
+            assert_equal(data['role'], 'supplier')
 
             response = self.client.post(
                 '/users/auth',
@@ -608,6 +618,8 @@ class TestUsersUpdate(BaseApplicationTest):
                 content_type='application/json')
 
             assert_equal(response.status_code, 200)
+            data = json.loads(response.get_data())['users']
+            assert_equal(data['emailAddress'], 'myshinynew@email.address')
 
             response = self.client.post(
                 '/users/auth',


### PR DESCRIPTION
3 changes to the API

1) Now the authenticate method respects whether the user is active and won't allow logins for inactive users.

2) We can now update the locked status of users. Send { "locked": false } as update JSON and the failed login count is reset

3) The update users endpoint now returns the User, not a success message. 