### PR TITLE
Migration to add G7-interested suppliers to `supplier_frameworks` table

### DIFF
--- a/migrations/versions/350_migrate_interested_suppliers.py
+++ b/migrations/versions/350_migrate_interested_suppliers.py
@@ -1,0 +1,43 @@
+"""Migrate g-cloud-7 interested suppliers
+
+Currently "registered interest" is stored in the audit events table.
+We instead want to use the supplier_frameworks table to record this
+information.
+
+This migration extracts supplier IDs from the relevant audit events
+and adds them to the supplier_frameworks table.
+
+Revision ID: 350_migrate_interested_suppliers
+Revises: 340
+Create Date: 2015-10-05 19:10:42.467269
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '350_migrate_interested_suppliers'
+down_revision = '340'
+
+from alembic import op
+
+
+def upgrade():
+    op.execute("""
+        INSERT INTO supplier_frameworks
+            (supplier_id, framework_id)
+        SELECT DISTINCT users.supplier_id AS supplier_id, frameworks.id AS framework_id
+            FROM users, audit_events, frameworks
+                WHERE audit_events.user = users.email_address
+                AND audit_events.type = 'register_framework_interest'
+                AND frameworks.slug = 'g-cloud-7'
+                AND (users.supplier_id, frameworks.id) NOT IN
+                    (SELECT supplier_id, framework_id FROM supplier_frameworks);
+    """)
+
+def downgrade():
+    op.execute("""
+        DELETE FROM supplier_frameworks
+            WHERE declaration IS NULL
+            AND framework_id = 
+                (SELECT id FROM frameworks 
+                    WHERE frameworks.slug = 'g-cloud-7');
+    """)

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,3 +6,6 @@ max-line-length = 120
 verbosity=2
 nocapture=1
 with-doctest=1
+
+[pytest]
+norecursedirs = venv venv3 src


### PR DESCRIPTION
First step towards: https://www.pivotaltracker.com/story/show/105005134

Currently "registered interest" is stored in the audit events table as `register_framework_interest` type events. We instead want to use the `supplier_frameworks` table to record which frameworks a supplier is interested in.

This migration extracts supplier IDs from the relevant audit events and adds them to the `supplier_frameworks` table.

It assumes that all audit events relate to the `g-cloud-7` framework.  This is fine because that's the only one that anyone has been able to register interest in up until now.