### PR TITLE
Complete draft service

### DIFF
--- a/app/draft_utils.py
+++ b/app/draft_utils.py
@@ -1,7 +1,7 @@
 from .models import Framework
 from .utils import get_json_from_request, json_has_required_keys, \
     json_has_matching_id
-from .validation import get_validation_errors
+from .validation import get_validation_errors, get_validator
 
 
 def validate_and_return_draft_request(draft_id=0):
@@ -17,8 +17,7 @@ def get_request_page_questions():
     return json_payload.get('page_questions', [])
 
 
-def get_draft_validation_errors(draft_json, lot,
-                                framework_id=0, slug=None, required=None):
+def get_draft_validation_errors(draft_json, framework_id=0, slug=None, required=None):
     if not slug and not framework_id:
         raise Exception('Validation requires either framework_id or slug')
     if not slug:
@@ -26,10 +25,37 @@ def get_draft_validation_errors(draft_json, lot,
             Framework.id == framework_id
         ).first()
         slug = framework.slug
+
     errs = get_validation_errors(
-        "services-{0}-{1}".format(slug, lot.lower()),
+        "services-{0}-{1}".format(slug, draft_json['lot'].lower()),
         draft_json,
         enforce_required=False,
         required_fields=required
     )
+    return errs
+
+
+def validate_draft(draft):
+    framework = Framework.query.filter(
+        Framework.id == draft.framework_id
+    ).first()
+
+    lot = draft.data['lot'].lower()
+    validator_name = 'services-{}-{}'.format(framework.slug, lot)
+
+    data = dict(draft.data.items())
+    data.update({
+        'supplierId': draft.supplier_id,
+        'status': draft.status
+    })
+
+    errs = get_validation_errors(
+        validator_name,
+        data,
+        enforce_required=True
+    )
+
+    # Drafts are valid even without the required service ID
+    errs.pop('id', None)
+
     return errs

--- a/app/main/views/drafts.py
+++ b/app/main/views/drafts.py
@@ -127,8 +127,6 @@ def list_draft_services():
         abort(404, "supplier_id '%d' not found" % supplier_id)
 
     services = DraftService.query.order_by(
-        asc(DraftService.framework_id),
-        asc(DraftService.data['lot'].cast(String).label('data_lot')),
         asc(DraftService.id)
     )
 

--- a/app/models.py
+++ b/app/models.py
@@ -518,7 +518,7 @@ class AuditEvent(db.Model):
         self.user = user
         self.acknowledged = False
 
-    def serialize(self):
+    def serialize(self, include_user=False):
         """
         :return: dictionary representation of an audit event
         """
@@ -548,6 +548,14 @@ class AuditEvent(db.Model):
                 'acknowledgedBy':
                     self.acknowledged_by,
             })
+
+        if include_user:
+            user = User.query.filter(
+                User.email_address == self.user
+            ).first()
+
+            if user:
+                data['userName'] = user.name
 
         return data
 

--- a/app/models.py
+++ b/app/models.py
@@ -471,8 +471,8 @@ class DraftService(db.Model, ServiceTableMixin):
         return DraftService(
             framework_id=self.framework_id,
             supplier_id=self.supplier_id,
-            data=self.data,
-            status=self.status
+            data=data,
+            status='not-submitted',
         )
 
     def serialize(self):

--- a/app/models.py
+++ b/app/models.py
@@ -464,6 +464,10 @@ class DraftService(db.Model, ServiceTableMixin):
         )
 
     def copy(self):
+        data = self.data.copy()
+        name = data.get('serviceName', '')
+        if len(name) <= 95:
+            data['serviceName'] = u"{} copy".format(name)
         return DraftService(
             framework_id=self.framework_id,
             supplier_id=self.supplier_id,

--- a/example_listings/G7-SCS.json
+++ b/example_listings/G7-SCS.json
@@ -25,7 +25,6 @@
    "priceMax": "36.56",
    "priceUnit": "Licence",
    "priceInterval": "6 months",
-   "priceString": "£34.65 per licence per 6 months",
    "vatIncluded": true,
    "educationPricing": false,
    "supportForThirdParties": true,

--- a/json_schemas/services-g-cloud-7-iaas.json
+++ b/json_schemas/services-g-cloud-7-iaas.json
@@ -112,9 +112,6 @@
         "Year"
       ]
     },
