### PR TITLE
Allow the API to be run with gunicorn

### DIFF
--- a/scripts/run_app.sh
+++ b/scripts/run_app.sh
@@ -14,4 +14,9 @@ export DM_SEARCH_API_URL=${DM_SEARCH_API_URL:=http://localhost:5001}
 echo "Environment variables in use:" 
 env | grep DM_
 
-python application.py runserver
+if [ "$1" = "gunicorn" ]; then
+  "$VIRTUAL_ENV/bin/pip" install gunicorn
+  "$VIRTUAL_ENV/bin/gunicorn" -w 4 -b 127.0.0.1:5000 application:application
+else
+  python application.py runserver
+fi


### PR DESCRIPTION
Sometimes it is useful to run more threads for the data API. For example, when loading in large amounts of data doing it through a single thread takes a long time.

This runs it through [gunicorn](http://gunicorn.org/) with 4 workers when `gunicorn` is provided as an argument. Gunicorn should not be the default because it is not used anywhere else.