### PR TITLE
Sourcing exports

### DIFF
--- a/scripts/generate_declaration_export_for_ccs_sourcing.py
+++ b/scripts/generate_declaration_export_for_ccs_sourcing.py
@@ -79,7 +79,7 @@ expected_totals = \
     }
 
 # map fields to processing method
-fields = \
+question_mapping = \
     {
         "PR1": process_boolean,
         "PR2": process_boolean,
@@ -149,8 +149,8 @@ def process_supplier_declaration(supplier_declaration, questions):
     """
     answers = []
     for question in questions:
-        if question in fields:
-            answers.append(fields[question](supplier_declaration, question))
+        if question in question_mapping:
+            answers.append(question_mapping[question](supplier_declaration, question))
     return answers
 
 # get the list of questions, in order, from the manifest

--- a/scripts/generate_declaration_export_for_ccs_sourcing.py
+++ b/scripts/generate_declaration_export_for_ccs_sourcing.py
@@ -1,7 +1,7 @@
 """
 
 Usage:
-    scripts/generate_declaration_export_for_ccs_sourcing.py <data_api_url> <data_api_token> <path_to_declaration_manifest> # noqa
+    scripts/generate_declaration_export_for_ccs_sourcing.py <data_api_url> <data_api_token> <path_to_manifest>
 
 Example:
     ./generate_declaration_export_for_ccs_sourcing.py http://api myToken /my/path/to/file/manifest.yml

--- a/scripts/generate_declaration_export_for_ccs_sourcing.py
+++ b/scripts/generate_declaration_export_for_ccs_sourcing.py
@@ -1,7 +1,7 @@
 """
 
 Usage:
-    scripts/generate_declaration_export_for_ccs_sourcing.py <data_api_url> <data_api_token> <path_to_declaration_manifest>
+    scripts/generate_declaration_export_for_ccs_sourcing.py <data_api_url> <data_api_token> <path_to_declaration_manifest> # noqa
 
 Example:
     ./generate_declaration_export_for_ccs_sourcing.py http://api myToken /my/path/to/file/manifest.yml
@@ -13,11 +13,13 @@ import yaml
 from docopt import docopt
 from dmutils.apiclient import DataAPIClient, HTTPError
 
+
 def get_or_else_none(map_to_check, key):
     """
         Use map.get to handle missing keys for object values
     """
     return map_to_check.get(key, None)
+
 
 def get_or_else_empty_string(map_to_check, key):
     """
@@ -25,11 +27,13 @@ def get_or_else_empty_string(map_to_check, key):
     """
     return map_to_check.get(key, "")
 
+
 def get_or_else_empty_list(map_to_check, key):
     """
         Use map.get to handle missing keys for list values
     """
     return map_to_check.get(key, [])
+
 
 def bool_to_yes_no(value):
         """
@@ -40,6 +44,7 @@ def bool_to_yes_no(value):
         if value:
             return "yes"
         return "no"
+
 
 def has_checked_all_boxes(array, total):
     """
@@ -54,6 +59,7 @@ def has_checked_all_boxes(array, total):
     else:
         return "passed"
 
+
 def process_boolean(declaration, field):
     value = get_or_else_none(declaration, field)
     if value is not None:
@@ -61,83 +67,87 @@ def process_boolean(declaration, field):
     else:
         return ""
 
+
 def process_string(declaration, field):
     return get_or_else_empty_string(declaration, field).encode("utf-8")
+
 
 def process_checkbox_counts(declaration, field):
     values = get_or_else_empty_list(declaration, field)
     return has_checked_all_boxes(values, expected_totals[field])
 
+
 def process_list_to_string(declaration, field):
     return ", ".encode("utf-8").join(get_or_else_empty_list(declaration, field))
 
+
 # expected length of checkbox groups - if users don't tick all they fail
-expected_totals = \
-    {
-       "SQ1-3": 5,
-       "SQC3": 10
-    }
+expected_totals = {
+    "SQ1-3": 5,
+    "SQC3": 10
+}
+
 
 # map fields to processing method
-question_mapping = \
-    {
-        "PR1": process_boolean,
-        "PR2": process_boolean,
-        "SQC2": process_boolean,
-        "PR5": process_boolean,
-        "PR3": process_boolean,
-        "PR4": process_boolean,
-        "SQ1-3": process_checkbox_counts,
-        "SQA2": process_boolean,
-        "SQA3": process_boolean,
-        "SQA4": process_boolean,
-        "SQA5": process_boolean,
-        "AQA5": process_boolean,
-        "AQA3": process_boolean,
-        "SQ5-1a": process_string,
-        "SQC3": process_checkbox_counts,
-        "SQ1-2a": process_string,
-        "SQ1-2b": process_string,
-        "SQ1-1a": process_string,
-        "SQ1-1b": process_string,
-        "SQ1-1ci": process_string,
-        "SQ1-1cii": process_string,
-        "SQ1-1k": process_string,
-        "SQ1-1d-i": process_string,
-        "SQ1-1d-ii": process_string,
-        "SQ1-1e": process_string,
-        "SQ1-1h": process_string,
-        "SQ5-2a": process_boolean,
-        "SQ1-1i-i": process_boolean,
-        "SQ1-1i-ii": process_string,
-        "SQ1-1j-i": process_list_to_string,
-        "SQ1-1j-ii": process_string,
-        "SQ1-1m": process_string,
-        "SQE2a": process_list_to_string,
-        "SQ1-1n": process_string,
-        "SQ1-1o": process_string,
-        "SQ2-1abcd": process_boolean,
-        "SQ2-1e": process_boolean,
-        "SQ2-1f": process_boolean,
-        "SQ2-1ghijklmn": process_boolean,
-        "SQ2-2a": process_boolean,
-        "SQ3-1a": process_boolean,
-        "SQ3-1b": process_boolean,
-        "SQ3-1c": process_boolean,
-        "SQ3-1d": process_boolean,
-        "SQ3-1e": process_boolean,
-        "SQ3-1f": process_boolean,
-        "SQ3-1g": process_boolean,
-        "SQ3-1h-i": process_boolean,
-        "SQ3-1h-ii": process_boolean,
-        "SQ3-1i-i": process_boolean,
-        "SQ3-1i-ii": process_boolean,
-        "SQ3-1j": process_boolean,
-        "SQ3-1k": process_string,
-        "SQ4-1a": process_boolean,
-        "SQ4-1b": process_boolean,
-        "SQ4-1c": process_string,
-    }
+question_mapping = {
+    "PR1": process_boolean,
+    "PR2": process_boolean,
+    "SQC2": process_boolean,
+    "PR5": process_boolean,
+    "PR3": process_boolean,
+    "PR4": process_boolean,
+    "SQ1-3": process_checkbox_counts,
+    "SQA2": process_boolean,
+    "SQA3": process_boolean,
+    "SQA4": process_boolean,
+    "SQA5": process_boolean,
+    "AQA5": process_boolean,
+    "AQA3": process_boolean,
+    "SQ5-1a": process_string,
+    "SQC3": process_checkbox_counts,
+    "SQ1-2a": process_string,
+    "SQ1-2b": process_string,
+    "SQ1-1a": process_string,
+    "SQ1-1b": process_string,
+    "SQ1-1ci": process_string,
+    "SQ1-1cii": process_string,
+    "SQ1-1k": process_string,
+    "SQ1-1d-i": process_string,
+    "SQ1-1d-ii": process_string,
+    "SQ1-1e": process_string,
+    "SQ1-1h": process_string,
+    "SQ5-2a": process_boolean,
+    "SQ1-1i-i": process_boolean,
+    "SQ1-1i-ii": process_string,
+    "SQ1-1j-i": process_list_to_string,
+    "SQ1-1j-ii": process_string,
+    "SQ1-1m": process_string,
+    "SQE2a": process_list_to_string,
+    "SQ1-1n": process_string,
+    "SQ1-1o": process_string,
+    "SQ2-1abcd": process_boolean,
+    "SQ2-1e": process_boolean,
+    "SQ2-1f": process_boolean,
+    "SQ2-1ghijklmn": process_boolean,
+    "SQ2-2a": process_boolean,
+    "SQ3-1a": process_boolean,
+    "SQ3-1b": process_boolean,
+    "SQ3-1c": process_boolean,
+    "SQ3-1d": process_boolean,
+    "SQ3-1e": process_boolean,
+    "SQ3-1f": process_boolean,
+    "SQ3-1g": process_boolean,
+    "SQ3-1h-i": process_boolean,
+    "SQ3-1h-ii": process_boolean,
+    "SQ3-1i-i": process_boolean,
+    "SQ3-1i-ii": process_boolean,
+    "SQ3-1j": process_boolean,
+    "SQ3-1k": process_string,
+    "SQ4-1a": process_boolean,
+    "SQ4-1b": process_boolean,
+    "SQ4-1c": process_string,
+}
+
 
 def process_supplier_declaration(supplier_declaration, questions):
     """
@@ -152,6 +162,7 @@ def process_supplier_declaration(supplier_declaration, questions):
         if question in question_mapping:
             answers.append(question_mapping[question](supplier_declaration, question))
     return answers
+
 
 # get the list of questions, in order, from the manifest
 def process_declaration_manifest(path_to_declaration_manifest):
@@ -171,6 +182,7 @@ def process_declaration_manifest(path_to_declaration_manifest):
             for question in declaration_page['questions']:
                 all_the_questions_in_order.append(question)
     return all_the_questions_in_order
+
 
 def headers(questions):
     """
@@ -193,6 +205,7 @@ def headers(questions):
         csv_headers.append("{}:{}".format(index+1, value))
     return csv_headers
 
+
 def supplier_has_completed_declaration(declaration):
     """
     If declartion has a value for any of the keys on the 4th page we treat it as completed
@@ -203,6 +216,7 @@ def supplier_has_completed_declaration(declaration):
     :return:
     """
     return "SQ2-2a" in declaration['selectionAnswers']['questionAnswers']
+
 
 def suppliers_on_framework(data_api_url, data_api_token, questions):
     """
@@ -245,6 +259,7 @@ def suppliers_on_framework(data_api_url, data_api_token, questions):
                 pass
             else:
                 raise e
+
 
 if __name__ == '__main__':
     arguments = docopt(__doc__)

--- a/scripts/generate_declaration_export_for_ccs_sourcing.py
+++ b/scripts/generate_declaration_export_for_ccs_sourcing.py
@@ -1,0 +1,256 @@
+"""
+
+Usage:
+    scripts/generate_declaration_export_for_ccs_sourcing.py <data_api_url> <data_api_token> <path_to_declaration_manifest>
+
+Example:
+    ./generate_declaration_export_for_ccs_sourcing.py http://api myToken /my/path/to/file/manifest.yml
+"""
+import csv
+import sys
+import yaml
+
+from docopt import docopt
+from dmutils.apiclient import DataAPIClient, HTTPError
+
+def get_or_else_none(map_to_check, key):
+    """
+        Use map.get to handle missing keys for object values
+    """
+    return map_to_check.get(key, None)
+
+def get_or_else_empty_string(map_to_check, key):
+    """
+        Use map.get to handle missing keys for string values
+    """
+    return map_to_check.get(key, "")
+
+def get_or_else_empty_list(map_to_check, key):
+    """
+        Use map.get to handle missing keys for list values
+    """
+    return map_to_check.get(key, [])
+
+def bool_to_yes_no(value):
+        """
+        Turn a boolean into a yes/no string
+        :param value eg True:
+        :return string eg "yes":
+        """
+        if value:
+            return "yes"
+        return "no"
+
+def has_checked_all_boxes(array, total):
+    """
+    Return a string indicating length of array compared with expected total
+
+    :param array eg ["value"]:
+    :param total eg 2:
+    :return "failed":
+    """
+    if len(array) < total:
+        return "failed"
+    else:
+        return "passed"
+
+def process_boolean(declaration, field):
+    value = get_or_else_none(declaration, field)
+    if value is not None:
+        return bool_to_yes_no(value)
+    else:
+        return ""
+
+def process_string(declaration, field):
+    return get_or_else_empty_string(declaration, field).encode("utf-8")
+
+def process_checkbox_counts(declaration, field):
+    values = get_or_else_empty_list(declaration, field)
+    return has_checked_all_boxes(values, expected_totals[field])
+
+def process_list_to_string(declaration, field):
+    return ", ".encode("utf-8").join(get_or_else_empty_list(declaration, field))
+
+# expected length of checkbox groups - if users don't tick all they fail
+expected_totals = \
+    {
+       "SQ1-3": 5,
+       "SQC3": 10
+    }
+
+# map fields to processing method
+fields = \
+    {
+        "PR1": process_boolean,
+        "PR2": process_boolean,
+        "SQC2": process_boolean,
+        "PR5": process_boolean,
+        "PR3": process_boolean,
+        "PR4": process_boolean,
+        "SQ1-3": process_checkbox_counts,
+        "SQA2": process_boolean,
+        "SQA3": process_boolean,
+        "SQA4": process_boolean,
+        "SQA5": process_boolean,
+        "AQA5": process_boolean,
+        "AQA3": process_boolean,
+        "SQ5-1a": process_string,
+        "SQC3": process_checkbox_counts,
+        "SQ1-2a": process_string,
+        "SQ1-2b": process_string,
+        "SQ1-1a": process_string,
+        "SQ1-1b": process_string,
+        "SQ1-1ci": process_string,
+        "SQ1-1cii": process_string,
+        "SQ1-1k": process_string,
+        "SQ1-1d-i": process_string,
+        "SQ1-1d-ii": process_string,
+        "SQ1-1e": process_string,
+        "SQ1-1h": process_string,
+        "SQ5-2a": process_boolean,
+        "SQ1-1i-i": process_boolean,
+        "SQ1-1i-ii": process_string,
+        "SQ1-1j-i": process_list_to_string,
+        "SQ1-1j-ii": process_string,
+        "SQ1-1m": process_string,
+        "SQE2a": process_list_to_string,
+        "SQ1-1n": process_string,
+        "SQ1-1o": process_string,
+        "SQ2-1abcd": process_boolean,
+        "SQ2-1e": process_boolean,
+        "SQ2-1f": process_boolean,
+        "SQ2-1ghijklmn": process_boolean,
+        "SQ2-2a": process_boolean,
+        "SQ3-1a": process_boolean,
+        "SQ3-1b": process_boolean,
+        "SQ3-1c": process_boolean,
+        "SQ3-1d": process_boolean,
+        "SQ3-1e": process_boolean,
+        "SQ3-1f": process_boolean,
+        "SQ3-1g": process_boolean,
+        "SQ3-1h-i": process_boolean,
+        "SQ3-1h-ii": process_boolean,
+        "SQ3-1i-i": process_boolean,
+        "SQ3-1i-ii": process_boolean,
+        "SQ3-1j": process_boolean,
+        "SQ3-1k": process_string,
+        "SQ4-1a": process_boolean,
+        "SQ4-1b": process_boolean,
+        "SQ4-1c": process_string,
+    }
+
+def process_supplier_declaration(supplier_declaration, questions):
+    """
+    Run through the answers from the supplier and process into a readable format
+    - processing methods defined above
+    :param supplier_declaration:
+    :param questions:
+    :return:
+    """
+    answers = []
+    for question in questions:
+        if question in fields:
+            answers.append(fields[question](supplier_declaration, question))
+    return answers
+
+# get the list of questions, in order, from the manifest
+def process_declaration_manifest(path_to_declaration_manifest):
+    """
+    Reads the manifest to get the order list of questions
+    - Used to ensure that we can match the JSON key (SQ3-1d)
+        to the position on the supplier web page (43)
+    - this allows for the CSV row to match the order of questions in the manifest
+        and subsequently the order on the application
+    :param path_to_declaration_manifest:
+    :return:
+    """
+    all_the_questions_in_order = []
+    with open(path_to_declaration_manifest, 'r') as f:
+        declaration_pages = yaml.load(f)
+        for declaration_page in declaration_pages:
+            for question in declaration_page['questions']:
+                all_the_questions_in_order.append(question)
+    return all_the_questions_in_order
+
+def headers(questions):
+    """
+    Generate the headers for the CSV file
+    - take an array of questions. The order is important
+    - Each question id is a column header
+    - Paired with the index+1 of it's position in the array
+    - Example: 43:SQ3-1d
+    - SQ3-1d is the old question id
+    - 43 is it's number on the supplier application
+    - Note array is prefixed with the DM supplier ID
+    :param questions:
+    :return array of strings representing headers:
+    """
+    csv_headers = list()
+    csv_headers.append('Digital Marketplace ID')
+    csv_headers.append('Digital Marketplace Name')
+    csv_headers.append('Digital Marketplace Duns number')
+    for index, value in enumerate(questions):
+        csv_headers.append("{}:{}".format(index+1, value))
+    return csv_headers
+
+def supplier_has_completed_declaration(declaration):
+    """
+    If declartion has a value for any of the keys on the 4th page we treat it as completed
+    All pages must be valid to save so any key set implies data saved on last page
+    To get to last page required all previous pages completed
+    SQ2-2a is the first compulsory question on the 4th page
+    :param declaration:
+    :return:
+    """
+    return "SQ2-2a" in declaration['selectionAnswers']['questionAnswers']
+
+def suppliers_on_framework(data_api_url, data_api_token, questions):
+    """
+    Generate the CSV
+    - takes the data api details
+    - iterates through all suppliers
+    - foreach supplier hits the declaration API to recover the answers
+    - builds CSV row for each supplier
+    :param data_api_url:
+    :param data_api_token:
+    :param questions:
+    :return:
+    """
+    client = DataAPIClient(data_api_url, data_api_token)
+
+    writer = csv.writer(sys.stdout, delimiter=',', quotechar='"')
+    writer.writerow(headers(questions))
+
+    for supplier in client.find_suppliers_iter():
+        try:
+            selection = client.get_selection_answers(supplier['id'], 'g-cloud-7')
+            if supplier_has_completed_declaration(selection):
+                processed_supplier_declaration = \
+                    process_supplier_declaration(
+                        selection['selectionAnswers']['questionAnswers'],
+                        questions
+                    )
+
+                supplier_declaration = list()
+                supplier_declaration.append(supplier['id'])
+                supplier_declaration.append(supplier['name'])
+                supplier_declaration.append(supplier.get('dunsNumber', ""))
+                for declaration in processed_supplier_declaration:
+                    supplier_declaration.append(declaration)
+
+                writer.writerow(supplier_declaration)
+        except HTTPError as e:
+            if e.status_code == 404:
+                # not all suppliers make a declaration so this is fine
+                pass
+            else:
+                raise e
+
+if __name__ == '__main__':
+    arguments = docopt(__doc__)
+
+    suppliers_on_framework(
+        data_api_url=arguments['<data_api_url>'],
+        data_api_token=arguments['<data_api_token>'],
+        questions=process_declaration_manifest(arguments['<path_to_declaration_manifest>'])
+    )

--- a/scripts/generate_lots_export_for_ccs_sourcing.py
+++ b/scripts/generate_lots_export_for_ccs_sourcing.py
@@ -30,7 +30,7 @@ def aggregate(drafts):
     result = {}
     g7_drafts = sorted(
         [g7 for g7 in drafts if g7['frameworkSlug'] == 'g-cloud-7' and 'serviceName' in g7],
-        key=lambda draft_to_sort: draft_to_sort['lot']
+        key=itemgetter('lot', 'status')
     )
 
     drafts_by_lot = groupby(g7_drafts, itemgetter('lot'))

--- a/scripts/generate_lots_export_for_ccs_sourcing.py
+++ b/scripts/generate_lots_export_for_ccs_sourcing.py
@@ -1,0 +1,132 @@
+"""
+
+Usage:
+    scripts/generate_lots_export_for_ccs_sourcing.py <data_api_url> <data_api_token>
+
+Example:
+    ./generate_lots_export_for_ccs_sourcing.py http://api myToken
+"""
+import csv
+import sys
+from itertools import groupby
+from operator import itemgetter
+from docopt import docopt
+from dmutils.apiclient import DataAPIClient, HTTPError
+
+def aggregate(drafts):
+    """
+    Process a list of drafts
+    - only process G7 drafts
+    - only process drafts with a service name as aborted copies are drafts
+        with no service but are NOT on supplier dashboards
+    - Group by lot
+    - Then Group by status
+    Returns a map keyed by lot.
+    - Each map entry is the count of drafts in each status
+    :param drafts: List of drafts services JSON objects
+    :return: Map of lot to status counts
+    """
+    result = {}
+    g7_drafts = sorted(
+        [g7 for g7 in drafts if g7['frameworkSlug'] == 'g-cloud-7' and 'serviceName' in g7],
+        key=lambda draft_to_sort: draft_to_sort['lot']
+    )
+
+    drafts_by_lot = groupby(g7_drafts, itemgetter('lot'))
+
+    for lot, draft in drafts_by_lot:
+        drafts_by_status_and_lot = groupby(draft, itemgetter('status'))
+        status_counts = {}
+        for status, drafts in drafts_by_status_and_lot:
+            status_counts[status] = len(list(drafts))
+        result[lot] = status_counts
+    return result
+
+def headers():
+    """
+    Generate the headers for the CSV file
+    :return array of strings representing headers:
+    """
+    csv_headers = list()
+    csv_headers.append('Digital Marketplace ID')
+    csv_headers.append('Digital Marketplace Name')
+    csv_headers.append('Digital Marketplace Duns number')
+    csv_headers.append('IaaS: Complete')
+    csv_headers.append('IaaS: Incomplete')
+    csv_headers.append('PaaS: Complete')
+    csv_headers.append('PaaS: Incomplete')
+    csv_headers.append('SaaS: Complete')
+    csv_headers.append('SaaS: Incomplete')
+    csv_headers.append('SCS: Complete')
+    csv_headers.append('SCS: Incomplete')
+    return csv_headers
+
+def submitted_count(drafts):
+    """
+    Get count of submitted services
+    Defaults to 0 if no submitted services
+    :param drafts:
+    :return:
+    """
+    return drafts.get('submitted', 0)
+
+def not_submitted_count(drafts):
+    """
+    Get count of not-submitted services
+    Defaults to 0 if no not-submitted services
+    :param drafts:
+    :return:
+    """
+    return drafts.get('not-submitted', 0)
+
+def suppliers_lot_count(data_api_url, data_api_token):
+    """
+    Generate the CSV
+    - takes the data api details
+    - iterates through all suppliers
+    - foreach supplier hits the draft API to recover the services
+    - builds CSV row for each supplier
+    :param data_api_url:
+    :param data_api_token:
+    :return:
+    """
+    client = DataAPIClient(data_api_url, data_api_token)
+
+    writer = csv.writer(sys.stdout, delimiter=',', quotechar='"')
+    writer.writerow(headers())
+
+    for supplier in client.find_suppliers_iter():
+        try:
+            drafts = list()
+            for draft_service in client.find_draft_services_iter(supplier['id']):
+                drafts.append(draft_service)
+
+            if drafts:
+                aggregations = aggregate(drafts)
+                supplier_row = list()
+                supplier_row.append(supplier['id'])
+                supplier_row.append(supplier['name'])
+                supplier_row.append(supplier.get('dunsNumber', ""))
+                supplier_row.append(submitted_count(aggregations.get('IaaS', {})))
+                supplier_row.append(not_submitted_count(aggregations.get('IaaS', {})))
+                supplier_row.append(submitted_count(aggregations.get('PaaS', {})))
+                supplier_row.append(not_submitted_count(aggregations.get('PaaS', {})))
+                supplier_row.append(submitted_count(aggregations.get('SaaS', {})))
+                supplier_row.append(not_submitted_count(aggregations.get('SaaS', {})))
+                supplier_row.append(submitted_count(aggregations.get('SCS', {})))
+                supplier_row.append(not_submitted_count(aggregations.get('SCS', {})))
+                writer.writerow(supplier_row)
+        except HTTPError as e:
+            if e.status_code == 404:
+                # not all suppliers make a declaration so this is fine
+                pass
+            else:
+                raise e
+
+if __name__ == '__main__':
+    arguments = docopt(__doc__)
+
+    suppliers_lot_count(
+        data_api_url=arguments['<data_api_url>'],
+        data_api_token=arguments['<data_api_token>']
+    )

--- a/scripts/generate_lots_export_for_ccs_sourcing.py
+++ b/scripts/generate_lots_export_for_ccs_sourcing.py
@@ -13,6 +13,7 @@ from operator import itemgetter
 from docopt import docopt
 from dmutils.apiclient import DataAPIClient, HTTPError
 
+
 def aggregate(drafts):
     """
     Process a list of drafts
@@ -42,6 +43,7 @@ def aggregate(drafts):
         result[lot] = status_counts
     return result
 
+
 def headers():
     """
     Generate the headers for the CSV file
@@ -61,6 +63,7 @@ def headers():
     csv_headers.append('SCS: Incomplete')
     return csv_headers
 
+
 def submitted_count(drafts):
     """
     Get count of submitted services
@@ -70,6 +73,7 @@ def submitted_count(drafts):
     """
     return drafts.get('submitted', 0)
 
+
 def not_submitted_count(drafts):
     """
     Get count of not-submitted services
@@ -78,6 +82,7 @@ def not_submitted_count(drafts):
     :return:
     """
     return drafts.get('not-submitted', 0)
+
 
 def suppliers_lot_count(data_api_url, data_api_token):
     """
@@ -122,6 +127,7 @@ def suppliers_lot_count(data_api_url, data_api_token):
                 pass
             else:
                 raise e
+
 
 if __name__ == '__main__':
     arguments = docopt(__doc__)


### PR DESCRIPTION
2 new scripts for CCS Sourcing exports

1) generate_declaration_export_for_ccs_sourcing.py
Used to generate a CSV file containing the supplier declaration data
- Gets every supplier from the supplier API
- For each supplier looks for a declaration for G7
- Checks that the declaration is complete by looking for the first compulsary field from page 4 - this is a proxy for "completed". All pages must be valid to be saved and all pages must be complete to get to page 4, so this *should* be sufficient in lieu of an actual status.
- Parses the declaration data into human readable form for presentation in the CSV
  - Booleans -> yes | no
  - Strings -> encoded to UTF-8, presented content as is
  - Required checkbox lists -> These are valid if all boxes are ticked. So presented as "passed" or "failed" depending on how long the list of values is compared to expected length.
  - Optional checkbox lists -> More informational, data presented as values joined by comma's, encoded to UTF-8.
- Uses Digital marketplace supplier ID, duns number and name as meta data.

2) generate_lots_export_for_ccs_sourcing.py
Generates the data around G7 services for each supplier.
- Get every supplier from supplier API
- For each supplier gets all the drafts
- For each draft filter the G7 ones, which have service names into a sublist
  - note that the service name check filters out "hanging" copies. Services that have been copied but have had no action taken exist in the DB but are not visible to suppliers and therefore are removed.
- Group this by lot, then by status.
- CSV has same meta columsn as (1) above
- Columns are status per lot, so submitted | not-submitted for each lot.