-    "priceString":{
-      "type":"string"
-    },
     "vatIncluded":{
       "type":"boolean"
     },
@@ -912,7 +909,6 @@
     "serviceBenefits",
     "priceMin",
     "priceUnit",
-    "priceString",
     "vatIncluded",
     "educationPricing",
     "trialOption",

--- a/json_schemas/services-g-cloud-7-paas.json
+++ b/json_schemas/services-g-cloud-7-paas.json
@@ -113,9 +113,6 @@
         "Year"
       ]
     },
-    "priceString":{
-      "type":"string"
-    },
     "vatIncluded":{
       "type":"boolean"
     },
@@ -913,7 +910,6 @@
     "serviceBenefits",
     "priceMin",
     "priceUnit",
-    "priceString",
     "vatIncluded",
     "educationPricing",
     "trialOption",

--- a/json_schemas/services-g-cloud-7-saas.json
+++ b/json_schemas/services-g-cloud-7-saas.json
@@ -112,9 +112,6 @@
         "Year"
       ]
     },
-    "priceString":{
-      "type":"string"
-    },
     "vatIncluded":{
       "type":"boolean"
     },
@@ -794,7 +791,6 @@
     "serviceBenefits",
     "priceMin",
     "priceUnit",
-    "priceString",
     "vatIncluded",
     "educationPricing",
     "trialOption",

--- a/json_schemas/services-g-cloud-7-scs.json
+++ b/json_schemas/services-g-cloud-7-scs.json
@@ -118,9 +118,6 @@
         "Year"
       ]
     },
-    "priceString":{
-      "type":"string"
-    },
     "vatIncluded":{
       "type":"boolean"
     },
@@ -196,7 +193,6 @@
     "serviceBenefits",
     "priceMin",
     "priceUnit",
-    "priceString",
     "vatIncluded",
     "educationPricing",
     "terminationCost",

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ psycopg2==2.5.4
 SQLAlchemy==1.0.5
 SQLAlchemy-Utils==0.30.5
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@4.2.0#egg=digitalmarketplace-utils==4.2.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@5.2.0#egg=digitalmarketplace-utils==5.2.0
 
 # For schema validation
 jsonschema==2.3.0

--- a/tests/app/views/test_drafts.py
+++ b/tests/app/views/test_drafts.py
@@ -805,6 +805,25 @@ class TestDraftServices(BaseApplicationTest):
             assert_equal(Service.query.count(), 2)
             assert_equal(DraftService.query.count(), 1)
 
+    def test_get_draft_returns_last_audit_event(self):
+        draft = json.loads(self.client.post(
+            '/draft-services/g-cloud-7/create',
+            data=json.dumps(self.create_draft_json),
+            content_type='application/json'
+        ).get_data())['services']
+
+        res = self.client.get(
+            '/draft-services/%d' % draft['id'],
+            data=json.dumps(self.create_draft_json),
+            content_type='application/json'
+        )
+
+        assert_equal(res.status_code, 200)
+        data = json.loads(res.get_data())
+        draft, audit_event = data['services'], data['auditEvents']
+
+        assert_equal(audit_event['type'], 'create_draft_service')
+
 
 class TestCopyDraft(BaseApplicationTest):
     def setup(self):

--- a/tests/app/views/test_drafts.py
+++ b/tests/app/views/test_drafts.py
@@ -903,6 +903,14 @@ class TestCopyDraft(BaseApplicationTest):
             'originalDraftId': self.draft_id
         })
 
