### PR TITLE
Remove terminationCost from G7 SaaS

### DIFF
--- a/json_schemas/services-g-cloud-7-saas.json
+++ b/json_schemas/services-g-cloud-7-saas.json
@@ -124,9 +124,6 @@
     "freeOption": {
       "type": "boolean"
     },
-    "terminationCost":{
-      "type":"boolean"
-    },
     "minimumContractPeriod":{
       "enum":[
         "Hour",
@@ -797,7 +794,6 @@
     "educationPricing",
     "trialOption",
     "freeOption",
-    "terminationCost",
     "minimumContractPeriod",
     "supportTypes",
     "supportForThirdParties",


### PR DESCRIPTION
terminationCost is not present in G-Cloud 6 SaaS schema and g6
content applies the question only for SCS, PaaS and IaaS.

Listing it in the G7 SaaS schema makes it impossible to complete a
G7 SaaS service as the form doesn't show the question at all, but
full service validation in the API fails.