### PR TITLE
[#100722784] Make apiType optional

### DIFF
--- a/json_schemas/services-g-cloud-7-iaas.json
+++ b/json_schemas/services-g-cloud-7-iaas.json
@@ -214,8 +214,7 @@
     "apiType": {
       "type": "string",
       "maxLength":200,
-      "pattern":"^(?:\\S+\\s+){0,19}\\S+$",
-      "minLength":1
+      "pattern":"^$|(^(?:\\S+\\s+){0,19}\\S+$)"
     },
     "networksConnected": {
       "type": "array",

--- a/json_schemas/services-g-cloud-7-paas.json
+++ b/json_schemas/services-g-cloud-7-paas.json
@@ -207,8 +207,7 @@
     "apiType": {
       "type": "string",
       "maxLength":200,
-      "pattern":"^(?:\\S+\\s+){0,19}\\S+$",
-      "minLength":1
+      "pattern":"^$|(^(?:\\S+\\s+){0,19}\\S+$)"
     },
     "networksConnected": {
       "type": "array",

--- a/json_schemas/services-g-cloud-7-saas.json
+++ b/json_schemas/services-g-cloud-7-saas.json
@@ -223,8 +223,7 @@
     "apiType": {
       "type": "string",
       "maxLength":200,
-      "pattern":"^(?:\\S+\\s+){0,19}\\S+$",
-      "minLength":1
+      "pattern":"^$|(^(?:\\S+\\s+){0,19}\\S+$)"
     },
     "networksConnected": {
       "type": "array",

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -421,6 +421,14 @@ def test_max_price_larger_than_min_price_causes_validation_error():
         yield assert_in, 'max_less_than_min', errs['priceMax']
 
 
+def test_api_type_is_optional():
+    data = load_example_listing("G6-PaaS")
+    del data["apiType"]
+    errs = get_validation_errors("services-g-cloud-7-paas", data)
+
+    assert not errs.get('apiType', None)
+
+
 def assert_example(name, result, expected):
     assert_equal(result, expected)
 


### PR DESCRIPTION
Fixes this bug: https://www.pivotaltracker.com/story/show/100722784

The minimum length requirement on apiType meant that it was giving a `required` validation error even though `apiType` is not in the list of required fields.

 The regular expression also needed to be modified to match an empty string, or that also caused a validation error when the page was submitted with nothing in the apiType field..