### PR TITLE
[#103779820] Auditing user updates properly

### DIFF
--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -8,6 +8,7 @@ from ... import db, encryption
 from ...models import User, AuditEvent, Supplier
 from ...utils import get_json_from_request, json_has_required_keys, \
     json_has_matching_id, pagination_links, get_valid_page_or_1
+from ...service_utils import validate_and_return_updater_request
 from ...validation import validate_user_json_or_400, validate_user_auth_json_or_400
 
 
@@ -160,6 +161,7 @@ def update_user(user_id):
     """
         Update a user. Looks user up in DB, and updates where necessary.
     """
+    update_details = validate_and_return_updater_request()
 
     user = User.query.filter(
         User.id == user_id
@@ -194,8 +196,11 @@ def update_user(user_id):
 
     audit = AuditEvent(
         audit_type=AuditTypes.update_user,
-        user=user.email_address,
-        data={'update': user_update},
+        user=update_details.get('updated_by', 'no user data'),
+        data={
+            'user': user.email_address,
+            'update': user_update
+        },
         db_object=user
     )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ SQLAlchemy==1.0.5
 SQLAlchemy-Utils==0.30.5
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.3#egg=python-json-logger==v0.1.3
-git+https://github.com/alphagov/digitalmarketplace-utils.git@6.9.2#egg=digitalmarketplace-utils==6.9.2
+git+https://github.com/alphagov/digitalmarketplace-utils.git@7.0.0#egg=digitalmarketplace-utils==7.0.0
 
 # For schema validation
 jsonschema==2.3.0

--- a/scripts/chpass.py
+++ b/scripts/chpass.py
@@ -44,7 +44,7 @@ def update_user_password(api_endpoint, api_token, user_email, new_password, unlo
         user = data_client.get_user(email_address=user_email)['users']
         data_client.update_user_password(user['id'], new_password)
         if unlock:
-            data_client.update_user(user['id'], locked=False)
+            data_client.update_user(user['id'], locked=False, updater=getpass.getuser())
             logger.info("User unlocked")
     except apiclient.APIError:
         sys.exit(1)

--- a/scripts/import_services_from_api.py
+++ b/scripts/import_services_from_api.py
@@ -88,8 +88,7 @@ class ServiceUpdater(object):
             client.import_service(
                 service['id'],
                 cleaned_data,
-                user,
-                None
+                user
             )
             return True
         except apiclient.APIError as e:

--- a/tests/app/test_users.py
+++ b/tests/app/test_users.py
@@ -481,6 +481,7 @@ class TestUsersUpdate(BaseApplicationTest):
             response = self.client.post(
                 '/users/123',
                 data=json.dumps({
+                    "update_details": {"updated_by": "a.user"},
                     'users': {
                         'password': '1234567890'
                     }}),
@@ -505,6 +506,7 @@ class TestUsersUpdate(BaseApplicationTest):
             response = self.client.post(
                 '/users/123',
                 data=json.dumps({
+                    "update_details": {"updated_by": "a.user"},
                     'users': {
                         'active': False
                     }}),
@@ -553,6 +555,7 @@ class TestUsersUpdate(BaseApplicationTest):
             response = self.client.post(
                 '/users/123',
                 data=json.dumps({
+                    "update_details": {"updated_by": "a.user"},
                     'users': {
                         'locked': False
                     }}),
@@ -586,6 +589,7 @@ class TestUsersUpdate(BaseApplicationTest):
             response = self.client.post(
                 '/users/123',
                 data=json.dumps({
+                    "update_details": {"updated_by": "a.user"},
                     'users': {
                         'locked': True
                     }}),
@@ -609,6 +613,7 @@ class TestUsersUpdate(BaseApplicationTest):
             response = self.client.post(
                 '/users/123',
                 data=json.dumps({
+                    "update_details": {"updated_by": "a.user"},
                     'users': {
                         'name': 'I Just Got Married'
                     }}),
@@ -635,6 +640,7 @@ class TestUsersUpdate(BaseApplicationTest):
             response = self.client.post(
                 '/users/123',
                 data=json.dumps({
+                    "update_details": {"updated_by": "a.user"},
                     'users': {
                         'name': 'I Just Got Married'
                     }}),
@@ -658,6 +664,7 @@ class TestUsersUpdate(BaseApplicationTest):
             response = self.client.post(
                 '/users/123',
                 data=json.dumps({
+                    "update_details": {"updated_by": "a.user"},
                     'users': {
                         'role': 'supplier',
                         'supplierId': 456
@@ -685,6 +692,7 @@ class TestUsersUpdate(BaseApplicationTest):
             response = self.client.post(
                 '/users/123',
                 data=json.dumps({
+                    "update_details": {"updated_by": "a.user"},
                     'users': {
                         'role': 'buyer'
                     }}),
@@ -712,6 +720,7 @@ class TestUsersUpdate(BaseApplicationTest):
             response = self.client.post(
                 '/users/456',
                 data=json.dumps({
+                    "update_details": {"updated_by": "a.user"},
                     'users': {
                         'role': 'buyer',
                         'supplierId': 456
@@ -728,6 +737,7 @@ class TestUsersUpdate(BaseApplicationTest):
             response = self.client.post(
                 '/users/123',
                 data=json.dumps({
+                    "update_details": {"updated_by": "a.user"},
                     'users': {
                         'role': 'shopkeeper'
                     }}),
@@ -741,6 +751,7 @@ class TestUsersUpdate(BaseApplicationTest):
         response = self.client.post(
             '/users/123',
             data=json.dumps({
+                "update_details": {"updated_by": "a.user"},
                 'users': {
                     'role': 'supplier'
                 }}),
@@ -755,6 +766,7 @@ class TestUsersUpdate(BaseApplicationTest):
             response = self.client.post(
                 '/users/123',
                 data=json.dumps({
+                    "update_details": {"updated_by": "a.user"},
                     'users': {
                         'emailAddress': 'myshinynew@email.address'
                     }}),


### PR DESCRIPTION
Part of this bug fix: https://www.pivotaltracker.com/story/show/103779820

The update user endpoint should expect updater details and save them in audit events.

Previously the auditing of user updates only recorded the user who had been updated and not the user who made the change.  We need both to have a proper record of changes made.

Depends on:
- [x] https://github.com/alphagov/digitalmarketplace-utils/pull/166/files