### PR TITLE
Add microsecond Apache request time

### DIFF
--- a/.ebextensions/apache_log.config
+++ b/.ebextensions/apache_log.config
@@ -4,8 +4,8 @@ files:
     owner: root
     group: root
     content: |
-      LogFormat "apache-access api \"%{DM-Request-ID}i\" %h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" cloudwatchlogs
+      LogFormat "apache-access api \"%{DM-Request-ID}i\" %h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" %D" cloudwatchlogs
       CustomLog logs/cwl_access_log cloudwatchlogs
 
-      LogFormat "{ \"application\": \"api\", \"logType\": \"apache-access\", \"requestId\": \"%{DM-Request-ID}i\", \"remoteHost\": \"%h\", \"remoteLogname\": \"%l\", \"user\": \"%u\", \"time\": \"%t\", \"request\": \"%r\", \"status\": %>s, \"size\": %b, \"referer\": \"%{Referer}i\", \"userAgent\": \"%{User-Agent}i\"}" cloudwatchjsonlogs
+      LogFormat "{ \"application\": \"api\", \"logType\": \"apache-access\", \"requestId\": \"%{DM-Request-ID}i\", \"remoteHost\": \"%h\", \"remoteLogname\": \"%l\", \"user\": \"%u\", \"time\": \"%t\", \"request\": \"%r\", \"status\": %>s, \"size\": %b, \"referer\": \"%{Referer}i\", \"userAgent\": \"%{User-Agent}i\", \"requestTimeMicro\": %D}" cloudwatchjsonlogs
       CustomLog logs/cwl_access_log.json cloudwatchjsonlogs


### PR DESCRIPTION
We currently only have request time from Nginx, however requests to APIs
do not go through Nginx. This change adds the request time to the Apache
access logs. The time is recorded in microseconds, unfortunately Apache
cannot log the request time in seconds with the sub-second component
like Nginx so I've opted for the microsecond option.

https://httpd.apache.org/docs/2.2/mod/mod_log_config.html#formats