### PR TITLE
Allow custom page size for audit events

### DIFF
--- a/app/main/views/audits.py
+++ b/app/main/views/audits.py
@@ -30,6 +30,10 @@ AUDIT_OBJECT_ID_FIELDS = {
 @main.route('/audit-events', methods=['GET'])
 def list_audits():
     page = get_valid_page_or_1()
+    try:
+        per_page = int(request.args.get('per_page', current_app.config['DM_API_SERVICES_PAGE_SIZE']))
+    except ValueError:
+        abort(400, 'invalid page size supplied')
 
     audits = AuditEvent.query.order_by(
         asc(AuditEvent.created_at)
@@ -84,7 +88,7 @@ def list_audits():
 
     audits = audits.paginate(
         page=page,
-        per_page=current_app.config['DM_API_SERVICES_PAGE_SIZE'],
+        per_page=per_page
     )
 
     return jsonify(


### PR DESCRIPTION
In about a day's time we will have over 100 statistic snapshots saved as audit events. By the end of G-Cloud 7 we will have about 1000 (35 days * 24 snapshots per day = 840).

Because the graphs need all the available snapshots we could either:

1. paginate through the snapshots using [the iter method in utils](https://github.com/alphagov/digitalmarketplace-utils/blob/master/dmutils/apiclient/base.py#L21-L43)
2. set the page size to 840 or greater

This commit allows for the possibility of doing 2., which should be less load on the API.