### PR TITLE
Stop detecting frameworks (on service import)

### DIFF
--- a/app/service_utils.py
+++ b/app/service_utils.py
@@ -29,10 +29,11 @@ def update_and_validate_service(service, service_payload):
     return service
 
 
-def validate_service(service):
-    framework = Framework.query.filter(
-        Framework.id == service.framework_id
-    ).first()
+def validate_service(service, framework=None):
+    if not framework:
+        framework = Framework.query.filter(
+            Framework.id == service.framework_id
+        ).first()
     slug = framework.slug
 
     if slug in ['g-cloud-4', 'g-cloud-5']:
@@ -48,13 +49,16 @@ def validate_service(service):
         'status': service.status
     })
 
-    data = drop_foreign_fields(
-        data,
-        ['service_id', 'supplierName', 'links', 'frameworkSlug', 'frameworkName', 'updatedAt'])
+    data = drop_api_exported_fields_so_that_api_import_will_validate(data)
     errs = get_validation_errors(validator_name, data, enforce_required=True)
     if errs:
         abort(400, errs)
     return
+
+
+def drop_api_exported_fields_so_that_api_import_will_validate(data):
+    return drop_foreign_fields(
+        data, ['service_id', 'supplierName', 'links', 'frameworkSlug', 'frameworkName', 'updatedAt'])
 
 
 def commit_and_archive_service(updated_service, update_details,

--- a/app/validation.py
+++ b/app/validation.py
@@ -91,33 +91,6 @@ def validate_user_auth_json_or_400(submitted_json):
         abort(400, "JSON was not a valid format. {}".format(e.message))
 
 
-def detect_framework_or_400(submitted_json):
-    framework = detect_framework(submitted_json)
-    if not framework:
-        abort(400, "JSON was not a valid format. {}".format(
-            reason_for_failure(submitted_json))
-        )
-
-    return framework
-
-
-def detect_framework(submitted_json):
-    schemas = [
-        ('G-Cloud 4', 'services-g-cloud-4'),
-        ('G-Cloud 5', 'services-g-cloud-5'),
-        ('G-Cloud 6', 'services-g-cloud-6'),
-        ('G-Cloud 7', 'services-g-cloud-7'),
-    ]
-    for framework_name, schema_prefix in schemas:
-        schema_names = [
-            name for name in SCHEMA_NAMES if name.startswith(schema_prefix)
-        ]
-        for schema_name in schema_names:
-            if validates_against_schema(schema_name, submitted_json):
-                return framework_name
-    return False
-
-
 def validate_supplier_json_or_400(submitted_json):
     try:
         get_validator('suppliers').validate(submitted_json)
@@ -178,46 +151,6 @@ def min_price_less_than_max_price(error_map, json_data):
             if Decimal(json_data['priceMin']) > Decimal(json_data['priceMax']):
                 return {'priceMax': 'max_less_than_min'}
     return {}
-
-
-def reason_for_failure(submitted_json):
-    response = []
-    try:
-        get_validator('services-g-cloud-4').validate(submitted_json)
-    except ValidationError as e1:
-        response.append('Not G4: %s' % e1.message)
-
-    try:
-        get_validator('services-g-cloud-5').validate(submitted_json)
-    except ValidationError as e1:
-        response.append('Not G5: %s' % e1.message)
-
-    try:
-        get_validator('services-g-cloud-6-scs').validate(submitted_json)
-    except ValidationError as e1:
-        response.append('Not SCS: %s' % e1.message)
-
-    try:
-        get_validator('services-g-cloud-6-saas').validate(submitted_json)
-    except ValidationError as e2:
-        response.append('Not SaaS: %s' % e2.message)
-
-    try:
-        get_validator('services-g-cloud-6-paas').validate(submitted_json)
-    except ValidationError as e3:
-        response.append('Not PaaS: %s' % e3.message)
-
-    try:
-        get_validator('services-g-cloud-6-iaas').validate(submitted_json)
-    except ValidationError as e4:
-        response.append('Not IaaS: %s' % e4.message)
-
-    try:
-        get_validator('services-g-cloud-7-scs').validate(submitted_json)
-    except ValidationError as e5:
-        response.append('Not 7-SCS: %s' % e5.message)
-
-    return '. '.join(response)
 
 
 def is_valid_service_id(service_id):

--- a/example_listings/G4.json
+++ b/example_listings/G4.json
@@ -9,6 +9,8 @@
   "supplierId": 1,
   "status": "disabled",
   "lot": "IaaS",
+  "frameworkName": "G-Cloud 4",
+  "frameworkSlug": "g-cloud-4",
   "serviceTypes": [
     "Storage"
   ],

--- a/example_listings/G5.json
+++ b/example_listings/G5.json
@@ -9,6 +9,8 @@
   "supplierId":1,
   "status":"published",
   "lot":"SaaS",
+  "frameworkName": "G-Cloud 5",
+  "frameworkSlug": "g-cloud-5",
   "serviceTypes":[
     "Marketing",
     "Software development tools"

--- a/example_listings/G6-IaaS.json
+++ b/example_listings/G6-IaaS.json
@@ -2,6 +2,8 @@
    "id": "1234567890123456",
    "supplierId": 1,
    "lot": "IaaS",
+   "frameworkName": "G-Cloud 6",
+   "frameworkSlug": "g-cloud-6",
    "title": "My Iaas Service",
    "createdAt": "2014-12-23T14:46:22Z",
    "serviceTypes": [

--- a/example_listings/G6-PaaS.json
+++ b/example_listings/G6-PaaS.json
@@ -2,6 +2,8 @@
    "id": "1234567890123457",
    "supplierId": 1,
    "lot": "PaaS",
+   "frameworkName": "G-Cloud 6",
+   "frameworkSlug": "g-cloud-6",
    "title": "\"My new PaaS\" Service with \"Quotes\"",
    "createdAt": "2014-12-22T17:32:37Z",
    "serviceBenefits": [

--- a/example_listings/G6-SCS.json
+++ b/example_listings/G6-SCS.json
@@ -2,6 +2,8 @@
    "id": "1234567890123459",
    "supplierId": 1,
    "lot": "SCS",
+   "frameworkName": "G-Cloud 6",
+   "frameworkSlug": "g-cloud-6",
    "title": "Finally, an SCS \"Service\u0027: ]",
    "createdAt": "2014-12-23T14:53:20Z",
    "serviceTypes": [

--- a/example_listings/G6-SaaS.json
+++ b/example_listings/G6-SaaS.json
@@ -2,6 +2,8 @@
    "id": "1234567890123458",
    "supplierId": 1,
    "lot": "SaaS",
+   "frameworkName": "G-Cloud 6",
+   "frameworkSlug": "g-cloud-6",
    "title": "A SaaS with lots of options",
    "createdAt": "2014-12-23T14:51:19Z",
    "serviceTypes": [

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -5,11 +5,10 @@ import json
 
 from nose.tools import assert_equal, assert_in, assert_not_in
 from jsonschema import validate, SchemaError, ValidationError
+from app.service_utils import drop_api_exported_fields_so_that_api_import_will_validate
 
-from app.validation import detect_framework, \
-    validates_against_schema, is_valid_service_id, \
-    is_valid_date, is_valid_acknowledged_state, get_validation_errors, \
-    is_valid_string
+from app.validation import validates_against_schema, is_valid_service_id, is_valid_date, \
+    is_valid_acknowledged_state, get_validation_errors, is_valid_string
 
 EXAMPLE_LISTING_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__),
                                                     '..', 'example_listings'))
@@ -241,52 +240,23 @@ def test_auth_user_validates():
         yield assert_equal, result, expected, message
 
 
-def test_example_json_validates_correctly():
-    cases = [
-        ("G4", "G-Cloud 4"),
-        ("G5", "G-Cloud 5"),
-        ("G6-SCS", "G-Cloud 6"),
-        ("G6-SaaS", "G-Cloud 6"),
-        ("G6-PaaS", "G-Cloud 6"),
-        ("G6-IaaS", "G-Cloud 6"),
-        ("G6-INVALID", False)
-    ]
-
-    for example, expected, in cases:
-        data = load_example_listing(example)
-        yield assert_example, example, detect_framework(data), expected
-
-
-def test_additional_fields_are_not_allowed():
-    cases = [
-        ("G4", False),
-        ("G5", False),
-        ("G6-SCS", False),
-        ("G6-SaaS", False),
-        ("G6-PaaS", False),
-        ("G6-IaaS", False)
-    ]
-
-    for example, expected in cases:
-        data = load_example_listing(example)
-        data.update({'newKey': 1})
-        yield assert_example, example, detect_framework(data), expected
-
-
 def test_valid_g4_service_has_no_validation_errors():
     data = load_example_listing("G4")
+    data = drop_api_exported_fields_so_that_api_import_will_validate(data)
     errs = get_validation_errors("services-g-cloud-4", data)
     assert not errs
 
 
 def test_valid_g5_service_has_no_validation_errors():
     data = load_example_listing("G5")
+    data = drop_api_exported_fields_so_that_api_import_will_validate(data)
     errs = get_validation_errors("services-g-cloud-5", data)
     assert not errs
 
 
 def test_valid_g6_service_has_no_validation_errors():
     data = load_example_listing("G6-PaaS")
+    data = drop_api_exported_fields_so_that_api_import_will_validate(data)
     errs = get_validation_errors("services-g-cloud-6-paas", data)
     assert not errs
 


### PR DESCRIPTION
Our import route was using some framework detection logic that we didn't need anymore, as services that are returned by the API have framework information included in their JSON content (set in the [`serialize()`](https://github.com/alphagov/digitalmarketplace-api/blob/master/app/models.py#L359) method for services).

_ 

As we're never creating a new service by directly importing them, we know that the import route only gets used to import services returned by the API.  So we can use the existing `validate_service` method to validate the service based on the correct schema, and now that's what we do.