### PR TITLE
Add ability to reset supplier details on a user update

### DIFF
--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -179,6 +179,9 @@ def update_user(user_id):
     if 'name' in user_update:
         user.name = user_update['name']
     if 'role' in user_update:
+        if user.role == 'supplier' and user_update['role'] != user.role:
+            user.supplier_id = None
+            user_update.pop('supplierId', None)
         user.role = user_update['role']
     if 'supplierId' in user_update:
         user.supplier_id = user_update['supplierId']


### PR DESCRIPTION
- providing an update that changes a role from supplier to another role will wipe the supplier details from the user.
- this allows them to be invited to other suppliers / admin user and so on.