### PR TITLE
Allow all declarations to be changed

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -263,8 +263,6 @@ def set_a_declaration(supplier_id, framework_slug):
     framework = Framework.query.filter(
         Framework.slug == framework_slug
     ).first_or_404()
-    if framework.status != 'open':
-        abort(400, 'Framework must be open')
 
     supplier_framework = SupplierFramework.find_by_supplier_and_framework(
         supplier_id, framework_slug

--- a/tests/app/views/test_suppliers.py
+++ b/tests/app/views/test_suppliers.py
@@ -908,30 +908,6 @@ class TestSetSupplierSupplierFramework(BaseApplicationTest):
                 .find_by_supplier_and_framework(0, 'test-open')
             assert_equal(answers.declaration['question'], 'answer2')
 
-    def test_can_only_set_questions_on_open_framework(self):
-        with self.app.app_context():
-            framework = Framework(
-                slug='test-pending',
-                name='Test pending',
-                framework='gcloud',
-                status='pending')
-            db.session.add(framework)
-            db.session.commit()
-
-            response = self.client.put(
-                '/suppliers/0/selection-answers/test-pending',
-                data=json.dumps({
-                    'updated_by': 'testing',
-                    'selectionAnswers': {
-                        'supplierId': 0,
-                        'frameworkSlug': 'test-pending',
-                        'questionAnswers': {
-                            'question': 'answer'
-                        }}}),
-                content_type='application/json')
-
-            assert_equal(response.status_code, 400)
-
     def test_invalid_payload_fails(self):
         with self.app.app_context():
             response = self.client.put(
@@ -1049,27 +1025,6 @@ class TestSetSupplierDeclarations(BaseApplicationTest):
             supplier_framework = SupplierFramework \
                 .find_by_supplier_and_framework(0, 'test-open')
             assert_equal(supplier_framework.declaration['question'], 'answer2')
-
-    def test_can_only_set_questions_on_open_framework(self):
-        with self.app.app_context():
-            framework = Framework(
-                slug='test-pending',
-                name='Test pending',
-                framework='gcloud',
-                status='pending')
-            db.session.add(framework)
-            db.session.commit()
-
-            response = self.client.put(
-                '/suppliers/0/frameworks/test-pending/declaration',
-                data=json.dumps({
-                    'updated_by': 'testing',
-                    'declaration': {
-                        'question': 'answer'
-                        }}),
-                content_type='application/json')
-
-            assert_equal(response.status_code, 400)
 
     def test_invalid_payload_fails(self):
         with self.app.app_context():


### PR DESCRIPTION
Allow supplier declarations to be changed regardless of what state the framework is in. I have discussed this with Cath and the declaration can change at any point in the process but who changes must be controlled. The who is managed by the frontend applications.