### PR TITLE
[#104625852] Don't audit updated passwords

### DIFF
--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -176,6 +176,7 @@ def update_user(user_id):
     if 'password' in user_update:
         user.password = encryption.hashpw(user_update['password'])
         user.password_changed_at = datetime.utcnow()
+        user_update['password'] = 'updated'
     if 'active' in user_update:
         user.active = user_update['active']
     if 'name' in user_update:


### PR DESCRIPTION
See: https://www.pivotaltracker.com/story/show/104625852

Currently the data stored with audit events involving a password update includes the un-hashed plain-text password.  We need to not do that.