### PR TITLE
PaaS does not require serviceTypes

### DIFF
--- a/json_schemas/services-g-cloud-7-paas.json
+++ b/json_schemas/services-g-cloud-7-paas.json
@@ -47,14 +47,6 @@
       "minLength":1
 
     },
-    "serviceTypes":{
-      "type":"array",
-      "uniqueItems":true,
-      "maxItems":5,
-      "items":{
-        "enum":["Compute", "Storage"]
-      }
-    },
     "serviceFeatures":{
       "type":"array",
       "minItems":1,
@@ -905,7 +897,6 @@
     "pricingDocumentURL",
     "serviceName",
     "serviceSummary",
-    "serviceTypes",
     "serviceFeatures",
     "serviceBenefits",
     "priceMin",


### PR DESCRIPTION
The fact that this doesn't break any tests is a worry. Currently we only explicitly test SCS services as that was the first that got implemented.