### PR TITLE
Remove required `postcode` when importing a supplier

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -13,6 +13,7 @@ from ...validation import (
 )
 from ...utils import pagination_links, drop_foreign_fields, get_json_from_request, \
     json_has_required_keys, json_has_matching_id, get_valid_page_or_1
+from ...supplier_utils import validate_and_return_supplier_request
 from dmutils.audit import AuditTypes
 
 
@@ -88,39 +89,9 @@ def get_supplier(supplier_id):
 
 @main.route('/suppliers/<int:supplier_id>', methods=['PUT'])
 def import_supplier(supplier_id):
-    supplier_data = get_json_from_request()
+    supplier_data = validate_and_return_supplier_request(supplier_id)
 
-    json_has_required_keys(
-        supplier_data,
-        ['suppliers']
-    )
-
-    supplier_data = supplier_data['suppliers']
-    supplier_data = drop_foreign_fields(supplier_data, ['links'])
-
-    json_has_required_keys(
-        supplier_data,
-        ['id', 'name', 'contactInformation']
-    )
-
-    contact_informations_data = [
-        drop_foreign_fields(contact_data, ['links'])
-        for contact_data in supplier_data['contactInformation']
-        ]
-
-    supplier_data['contactInformation'] = contact_informations_data
-
-    for contact_information_data in contact_informations_data:
-        json_has_required_keys(
-            contact_information_data,
-            ['contactName', 'email']
-        )
-
-    validate_supplier_json_or_400(supplier_data)
-
-    # Check that `supplier_id` matches the JSON-supplied `id`
-    json_has_matching_id(supplier_data, supplier_id)
-
+    contact_informations_data = supplier_data['contactInformation']
     supplier_data = drop_foreign_fields(
         supplier_data,
         ['contactInformation']
@@ -157,36 +128,9 @@ def import_supplier(supplier_id):
 
 @main.route('/suppliers', methods=['POST'])
 def create_supplier():
-    supplier_data = get_json_from_request()
+    supplier_data = validate_and_return_supplier_request()
 
-    json_has_required_keys(
-        supplier_data,
-        ['suppliers']
-    )
-
-    supplier_data = supplier_data['suppliers']
-    supplier_data = drop_foreign_fields(supplier_data, ['links'])
-
-    json_has_required_keys(
-        supplier_data,
-        ['name', 'contactInformation']
-    )
-
-    contact_informations_data = [
-        drop_foreign_fields(contact_data, ['links'])
-        for contact_data in supplier_data['contactInformation']
-        ]
-
-    supplier_data['contactInformation'] = contact_informations_data
-
-    for contact_information_data in contact_informations_data:
-        json_has_required_keys(
-            contact_information_data,
-            ['contactName', 'email']
-        )
-
-    validate_new_supplier_json_or_400(supplier_data)
-
+    contact_informations_data = supplier_data['contactInformation']
     supplier_data = drop_foreign_fields(
         supplier_data,
         ['contactInformation']

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -113,7 +113,7 @@ def import_supplier(supplier_id):
     for contact_information_data in contact_informations_data:
         json_has_required_keys(
             contact_information_data,
-            ['contactName', 'email', 'postcode']
+            ['contactName', 'email']
         )
 
     validate_supplier_json_or_400(supplier_data)

--- a/app/supplier_utils.py
+++ b/app/supplier_utils.py
@@ -1,0 +1,23 @@
+from .validation import validate_supplier_json_or_400, validate_new_supplier_json_or_400
+from .utils import get_json_from_request, json_has_matching_id, json_has_required_keys, drop_foreign_fields
+
+
+def validate_and_return_supplier_request(supplier_id=None):
+    json_payload = get_json_from_request()
+    json_has_required_keys(json_payload, ['suppliers'])
+    json_has_required_keys(json_payload['suppliers'], ['contactInformation'])
+
+    # remove unnecessary fields
+    json_payload['suppliers'] = drop_foreign_fields(json_payload['suppliers'], ['links'])
+    json_payload['suppliers']['contactInformation'] = [
+        drop_foreign_fields(contact_data, ['links'])
+        for contact_data in json_payload['suppliers']['contactInformation']
+    ]
+
+    if supplier_id:
+        validate_supplier_json_or_400(json_payload['suppliers'])
+        json_has_matching_id(json_payload['suppliers'], supplier_id)
+    else:
+        validate_new_supplier_json_or_400(json_payload['suppliers'])
+
+    return json_payload['suppliers']

--- a/tests/app/views/test_suppliers.py
+++ b/tests/app/views/test_suppliers.py
@@ -382,15 +382,13 @@ class TestPutSupplier(BaseApplicationTest, JSONUpdateTestMixin):
         payload = self.load_example_listing("Supplier")
 
         payload['contactInformation'][0].pop('email')
-        payload['contactInformation'][0].pop('postcode')
         payload['contactInformation'][0].pop('contactName')
 
         response = self.put_import_supplier(payload)
         assert_equal(response.status_code, 400)
         for item in ['Invalid JSON must have',
                      'contactName',
-                     'email',
-                     'postcode']:
+                     'email']:
             assert_in(item,
                       json.loads(response.get_data())['error'])
 

--- a/tests/app/views/test_suppliers.py
+++ b/tests/app/views/test_suppliers.py
@@ -363,34 +363,64 @@ class TestPutSupplier(BaseApplicationTest, JSONUpdateTestMixin):
 
         response = self.put_import_supplier(payload)
         assert_equal(response.status_code, 400)
-        for item in ['Invalid JSON must have', 'contactInformation']:
+        for item in ['Invalid JSON must have', '\'contactInformation\'']:
             assert_in(item,
                       json.loads(response.get_data())['error'])
 
+    def test_when_supplier_has_a_missing_key(self):
+        payload = self.load_example_listing("Supplier")
+        payload.pop('id')
+
+        response = self.put_import_supplier(payload)
+        assert_equal(response.status_code, 400)
+        for item in ['JSON was not a valid format',
+                     '\'id\'',
+                     'is a required property']:
+            assert_in(
+                item, json.loads(response.get_data())['error'])
+
     def test_when_supplier_has_missing_keys(self):
         payload = self.load_example_listing("Supplier")
+
+        # only one key is returned in the error message
         payload.pop('id')
         payload.pop('name')
 
         response = self.put_import_supplier(payload)
         assert_equal(response.status_code, 400)
-        for item in ['Invalid JSON must have', 'id', 'name']:
-            assert_in(item,
-                      json.loads(response.get_data())['error'])
+        for item in ['JSON was not a valid format',
+                     '\'id\'',
+                     'is a required property']:
+            assert_in(
+                item, json.loads(response.get_data())['error'])
+
+    def test_when_supplier_contact_information_has_a_missing_key(self):
+        payload = self.load_example_listing("Supplier")
+
+        payload['contactInformation'][0].pop('email')
+
+        response = self.put_import_supplier(payload)
+        assert_equal(response.status_code, 400)
+        for item in ['JSON was not a valid format',
+                     '\'email\'',
+                     'is a required property']:
+            assert_in(
+                item, json.loads(response.get_data())['error'])
 
     def test_when_supplier_contact_information_has_missing_keys(self):
         payload = self.load_example_listing("Supplier")
 
+        # only one key is returned in the error message
         payload['contactInformation'][0].pop('email')
         payload['contactInformation'][0].pop('contactName')
 
         response = self.put_import_supplier(payload)
         assert_equal(response.status_code, 400)
-        for item in ['Invalid JSON must have',
-                     'contactName',
-                     'email']:
-            assert_in(item,
-                      json.loads(response.get_data())['error'])
+        for item in ['JSON was not a valid format',
+                     '\'contactName\'',
+                     'is a required property']:
+            assert_in(
+                item, json.loads(response.get_data())['error'])
 
     def test_when_supplier_has_extra_keys(self):
         payload = self.load_example_listing("Supplier")
@@ -963,31 +993,28 @@ class TestPostSupplier(BaseApplicationTest, JSONUpdateTestMixin):
 
         response = self.post_supplier(payload)
         assert_equal(response.status_code, 400)
-        for item in ['Invalid JSON must have', 'contactInformation']:
+        for item in ['Invalid JSON must have', '\'contactInformation\'']:
             assert_in(item,
                       json.loads(response.get_data())['error'])
 
-    def test_when_supplier_has_missing_keys(self):
+    def test_when_supplier_has_a_missing_key(self):
         payload = self.load_example_listing("new-supplier")
         payload.pop('name')
 
         response = self.post_supplier(payload)
         assert_equal(response.status_code, 400)
-        for item in ['Invalid JSON must have', 'name']:
+        for item in ['JSON was not a valid format', '\'name\'', 'is a required property']:
             assert_in(item,
                       json.loads(response.get_data())['error'])
 
-    def test_when_supplier_contact_information_has_missing_keys(self):
+    def test_when_supplier_contact_information_has_a_missing_key(self):
         payload = self.load_example_listing("new-supplier")
 
         payload['contactInformation'][0].pop('email')
-        payload['contactInformation'][0].pop('contactName')
 
         response = self.post_supplier(payload)
         assert_equal(response.status_code, 400)
-        for item in ['Invalid JSON must have',
-                     'contactName',
-                     'email']:
+        for item in ['JSON was not a valid format', '\'email\'', 'is a required property']:
             assert_in(item,
                       json.loads(response.get_data())['error'])
 


### PR DESCRIPTION
Last change to `/json_schemas/contact-information.json` removed the postcode as a required part of contact information, but this wasn't reflected in the `PUT` import method.
As a consequence, `/scripts/import_suppliers_from_api.py` was failing to import suppliers without postcodes.
Also updated the implicated test.