### PR TITLE
Add `assurance_required` key to validation errors

### DIFF
--- a/app/validation.py
+++ b/app/validation.py
@@ -289,6 +289,8 @@ def _translate_json_schema_error(key, message):
             or "is less than" in message \
             or "is greater than" in message:
             return 'not_a_number'
+    if message.startswith("None is not one of [u'Service provider assertion'"):
+        return 'assurance_required'
     return message
 
 


### PR DESCRIPTION
Required as part of this story/bugfix: https://www.pivotaltracker.com/story/show/102149718

All the different types of assurance array have "Service provider assertion" as the first option, so this should work OK.