### PR TITLE
[102665190] Require both value and assurance for assurance questions

### DIFF
--- a/app/validation.py
+++ b/app/validation.py
@@ -281,6 +281,8 @@ def _translate_json_schema_error(key, message):
         else:
             # A string that is too long
             return 'under_character_limit'
+    if "is not one of [u'Unit', u'Person'" in message:
+        return 'no_unit_specified'
     if 'does not match' in message:
         if key in ['priceMin', 'priceMax']:
             return 'not_money_format'

--- a/app/validation.py
+++ b/app/validation.py
@@ -271,8 +271,9 @@ def is_valid_string(string, minlength=1, maxlength=255):
 
 
 def _translate_json_schema_error(key, message):
-    if message.endswith('is too short'):
-        return 'answer_required'
+    if message.endswith('is too short') \
+            or message.endswith("'value' is a required property"):
+                return 'answer_required'
     if message.endswith('is too long'):
         if message.startswith('['):
             # A list that is too long - all our lists are max 10 items
@@ -285,12 +286,13 @@ def _translate_json_schema_error(key, message):
             return 'not_money_format'
         else:
             return 'under_{}_words'.format(_get_word_count(message))
-    if "is not of type 'number'" in message \
+    if "is not of type u'number'" in message \
             or "is less than" in message \
             or "is greater than" in message:
             return 'not_a_number'
-    if message.startswith("None is not one of [u'Service provider assertion'"):
-        return 'assurance_required'
+    if message.startswith("None is not one of [u'Service provider assertion'") \
+            or message.endswith("'assurance' is a required property"):
+                return 'assurance_required'
     return message
 
 

--- a/app/validation.py
+++ b/app/validation.py
@@ -33,6 +33,9 @@ SCHEMA_NAMES = [
 ]
 FORMAT_CHECKER = FormatChecker()
 
+PRICE_UNIT_ERROR_REGEX = re.compile(".* is not one of .*'Unit', .?'Person'")
+ASSERTION_ERROR_REGEX = re.compile("None is not one of .*'Service provider assertion'")
+
 
 def load_schemas(schemas_path, schema_names):
     loaded_schemas = {}
@@ -274,6 +277,7 @@ def _translate_json_schema_error(key, message):
     if message.endswith('is too short') \
             or message.endswith("'value' is a required property"):
                 return 'answer_required'
+
     if message.endswith('is too long'):
         if message.startswith('['):
             # A list that is too long - all our lists are max 10 items
@@ -281,20 +285,26 @@ def _translate_json_schema_error(key, message):
         else:
             # A string that is too long
             return 'under_character_limit'
-    if "is not one of [u'Unit', u'Person'" in message:
-        return 'no_unit_specified'
+
     if 'does not match' in message:
         if key in ['priceMin', 'priceMax']:
             return 'not_money_format'
         else:
             return 'under_{}_words'.format(_get_word_count(message))
+
+    match = PRICE_UNIT_ERROR_REGEX.match(message)
+    if match:
+        return 'no_unit_specified'
+
     if "is not of type u'number'" in message \
             or "is less than" in message \
             or "is greater than" in message:
             return 'not_a_number'
-    if message.startswith("None is not one of [u'Service provider assertion'") \
-            or message.endswith("'assurance' is a required property"):
+
+    match = ASSERTION_ERROR_REGEX.match(message)
+    if match or message.endswith("'assurance' is a required property"):
                 return 'assurance_required'
+
     return message
 
 

--- a/json_schemas/services-g-cloud-7-iaas.json
+++ b/json_schemas/services-g-cloud-7-iaas.json
@@ -291,7 +291,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation", "CESG-assured components"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "dataProtectionWithinService": {
       "type": "object",
@@ -307,7 +308,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation", "CESG-assured components"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "dataProtectionBetweenServices": {
       "type": "object",
@@ -323,7 +325,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation", "CESG-assured components"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "datacentreLocations": {
       "type": "object",
