### PR TITLE
[#102567802] Updates to CCS admin roles

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -242,7 +242,8 @@ class User(db.Model):
         'buyer',
         'supplier',
         'admin',
-        'admin-ccs',
+        'admin-ccs-category',
+        'admin-ccs-sourcing',
     ]
 
     id = db.Column(db.Integer, primary_key=True)

--- a/json_schemas/users.json
+++ b/json_schemas/users.json
@@ -19,7 +19,7 @@
       "minLength": 10
     },
     "role": {
-      "enum": ["buyer", "supplier", "admin", "admin-ccs"]
+      "enum": ["buyer", "supplier", "admin", "admin-ccs-category", "admin-ccs-sourcing"]
     },
     "supplierId": {
       "type": "integer"

--- a/migrations/versions/290_add_admin_ccs_sourcing_role.py
+++ b/migrations/versions/290_add_admin_ccs_sourcing_role.py
@@ -1,0 +1,25 @@
+"""Add admin-ccs-sourcing role and rename admin-ccs to admin-ccs-category
+
+Revision ID: 290_add_admin_ccs_sourcing_role
+Revises: 280_switch_g7_framework_to_open
+Create Date: 2015-09-07 11:10:00.000000
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '290_add_admin_ccs_sourcing_role'
+down_revision = '280_switch_g7_framework_to_open'
+
+from alembic import op
+
+
+def upgrade():
+    op.execute("COMMIT")  # See: http://stackoverflow.com/a/30910417/15720
+    op.execute("ALTER TYPE user_roles_enum ADD VALUE 'admin-ccs-category' AFTER 'admin-ccs';")
+    op.execute("ALTER TYPE user_roles_enum ADD VALUE 'admin-ccs-sourcing' AFTER 'admin-ccs-category';")
+    op.execute("UPDATE users SET role = 'admin-ccs-category' WHERE role = 'admin-ccs';")
+
+
+def downgrade():
+    op.execute("UPDATE users SET role = 'admin-ccs' WHERE role = 'admin-ccs-category';")
+    # Can't remove values from enum so no way to roll that part back

--- a/tests/app/test_users.py
+++ b/tests/app/test_users.py
@@ -187,20 +187,51 @@ class TestUsersPost(BaseApplicationTest, JSONUpdateTestMixin):
         data = json.loads(response.get_data())["users"]
         assert_equal(data["emailAddress"], "joeblogs@email.com")
 
-    def test_can_post_an_admin_ccs_user(self):
+    def test_can_post_an_admin_ccs_category_user(self):
         response = self.client.post(
             '/users',
             data=json.dumps({
                 'users': {
                     'emailAddress': 'joeblogs@email.com',
                     'password': '1234567890',
-                    'role': 'admin-ccs',
+                    'role': 'admin-ccs-category',
                     'name': 'joe bloggs'}}),
             content_type='application/json')
 
         assert_equal(response.status_code, 201)
         data = json.loads(response.get_data())["users"]
         assert_equal(data["emailAddress"], "joeblogs@email.com")
+
+    def test_can_post_an_admin_ccs_sourcing_user(self):
+        response = self.client.post(
+            '/users',
+            data=json.dumps({
+                'users': {
+                    'emailAddress': 'joeblogs+sourcing@email.com',
+                    'password': '1234567890',
+                    'role': 'admin-ccs-sourcing',
+                    'name': 'joe bloggs'}}),
+            content_type='application/json')
+
+        assert_equal(response.status_code, 201)
+        data = json.loads(response.get_data())["users"]
+        assert_equal(data["emailAddress"], "joeblogs+sourcing@email.com")
+
+    # The admin-ccs role is no longer in use
+    def test_can_not_post_an_admin_ccs_user(self):
+        response = self.client.post(
+            '/users',
+            data=json.dumps({
+                'users': {
+                    'emailAddress': 'joeblogs+admin@email.com',
+                    'password': '1234567890',
+                    'role': 'admin-ccs',
+                    'name': 'joe bloggs'}}),
+            content_type='application/json')
+
+        assert_equal(response.status_code, 400)
+        error = json.loads(response.get_data())['error']
+        assert_in("'admin-ccs' is not one of", error)
 
     def test_can_post_a_supplier_user(self):
         with self.app.app_context():


### PR DESCRIPTION
Requirted as part of this story: https://www.pivotaltracker.com/story/show/102567802

* Create two new CCS roles - `admin-ccs-category` and `admin-ccs-sourcing`
* Deprecate the existing `admin-ccs` role

Postgres doesn't allow the removal of values from an enum, so the `admin-ccs` value is still in the list, but should not be used.