### PR TITLE
Allow audit event with no user

### DIFF
--- a/app/main/views/audits.py
+++ b/app/main/views/audits.py
@@ -100,7 +100,7 @@ def create_audit_event():
     json_payload = get_json_from_request()  # TODO test
     json_has_required_keys(json_payload, ['auditEvents'])  # TODO test
     audit_event_data = json_payload['auditEvents']
-    json_has_required_keys(audit_event_data, ["type", "user", "data"])
+    json_has_required_keys(audit_event_data, ["type", "data"])
 
     if 'objectType' not in audit_event_data:
         if 'objectId' in audit_event_data:
@@ -126,7 +126,7 @@ def create_audit_event():
 
     audit_event = AuditEvent(
         audit_type=AuditTypes[audit_event_data['type']],
-        user=audit_event_data['user'],
+        user=audit_event_data.get('user'),
         data=audit_event_data['data'],
         db_object=db_object)
 

--- a/tests/app/views/test_audits.py
+++ b/tests/app/views/test_audits.py
@@ -333,6 +333,17 @@ class TestCreateAuditEvent(BaseApplicationTest):
 
         assert_equal(res.status_code, 201)
 
+    def test_create_audit_event_with_no_user(self):
+        audit_event = self.audit_event()
+        del audit_event['user']
+
+        res = self.client.post(
+            '/audit-events',
+            data=json.dumps({'auditEvents': audit_event}),
+            content_type='application/json')
+
+        assert_equal(res.status_code, 201)
+
     def test_should_fail_if_no_type_is_given(self):
         audit_event = self.audit_event()
         del audit_event['type']
@@ -358,19 +369,6 @@ class TestCreateAuditEvent(BaseApplicationTest):
 
         assert_equal(res.status_code, 400)
         assert_equal(data['error'], "invalid audit type supplied")
-
-    def test_should_fail_if_no_user_is_given(self):
-        audit_event = self.audit_event()
-        del audit_event['user']
-
-        res = self.client.post(
-            '/audit-events',
-            data=json.dumps({'auditEvents': audit_event}),
-            content_type='application/json')
-        data = json.loads(res.get_data())
-
-        assert_equal(res.status_code, 400)
-        assert_true(data['error'].startswith("Invalid JSON"))
 
     def test_should_fail_if_no_data_is_given(self):
         audit_event = self.audit_event()


### PR DESCRIPTION
Audit events are allowed to be created with no associated user. This
makes the API create audit event endpoint also allow this. There is a
requirement in the frontend to create an audit event for sending an
invite email on creation of a supplier, before the user has logged in.