### PR TITLE
Bump utils version to 6.9.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ SQLAlchemy==1.0.5
 SQLAlchemy-Utils==0.30.5
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.3#egg=python-json-logger==v0.1.3
-git+https://github.com/alphagov/digitalmarketplace-utils.git@6.6.0#egg=digitalmarketplace-utils==6.6.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@6.9.2#egg=digitalmarketplace-utils==6.9.2
 
 # For schema validation
 jsonschema==2.3.0


### PR DESCRIPTION
This will be required for this story: https://www.pivotaltracker.com/story/show/103088520

Depends on:
- [x] https://github.com/alphagov/digitalmarketplace-utils/pull/162

These are the utils changes being brought in (all except the extra required audit type, because 6.9.2. isn't merged yet):
https://github.com/alphagov/digitalmarketplace-utils/compare/6.6.0...6.9.1

Can't see anything there that affects the API, and I've tested locally with the updated utils version - supplier app functions and and API tests pass OK.