### PR TITLE
Rename selection answers to declaration

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -4,7 +4,7 @@ from flask import jsonify, abort, request, current_app
 from sqlalchemy.exc import IntegrityError, DataError
 from .. import main
 from ... import db
-from ...models import Supplier, ContactInformation, AuditEvent, Service, SelectionAnswers, Framework
+from ...models import Supplier, ContactInformation, AuditEvent, Service, SupplierFramework, Framework
 from ...validation import (
     validate_supplier_json_or_400,
     validate_contact_information_json_or_400,
@@ -249,13 +249,13 @@ def update_contact_information(supplier_id, contact_id):
 
 @main.route('/suppliers/<supplier_id>/declarations/<framework_slug>', methods=['GET'])
 def get_a_declaration(supplier_id, framework_slug):
-    declaration = SelectionAnswers.find_by_supplier_and_framework(
+    supplier_framework = SupplierFramework.find_by_supplier_and_framework(
         supplier_id, framework_slug
     )
-    if declaration is None:
+    if supplier_framework is None:
         abort(404)
 
-    return jsonify(declarations=declaration.serialize())
+    return jsonify(declaration=supplier_framework.declaration)
 
 
 @main.route('/suppliers/<supplier_id>/declarations/<framework_slug>', methods=['PUT'])
@@ -266,36 +266,34 @@ def set_a_declaration(supplier_id, framework_slug):
     if framework.status != 'open':
         abort(400, 'Framework must be open')
 
-    declaration = SelectionAnswers.find_by_supplier_and_framework(
+    supplier_framework = SupplierFramework.find_by_supplier_and_framework(
         supplier_id, framework_slug
     )
-    if declaration is not None:
-        status_code = 200
+    if supplier_framework is not None:
+        status_code = 200 if supplier_framework.declaration else 201
     else:
         supplier = Supplier.query.filter(
             Supplier.supplier_id == supplier_id
         ).first_or_404()
 
-        declaration = SelectionAnswers(
+        supplier_framework = SupplierFramework(
             supplier_id=supplier.supplier_id,
             framework_id=framework.id,
-            question_answers={}
+            declaration={}
         )
         status_code = 201
 
     request_data = get_json_from_request()
-    json_has_required_keys(request_data, ['declarations', 'updated_by'])
-    declarations_data = request_data['declarations']
-    json_has_required_keys(declarations_data, ['questionAnswers'])
+    json_has_required_keys(request_data, ['declaration', 'updated_by'])
 
-    declaration.question_answers = declarations_data['questionAnswers']
-    db.session.add(declaration)
+    supplier_framework.declaration = request_data['declaration']
+    db.session.add(supplier_framework)
     db.session.add(
         AuditEvent(
             audit_type=AuditTypes.answer_selection_questions,
-            db_object=declaration,
+            db_object=supplier_framework,
             user=request_data['updated_by'],
-            data={'update': declarations_data})
+            data={'update': request_data['declaration']})
     )
 
     try:
@@ -304,18 +302,18 @@ def set_a_declaration(supplier_id, framework_slug):
         db.session.rollback()
         abort(400, "Database Error: {}".format(e))
 
-    return jsonify(declarations=declaration.serialize()), status_code
+    return jsonify(declaration=supplier_framework.declaration), status_code
 
 
 @main.route('/suppliers/<supplier_id>/selection-answers/<framework_slug>', methods=['GET'])
 def get_selection_questions(supplier_id, framework_slug):
-    application = SelectionAnswers.find_by_supplier_and_framework(
+    supplier_framework = SupplierFramework.find_by_supplier_and_framework(
         supplier_id, framework_slug
     )
-    if application is None:
+    if supplier_framework is None:
         abort(404)
 
-    return jsonify(selectionAnswers=application.serialize())
+    return jsonify(selectionAnswers=supplier_framework.serialize())
 
 
 @main.route('/suppliers/<supplier_id>/selection-answers/<framework_slug>', methods=['PUT'])
@@ -326,20 +324,20 @@ def set_selection_questions(supplier_id, framework_slug):
     if framework.status != 'open':
         abort(400, 'Framework must be open')
 
-    answers = SelectionAnswers.find_by_supplier_and_framework(
+    supplier_framework = SupplierFramework.find_by_supplier_and_framework(
         supplier_id, framework_slug
     )
-    if answers is not None:
+    if supplier_framework is not None:
         status_code = 200
     else:
         supplier = Supplier.query.filter(
             Supplier.supplier_id == supplier_id
         ).first_or_404()
 
-        answers = SelectionAnswers(
+        supplier_framework = SupplierFramework(
             supplier_id=supplier.supplier_id,
             framework_id=framework.id,
-            question_answers={}
+            declaration={}
         )
         status_code = 201
 
@@ -348,12 +346,12 @@ def set_selection_questions(supplier_id, framework_slug):
     answers_data = request_data['selectionAnswers']
     json_has_required_keys(answers_data, ['questionAnswers'])
 
-    answers.question_answers = answers_data['questionAnswers']
-    db.session.add(answers)
+    supplier_framework.declaration = answers_data['questionAnswers']
+    db.session.add(supplier_framework)
     db.session.add(
         AuditEvent(
             audit_type=AuditTypes.answer_selection_questions,
-            db_object=answers,
+            db_object=supplier_framework,
             user=request_data['updated_by'],
             data={'update': answers_data})
     )
@@ -364,4 +362,4 @@ def set_selection_questions(supplier_id, framework_slug):
         db.session.rollback()
         abort(400, "Database Error: {}".format(e))
 
-    return jsonify(selectionAnswers=answers.serialize()), status_code
+    return jsonify(selectionAnswers=supplier_framework.serialize()), status_code

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -247,7 +247,7 @@ def update_contact_information(supplier_id, contact_id):
     return jsonify(contactInformation=contact.serialize())
 
 
-@main.route('/suppliers/<supplier_id>/declarations/<framework_slug>', methods=['GET'])
+@main.route('/suppliers/<supplier_id>/frameworks/<framework_slug>/declaration', methods=['GET'])
 def get_a_declaration(supplier_id, framework_slug):
     supplier_framework = SupplierFramework.find_by_supplier_and_framework(
         supplier_id, framework_slug
@@ -258,7 +258,7 @@ def get_a_declaration(supplier_id, framework_slug):
     return jsonify(declaration=supplier_framework.declaration)
 
 
-@main.route('/suppliers/<supplier_id>/declarations/<framework_slug>', methods=['PUT'])
+@main.route('/suppliers/<supplier_id>/frameworks/<framework_slug>/declaration', methods=['PUT'])
 def set_a_declaration(supplier_id, framework_slug):
     framework = Framework.query.filter(
         Framework.slug == framework_slug

--- a/app/models.py
+++ b/app/models.py
@@ -201,8 +201,8 @@ class Supplier(db.Model):
         return self
 
 
-class SelectionAnswers(db.Model):
-    __tablename__ = 'selection_answers'
+class SupplierFramework(db.Model):
+    __tablename__ = 'supplier_frameworks'
 
     supplier_id = db.Column(db.Integer,
                             db.ForeignKey('suppliers.supplier_id'),
@@ -210,29 +210,30 @@ class SelectionAnswers(db.Model):
     framework_id = db.Column(db.Integer,
                              db.ForeignKey('frameworks.id'),
                              primary_key=True)
-    question_answers = db.Column(JSON)
+    declaration = db.Column(JSON)
 
     supplier = db.relationship(Supplier, lazy='joined', innerjoin=True)
     framework = db.relationship(Framework, lazy='joined', innerjoin=True)
 
     @staticmethod
     def find_by_framework(framework_slug):
-        return SelectionAnswers.query.filter(
-            SelectionAnswers.framework.has(
+        return SupplierFramework.query.filter(
+            SupplierFramework.framework.has(
                 Framework.slug == framework_slug)
         )
 
     @staticmethod
     def find_by_supplier_and_framework(supplier_id, framework_slug):
-        return SelectionAnswers.find_by_framework(framework_slug).filter(
-            SelectionAnswers.supplier_id == supplier_id
+        return SupplierFramework.find_by_framework(framework_slug).filter(
+            SupplierFramework.supplier_id == supplier_id
         ).first()
 
     def serialize(self):
         return {
             "supplierId": self.supplier_id,
             "frameworkSlug": self.framework.slug,
-            "questionAnswers": self.question_answers,
+            "questionAnswers": self.declaration,
+            "declaration": self.declaration,
         }
 
 

--- a/migrations/versions/310_rename_to_supplier_frameworks.py
+++ b/migrations/versions/310_rename_to_supplier_frameworks.py
@@ -1,0 +1,43 @@
+"""Rename selection_answers to supplier_frameworks
+
+Declaration is the name we have settled on for the questions that
+a supplier answers to get onto a framework. As there are more details
+that we seem to need to hang on this relationship, such as whether
+they've registered interest, this has been pulled out into a table
+that more generally models the relationship between a supplier and
+frameworks.
+
+Revision ID: 310_rename_selection_answers
+Revises: 300_make_g7_pending
+Create Date: 2015-10-05 19:10:42.467269
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '310_rename_selection_answers'
+down_revision = '300_make_g7_pending'
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+def upgrade():
+    # Copied from 150_add_selection_answers.py
+    op.create_table(
+        'supplier_frameworks',
+        sa.Column('supplier_id', sa.Integer(), nullable=False),
+        sa.Column('framework_id', sa.Integer(), nullable=False),
+        sa.Column('declaration', postgresql.JSON(), nullable=True),
+        sa.ForeignKeyConstraint(['framework_id'], ['frameworks.id'], ),
+        sa.ForeignKeyConstraint(['supplier_id'], ['suppliers.supplier_id'], ),
+        sa.PrimaryKeyConstraint('supplier_id', 'framework_id')
+    )
+    op.execute("""
+        INSERT INTO supplier_frameworks(supplier_id, framework_id, declaration)
+        SELECT supplier_id, framework_id, question_answers FROM selection_answers
+    """)
+
+
+def downgrade():
+    op.execute('DROP TABLE supplier_frameworks')

--- a/tests/app/__init__.py
+++ b/tests/app/__init__.py
@@ -29,6 +29,7 @@ def teardown():
     with app.app_context():
         db.session.remove()
         db.engine.execute("drop sequence suppliers_supplier_id_seq cascade")
+        db.engine.execute("drop table selection_answers cascade")
         db.drop_all()
         db.engine.execute("drop table alembic_version")
         insp = inspect(db.engine)

--- a/tests/app/views/test_frameworks.py
+++ b/tests/app/views/test_frameworks.py
@@ -6,7 +6,7 @@ from nose.tools import assert_equal
 from dmutils.audit import AuditTypes
 
 from ..helpers import BaseApplicationTest
-from app.models import db, Framework, SelectionAnswers, DraftService, AuditEvent, Supplier, User
+from app.models import db, Framework, SupplierFramework, DraftService, AuditEvent, Supplier, User
 
 
 class TestListFrameworks(BaseApplicationTest):
@@ -51,10 +51,10 @@ class TestFrameworkStats(BaseApplicationTest):
         with self.app.app_context():
             for supplier_id in supplier_ids:
                 db.session.add(
-                    SelectionAnswers(
+                    SupplierFramework(
                         framework_id=framework_id,
                         supplier_id=supplier_id,
-                        question_answers={'status': status},
+                        declaration={'status': status},
                     )
                 )
 

--- a/tests/app/views/test_suppliers.py
+++ b/tests/app/views/test_suppliers.py
@@ -962,7 +962,7 @@ class TestGetSupplierDeclarations(BaseApplicationTest):
 
     def test_get_selection_answers(self):
         response = self.client.get(
-            '/suppliers/0/declarations/g-cloud-4')
+            '/suppliers/0/frameworks/g-cloud-4/declaration')
 
         data = json.loads(response.get_data())
         assert_equal(response.status_code, 200)
@@ -970,20 +970,20 @@ class TestGetSupplierDeclarations(BaseApplicationTest):
 
     def test_get_non_existent_by_framework(self):
         response = self.client.get(
-            '/suppliers/0/declarations/g-cloud-5')
+            '/suppliers/0/frameworks/g-cloud-5/declaration')
 
         assert_equal(response.status_code, 404)
 
     def test_get_non_existent_by_supplier(self):
         response = self.client.get(
-            '/suppliers/123/declarations/g-cloud-4')
+            '/suppliers/123/frameworks/g-cloud-4/declaration')
 
         assert_equal(response.status_code, 404)
 
 
 class TestSetSupplierDeclarations(BaseApplicationTest):
     method = 'put'
-    endpoint = '/suppliers/0/declarations/g-cloud-4'
+    endpoint = '/suppliers/0/frameworks/g-cloud-4/declaration'
 
     def setup(self):
         super(TestSetSupplierDeclarations, self).setup()
@@ -1010,7 +1010,7 @@ class TestSetSupplierDeclarations(BaseApplicationTest):
     def test_add_new_declaration(self):
         with self.app.app_context():
             response = self.client.put(
-                '/suppliers/0/declarations/test-open',
+                '/suppliers/0/frameworks/test-open/declaration',
                 data=json.dumps({
                     'updated_by': 'testing',
                     'declaration': {
@@ -1036,7 +1036,7 @@ class TestSetSupplierDeclarations(BaseApplicationTest):
             db.session.commit()
 
             response = self.client.put(
-                '/suppliers/0/declarations/test-open',
+                '/suppliers/0/frameworks/test-open/declaration',
                 data=json.dumps({
                     'updated_by': 'testing',
                     'declaration': {
@@ -1061,7 +1061,7 @@ class TestSetSupplierDeclarations(BaseApplicationTest):
             db.session.commit()
 
             response = self.client.put(
-                '/suppliers/0/declarations/test-pending',
+                '/suppliers/0/frameworks/test-pending/declaration',
                 data=json.dumps({
                     'updated_by': 'testing',
                     'declaration': {
@@ -1074,7 +1074,7 @@ class TestSetSupplierDeclarations(BaseApplicationTest):
     def test_invalid_payload_fails(self):
         with self.app.app_context():
             response = self.client.put(
-                '/suppliers/0/declarations/test-open',
+                '/suppliers/0/frameworks/test-open/declaration',
                 data=json.dumps({
                     'invalid': {
                     }


### PR DESCRIPTION
The language we have now settled on for this is the supplier declaration however it is still referred to as the selection questions in the data API. This change brings the API in line with the language used elsewhere.

Rather than renaming the table and routes to supplier declaration I have use the name `supplier_frameworks`. There are other pieces of information such as whether a supplier has registered interest in a framework that we currently query from the audit table. This was a temporary hack for expediency, now they can be hung off this table.

## ~~Causes downtime~~

~~This change is backwards compatible with respect to the apps that depend on the endpoint. However, because it changes the name of the table it will cause requests against `/suppliers/{}/selection-answers/{}` to fail for the duration of the release.~~

## :sparkles: this has been tested locally with the functional tests :sparkles: 

SSP functional tests with the framework open as well.