### PR TITLE
Snapshot framework stats

### DIFF
--- a/app/main/views/audits.py
+++ b/app/main/views/audits.py
@@ -17,11 +17,13 @@ from ...utils import get_json_from_request, json_has_required_keys
 AUDIT_OBJECT_TYPES = {
     "suppliers": models.Supplier,
     "services": models.Service,
+    "frameworks": models.Framework,
 }
 
 AUDIT_OBJECT_ID_FIELDS = {
     "suppliers": models.Supplier.supplier_id,
     "services": models.Service.service_id,
+    "frameworks": models.Framework.slug,
 }
 
 

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -83,6 +83,7 @@ def get_framework_stats(framework_slug):
             ).outerjoin(
                 drafts_alias
             ).filter(
+                AuditEvent.object_type == 'Supplier',
                 AuditEvent.type == 'register_framework_interest'
             ).group_by(
                 SelectionAnswers.framework_id, drafts_alias.supplier_id.isnot(None)

--- a/app/models.py
+++ b/app/models.py
@@ -510,9 +510,8 @@ class AuditEvent(db.Model):
     __tablename__ = 'audit_events'
 
     id = db.Column(db.Integer, primary_key=True)
-    type = db.Column(db.String, nullable=False)
-    created_at = db.Column(db.DateTime, nullable=False,
-                           default=datetime.utcnow)
+    type = db.Column(db.String, index=True, nullable=False)
+    created_at = db.Column(db.DateTime, index=True, nullable=False, default=datetime.utcnow)
     user = db.Column(db.String)
     data = db.Column(JSON)
 
@@ -581,6 +580,9 @@ class AuditEvent(db.Model):
                 data['userName'] = user.name
 
         return data
+
+
+db.Index('idx_audit_events_object', AuditEvent.object_type, AuditEvent.object_id)
 
 
 def filter_null_value_fields(obj):

--- a/migrations/versions/270_add_audit_events_indexes.py
+++ b/migrations/versions/270_add_audit_events_indexes.py
@@ -1,0 +1,25 @@
+"""Add audit_events type, object and created_at indexes
+
+Revision ID: 270_add_audit_events_indexes
+Revises: 260_add_admin_ccs_user_role
+Create Date: 2015-08-26 11:18:44.886576
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '270_add_audit_events_indexes'
+down_revision = '260_add_admin_ccs_user_role'
+
+from alembic import op
+
+
+def upgrade():
+    op.create_index(op.f('ix_audit_events_type'), 'audit_events', ['type'], unique=False)
+    op.create_index('idx_audit_events_object', 'audit_events', ['object_type', 'object_id'], unique=False)
+    op.create_index(op.f('ix_audit_events_created_at'), 'audit_events', ['created_at'], unique=False)
+
+
+def downgrade():
+    op.drop_index(op.f('ix_audit_events_type'), table_name='audit_events')
+    op.drop_index('idx_audit_events_object', table_name='audit_events')
+    op.drop_index(op.f('ix_audit_events_created_at'), table_name='audit_events')

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ psycopg2==2.5.4
 SQLAlchemy==1.0.5
 SQLAlchemy-Utils==0.30.5
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@6.0.0#egg=digitalmarketplace-utils==6.0.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@6.5.0#egg=digitalmarketplace-utils==6.5.0
 
 # For schema validation
 jsonschema==2.3.0

--- a/scripts/snapshot_framework_stats.py
+++ b/scripts/snapshot_framework_stats.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+"""Change user password
+
+Usage:
+    snapshot_framework_stats.py <framework_slug> <stage> <api_token>
+
+Example:
+    ./snapshot_framework_stats.py g-cloud-7 dev myToken
+"""
+
+import sys
+import logging
+
+logger = logging.getLogger('script')
+logging.basicConfig(level=logging.INFO)
+
+from docopt import docopt
+
+from dmutils import apiclient
+from dmutils.audit import AuditTypes
+
+
+def get_api_endpoint_from_stage(stage):
+    stage_prefixes = {
+        'preview': 'preview-api.development',
+        'staging': 'staging-api',
+        'production': 'api'
+    }
+
+    if stage in ['local', 'dev', 'development']:
+        return 'http://localhost:5000'
+
+    return "https://{}.digitalmarketplace.service.gov.uk".format(
+        stage_prefixes[stage]
+    )
+
+
+def snapshot_framework_stats(api_endpoint, api_token, framework_slug):
+    data_client = apiclient.DataAPIClient(api_endpoint, api_token)
+
+    try:
+        stats = data_client.get_framework_stats(framework_slug)
+        data_client.create_audit_event(
+            AuditTypes.snapshot_framework_stats,
+            data=stats,
+            object_type='frameworks',
+            object_id=framework_slug
+        )
+    except apiclient.APIError:
+        sys.exit(1)
+
+    logger.info("Framework stats snapshot saved")
+
+
+if __name__ == '__main__':
+    arguments = docopt(__doc__)
+
+    snapshot_framework_stats(
+        get_api_endpoint_from_stage(arguments['<stage>']),
+        arguments['<api_token>'],
+        arguments['<framework_slug>'],
+    )


### PR DESCRIPTION
#### Add "frameworks" to the list of audit object types
Framework stats snapshot events are associated with a framework
object, so this adds "frameworks" to the list of object types that
can be used with audit events API endpoints.

Framework slug is used as object_id since similar to service_id it's
used to reference the framework object everywhere outside the API.

#### Add snapshot_framework_stats.py script
Requests the framework stats for the given environment and stores
the response in a new audit event associated with the given
framework.

#### Add audit_events type, created_at and object indexes
Adds three separate indexes:

* Index on audit_events.type, since it's the most useful filter for
  listing audit events
* Index on audit_events.created_at for timestamp filters
* Multicolumn index on (object_type, object_id) for filters based on
  referenced object.

#### Take advantage of new audit_events index in framework stats
When joining suppliers with audit events there's no need to have
a object_type filter, since framework interest events are always
related to a supplier object. But adding additional object_type
filter allows the DB to take advantage of the new multicolumn
(object_type, object_id) index.