### PR TITLE
Allow priceMax to be empty string

### DIFF
--- a/app/validation.py
+++ b/app/validation.py
@@ -170,7 +170,7 @@ def get_validation_errors(validator_name, json_data,
 
 
 def min_price_less_than_max_price(error_map, json_data):
-    if 'priceMin' in json_data and 'priceMax' in json_data:
+    if 'priceMin' in json_data and json_data.get('priceMax'):
         if 'priceMin' not in error_map and 'priceMax' not in error_map:
             if Decimal(json_data['priceMin']) > Decimal(json_data['priceMax']):
                 return {'priceMax': 'max_less_than_min'}

--- a/json_schemas/services-g-cloud-7-iaas.json
+++ b/json_schemas/services-g-cloud-7-iaas.json
@@ -80,7 +80,7 @@
     },
     "priceMax":{
       "type": "string",
-      "pattern": "^\\d+(?:\\.\\d{1,5})?$"
+      "pattern": "^$|^\\d+(?:\\.\\d{1,5})?$"
     },
     "priceUnit":{
       "enum":[

--- a/json_schemas/services-g-cloud-7-paas.json
+++ b/json_schemas/services-g-cloud-7-paas.json
@@ -73,7 +73,7 @@
     },
     "priceMax":{
       "type": "string",
-      "pattern": "^\\d+(?:\\.\\d{1,5})?$"
+      "pattern": "^$|^\\d+(?:\\.\\d{1,5})?$"
     },
     "priceUnit":{
       "enum":[

--- a/json_schemas/services-g-cloud-7-saas.json
+++ b/json_schemas/services-g-cloud-7-saas.json
@@ -80,7 +80,7 @@
     },
     "priceMax":{
       "type": "string",
-      "pattern": "^\\d+(?:\\.\\d{1,5})?$"
+      "pattern": "^$|^\\d+(?:\\.\\d{1,5})?$"
     },
     "priceUnit":{
       "enum":[

--- a/json_schemas/services-g-cloud-7-scs.json
+++ b/json_schemas/services-g-cloud-7-scs.json
@@ -86,7 +86,7 @@
     },
     "priceMax":{
       "type": "string",
-      "pattern": "^\\d+(?:\\.\\d{1,5})?$"
+      "pattern": "^$|^\\d+(?:\\.\\d{1,5})?$"
     },
     "priceUnit":{
       "enum":[


### PR DESCRIPTION
Right now, there's no way to remove priceMax once it was set, even
though the field is optional. Empty values set in the supplier frontend
are filtered before being sent to the API.

Sending the empty priceMax without filtering causes a validation error
as priceMax pattern doesn't allow empty strings.

Similar to apiType, we need to add an empty string as a possible value
for priceMax.

This way, we can send the `{"priceMax": ""}` update to remove the
priceMax. While this doesn't remove the key from service data,
empty string is treated the same way by the frontend toolkit.

This is similar to how other optional fields can have either a missing
field or an empty value (empty string or empty list). We should be able
to filter them from the service data in the future if necessary.