### PR TITLE
Add JSON application logging to CloudWatch logs

### DIFF
--- a/.ebextensions/cwl-logs-application.config
+++ b/.ebextensions/cwl-logs-application.config
@@ -4,8 +4,10 @@ Mappings:
     ApplicationLogs:
       LogDirectory: "/var/log/digitalmarketplace"
       LogFile: "/var/log/digitalmarketplace/application.log"
+      JSONLogFile: "/var/log/digitalmarketplace/application.log.json"
       TimestampFormat: "%Y-%m-%dT%H:%M:%S"
       LogGroupName: {"Fn::GetOptionSetting": {"OptionName": "LogGroupName"}}
+      JSONLogGroupName: {"Fn::GetOptionSetting": {"OptionName": "JSONLogGroupName"}}
       ApplicationName: {"Fn::GetOptionSetting": {"OptionName": "ApplicationName"}}
 
 Resources:
@@ -22,6 +24,12 @@ Resources:
                 log_stream_name = `{"Fn::Join": ["-", ["application", {"Fn::FindInMap":["CWLogs", "ApplicationLogs", "ApplicationName"]}]]}`
                 datetime_format = `{"Fn::FindInMap":["CWLogs", "ApplicationLogs", "TimestampFormat"]}`
                 multi_line_start_pattern = {datetime_format}
+
+                [application-logs-json]
+                file = `{"Fn::FindInMap":["CWLogs", "ApplicationLogs", "JSONLogFile"]}`
+                log_group_name = `{"Fn::FindInMap":["CWLogs", "ApplicationLogs", "JSONLogGroupName"]}`
+                log_stream_name = `{"Fn::Join": ["-", ["application", {"Fn::FindInMap":["CWLogs", "ApplicationLogs", "ApplicationName"]}]]}`
+                datetime_format = `{"Fn::FindInMap":["CWLogs", "ApplicationLogs", "TimestampFormat"]}`
 
                 [application-logs-combined]
                 file = `{"Fn::FindInMap":["CWLogs", "ApplicationLogs", "LogFile"]}`
@@ -40,7 +48,7 @@ container_commands:
     command: "mkdir -p /var/log/digitalmarketplace/"
   # if we don't create the file ourselves it gets owned by root
   02-create-file:
-    command: "touch /var/log/digitalmarketplace/application.log"
+    command: "touch /var/log/digitalmarketplace/application.log /var/logs/digitalmarketplace/application.log.json"
   03-change-permissions:
     command: "chmod -R 777 /var/log/digitalmarketplace/"
   04-change-ownership:

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,8 @@ psycopg2==2.5.4
 SQLAlchemy==1.0.5
 SQLAlchemy-Utils==0.30.5
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@6.5.0#egg=digitalmarketplace-utils==6.5.0
+git+https://github.com/madzak/python-json-logger.git@v0.1.3#egg=python-json-logger==v0.1.3
+git+https://github.com/alphagov/digitalmarketplace-utils.git@6.6.0#egg=digitalmarketplace-utils==6.6.0
 
 # For schema validation
 jsonschema==2.3.0


### PR DESCRIPTION
This adds JSON application logs to CloudWatch logs. See: https://github.com/alphagov/digitalmarketplace-utils/pull/151