### PR TITLE
[#100513836] Percentages should be less than 100

### DIFF
--- a/app/validation.py
+++ b/app/validation.py
@@ -285,8 +285,10 @@ def _translate_json_schema_error(key, message):
             return 'not_money_format'
         else:
             return 'under_{}_words'.format(_get_word_count(message))
-    if "is not of type 'number'" in message:
-        return 'not_a_number'
+    if "is not of type 'number'" in message \
+            or "is less than" in message \
+            or "is greater than" in message:
+            return 'not_a_number'
     return message
 
 

--- a/json_schemas/services-g-cloud-7-iaas.json
+++ b/json_schemas/services-g-cloud-7-iaas.json
@@ -444,7 +444,10 @@
       "type": "object",
       "properties": {
         "value": {
-          "type": "number"
+          "type": "number",
+          "minimum": 0,
+          "maximum": 100,
+          "exclusiveMaximum": true
         },
         "assurance": {
           "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]

--- a/json_schemas/services-g-cloud-7-paas.json
+++ b/json_schemas/services-g-cloud-7-paas.json
@@ -437,7 +437,10 @@
       "type": "object",
       "properties": {
         "value": {
-          "type": "number"
+          "type": "number",
+          "minimum": 0,
+          "maximum": 100,
+          "exclusiveMaximum": true
         },
         "assurance": {
           "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]

--- a/json_schemas/services-g-cloud-7-saas.json
+++ b/json_schemas/services-g-cloud-7-saas.json
@@ -397,7 +397,10 @@
       "type": "object",
       "properties": {
         "value": {
-          "type": "number"
+          "type": "number",
+          "minimum": 0,
+          "maximum": 100,
+          "exclusiveMaximum": true
         },
         "assurance": {
           "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -368,6 +368,14 @@ def test_string_too_long_causes_validation_error():
     assert "under_character_limit" in errs['serviceName']
 
 
+def test_percentage_out_of_range_causes_validation_error():
+    data = load_example_listing("G6-PaaS")
+    data.update({'serviceAvailabilityPercentage':
+                {"value": 101, "assurance": "Service provider assertion"}})
+    errs = get_validation_errors("services-g-cloud-7-paas", data)
+    assert "not_a_number" in errs['serviceAvailabilityPercentage']
+
+
 def test_price_not_money_format_validation_error():
     cases = [
         "",  # not provided


### PR DESCRIPTION
Fixes this bug: https://www.pivotaltracker.com/story/show/100513836

I've re-used the existing `not_a_number` validations key because it gives the correct validation message from the SSP content.