### PR TITLE
Add decorator to set PostgreSQL isolation level

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -47,7 +47,8 @@ def isolation_level(level):
     """
     def decorator(view):
         def view_wrapper(*args, **kwargs):
-            db.session.connection(execution_options={'isolation_level': level})
+            if flask_featureflags.is_active('TRANSACTION_ISOLATION'):
+                db.session.connection(execution_options={'isolation_level': level})
             return view(*args, **kwargs)
         return view_wrapper
     return decorator

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -34,3 +34,20 @@ def create_app(config_name):
         application.register_blueprint(explorer_blueprint)
 
     return application
+
+
+def isolation_level(level):
+    """Return a Flask view decorator to set SQLAlchemy isolation level
+
+    Usage::
+        @isolation_level("SERIALIZABLE")
+        @view("/thingy/<id>", methods=["POST"])
+        def create_thing(id):
+            ...
+    """
+    def decorator(view):
+        def view_wrapper(*args, **kwargs):
+            db.session.connection(execution_options={'isolation_level': level})
+            return view(*args, **kwargs)
+        return view_wrapper
+    return decorator

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,3 +1,4 @@
+from functools import wraps
 from flask import Flask
 from flask.ext.bootstrap import Bootstrap
 from flask.ext.sqlalchemy import SQLAlchemy
@@ -40,12 +41,13 @@ def isolation_level(level):
     """Return a Flask view decorator to set SQLAlchemy isolation level
 
     Usage::
-        @isolation_level("SERIALIZABLE")
         @view("/thingy/<id>", methods=["POST"])
+        @isolation_level("SERIALIZABLE")
         def create_thing(id):
             ...
     """
     def decorator(view):
+        @wraps(view)
         def view_wrapper(*args, **kwargs):
             if flask_featureflags.is_active('TRANSACTION_ISOLATION'):
                 db.session.connection(execution_options={'isolation_level': level})

--- a/app/main/views/drafts.py
+++ b/app/main/views/drafts.py
@@ -6,7 +6,7 @@ from sqlalchemy import asc, desc
 from sqlalchemy.types import String
 
 from .. import main
-from ... import db
+from ... import db, isolation_level
 from ...utils import drop_foreign_fields, json_has_required_keys
 from ...validation import is_valid_service_id_or_400
 from ...models import Service, DraftService, Supplier, AuditEvent, Framework, User
@@ -65,6 +65,7 @@ def copy_draft_service_from_existing_service(service_id):
 
 
 @main.route('/draft-services/<int:draft_id>', methods=['POST'])
+@isolation_level("SERIALIZABLE")
 def edit_draft_service(draft_id):
     """
     Edit a draft service

--- a/config.py
+++ b/config.py
@@ -23,6 +23,8 @@ class Config:
     # Feature Flags
     RAISE_ERROR_ON_MISSING_FEATURES = True
 
+    FEATURE_FLAGS_TRANSACTION_ISOLATION = False
+
     DM_API_SERVICES_PAGE_SIZE = 100
     DM_API_SUPPLIERS_PAGE_SIZE = 100
     SQLALCHEMY_COMMIT_ON_TEARDOWN = False
@@ -40,6 +42,7 @@ class Test(Config):
     SQLALCHEMY_DATABASE_URI = 'postgresql://localhost/digitalmarketplace_test'
     DM_API_SERVICES_PAGE_SIZE = 5
     DM_API_SUPPLIERS_PAGE_SIZE = 5
+    FEATURE_FLAGS_TRANSACTION_ISOLATION = enabled_since('2015-08-27')
 
 
 class Development(Config):
@@ -47,15 +50,29 @@ class Development(Config):
 
 
 class Live(Config):
+    """Base config for deployed environments"""
     DEBUG = False
     ALLOW_EXPLORER = False
     DM_HTTP_PROTO = 'https'
 
 
+class Preview(Live):
+    FEATURE_FLAGS_TRANSACTION_ISOLATION = enabled_since('2015-08-27')
+
+
+class Staging(Live):
+    pass
+
+
+class Production(Live):
+    pass
+
+
 configs = {
     'development': Development,
-    'preview': Live,
-    'staging': Live,
-    'production': Live,
     'test': Test,
+
+    'preview': Preview,
+    'staging': Staging,
+    'production': Production,
 }

--- a/tests/app/views/test_drafts.py
+++ b/tests/app/views/test_drafts.py
@@ -288,6 +288,11 @@ class TestDraftServices(BaseApplicationTest):
         assert_equal(data2['services']['serviceTypes'], ['Implementation'])
         assert_equal(data2['services']['serviceBenefits'], ['Tests pass'])
 
+    @mock.patch('app.db')
+    def test_update_draft_uses_serializable_isolation_level(self, db):
+        self.client.post('/draft-services/1234')
+        db.session.connection.assert_called_with(execution_options={'isolation_level': 'SERIALIZABLE'})
+
     def test_update_draft_should_create_audit_event(self):
         res = self.client.post(
             '/draft-services/g-cloud-7/create',


### PR DESCRIPTION
## Do not merge!

This is just for discussion.

Add a Flask decorator to allow the PostgreSQL transaction isolation level to be set per request.

On some update requests we can run into concurrency issues because we read a row with a big blob of JSON from the database make some changes and then write it back. If another process was also doing this, even if it was in another part of the JSON there would be a race condition and the last writer would win. PostgreSQL has a transaction isolation level [1] called SERIALIZABLE that will cause a failure if any of the rows that a transaction trys to work with are changed while it is running. We don't want to set this isolation level on all transactions because it's more costly and often we don't care. This change allows us to set the isolation level on a single request transaction.

[1] http://www.postgresql.org/docs/9.1/static/transaction-iso.html