+    def test_should_not_copy_draft_without_update_details(self):
+        res = self.client.post(
+            '/draft-services/%s/copy' % self.draft_id,
+            data=json.dumps({}),
+            content_type='application/json')
+
+        assert_equal(res.status_code, 400)
+
     def test_should_not_create_draft_with_invalid_data(self):
         res = self.client.post(
             '/draft-services/1000/copy',
@@ -971,6 +979,14 @@ class TestCompleteDraft(BaseApplicationTest):
         assert_equal(data['auditEvents'][1]['data'], {
             'draftId': self.draft_id,
         })
+
+    def test_should_not_complete_draft_without_update_details(self):
+        res = self.client.post(
+            '/draft-services/%s/complete' % self.draft_id,
+            data=json.dumps({}),
+            content_type='application/json')
+
+        assert_equal(res.status_code, 400)
 
     def test_should_not_complete_invalid_draft(self):
         create_draft_json = {

--- a/tests/app/views/test_drafts.py
+++ b/tests/app/views/test_drafts.py
@@ -853,7 +853,8 @@ class TestCopyDraft(BaseApplicationTest):
             },
             'services': {
                 'lot': 'SCS',
-                'supplierId': 1
+                'supplierId': 1,
+                'serviceName': "Draft",
             }
         }
 
@@ -874,6 +875,7 @@ class TestCopyDraft(BaseApplicationTest):
         data = json.loads(res.get_data())
         assert_equal(res.status_code, 201)
         assert_equal(data['services']['lot'], 'SCS')
+        assert_equal(data['services']['serviceName'], 'Draft copy')
         assert_equal(data['services']['supplierId'], 1)
         assert_equal(data['services']['frameworkSlug'], self.draft['frameworkSlug'])
         assert_equal(data['services']['frameworkName'], self.draft['frameworkName'])

--- a/tests/app/views/test_drafts.py
+++ b/tests/app/views/test_drafts.py
@@ -855,6 +855,7 @@ class TestCopyDraft(BaseApplicationTest):
                 'lot': 'SCS',
                 'supplierId': 1,
                 'serviceName': "Draft",
+                'status': 'submitted'
             }
         }
 
@@ -875,6 +876,7 @@ class TestCopyDraft(BaseApplicationTest):
         data = json.loads(res.get_data())
         assert_equal(res.status_code, 201)
         assert_equal(data['services']['lot'], 'SCS')
+        assert_equal(data['services']['status'], 'not-submitted')
         assert_equal(data['services']['serviceName'], 'Draft copy')
         assert_equal(data['services']['supplierId'], 1)
         assert_equal(data['services']['frameworkSlug'], self.draft['frameworkSlug'])


### PR DESCRIPTION
### Add /complete draft endpoint
Validates the full draft JSON (skipping the service ID error, since
drafts don't have an ID) and sets the status to 'submitted'.

### Remove priceString from G7 JSON schemas
"priceString" was replaced by separate max/minPrice fields, so it
shouldn't be a part of the G7 schema.

It's not removed from G6 to keep existing services valid.

### Order draft services by ID only
Ordering services by lot means that copied and new services appear
in the middle of the list. Instead, we order services by `id` and
let the frontend to reverse the order or apply a different sort
method.

### Return last audit event related to a draft in GET draft response
Finds the last create/update/complete event related to the given
draft and returnes it together with the draft service data.

Audit event data is used for "Last edited" block on the draft page.

### Append ' copy' to the copied draft name
Draft copies are named "<original name> copy" to avoid accidental
duplicate names in submitted services.

Since the name change doesn't go through service validation it's
possible that the new draft name is longer than the serviceName
limit of 100 characters and won't pass validation if the draft
is completed.

To avoid this there's an additional check that adds " copy" only
if the new name will stay below the 100 character limit. Since the
limit can only be increased without breaking existing services this
check should be enough to make sure that the new service name passes
the validation length rule in the future.

### Always set copied draft status to 'not-submitted'
Since there's no way to change draft status from 'submitted' to
'not-submitted' new drafts should always start in the 'not-submitted'
state, even if copied from the 'submitted' draft.