### PR TITLE
Set null prices to empty strings

### DIFF
--- a/scripts/oneoff/fix-pricing.py
+++ b/scripts/oneoff/fix-pricing.py
@@ -20,9 +20,15 @@ def update(client):
             if isinstance(service.get('priceMin'), (int, float)):
                 change = True
                 service['priceMin'] = '{}'.format(service['priceMin'])
+            elif service.get('priceMin') is None:
+                change = True
+                service['priceMin'] = ''
             if isinstance(service.get('priceMax'), (int, float)):
                 change = True
                 service['priceMax'] = '{}'.format(service['priceMax'])
+            elif service.get('priceMax') is None:
+                change = True
+                service['priceMax'] = ''
             if change:
                 try:
                     client.update_service(service['id'], service, 'migration')


### PR DESCRIPTION
The new G5 / G6 schema does not allow null prices, rather it expects
empty strings.