### PR TITLE
Add an endpoint for stats about a framework

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -1,7 +1,8 @@
 from flask import jsonify
+import datetime
 
 from .. import main
-from ...models import Framework
+from ...models import Framework, DraftService, Service, User, Supplier, SelectionAnswers
 
 
 @main.route('/frameworks', methods=['GET'])
@@ -11,3 +12,18 @@ def list_frameworks():
     return jsonify(
         frameworks=[f.serialize() for f in frameworks]
     )
+
+
+@main.route('/frameworks/g-cloud-7/stats', methods=['GET'])
+def get_framework_stats():
+
+    seven_days_ago = datetime.datetime.now() + datetime.timedelta(-7)
+
+    return str({
+        'drafts': DraftService.query.filter(DraftService.status == "not-submitted").count(),
+        'complete': DraftService.query.filter(DraftService.status == "submitted").count(),
+        'users': User.query.count(),
+        'active_users': User.query.filter(User.logged_in_at > seven_days_ago).count(),
+        'suppliers': Supplier.query.count(),
+        'suppliers_with_complete_declaration': SelectionAnswers.find_by_framework('g-cloud-7').count()
+    })

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -16,8 +16,15 @@ def list_frameworks():
     )
 
 
-@main.route('/frameworks/g-cloud-7/stats', methods=['GET'])
-def get_framework_stats():
+@main.route('/frameworks/<string:framework_slug>/stats', methods=['GET'])
+def get_framework_stats(framework_slug):
+
+    framework = Framework.query.filter(
+        Framework.slug == framework_slug
+    ).first()
+
+    if not framework:
+        abort(404, "'{}' is not a framework".format(framework.slug))
 
     seven_days_ago = datetime.datetime.utcnow() + datetime.timedelta(-7)
     lot_column = DraftService.data['lot'].cast(String).label('lot')
@@ -25,13 +32,24 @@ def get_framework_stats():
     return str({
         'services_by_status': dict(db.session.query(
                 DraftService.status, func.count(DraftService.status)
-            ).group_by(DraftService.status)),
+            ).group_by(
+                DraftService.status
+            ).filter(
+                DraftService.framework_id == framework.id
+            )),
         'services_by_lot': dict(db.session.query(
                 lot_column, func.count(lot_column)
-            ).group_by(lot_column).all()),
+            ).group_by(
+                lot_column
+            ).filter(
+                DraftService.framework_id == framework.id
+            ).all()),
         'users': User.query.count(),
         'active_users': User.query.filter(User.logged_in_at > seven_days_ago).count(),
         'suppliers': Supplier.query.count(),
-        'suppliers_interested': AuditEvent.query.filter(AuditEvent.type == 'register_framework_interest').count(),
-        'suppliers_with_complete_declaration': SelectionAnswers.find_by_framework('g-cloud-7').count()
+        'suppliers_interested': AuditEvent.query.filter(
+                AuditEvent.data['frameworkSlug'].cast(String) == framework_slug,
+                AuditEvent.type == 'register_framework_interest'
+            ).count(),
+        'suppliers_with_complete_declaration': SelectionAnswers.find_by_framework(framework_slug).count()
     })

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -42,13 +42,13 @@ def get_framework_stats(framework_slug):
     drafts_alias = orm.aliased(DraftService, has_completed_drafts_query)
 
     def label_columns(labels, query):
