### PR TITLE
Fix application.py python 3 syntax error

### DIFF
--- a/application.py
+++ b/application.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
+
 import os
 
 from flask.ext.script import Manager, Server
@@ -19,7 +21,7 @@ manager.add_command('db', MigrateCommand)
 def list_routes():
     """List URLs of all application routes."""
     for rule in sorted(application.url_map.iter_rules(), key=lambda r: r.rule):
-        print "{:10} {}".format(", ".join(rule.methods - set(['OPTIONS', 'HEAD'])), rule.rule)
+        print("{:10} {}".format(", ".join(rule.methods - set(['OPTIONS', 'HEAD'])), rule.rule))
 
 if __name__ == '__main__':
     manager.run()


### PR DESCRIPTION
list_routes used print statement, which wasn't picked up by tests
since they never import application.py