### PR TITLE
Accept page_questions top-level key in draft update requests

### DIFF
--- a/app/draft_utils.py
+++ b/app/draft_utils.py
@@ -12,6 +12,11 @@ def validate_and_return_draft_request(draft_id=0):
     return json_payload['services']
 
 
+def get_request_page_questions():
+    json_payload = get_json_from_request()
+    return json_payload.get('page_questions', [])
+
+
 def get_draft_validation_errors(draft_json, lot,
                                 framework_id=0, slug=None, required=None):
     if not slug and not framework_id:

--- a/app/main/views/drafts.py
+++ b/app/main/views/drafts.py
@@ -13,7 +13,10 @@ from ...models import Service, DraftService, Supplier, AuditEvent, Framework
 from ...service_utils import validate_and_return_updater_request, \
     update_and_validate_service, index_service, \
     commit_and_archive_service, create_service_from_draft
-from ...draft_utils import validate_and_return_draft_request, get_draft_validation_errors
+from ...draft_utils import (
+    validate_and_return_draft_request, get_draft_validation_errors,
+    get_request_page_questions
+)
 
 
 @main.route('/draft-services/copy-from/<string:service_id>', methods=['PUT'])
@@ -71,7 +74,8 @@ def edit_draft_service(draft_id):
 
     updater_json = validate_and_return_updater_request()
     update_json = validate_and_return_draft_request()
-    page_questions = update_json.pop('page_questions', [])
+    page_questions = get_request_page_questions()
+
     draft = DraftService.query.filter(
         DraftService.id == draft_id
     ).first_or_404()


### PR DESCRIPTION
`page_questions` should not be a part of the service data. This is
the API part of the change that also requres an update to the utils
and supplier frontend that send the `page_questions` to the API.