### PR TITLE
Add endpoints for suppliers to register interest in a framework

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -113,3 +113,20 @@ def get_framework_stats(framework_slug):
             ).all()
         )
     })
+
+
+@main.route('/frameworks/<string:framework_slug>/interest', methods=['GET'])
+def get_framework_interest(framework_slug):
+    framework = Framework.query.filter(
+        Framework.slug == framework_slug
+    ).first_or_404()
+
+    supplier_frameworks = SupplierFramework.query.filter(
+        SupplierFramework.framework_id == framework.id
+    ).all()
+
+    supplier_ids = []
+    for supplier_framework in supplier_frameworks:
+        supplier_ids.append(supplier_framework.supplier_id)
+
+    return jsonify(interestedSuppliers=supplier_ids)

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -7,7 +7,6 @@ from datetime import datetime
 from nose.tools import assert_equal, assert_in
 
 from app import create_app, db
-from sqlalchemy import Sequence
 from app.models import Service, Supplier, ContactInformation, Framework
 
 TEST_SUPPLIERS_COUNT = 3
@@ -190,6 +189,7 @@ class BaseApplicationTest(object):
         db.session.add(Framework(name="Digital Outcomes and Specialists",
                                  framework='dos', status='open',
                                  slug='digital-outcomes-and-specialists'))
+        db.session.commit()
 
 
 class JSONUpdateTestMixin(object):

--- a/tests/app/views/test_frameworks.py
+++ b/tests/app/views/test_frameworks.py
@@ -234,3 +234,36 @@ class TestFrameworkStats(BaseApplicationTest):
                 {u'count': 5, u'recent_login': True},
             ]
         })
+
+
+class TestGetFrameworkInterest(BaseApplicationTest):
+    def setup(self):
+        super(TestGetFrameworkInterest, self).setup()
+
+        self.register_g7_interest(5)
+
+    def register_g7_interest(self, num):
+        self.setup_dummy_suppliers(num)
+        with self.app.app_context():
+            for supplier_id in range(num):
+                db.session.add(
+                    SupplierFramework(
+                        framework_id=4,
+                        supplier_id=supplier_id
+                    )
+                )
+            db.session.commit()
+
+    def test_interested_suppliers_are_returned(self):
+        with self.app.app_context():
+            response = self.client.get('/frameworks/g-cloud-7/interest')
+
+            assert_equal(response.status_code, 200)
+            data = json.loads(response.get_data())
+            assert_equal(data['interestedSuppliers'], [0, 1, 2, 3, 4])
+
+    def test_a_404_is_raised_if_it_does_not_exist(self):
+        with self.app.app_context():
+            response = self.client.get('/frameworks/biscuits-for-gov/interest')
+
+            assert_equal(response.status_code, 404)


### PR DESCRIPTION
Interest in a framework will now be stored in the `supplier_frameworks` table rather than in audit events.  This adds the endpoints required to register interest and get the frameworks that a supplier is interested in.

Question: what should the return value from the POST endpoint be?  It only allows adding interest in a new framework, not updating all frameworks that the supplier is interested in.  So I have it return only the new framework that has been registered, e.g. any supplier registering interest in g-cloud-9 would get the response:
`{"frameworkInterest": "g-cloud9"}`

The other possibility would be to return the full updated list of all frameworks that the supplier is now registered in, just like the GET endpoint added here - e.g. something like `{"frameworks"=["g-cloud-5", "g-cloud-7", "g-cloud-9"]}`.  That seems not quite right because this POST endpoint can't be used to change any of those other frameworks.  But comments welcome, I can see either way could make sense.

Or does it not really matter because nothing actually looks at the JSON responses from successful POST requests anyway (except our tests)?