### PR TITLE
[#103088246] Add skeleton DOS schema and allow DOS drafts to be created

### DIFF
--- a/app/validation.py
+++ b/app/validation.py
@@ -24,6 +24,7 @@ SCHEMA_NAMES = [
     'services-g-cloud-7-saas',
     'services-g-cloud-7-paas',
     'services-g-cloud-7-scs',
+    'services-digital-outcomes-and-specialists-lot1',
     'services-update',
     'users',
     'users-auth',

--- a/example_listings/DOS-LOT1.json
+++ b/example_listings/DOS-LOT1.json
@@ -1,0 +1,5 @@
+{
+  "supplierId": 1,
+  "lot": "LOT1",
+  "example": "This is an example"
+}

--- a/json_schemas/services-digital-outcomes-and-specialists-lot1.json
+++ b/json_schemas/services-digital-outcomes-and-specialists-lot1.json
@@ -1,0 +1,39 @@
+{
+  "title":"Digital Outcomes and Specialists LOT1 Service Schema",
+  "$schema":"http://json-schema.org/schema#",
+  "type":"object",
+  "additionalProperties":false,
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^([0-9]{16})$"
+    },
+    "status": {
+      "enum": [
+        "disabled",
+        "enabled",
+        "published",
+        "submitted",
+        "not-submitted"
+      ]
+    },
+    "supplierId": {
+      "type": "integer"
+    },
+    "lot": {
+      "enum": [
+        "LOT1"
+      ]
+    },
+    "example": {
+      "type": "string"
+    }
+  },
+  "required":[
+    "id",
+    "supplierId",
+    "status",
+    "lot",
+    "example"
+  ]
+}

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -181,6 +181,16 @@ class BaseApplicationTest(object):
         return datetime.strptime(
             value, from_format)
 
+    def bootstrap_dos(self):
+        old_level = db.session.connection().connection.isolation_level
+        db.session.connection().connection.set_isolation_level(0)
+        db.session.execute("ALTER TYPE framework_enum ADD VALUE 'dos' AFTER 'gcloud';")
+        db.session.execute("ALTER TYPE framework_status_enum ADD VALUE 'coming' BEFORE 'pending';")
+        db.session.connection().connection.set_isolation_level(old_level)
+        db.session.add(Framework(name="Digital Outcomes and Specialists",
+                                 framework='dos', status='open',
+                                 slug='digital-outcomes-and-specialists'))
+
 
 class JSONUpdateTestMixin(object):
     """


### PR DESCRIPTION
The tests add the `dos` framework to the database to allow the tests to run - once `dos` exists in all environments we should remove the `bootstrap_dos()` part of these tests.