### PR TITLE
Add endpoint to get the status of a framework by framework slug

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -16,6 +16,18 @@ def list_frameworks():
     )
 
 
+@main.route('/frameworks/<string:framework_slug>/status', methods=['GET'])
+def get_framework_status(framework_slug):
+    framework = Framework.query.filter(
+        Framework.slug == framework_slug
+    ).first()
+
+    if not framework:
+        abort(404, "'{}' is not a framework".format(framework_slug))
+
+    return jsonify(status=framework.status)
+
+
 @main.route('/frameworks/<string:framework_slug>/stats', methods=['GET'])
 def get_framework_stats(framework_slug):
 

--- a/tests/app/views/test_frameworks.py
+++ b/tests/app/views/test_frameworks.py
@@ -20,6 +20,30 @@ class TestListFrameworks(BaseApplicationTest):
                          len(Framework.query.all()))
 
 
+class TestGetFrameworkStatus(BaseApplicationTest):
+    def test_status_is_returned_for_existing_frameworks(self):
+        with self.app.app_context():
+            response = self.client.get('/frameworks/g-cloud-6/status')
+            data = json.loads(response.get_data())
+
+            assert_equal(response.status_code, 200)
+            assert_equal(data['status'], "live")
+
+            response = self.client.get('/frameworks/g-cloud-4/status')
+            data = json.loads(response.get_data())
+
+            assert_equal(response.status_code, 200)
+            assert_equal(data['status'], "expired")
+
+    def test_404_for_non_existing_frameworks(self):
+        with self.app.app_context():
+            response = self.client.get('/frameworks/biscuits-for-gov/status')
+            data = json.loads(response.get_data())
+
+            assert_equal(response.status_code, 404)
+            assert_equal(data['error'], "'biscuits-for-gov' is not a framework")
+
+
 class TestFrameworkStats(BaseApplicationTest):
     def create_selection_answers(self, framework_id, supplier_ids, status=None):
         with self.app.app_context():


### PR DESCRIPTION
Keeping it as simple as possible e.g.:
- `/frameworks/g-cloud-6/status` -> `{"status": "live"}`
- `/frameworks/g-cloud-7/status` -> `{"status": "open"}`