-        return [dict(zip(labels, item)) for item in query]
+        return [dict(zip(labels, item)) for item in sorted(query)]
 
     return jsonify({
         'services': label_columns(
-            ['status', 'lot', 'declaration_made', 'count'],
+            ['lot', 'status', 'declaration_made', 'count'],
             db.session.query(
-                DraftService.status, lot_column, SelectionAnswers.framework_id.isnot(None), func.count()
+                lot_column, DraftService.status, SelectionAnswers.framework_id.isnot(None), func.count()
             ).outerjoin(
                 SelectionAnswers, DraftService.supplier_id == SelectionAnswers.supplier_id
             ).group_by(

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -42,7 +42,10 @@ def get_framework_stats(framework_slug):
     drafts_alias = orm.aliased(DraftService, has_completed_drafts_query)
 
     def label_columns(labels, query):
-        return [dict(zip(labels, item)) for item in sorted(query)]
+        return [
+            dict(zip(labels, item))
+            for item in sorted(query, key=lambda x: list(map(str, x)))
+        ]
 
     return jsonify({
         'services': label_columns(

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -44,8 +44,13 @@ def get_framework_stats(framework_slug):
         ).filter(
             DraftService.framework_id == framework.id
         ).all()),
-        'users': User.query.count(),
-        'active_users': User.query.filter(User.logged_in_at > seven_days_ago).count(),
+        'supplier_users': User.query.filter(
+            User.role == 'supplier'
+        ).count(),
+        'active_supplier_users': User.query.filter(
+            User.role == 'supplier',
+            User.logged_in_at > seven_days_ago
+        ).count(),
         'suppliers': Supplier.query.count(),
         'suppliers_interested': AuditEvent.query.filter(
             AuditEvent.data['frameworkSlug'].cast(String) == framework_slug,

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -1,8 +1,10 @@
 from flask import jsonify
+from sqlalchemy.types import String
+from sqlalchemy import func
 import datetime
 
 from .. import main
-from ...models import Framework, DraftService, Service, User, Supplier, SelectionAnswers
+from ...models import db, Framework, DraftService, Service, User, Supplier, SelectionAnswers, AuditEvent
 
 
 @main.route('/frameworks', methods=['GET'])
@@ -18,12 +20,21 @@ def list_frameworks():
 def get_framework_stats():
 
     seven_days_ago = datetime.datetime.now() + datetime.timedelta(-7)
+    lot_column = DraftService.data['lot'].cast(String).label('lot')
 
     return str({
-        'drafts': DraftService.query.filter(DraftService.status == "not-submitted").count(),
-        'complete': DraftService.query.filter(DraftService.status == "submitted").count(),
+        'services_drafts': DraftService.query.filter(
+                DraftService.status == "not-submitted"
+            ).count(),
+        'services_complete': DraftService.query.filter(
+                DraftService.status == "submitted"
+            ).count(),
+        'services_by_lot': dict(db.session.query(
+                lot_column, func.count(lot_column)
+            ).group_by(lot_column).all()),
         'users': User.query.count(),
         'active_users': User.query.filter(User.logged_in_at > seven_days_ago).count(),
         'suppliers': Supplier.query.count(),
+        'suppliers_interested': AuditEvent.query.filter(AuditEvent.type == 'register_framework_interest').count(),
         'suppliers_with_complete_declaration': SelectionAnswers.find_by_framework('g-cloud-7').count()
     })

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -23,12 +23,9 @@ def get_framework_stats():
     lot_column = DraftService.data['lot'].cast(String).label('lot')
 
     return str({
-        'services_drafts': DraftService.query.filter(
-                DraftService.status == "not-submitted"
-            ).count(),
-        'services_complete': DraftService.query.filter(
-                DraftService.status == "submitted"
-            ).count(),
+        'services_by_status': dict(db.session.query(
+                DraftService.status, func.count(DraftService.status)
+            ).group_by(DraftService.status)),
         'services_by_lot': dict(db.session.query(
                 lot_column, func.count(lot_column)
             ).group_by(lot_column).all()),

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -19,7 +19,7 @@ def list_frameworks():
 @main.route('/frameworks/g-cloud-7/stats', methods=['GET'])
 def get_framework_stats():
 
-    seven_days_ago = datetime.datetime.now() + datetime.timedelta(-7)
+    seven_days_ago = datetime.datetime.utcnow() + datetime.timedelta(-7)
     lot_column = DraftService.data['lot'].cast(String).label('lot')
 
     return str({

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -31,25 +31,25 @@ def get_framework_stats(framework_slug):
 
     return str({
         'services_by_status': dict(db.session.query(
-                DraftService.status, func.count(DraftService.status)
-            ).group_by(
-                DraftService.status
-            ).filter(
-                DraftService.framework_id == framework.id
-            )),
+            DraftService.status, func.count(DraftService.status)
+        ).group_by(
+            DraftService.status
+        ).filter(
+            DraftService.framework_id == framework.id
+        )),
         'services_by_lot': dict(db.session.query(
-                lot_column, func.count(lot_column)
-            ).group_by(
-                lot_column
-            ).filter(
-                DraftService.framework_id == framework.id
-            ).all()),
+            lot_column, func.count(lot_column)
+        ).group_by(
+            lot_column
+        ).filter(
+            DraftService.framework_id == framework.id
+        ).all()),
         'users': User.query.count(),
         'active_users': User.query.filter(User.logged_in_at > seven_days_ago).count(),
         'suppliers': Supplier.query.count(),
         'suppliers_interested': AuditEvent.query.filter(
-                AuditEvent.data['frameworkSlug'].cast(String) == framework_slug,
-                AuditEvent.type == 'register_framework_interest'
-            ).count(),
+            AuditEvent.data['frameworkSlug'].cast(String) == framework_slug,
+            AuditEvent.type == 'register_framework_interest'
+        ).count(),
         'suppliers_with_complete_declaration': SelectionAnswers.find_by_framework(framework_slug).count()
     })

--- a/app/models.py
+++ b/app/models.py
@@ -215,11 +215,15 @@ class SelectionAnswers(db.Model):
     framework = db.relationship(Framework, lazy='joined', innerjoin=True)
 
     @staticmethod
-    def find_by_supplier_and_framework(supplier_id, framework_slug):
+    def find_by_framework(framework_slug):
         return SelectionAnswers.query.filter(
             SelectionAnswers.framework.has(
                 Framework.slug == framework_slug)
-        ).filter(
+        )
+
+    @staticmethod
+    def find_by_supplier_and_framework(supplier_id, framework_slug):
+        return SelectionAnswers.find_by_framework(framework_slug).filter(
             SelectionAnswers.supplier_id == supplier_id
         ).first()
 

--- a/tests/app/views/test_frameworks.py
+++ b/tests/app/views/test_frameworks.py
@@ -1,10 +1,12 @@
-from __future__ import absolute_import
+import datetime
 
 from flask import json
 from nose.tools import assert_equal
 
+from dmutils.audit import AuditTypes
+
 from ..helpers import BaseApplicationTest
-from app.models import Framework
+from app.models import db, Framework, SelectionAnswers, DraftService, AuditEvent, Supplier, User
 
 
 class TestListFrameworks(BaseApplicationTest):
@@ -16,3 +18,174 @@ class TestListFrameworks(BaseApplicationTest):
             assert_equal(response.status_code, 200)
             assert_equal(len(data['frameworks']),
                          len(Framework.query.all()))
+
+
+class TestFrameworkStats(BaseApplicationTest):
+    def create_selection_answers(self, framework_id, supplier_ids):
+        with self.app.app_context():
+            for supplier_id in supplier_ids:
+                db.session.add(
+                    SelectionAnswers(
+                        framework_id=framework_id,
+                        supplier_id=supplier_id,
+                        question_answers='{}',
+                    )
+                )
+
+            db.session.commit()
+
+    def create_framework_interest_audit_event(self, framework_id, supplier_ids):
+        with self.app.app_context():
+            for supplier_id in supplier_ids:
+                db.session.add(
+                    AuditEvent(
+                        audit_type=AuditTypes.register_framework_interest,
+                        user='supplier@user.dmdev',
+                        data='{}',
+                        db_object=Supplier.query.filter(
+                            Supplier.supplier_id == supplier_id
+                        ).first()
+                    )
+                )
+
+            db.session.commit()
+
+    def create_drafts(self, framework_id, supplier_id_count_pairs, status='not-submitted'):
+        with self.app.app_context():
+            for supplier_id, count in supplier_id_count_pairs:
+                for ind in range(count):
+                    db.session.add(
+                        DraftService(
+                            framework_id=framework_id,
+                            supplier_id=supplier_id,
+                            data={
+                                'lot': ['IaaS', 'PaaS', 'SaaS', 'SCS'][ind % 4]
+                            },
+                            status=status
+                        )
+                    )
+
+            db.session.commit()
+
+    def create_users(self, supplier_ids, logged_in_at):
+        with self.app.app_context():
+            for supplier_id in supplier_ids:
+                db.session.add(
+                    User(
+                        name='supplier user',
+                        email_address='supplier-{}@user.dmdev'.format(supplier_id),
+                        password='testpassword',
+                        active=True,
+                        password_changed_at=datetime.datetime.utcnow(),
+                        role='supplier',
+                        supplier_id=supplier_id,
+                        logged_in_at=logged_in_at
+                    )
+                )
+
+            db.session.commit()
+
+    def setup_data(self, framework_slug):
+        with self.app.app_context():
+            framework = Framework.query.filter(Framework.slug == framework_slug).first()
+
+        self.setup_dummy_suppliers(30)
+        self.create_framework_interest_audit_event(framework.id, range(20))
+        self.create_selection_answers(framework.id, range(12))
+        self.create_drafts(framework.id, [
+            (1, 1),   # 1 IaaS; with declaration
+            (2, 7),   # 1 of each + IaaS, PaaS, SaaS; with declaration
+            (3, 2),   # IaaS + PaaS; with declaration
+            (14, 3),  # IaaS + PaaS + SaaS; without declaration
+        ])
+        self.create_drafts(framework.id, [
+            (1, 2),   # IaaS + PaaS; with declaration
+            (2, 15),  # 3 of each + IaaS, PaaS, SaaS; with declaration
+            (3, 2),   # IaaS + PaaS; with declaration
+            (14, 7),  # 1 of each + IaaS + PaaS + SaaS; without declaration
+        ], status='submitted')
+
+        self.create_users(
+            [1, 2, 3, 4, 5],
+            logged_in_at=datetime.datetime.utcnow() - datetime.timedelta(days=1)
+        )
+
+        self.create_users(
+            [6, 7, 8, 9],
+            logged_in_at=datetime.datetime.utcnow() - datetime.timedelta(days=10)
+        )
+
+        self.create_users(
+            [10, 11],
+            logged_in_at=None
+        )
+
+    def test_stats(self):
+        self.setup_data('g-cloud-7')
+
+        response = self.client.get('/frameworks/g-cloud-7/stats')
+        assert_equal(json.loads(response.get_data()), {
+            u'services': [
+                {u'count': 1, u'status': u'not-submitted',
+                 u'declaration_made': False, u'lot': u'IaaS'},
+                {u'count': 4, u'status': u'not-submitted',
+                 u'declaration_made': True, u'lot': u'IaaS'},
+                {u'count': 2, u'status': u'submitted',
+                 u'declaration_made': False, u'lot': u'IaaS'},
+                {u'count': 6, u'status': u'submitted',
+                 u'declaration_made': True, u'lot': u'IaaS'},
+
+                {u'count': 1, u'status': u'not-submitted',
+                 u'declaration_made': False, u'lot': u'PaaS'},
+                {u'count': 3, u'status': u'not-submitted',
+                 u'declaration_made': True, u'lot': u'PaaS'},
+                {u'count': 2, u'status': u'submitted',
+                 u'declaration_made': False, u'lot': u'PaaS'},
+                {u'count': 6, u'status': u'submitted',
+                 u'declaration_made': True, u'lot': u'PaaS'},
+
+                {u'count': 1, u'status': u'not-submitted',
+                 u'declaration_made': True, u'lot': u'SCS'},
+                {u'count': 1, u'status': u'submitted',
+                 u'declaration_made': False, u'lot': u'SCS'},
+                {u'count': 3, u'status': u'submitted',
+                 u'declaration_made': True, u'lot': u'SCS'},
+
+                {u'count': 1, u'status': u'not-submitted',
+                 u'declaration_made': False, u'lot': u'SaaS'},
+                {u'count': 2, u'status': u'not-submitted',
+                 u'declaration_made': True, u'lot': u'SaaS'},
+                {u'count': 2, u'status': u'submitted',
+                 u'declaration_made': False, u'lot': u'SaaS'},
+                {u'count': 4, u'status': u'submitted',
+                 u'declaration_made': True, u'lot': u'SaaS'}
+            ],
+            u'interested_suppliers': [
+                {u'count': 7, u'has_made_declaration': False, u'has_completed_services': False},
+                {u'count': 1, u'has_made_declaration': False, u'has_completed_services': True},
+                {u'count': 9, u'has_made_declaration': True,  u'has_completed_services': False},
+                {u'count': 3, u'has_made_declaration': True,  u'has_completed_services': True},
+            ],
+            u'supplier_users': [
+                {u'count': 2, u'recent_login': None},
+                {u'count': 4, u'recent_login': False},
+                {u'count': 5, u'recent_login': True},
+            ]
+        })
+
+    def test_stats_are_for_g_cloud_7_only(self):
+        self.setup_data('g-cloud-6')
+        response = self.client.get('/frameworks/g-cloud-7/stats')
+        assert_equal(json.loads(response.get_data()), {
+            u'interested_suppliers': [
+                # No suppliers with completed G7 services
+                {u'count': 8, u'has_completed_services': False, u'has_made_declaration': False},
+                {u'count': 12, u'has_completed_services': False, u'has_made_declaration': True},
+            ],
+            u'services': [],
+            u'supplier_users': [
+                {u'count': 2, u'recent_login': None},
+                {u'count': 4, u'recent_login': False},
+                {u'count': 5, u'recent_login': True},
+            ]
+        })

--- a/tests/app/views/test_frameworks.py
+++ b/tests/app/views/test_frameworks.py
@@ -167,8 +167,8 @@ class TestFrameworkStats(BaseApplicationTest):
                 {u'count': 3, u'has_made_declaration': True,  u'has_completed_services': True},
             ],
             u'supplier_users': [
-                {u'count': 2, u'recent_login': None},
                 {u'count': 4, u'recent_login': False},
+                {u'count': 2, u'recent_login': None},
                 {u'count': 5, u'recent_login': True},
             ]
         })
@@ -184,8 +184,8 @@ class TestFrameworkStats(BaseApplicationTest):
             ],
             u'services': [],
             u'supplier_users': [
-                {u'count': 2, u'recent_login': None},
                 {u'count': 4, u'recent_login': False},
+                {u'count': 2, u'recent_login': None},
                 {u'count': 5, u'recent_login': True},
             ]
         })


