### PR TITLE
Add framework slug to service JSON

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -157,7 +157,7 @@ def import_service(service_id):
 
     service_data = drop_foreign_fields(
         service_json,
-        ['supplierName', 'links', 'frameworkName']
+        ['supplierName', 'links', 'frameworkSlug', 'frameworkName']
     )
     service_data = strip_whitespace_from_data(service_data)
     framework = detect_framework_or_400(service_data)

--- a/app/models.py
+++ b/app/models.py
@@ -358,6 +358,8 @@ class ServiceTableMixin(object):
         data.pop('frameworkName', None)
         data.pop('status', None)
         data.pop('links', None)
+        data.pop('updatedAt', None)
+        data.pop('createdAt', None)
         current_data = dict(self.data.items())
         current_data.update(data)
         current_data = strip_whitespace_from_data(current_data)

--- a/app/models.py
+++ b/app/models.py
@@ -334,6 +334,7 @@ class ServiceTableMixin(object):
             'id': self.service_id,
             'supplierId': self.supplier.supplier_id,
             'supplierName': self.supplier.name,
+            'frameworkSlug': self.framework.slug,
             'frameworkName': self.framework.name,
             'updatedAt': self.updated_at.strftime(DATETIME_FORMAT),
             'createdAt': self.created_at.strftime(DATETIME_FORMAT),
@@ -353,6 +354,7 @@ class ServiceTableMixin(object):
 
         data.pop('supplierId', None)
         data.pop('supplierName', None)
+        data.pop('frameworkSlug', None)
         data.pop('frameworkName', None)
         data.pop('status', None)
         data.pop('links', None)

--- a/app/service_utils.py
+++ b/app/service_utils.py
@@ -53,7 +53,7 @@ def validate_service(service):
 
     data = drop_foreign_fields(
         data,
-        ['service_id', 'supplierName', 'links', 'frameworkName', 'updatedAt'])
+        ['service_id', 'supplierName', 'links', 'frameworkSlug', 'frameworkName', 'updatedAt'])
     errs = get_validation_errors(validator_name, data, enforce_required=True)
     if errs:
         abort(400, errs)

--- a/tests/app/views/test_drafts.py
+++ b/tests/app/views/test_drafts.py
@@ -213,6 +213,7 @@ class TestDraftServices(BaseApplicationTest):
 
         data = json.loads(res.get_data())
         assert_equal(res.status_code, 201)
+        assert_equal(data['services']['frameworkSlug'], 'g-cloud-7')
         assert_equal(data['services']['frameworkName'], 'G-Cloud 7')
         assert_equal(data['services']['status'], 'not-submitted')
         assert_equal(data['services']['supplierId'], 1)
@@ -280,6 +281,7 @@ class TestDraftServices(BaseApplicationTest):
             content_type='application/json')
         data2 = json.loads(res2.get_data())
         assert_equal(res2.status_code, 200)
+        assert_equal(data2['services']['frameworkSlug'], 'g-cloud-7')
         assert_equal(data2['services']['frameworkName'], 'G-Cloud 7')
         assert_equal(data2['services']['status'], 'not-submitted')
         assert_equal(data2['services']['supplierId'], 1)
@@ -854,8 +856,8 @@ class TestCopyDraft(BaseApplicationTest):
         assert_equal(res.status_code, 201)
         assert_equal(data['services']['lot'], 'SCS')
         assert_equal(data['services']['supplierId'], 1)
-        assert_equal(data['services']['frameworkName'],
-                     self.draft['frameworkName'])
+        assert_equal(data['services']['frameworkSlug'], self.draft['frameworkSlug'])
+        assert_equal(data['services']['frameworkName'], self.draft['frameworkName'])
 
     def test_copy_draft_should_create_audit_event(self):
         res = self.client.post(

--- a/tests/app/views/test_services.py
+++ b/tests/app/views/test_services.py
@@ -238,6 +238,7 @@ class TestListServices(BaseApplicationTest):
         data = json.loads(response.get_data())
         service = data['services'][0]
 
+        assert_equal(service['frameworkSlug'], u'g-cloud-6')
         assert_equal(service['frameworkName'], u'G-Cloud 6')
 
     def test_list_services_returns_supplier_info(self):
@@ -914,7 +915,7 @@ class TestPostService(BaseApplicationTest):
 
     def test_json_postgres_field_should_not_include_column_fields(self):
         non_json_fields = [
-            'supplierName', 'links', 'frameworkName', 'status', 'id']
+            'supplierName', 'links', 'frameworkSlug', 'frameworkName', 'status', 'id']
         with self.app.app_context():
             response = self.client.get('/services/{}'.format(self.service_id))
             data = json.loads(response.get_data())
@@ -1338,7 +1339,7 @@ class TestPutService(BaseApplicationTest, JSONUpdateTestMixin):
 
     def test_json_postgres_data_column_should_not_include_column_fields(self):
         non_json_fields = [
-            'supplierName', 'links', 'frameworkName', 'status', 'id',
+            'supplierName', 'links', 'frameworkSlug', 'frameworkName', 'status', 'id',
             'supplierId', 'updatedAt', 'createdAt']
         with self.app.app_context():
             payload = self.load_example_listing("G6-IaaS")

--- a/tests/app/views/test_services.py
+++ b/tests/app/views/test_services.py
@@ -915,7 +915,7 @@ class TestPostService(BaseApplicationTest):
 
     def test_json_postgres_field_should_not_include_column_fields(self):
         non_json_fields = [
-            'supplierName', 'links', 'frameworkSlug', 'frameworkName', 'status', 'id']
+            'supplierName', 'links', 'frameworkSlug', 'updatedAt', 'createdAt', 'frameworkName', 'status', 'id']
         with self.app.app_context():
             response = self.client.get('/services/{}'.format(self.service_id))
             data = json.loads(response.get_data())
@@ -1339,7 +1339,7 @@ class TestPutService(BaseApplicationTest, JSONUpdateTestMixin):
 
     def test_json_postgres_data_column_should_not_include_column_fields(self):
         non_json_fields = [
-            'supplierName', 'links', 'frameworkSlug', 'frameworkName', 'status', 'id',
+            'supplierName', 'links', 'frameworkSlug', 'updatedAt', 'createdAt', 'frameworkName', 'status', 'id',
             'supplierId', 'updatedAt', 'createdAt']
         with self.app.app_context():
             payload = self.load_example_listing("G6-IaaS")


### PR DESCRIPTION
## Add framework slug to service JSON
Framework slug is used in new document upload paths as a document
directory.

## Don't save updated/createdAt to service JSON on update
Removes updatedAt and createdAt fields from the update
JSON so that they're not saved as part of service data.