### PR TITLE
[#100216314] Make delete draft take user ID as a parameter

### DIFF
--- a/app/main/views/drafts.py
+++ b/app/main/views/drafts.py
@@ -9,7 +9,7 @@ from .. import main
 from ... import db
 from ...utils import drop_foreign_fields, json_has_required_keys
 from ...validation import is_valid_service_id_or_400
-from ...models import Service, DraftService, Supplier, AuditEvent, Framework
+from ...models import AuditEvent, DraftService, Framework, Service, Supplier, User
 from ...service_utils import validate_and_return_updater_request, \
     update_and_validate_service, index_service, \
     commit_and_archive_service, create_service_from_draft
@@ -168,16 +168,22 @@ def delete_draft_service(draft_id):
     :param draft_id:
     :return:
     """
-
-    updater_json = validate_and_return_updater_request()
-
+    user_id = request.args.get('user_id')
+    if user_id is None:
+        abort(400, "Invalid argument: user_id is required")
+    try:
+        user_id = int(user_id)
+    except ValueError:
+        abort(400, "Invalid user_id: %s" % user_id)
+    user = User.query.filter(User.id == user_id).first()
+    if not user:
+        abort(404, "user_id '%d' not found" % user_id)
     draft = DraftService.query.filter(
         DraftService.id == draft_id
     ).first_or_404()
-
     audit = AuditEvent(
         audit_type=AuditTypes.delete_draft_service,
-        user=updater_json['updated_by'],
+        user=user.email_address,
         data={
             "draftId": draft_id,
             "serviceId": draft.service_id

--- a/app/main/views/drafts.py
+++ b/app/main/views/drafts.py
@@ -168,9 +168,9 @@ def delete_draft_service(draft_id):
     :param draft_id:
     :return:
     """
-    user_id = request.args.get('user_id')
+    user_id = request.headers.get('user-id', None)
     if user_id is None:
-        abort(400, "Invalid argument: user_id is required")
+        abort(400, "Invalid request: user-id must be set in header")
     try:
         user_id = int(user_id)
     except ValueError:

--- a/tests/app/views/test_drafts.py
+++ b/tests/app/views/test_drafts.py
@@ -1,10 +1,11 @@
+from sqlalchemy.sql.functions import now
 from tests.app.helpers import BaseApplicationTest
 from datetime import datetime
 from flask import json
 import mock
 from sqlalchemy.exc import IntegrityError
 from app.models import Supplier, ContactInformation, Service, Framework, \
-    DraftService
+    DraftService, User
 from app import db
 
 from nose.tools import assert_equal, assert_in, assert_raises
@@ -34,6 +35,11 @@ class TestDraftServices(BaseApplicationTest):
         with self.app.app_context():
             db.session.add(
                 Supplier(supplier_id=1, name=u"Supplier 1")
+            )
+            db.session.add(
+                User(id=123, name="Joe Bloggs", email_address="joeblogs",
+                     password="pass", active=True, password_changed_at=now(),
+                     role="supplier", supplier_id=1)
             )
             db.session.add(
                 ContactInformation(
@@ -195,10 +201,23 @@ class TestDraftServices(BaseApplicationTest):
 
         assert_equal(res.status_code, 400)
 
-    def test_reject_delete_with_no_update_details(self):
+    def test_reject_delete_with_no_user_id(self):
         res = self.client.delete('/draft-services/0000000000')
 
         assert_equal(res.status_code, 400)
+        data = json.loads(res.get_data())
+        assert_in(
+            'Invalid argument: user_id is required',
+            data['error'])
+
+    def test_reject_delete_with_invalid_user_id(self):
+        res = self.client.delete('/draft-services/0000000000?user_id=invalid')
+
+        assert_equal(res.status_code, 400)
+        data = json.loads(res.get_data())
+        assert_in(
+            'Invalid user_id: invalid',
+            data['error'])
 
     def test_reject_publish_with_no_update_details(self):
         res = self.client.post('/draft-services/0000000000/publish')
@@ -430,10 +449,21 @@ class TestDraftServices(BaseApplicationTest):
 
     def test_should_404_on_delete_a_draft_that_doesnt_exist(self):
         res = self.client.delete(
-            '/draft-services/0000000000',
-            data=json.dumps(self.updater_json),
-            content_type='application/json')
+            '/draft-services/0000000000?user_id=123')
         assert_equal(res.status_code, 404)
+        data = json.loads(res.get_data())
+        assert_in(
+            'The requested URL was not found on the server.',
+            data['error'])
+
+    def test_should_404_on_delete_a_draft_when_user_id_doesnt_exist(self):
+        res = self.client.delete(
+            '/draft-services/0000000000?user_id=1234')
+        assert_equal(res.status_code, 404)
+        data = json.loads(res.get_data())
+        assert_in(
+            "user_id '1234' not found",
+            data['error'])
 
     def test_should_delete_a_draft(self):
         res = self.client.put(
@@ -445,9 +475,7 @@ class TestDraftServices(BaseApplicationTest):
         fetch = self.client.get('/draft-services/{}'.format(draft_id))
         assert_equal(fetch.status_code, 200)
         delete = self.client.delete(
-            '/draft-services/{}'.format(draft_id),
-            data=json.dumps(self.updater_json),
-            content_type='application/json')
+            '/draft-services/{}?user_id=123'.format(draft_id))
         assert_equal(delete.status_code, 200)
 
         audit_response = self.client.get('/audit-events')

--- a/tests/app/views/test_drafts.py
+++ b/tests/app/views/test_drafts.py
@@ -202,16 +202,18 @@ class TestDraftServices(BaseApplicationTest):
         assert_equal(res.status_code, 400)
 
     def test_reject_delete_with_no_user_id(self):
-        res = self.client.delete('/draft-services/0000000000')
+        res = self.client.delete('/draft-services/0000000000',
+                                 headers={})
 
         assert_equal(res.status_code, 400)
         data = json.loads(res.get_data())
         assert_in(
-            'Invalid argument: user_id is required',
+            'Invalid request: user-id must be set in header',
             data['error'])
 
     def test_reject_delete_with_invalid_user_id(self):
-        res = self.client.delete('/draft-services/0000000000?user_id=invalid')
+        res = self.client.delete('/draft-services/0000000000',
+                                 headers={"user-id": "invalid"})
 
         assert_equal(res.status_code, 400)
         data = json.loads(res.get_data())
@@ -448,8 +450,8 @@ class TestDraftServices(BaseApplicationTest):
         assert_equal(fetch.status_code, 404)
 
     def test_should_404_on_delete_a_draft_that_doesnt_exist(self):
-        res = self.client.delete(
-            '/draft-services/0000000000?user_id=123')
+        res = self.client.delete('/draft-services/0000000000',
+                                 headers={"user-id": 123})
         assert_equal(res.status_code, 404)
         data = json.loads(res.get_data())
         assert_in(
@@ -457,8 +459,8 @@ class TestDraftServices(BaseApplicationTest):
             data['error'])
 
     def test_should_404_on_delete_a_draft_when_user_id_doesnt_exist(self):
-        res = self.client.delete(
-            '/draft-services/0000000000?user_id=1234')
+        res = self.client.delete('/draft-services/0000000000',
+                                 headers={"user-id": 1234})
         assert_equal(res.status_code, 404)
         data = json.loads(res.get_data())
         assert_in(
@@ -475,7 +477,8 @@ class TestDraftServices(BaseApplicationTest):
         fetch = self.client.get('/draft-services/{}'.format(draft_id))
         assert_equal(fetch.status_code, 200)
         delete = self.client.delete(
-            '/draft-services/{}?user_id=123'.format(draft_id))
+            '/draft-services/{}'.format(draft_id),
+            headers={"user-id": 123})
         assert_equal(delete.status_code, 200)
 
         audit_response = self.client.get('/audit-events')


### PR DESCRIPTION
HTTP DELETEs can't take a JSON payload, so the previous version of the DELETE endpoint wouldn't work.

Fortunately nothing was using it.

This changes the endpoint to take `user_id` as a parameter to allow auditing of who deleted the draft.

There is a corresponding pull-request to update the API client here: https://github.com/alphagov/digitalmarketplace-utils/pull/119