### PR TITLE
Make 'create_supplier' call match new name

### DIFF
--- a/scripts/import_suppliers_from_api.py
+++ b/scripts/import_suppliers_from_api.py
@@ -69,7 +69,7 @@ class SupplierUpdater(object):
     def __call__(self, supplier):
         client = apiclient.DataAPIClient(self.endpoint, self.access_token)
         try:
-            client.create_supplier(supplier['id'],
+            client.import_supplier(supplier['id'],
                                    self.clean_data(supplier, supplier['id']))
         except apiclient.APIError as e:
             print("ERROR: {}. {} not imported".format(e.message,


### PR DESCRIPTION
This method was renamed to be 'import_supplier' when the new create supplier route was added.

See https://github.com/alphagov/digitalmarketplace-utils/commit/e0e19d29e74d6d7ff3f71d8679414a2b4484cd69 for details.