### PR DESCRIPTION
This pull request:
- gives us count for some things that we think we might want to count, based on [#100215966](https://www.pivotaltracker.com/story/show/100215966)

It doesn't:
- deal with snapshotting these counts over time, which will probably happen in a separate app

--

Sample output:

``` json
{
  "interested_suppliers": [
    {
      "count": 2,
      "has_made_declaration": false
    },
    {
      "count": 12,
      "has_made_declaration": true
    }
  ],
  "services": [
    {
      "count": 1,
      "declaration_made": true,
      "lot": "PaaS",
      "status": "not-submitted"
    },
    {
      "count": 1,
      "declaration_made": false,
      "lot": "IaaS",
      "status": "not-submitted"
    },
    {
      "count": 1,
      "declaration_made": false,
      "lot": "SCS",
      "status": "not-submitted"
    },
    {
      "count": 1,
      "declaration_made": false,
      "lot": "SaaS",
      "status": "not-submitted"
    },
    {
      "count": 1,
      "declaration_made": false,
      "lot": "PaaS",
      "status": "not-submitted"
    },
    {
      "count": 1,
      "declaration_made": true,
      "lot": "SCS",
      "status": "submitted"
    },
    {
      "count": 2,
      "declaration_made": true,
      "lot": "SCS",
      "status": "not-submitted"
    }
  ],
  "supplier_users": [
    {
      "count": 2381,
      "recent_login": null
    },
    {
      "count": 3,
      "recent_login": true
    },
    {
      "count": 2,
      "recent_login": false
    }
  ]
}
```