### PR TITLE
Switch remaining metric filters to JSON

### DIFF
--- a/.ebextensions/cwl-logs-apache-access.config
+++ b/.ebextensions/cwl-logs-apache-access.config
@@ -37,10 +37,10 @@ Mappings:
     FilterPatterns:
       Http400To403MetricFilter: "{ $.logType = apache-access && $.application = api && $.status >= 400 && $.status <= 403 }"
       HttpNon400To403MetricFilter: "{ $.logType = apache-access && $.application = api && ($.status < 400 || $.status > 403) }"
-      Http4xxMetricFilter: "[type=apache-access, app=api, ..., status=4*, size, referer, agent]"
-      HttpNon4xxMetricFilter: "[type=apache-access, app=api, ..., status!=4*, size, referer, agent]"
-      Http5xxMetricFilter: "[type=apache-access, app=api, ..., status=5*, size, referer, agent]"
-      HttpNon5xxMetricFilter: "[type=apache-access, app=api, ..., status!=5*, size, referer, agent]"
+      Http4xxMetricFilter: "{ $.logType = apache-access && $.application = api && $.status = 4* }"
+      HttpNon4xxMetricFilter: "{ $.logType = apache-access && $.application = api && $.status != 4* }"
+      Http5xxMetricFilter: "{ $.logType = apache-access && $.application = api && $.status = 5* }"
+      HttpNon5xxMetricFilter: "{ $.logType = apache-access && $.application = api && $.status != 5* }"
 
 
 Outputs:
@@ -106,7 +106,7 @@ Resources :
   AWSEBCWLHttp4xxMetricFilter :
     Type : "AWS::Logs::MetricFilter"
     Properties :
-      LogGroupName: {"Fn::FindInMap":["CWLogs", "AccessLogs", "LogGroupName"]}
+      LogGroupName: {"Fn::FindInMap":["CWLogs", "AccessLogs", "JSONLogGroupName"]}
       FilterPattern : {"Fn::FindInMap":["CWLogs", "FilterPatterns", "Http4xxMetricFilter"]}
       MetricTransformations :
         - MetricValue : 1
@@ -117,7 +117,7 @@ Resources :
     Type : "AWS::Logs::MetricFilter"
     DependsOn : AWSEBCWLHttp4xxMetricFilter
     Properties :
-      LogGroupName: {"Fn::FindInMap":["CWLogs", "AccessLogs", "LogGroupName"]}
+      LogGroupName: {"Fn::FindInMap":["CWLogs", "AccessLogs", "JSONLogGroupName"]}
       FilterPattern : {"Fn::FindInMap":["CWLogs", "FilterPatterns", "HttpNon4xxMetricFilter"]}
       MetricTransformations :
         - MetricValue : 0
@@ -127,7 +127,7 @@ Resources :
   AWSEBCWLHttp5xxMetricFilter :
     Type : "AWS::Logs::MetricFilter"
     Properties :
-      LogGroupName: {"Fn::FindInMap":["CWLogs", "AccessLogs", "LogGroupName"]}
+      LogGroupName: {"Fn::FindInMap":["CWLogs", "AccessLogs", "JSONLogGroupName"]}
       FilterPattern : {"Fn::FindInMap":["CWLogs", "FilterPatterns", "Http5xxMetricFilter"]}
       MetricTransformations :
         - MetricValue : 1
@@ -138,7 +138,7 @@ Resources :
     Type : "AWS::Logs::MetricFilter"
     DependsOn : AWSEBCWLHttp5xxMetricFilter
     Properties :
-      LogGroupName: {"Fn::FindInMap":["CWLogs", "AccessLogs", "LogGroupName"]}
+      LogGroupName: {"Fn::FindInMap":["CWLogs", "AccessLogs", "JSONLogGroupName"]}
       FilterPattern : {"Fn::FindInMap":["CWLogs", "FilterPatterns", "HttpNon5xxMetricFilter"]}
       MetricTransformations :
         - MetricValue : 0


### PR DESCRIPTION
Adding the request time to the end of the Apache logs changes what the metric filter pattern actually does. JSON metric filters are much more robust to this kind of change.