### PR TITLE
Minor bug fixes and 'not_a_number' validation

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -1,6 +1,7 @@
 from flask import url_for as base_url_for
 from flask import abort, request
 from six import string_types
+from werkzeug.exceptions import BadRequest
 
 
 def link(rel, href):
@@ -41,7 +42,10 @@ def get_json_from_request():
     if request.content_type not in ['application/json',
                                     'application/json; charset=UTF-8']:
         abort(400, "Unexpected Content-Type, expecting 'application/json'")
-    data = request.get_json()
+    try:
+        data = request.get_json()
+    except BadRequest as e:
+        data = None
     if data is None:
         abort(400, "Invalid JSON; must be a valid JSON object")
     return data

--- a/app/validation.py
+++ b/app/validation.py
@@ -264,6 +264,8 @@ def _translate_json_schema_error(message):
             return 'under_character_limit'
     if 'does not match' in message:
         return 'under_{}_words'.format(_get_word_count(message))
+    if "is not of type 'number'" in message:
+        return 'not_a_number'
     return message
 
 

--- a/app/validation.py
+++ b/app/validation.py
@@ -70,8 +70,10 @@ def validate_updater_json_or_400(submitted_json):
 
 
 def validate_user_json_or_400(submitted_json):
-    if not validates_against_schema('users', submitted_json):
-        abort(400, "JSON was not a valid format")
+    try:
+        get_validator('users').validate(submitted_json)
+    except ValidationError as e:
+        abort(400, "JSON was not a valid format. {}".format(e.message))
     if submitted_json['role'] == 'supplier' \
             and 'supplierId' not in submitted_json:
         abort(400, "No supplier id provided for supplier user")

--- a/json_schemas/users.json
+++ b/json_schemas/users.json
@@ -30,6 +30,7 @@
   },
   "required": [
     "name",
+    "role",
     "emailAddress",
     "password"
   ]

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -176,7 +176,7 @@ class JSONUpdateTestMixin(object):
             content_type='application/json')
 
         assert_equal(response.status_code, 400)
-        assert_in(b'a request that this server could not understand',
+        assert_in(b'Invalid JSON',
                   response.get_data())
 
     def test_invalid_json_causes_failure(self):

--- a/tests/app/test_users.py
+++ b/tests/app/test_users.py
@@ -346,7 +346,7 @@ class TestUsersPost(BaseApplicationTest, JSONUpdateTestMixin):
 
         assert_equal(response.status_code, 400)
         data = json.loads(response.get_data())["error"]
-        assert_equal(data, "JSON was not a valid format")
+        assert_in("JSON was not a valid format", data)
 
     def test_return_400_for_invalid_user_role(self):
         response = self.client.post(
@@ -361,7 +361,7 @@ class TestUsersPost(BaseApplicationTest, JSONUpdateTestMixin):
 
         assert_equal(response.status_code, 400)
         data = json.loads(response.get_data())["error"]
-        assert_equal(data, "JSON was not a valid format")
+        assert_in("JSON was not a valid format", data)
 
 
 class TestUsersUpdate(BaseApplicationTest):

--- a/tests/app/views/test_audits.py
+++ b/tests/app/views/test_audits.py
@@ -40,7 +40,7 @@ class TestAudits(BaseApplicationTest):
         assert_equal(data['auditEvents'][0]['data']['request'], 'data')
 
     def test_should_get_audit_event_using_audit_date(self):
-        today = datetime.now().strftime("%Y-%m-%d")
+        today = datetime.utcnow().strftime("%Y-%m-%d")
 
         self.add_audit_events(1)
         response = self.client.get('/audit-events?audit-date={}'.format(today))

--- a/tests/app/views/test_services.py
+++ b/tests/app/views/test_services.py
@@ -460,7 +460,7 @@ class TestPostService(BaseApplicationTest):
                 content_type='application/json')
 
             assert_equal(response.status_code, 400)
-            assert_in(b'a request that this server could not understand',
+            assert_in(b'Invalid JSON',
                       response.get_data())
 
     def test_can_post_a_valid_service_update(self):


### PR DESCRIPTION
## Correctly handle invalid JSON

Before this change invalid JSON would cause Werkzeug to raise an error which would not be formatted in our standard way. The body of this error would not be JSON.

## Fix user validation and improve error messaging

The role is required as it's used on the very next line. This change also adds in detailed error messaging like for service.

## Fix UTC bug in audit tests

This bug only manifests itself between 12 and 1am BST. Today BST is the next day according to UTC.

## Add validation message for 'not_a_number'

This makes it easier to parse errors where a field is not a number.