### PR TITLE
Add Framework slug to list response

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -37,6 +37,7 @@ class Framework(db.Model):
         return {
             'id': self.id,
             'name': self.name,
+            'slug': self.slug,
             'framework': self.framework,
             'status': self.status,
         }

--- a/tests/app/views/test_frameworks.py
+++ b/tests/app/views/test_frameworks.py
@@ -18,6 +18,8 @@ class TestListFrameworks(BaseApplicationTest):
             assert_equal(response.status_code, 200)
             assert_equal(len(data['frameworks']),
                          len(Framework.query.all()))
+            assert_equal(sorted(data['frameworks'][0].keys()),
+                         ['framework', 'id', 'name', 'slug', 'status'])
 
 
 class TestGetFrameworkStatus(BaseApplicationTest):


### PR DESCRIPTION
This is needed for listing frameworks as the slug is used in subsequent requests.