@@ -339,7 +342,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "dataManagementLocations": {
       "type": "object",
@@ -355,7 +359,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "legalJurisdiction": {
       "type": "object",
@@ -366,7 +371,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "datacentreProtectionDisclosure": {
       "type": "object",
@@ -377,7 +383,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "dataAtRestProtections": {
       "type": "object",
@@ -393,7 +400,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation", "CESG-assured components"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "dataSecureDeletion": {
       "type": "object",
@@ -404,7 +412,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation", "CESG-assured components"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "dataStorageMediaDisposal": {
       "type": "object",
@@ -415,7 +424,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion", "Independent testing of implementation", "CESG-assured components"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "dataSecureEquipmentDisposal": {
       "type": "object",
@@ -426,7 +436,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion", "CESG-assured components"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "dataRedundantEquipmentAccountsRevoked": {
       "type": "object",
@@ -437,7 +448,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "serviceAvailabilityPercentage": {
       "type": "object",
@@ -451,7 +463,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "cloudDeploymentModel": {
       "type": "object",
@@ -462,7 +475,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "otherConsumers": {
       "type": "object",
@@ -473,7 +487,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "servicesSeparation": {
       "type": "object",
@@ -484,7 +499,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent testing of implementation", "Assurance of service design", "CESG-assured components"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "servicesManagementSeparation": {
       "type": "object",
@@ -495,7 +511,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent testing of implementation", "Assurance of service design", "CESG-assured components"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "governanceFramework": {
       "type": "object",
@@ -506,7 +523,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "configurationTracking": {
       "type": "object",
@@ -517,7 +535,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "changeImpactAssessment": {
       "type": "object",
@@ -528,7 +547,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "vulnerabilityAssessment": {
       "type": "object",
@@ -539,7 +559,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "vulnerabilityMonitoring": {
       "type": "object",
@@ -550,7 +571,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "vulnerabilityMitigationPrioritisation": {
       "type": "object",
@@ -561,7 +583,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "vulnerabilityTracking": {
       "type": "object",
@@ -572,7 +595,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "vulnerabilityTimescales": {
       "type": "object",
@@ -583,7 +607,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "eventMonitoring": {
       "type": "object",
@@ -594,7 +619,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "incidentManagementProcess": {
       "type": "object",
@@ -605,7 +631,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "incidentManagementReporting": {
       "type": "object",
@@ -616,7 +643,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "incidentDefinitionPublished": {
       "type": "object",
@@ -627,7 +655,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "personnelSecurityChecks": {
       "type": "object",
@@ -643,7 +672,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "secureDevelopment": {
       "type": "object",
@@ -654,7 +684,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "secureDesign": {
       "type": "object",
@@ -665,7 +696,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "secureConfigurationManagement": {
       "type": "object",
@@ -676,7 +708,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "thirdPartyDataSharingInformation": {
       "type": "object",
@@ -687,7 +720,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "thirdPartySecurityRequirements": {
       "type": "object",
@@ -698,7 +732,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "thirdPartyRiskAssessment": {
       "type": "object",
@@ -709,7 +744,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "thirdPartyComplianceMonitoring": {
       "type": "object",
@@ -720,7 +756,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "hardwareSoftwareVerification": {
       "type": "object",
@@ -731,7 +768,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "userAuthenticateManagement": {
       "type": "object",
@@ -742,7 +780,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "userAuthenticateSupport": {
       "type": "object",
@@ -753,7 +792,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "userAccessControlManagement": {
       "type": "object",
@@ -764,7 +804,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "restrictAdministratorPermissions": {
       "type": "object",
@@ -775,7 +816,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "managementInterfaceProtection": {
       "type": "object",
@@ -786,7 +828,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "identityAuthenticationControls": {
       "type": "object",
@@ -802,7 +845,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent testing of implementation", "CESG-assured components"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "onboardingGuidance": {
       "type": "object",
@@ -813,7 +857,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "interconnectionMethods": {
       "type": "object",
@@ -829,7 +874,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "serviceManagementModel": {
       "type": "object",
@@ -845,7 +891,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "auditInformationProvided": {
       "type": "object",
@@ -856,7 +903,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "deviceAccessMethod": {
       "type": "object",
@@ -872,7 +920,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "serviceConfigurationGuidance": {
       "type": "object",
@@ -883,7 +932,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "trainingProvided": {
       "type": "object",
@@ -894,7 +944,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     }
   },
   "required":[

--- a/json_schemas/services-g-cloud-7-paas.json
+++ b/json_schemas/services-g-cloud-7-paas.json
@@ -284,7 +284,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation", "CESG-assured components"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "dataProtectionWithinService": {
       "type": "object",
@@ -300,7 +301,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation", "CESG-assured components"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "dataProtectionBetweenServices": {
       "type": "object",
@@ -316,7 +318,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation", "CESG-assured components"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "datacentreLocations": {
       "type": "object",
@@ -332,7 +335,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "dataManagementLocations": {
       "type": "object",
@@ -348,7 +352,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "legalJurisdiction": {
       "type": "object",
@@ -359,7 +364,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "datacentreProtectionDisclosure": {
       "type": "object",
@@ -370,7 +376,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "dataAtRestProtections": {
       "type": "object",
@@ -386,7 +393,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation", "CESG-assured components"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "dataSecureDeletion": {
       "type": "object",
@@ -397,7 +405,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation", "CESG-assured components"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "dataStorageMediaDisposal": {
       "type": "object",
@@ -419,7 +428,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion", "CESG-assured components"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "dataRedundantEquipmentAccountsRevoked": {
       "type": "object",
@@ -430,7 +440,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "serviceAvailabilityPercentage": {
       "type": "object",
@@ -444,7 +455,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "cloudDeploymentModel": {
       "type": "object",
@@ -455,7 +467,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "otherConsumers": {
       "type": "object",
@@ -466,7 +479,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "servicesSeparation": {
       "type": "object",
@@ -477,7 +491,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent testing of implementation", "Assurance of service design", "CESG-assured components"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "servicesManagementSeparation": {
       "type": "object",
@@ -488,7 +503,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent testing of implementation", "Assurance of service design", "CESG-assured components"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "governanceFramework": {
       "type": "object",
@@ -499,7 +515,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "configurationTracking": {
       "type": "object",
@@ -510,7 +527,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "changeImpactAssessment": {
       "type": "object",
@@ -521,7 +539,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "vulnerabilityAssessment": {
       "type": "object",
@@ -532,7 +551,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "vulnerabilityMonitoring": {
       "type": "object",
@@ -543,7 +563,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "vulnerabilityMitigationPrioritisation": {
       "type": "object",
@@ -554,7 +575,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "vulnerabilityTracking": {
       "type": "object",
@@ -565,7 +587,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "vulnerabilityTimescales": {
       "type": "object",
@@ -576,7 +599,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "eventMonitoring": {
       "type": "object",
@@ -587,7 +611,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "incidentManagementProcess": {
       "type": "object",
@@ -598,7 +623,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "incidentManagementReporting": {
       "type": "object",
@@ -609,7 +635,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "incidentDefinitionPublished": {
       "type": "object",
@@ -620,7 +647,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "personnelSecurityChecks": {
       "type": "object",
@@ -636,7 +664,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "secureDevelopment": {
       "type": "object",
@@ -647,7 +676,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "secureDesign": {
       "type": "object",
@@ -658,7 +688,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "secureConfigurationManagement": {
       "type": "object",
@@ -669,7 +700,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "thirdPartyDataSharingInformation": {
       "type": "object",
@@ -680,7 +712,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "thirdPartySecurityRequirements": {
       "type": "object",
@@ -691,7 +724,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "thirdPartyRiskAssessment": {
       "type": "object",
@@ -702,7 +736,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "thirdPartyComplianceMonitoring": {
       "type": "object",
@@ -713,7 +748,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "hardwareSoftwareVerification": {
       "type": "object",
@@ -724,7 +760,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "userAuthenticateManagement": {
       "type": "object",
@@ -735,7 +772,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "userAuthenticateSupport": {
       "type": "object",
@@ -746,7 +784,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "userAccessControlManagement": {
       "type": "object",
@@ -757,7 +796,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "restrictAdministratorPermissions": {
       "type": "object",
@@ -768,7 +808,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "managementInterfaceProtection": {
       "type": "object",
@@ -779,7 +820,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "identityAuthenticationControls": {
       "type": "object",
@@ -795,7 +837,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent testing of implementation", "CESG-assured components"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "onboardingGuidance": {
       "type": "object",
@@ -806,7 +849,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "interconnectionMethods": {
       "type": "object",
@@ -822,7 +866,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "serviceManagementModel": {
       "type": "object",
@@ -838,7 +883,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "auditInformationProvided": {
       "type": "object",
@@ -849,7 +895,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "deviceAccessMethod": {
       "type": "object",
@@ -865,7 +912,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "serviceConfigurationGuidance": {
       "type": "object",
@@ -876,7 +924,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "trainingProvided": {
       "type": "object",
@@ -887,7 +936,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     }
   },
   "required": [

--- a/json_schemas/services-g-cloud-7-saas.json
+++ b/json_schemas/services-g-cloud-7-saas.json
@@ -306,7 +306,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation", "CESG-assured components"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "datacentreLocations": {
       "type": "object",
@@ -322,7 +323,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "dataManagementLocations": {
       "type": "object",
@@ -338,7 +340,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "legalJurisdiction": {
       "type": "object",
@@ -349,7 +352,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "datacentreProtectionDisclosure": {
       "type": "object",
@@ -360,7 +364,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "dataAtRestProtections": {
       "type": "object",
@@ -376,7 +381,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation", "CESG-assured components"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "dataSecureDeletion": {
       "type": "object",
@@ -387,7 +393,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation", "CESG-assured components"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "serviceAvailabilityPercentage": {
       "type": "object",
@@ -401,7 +408,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "cloudDeploymentModel": {
       "type": "object",
@@ -412,7 +420,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "otherConsumers": {
       "type": "object",
@@ -423,7 +432,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "servicesSeparation": {
       "type": "object",
@@ -434,7 +444,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent testing of implementation", "Assurance of service design", "CESG-assured components"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "servicesManagementSeparation": {
       "type": "object",
@@ -445,7 +456,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent testing of implementation", "Assurance of service design", "CESG-assured components"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "governanceFramework": {
       "type": "object",
@@ -456,7 +468,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "changeImpactAssessment": {
       "type": "object",
@@ -467,7 +480,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "vulnerabilityAssessment": {
       "type": "object",
@@ -478,7 +492,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "vulnerabilityMonitoring": {
       "type": "object",
@@ -489,7 +504,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "vulnerabilityMitigationPrioritisation": {
       "type": "object",
@@ -500,7 +516,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "vulnerabilityTracking": {
       "type": "object",
@@ -511,7 +528,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "vulnerabilityTimescales": {
       "type": "object",
@@ -522,7 +540,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "eventMonitoring": {
       "type": "object",
@@ -533,7 +552,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "incidentManagementProcess": {
       "type": "object",
@@ -544,7 +564,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "incidentManagementReporting": {
       "type": "object",
@@ -555,7 +576,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "incidentDefinitionPublished": {
       "type": "object",
@@ -566,7 +588,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "personnelSecurityChecks": {
       "type": "object",
@@ -582,7 +605,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "secureDevelopment": {
       "type": "object",
@@ -593,7 +617,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "secureDesign": {
       "type": "object",
@@ -604,7 +629,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "secureConfigurationManagement": {
       "type": "object",
@@ -615,7 +641,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "thirdPartyDataSharingInformation": {
       "type": "object",
@@ -626,7 +653,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "thirdPartySecurityRequirements": {
       "type": "object",
@@ -637,7 +665,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "thirdPartyRiskAssessment": {
       "type": "object",
@@ -648,7 +677,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "thirdPartyComplianceMonitoring": {
       "type": "object",
@@ -659,7 +689,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "userAuthenticateManagement": {
       "type": "object",
@@ -670,7 +701,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "userAuthenticateSupport": {
       "type": "object",
@@ -681,7 +713,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "userAccessControlManagement": {
       "type": "object",
@@ -692,7 +725,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "restrictAdministratorPermissions": {
       "type": "object",
@@ -703,7 +737,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "identityAuthenticationControls": {
       "type": "object",
@@ -719,7 +754,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent testing of implementation", "CESG-assured components"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "serviceManagementModel": {
       "type": "object",
@@ -735,7 +771,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "auditInformationProvided": {
       "type": "object",
@@ -746,7 +783,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "deviceAccessMethod": {
       "type": "object",
@@ -762,7 +800,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     },
     "trainingProvided": {
       "type": "object",
@@ -773,7 +812,8 @@
         "assurance": {
           "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "required": ["value", "assurance"]
     }
   },
   "required": [

--- a/tests/app/views/test_drafts.py
+++ b/tests/app/views/test_drafts.py
@@ -369,7 +369,7 @@ class TestDraftServices(BaseApplicationTest):
         data = json.loads(res.get_data())
         assert_equal(res.status_code, 400)
         assert_in("'badField' was unexpected", str(data['error']['_form']))
-        assert_in("'chickens' is not one of", data['error']['priceUnit'])
+        assert_in("no_unit_specified", data['error']['priceUnit'])
 
     def test_should_create_draft_from_existing_service(self):
         res = self.client.put(

--- a/tests/app/views/test_services.py
+++ b/tests/app/views/test_services.py
@@ -655,7 +655,7 @@ class TestPostService(BaseApplicationTest):
                 content_type='application/json')
 
             assert_equal(response.status_code, 400)
-            assert_in("'per Truth' is not one of",
+            assert_in("no_unit_specified",
                       json.loads(response.get_data())['error']['priceUnit'])
 
     def test_updated_service_is_archived_right_away(self):

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -381,7 +381,7 @@ def test_assurance_only_causes_validation_error():
     data.update({'serviceAvailabilityPercentage':
                 {"assurance": "Service provider assertion"}})
     errs = get_validation_errors("services-g-cloud-7-paas", data)
-    assert "'value' is a required property" in errs['serviceAvailabilityPercentage']
+    assert "answer_required" in errs['serviceAvailabilityPercentage']
 
 
 def test_value_only_causes_validation_error():
@@ -389,7 +389,7 @@ def test_value_only_causes_validation_error():
     data.update({'serviceAvailabilityPercentage':
                 {"value": 99.9}})
     errs = get_validation_errors("services-g-cloud-7-paas", data)
-    assert "'assurance' is a required property" in errs['serviceAvailabilityPercentage']
+    assert "assurance_required" in errs['serviceAvailabilityPercentage']
 
 
 def test_price_not_money_format_validation_error():

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -376,6 +376,22 @@ def test_percentage_out_of_range_causes_validation_error():
     assert "not_a_number" in errs['serviceAvailabilityPercentage']
 
 
+def test_assurance_only_causes_validation_error():
+    data = load_example_listing("G6-PaaS")
+    data.update({'serviceAvailabilityPercentage':
+                {"assurance": "Service provider assertion"}})
+    errs = get_validation_errors("services-g-cloud-7-paas", data)
+    assert "'value' is a required property" in errs['serviceAvailabilityPercentage']
+
+
+def test_value_only_causes_validation_error():
+    data = load_example_listing("G6-PaaS")
+    data.update({'serviceAvailabilityPercentage':
+                {"value": 99.9}})
+    errs = get_validation_errors("services-g-cloud-7-paas", data)
+    assert "'assurance' is a required property" in errs['serviceAvailabilityPercentage']
+
+
 def test_price_not_money_format_validation_error():
     cases = [
         "foo",  # not numeric


### PR DESCRIPTION
Assurance questions haven't required both fields up until now, but they should.

This will be useful for fixing this bug: https://www.pivotaltracker.com/story/show/102562916

And also fixes this bug: https://www.pivotaltracker.com/story/show/102665190