### PR TITLE
Changed prefix for *any* servcies by supplier query

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -40,7 +40,7 @@ def list_suppliers():
         suppliers = Supplier.query.order_by(Supplier.name)
 
     if prefix:
-        if prefix == '123':
+        if prefix == 'other':
             suppliers = suppliers.filter(
                 Supplier.name.op('~')('^[^A-Za-z]'))
         else:

--- a/tests/app/views/test_suppliers.py
+++ b/tests/app/views/test_suppliers.py
@@ -114,19 +114,19 @@ class TestListSuppliers(BaseApplicationTest):
     def test_other_prefix_returns_non_alphanumeric_suppliers(self):
         with self.app.app_context():
             db.session.add(
-                Supplier(supplier_id=999, name=u"123 Supplier")
+                Supplier(supplier_id=999, name=u"999 Supplier")
             )
             self.setup_dummy_service(service_id=123, supplier_id=999)
             db.session.commit()
 
-            response = self.client.get('/suppliers?prefix=123')
+            response = self.client.get('/suppliers?prefix=other')
 
             data = json.loads(response.get_data())
             assert_equal(200, response.status_code)
             assert_equal(1, len(data['suppliers']))
             assert_equal(999, data['suppliers'][0]['id'])
             assert_equal(
-                u"123 Supplier",
+                u"999 Supplier",
                 data['suppliers'][0]['name']
             )
 


### PR DESCRIPTION
- This used to require '123' to perform the any non-alphanumeric supplier name search
- Changed to 'other' to be more clear
- Matched changes in buyer app
- This needs to go first