### PR TITLE
Improve supplier list query performance

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -29,20 +29,15 @@ def list_suppliers():
     if framework:
         is_valid_string_or_400(framework)
 
-        active_services = Service.query.join(
-            Service.framework
+        suppliers = Supplier.query.join(
+            Service.supplier, Service.framework
         ).filter(
             Framework.status == 'live',
             Framework.framework == framework,
             Service.status == 'published'
-        ).distinct('supplier_id').subquery()
-
-        suppliers = Supplier.query.join(
-            active_services,
-            Supplier.supplier_id == active_services.c.supplier_id
-        ).order_by(Supplier.name)
+        ).order_by(Supplier.name, Supplier.supplier_id)
     else:
-        suppliers = Supplier.query.order_by(Supplier.name)
+        suppliers = Supplier.query.order_by(Supplier.name, Supplier.supplier_id)
 
     if duns_number:
         is_valid_string_or_400(duns_number)
@@ -58,6 +53,8 @@ def list_suppliers():
             # case insensitive LIKE comparison for matching supplier names
             suppliers = suppliers.filter(
                 Supplier.name.ilike(prefix + '%'))
+
+    suppliers = suppliers.distinct(Supplier.name, Supplier.supplier_id)
 
     try:
         suppliers = suppliers.paginate(

--- a/tests/app/views/test_suppliers.py
+++ b/tests/app/views/test_suppliers.py
@@ -194,6 +194,9 @@ class TestListSuppliersOnFramework(BaseApplicationTest):
                 service_id=1, supplier_id=1
             )
             self.setup_dummy_service(
+                service_id=4, supplier_id=1, status='enabled'
+            )
+            self.setup_dummy_service(
                 service_id=2, supplier_id=2, framework_id=2
             )
             self.setup_dummy_service(


### PR DESCRIPTION
While investigating the Apache access logs for the API the `/suppliers` route was identified as one of the slowest routes when filtering by framework. The median response time is ~600ms and the 90th percentile
is ~700ms.

The distinct subquery joining to the services table was not being not being optimised by the query planner very well. The query needs to join into the services table to restrict the suppliers to only those that have live services in the requested framework. However, it only needs to check that each supplier has at least one published service. The query planner can optimise this but seems to confused with the multiple layers of nested queries that SQLAlchemy creates. This change flattens the query out making it easier for the optimiser to do it's stuff. The order by is extended with the supplier ID because PostgreSQL requires the distinct keys to be a prefix of the order keys.

Testing locally shows that this change improves performance by about 10x from ~500ms to ~50ms