### PR TITLE
[#106103948] Pass/fail for supplier frameworks

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -39,10 +39,7 @@ def get_framework_stats(framework_slug):
 
     framework = Framework.query.filter(
         Framework.slug == framework_slug
-    ).first()
-
-    if not framework:
-        abort(404, "'{}' is not a framework".format(framework.slug))
+    ).first_or_404()
 
     seven_days_ago = datetime.datetime.utcnow() + datetime.timedelta(-7)
 

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -341,7 +341,7 @@ def register_interest_in_framework(supplier_id, framework_slug):
     ).first_or_404()
 
     interest_record = SupplierFramework.query.filter(
-        SupplierFramework.supplier_id == supplier_id,
+        SupplierFramework.supplier_id == supplier.supplier_id,
         SupplierFramework.framework_id == framework.id
     ).first()
 
@@ -349,13 +349,13 @@ def register_interest_in_framework(supplier_id, framework_slug):
         return jsonify(frameworkInterest=interest_record.serialize()), 200
     else:
         interest_record = SupplierFramework(
-            supplier_id=supplier_id,
+            supplier_id=supplier.supplier_id,
             framework_id=framework.id
         )
         audit_event = AuditEvent(
             audit_type=AuditTypes.register_framework_interest,
             user=updater_json.get('user'),
-            data={'supplierId': supplier_id, 'frameworkSlug': framework_slug},
+            data={'supplierId': supplier.supplier_id, 'frameworkSlug': framework_slug},
             db_object=supplier
         )
 
@@ -382,16 +382,15 @@ def register_framework_interest(supplier_id, framework_slug):
         Supplier.supplier_id == supplier_id
     ).first_or_404()
 
-    interest_record = SupplierFramework.query.filter(
-        SupplierFramework.supplier_id == supplier_id,
-        SupplierFramework.framework_id == framework.id
-    ).first()
-
     json_payload = get_json_from_request()
     json_payload.pop('update_details')
     if json_payload:
         abort(400, "This PUT endpoint does not take a payload.")
 
+    interest_record = SupplierFramework.query.filter(
+        SupplierFramework.supplier_id == supplier.supplier_id,
+        SupplierFramework.framework_id == framework.id
+    ).first()
     if interest_record:
         return jsonify(frameworkInterest=interest_record.serialize()), 200
 
@@ -399,7 +398,7 @@ def register_framework_interest(supplier_id, framework_slug):
         abort(400, "'{}' framework is not open".format(framework_slug))
 
     interest_record = SupplierFramework(
-        supplier_id=supplier_id,
+        supplier_id=supplier.supplier_id,
         framework_id=framework.id
     )
     audit_event = AuditEvent(
@@ -437,7 +436,7 @@ def update_supplier_framework_details(supplier_id, framework_slug):
     update_json = json_payload["frameworkInterest"]
 
     interest_record = SupplierFramework.query.filter(
-        SupplierFramework.supplier_id == supplier_id,
+        SupplierFramework.supplier_id == supplier.supplier_id,
         SupplierFramework.framework_id == framework.id
     ).first()
 

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -433,8 +433,8 @@ def update_supplier_framework_details(supplier_id, framework_slug):
     ).first_or_404()
 
     json_payload = get_json_from_request()
-    json_has_required_keys(json_payload, ["update"])
-    update_json = json_payload["update"]
+    json_has_required_keys(json_payload, ["frameworkInterest"])
+    update_json = json_payload["frameworkInterest"]
 
     interest_record = SupplierFramework.query.filter(
         SupplierFramework.supplier_id == supplier_id,

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -454,8 +454,8 @@ def update_supplier_framework_details(supplier_id, framework_slug):
         # Updating an existing supplier_frameworks entry
         audit_event = AuditEvent(
             audit_type=AuditTypes.supplier_update,
-            user=updater_json.get('user'),
-            data={'supplierId': supplier_id, 'frameworkSlug': framework_slug, 'update': update_json},
+            user=updater_json.get('updated_by'),
+            data={'supplierId': supplier.supplier_id, 'frameworkSlug': framework_slug, 'update': update_json},
             db_object=supplier
         )
         status_code = 200
@@ -470,8 +470,8 @@ def update_supplier_framework_details(supplier_id, framework_slug):
         )
         audit_event = AuditEvent(
             audit_type=AuditTypes.register_framework_interest,
-            user=updater_json.get('user'),
-            data={'supplierId': supplier_id, 'frameworkSlug': framework_slug},
+            user=updater_json.get('updated_by'),
+            data={'supplierId': supplier.supplier_id, 'frameworkSlug': framework_slug},
             db_object=supplier
         )
         status_code = 201

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -376,8 +376,10 @@ def get_registered_frameworks(supplier_id):
     return jsonify(frameworks=slugs)
 
 
+# TODO: deprecated - remove route once all frontend apps are using utils version 10.8.0 or higher
 @main.route('/suppliers/<supplier_id>/frameworks/<framework_slug>/interest', methods=['POST'])
 def register_interest_in_framework(supplier_id, framework_slug):
+    current_app.logger.warning("Deprecated /suppliers/<supplier_id>/frameworks/<framework_slug>/interest route")
     updater_json = validate_and_return_updater_request()
 
     framework = Framework.query.filter(
@@ -422,3 +424,70 @@ def register_interest_in_framework(supplier_id, framework_slug):
             return jsonify(message="Database Error: {0}".format(e)), 400
 
         return jsonify(frameworkInterest=interest_record.serialize()), 201
+
+
+@main.route('/suppliers/<supplier_id>/frameworks/<framework_slug>', methods=['POST'])
+def update_supplier_framework_details(supplier_id, framework_slug):
+    updater_json = validate_and_return_updater_request()
+
+    framework = Framework.query.filter(
+        Framework.slug == framework_slug
+    ).first_or_404()
+
+    supplier = Supplier.query.filter(
+        Supplier.supplier_id == supplier_id
+    ).first()
+
+    if supplier is None:
+        abort(404, "supplier_id '{}' not found".format(supplier_id))
+
+    json_payload = get_json_from_request()
+    json_has_required_keys(json_payload, ["update"])
+    update_json = json_payload["update"]
+
+    interest_record = SupplierFramework.query.filter(
+        SupplierFramework.supplier_id == supplier_id,
+        SupplierFramework.framework_id == framework.id
+    ).first()
+
+    if interest_record:
+        # Updating an existing supplier_frameworks entry
+        audit_event = AuditEvent(
+            audit_type=AuditTypes.supplier_update,
+            user=updater_json.get('user'),
+            data={'supplierId': supplier_id, 'frameworkSlug': framework_slug, 'update': update_json},
+            db_object=supplier
+        )
+        status_code = 200
+
+    else:
+        # Registering interest for the first time
+        if framework.status != 'open':
+            abort(400, "'{}' framework is not open".format(framework_slug))
+        interest_record = SupplierFramework(
+            supplier_id=supplier_id,
+            framework_id=framework.id
+        )
+        audit_event = AuditEvent(
+            audit_type=AuditTypes.register_framework_interest,
+            user=updater_json.get('user'),
+            data={'supplierId': supplier_id, 'frameworkSlug': framework_slug},
+            db_object=supplier
+        )
+        status_code = 201
+
+    if 'onFramework' in update_json:
+        interest_record.on_framework = update_json['onFramework']
+        if interest_record.on_framework is True and interest_record.agreement_returned is None:
+            interest_record.agreement_returned = False
+    if 'agreementReturned' in update_json:
+        interest_record.agreement_returned = update_json['agreementReturned']
+    try:
+        db.session.add(interest_record)
+        db.session.add(audit_event)
+        db.session.commit()
+    except IntegrityError as e:
+        db.session.rollback()
+        return jsonify(message="Database Error: {0}".format(e)), 400
+
+    return jsonify(frameworkInterest=interest_record.serialize()), status_code

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -157,10 +157,7 @@ def update_supplier(supplier_id):
 
     supplier = Supplier.query.filter(
         Supplier.supplier_id == supplier_id
-    ).first()
-
-    if supplier is None:
-        abort(404, "supplier_id '%d' not found" % supplier_id)
+    ).first_or_404()
 
     json_has_required_keys(
         request_data,
@@ -206,10 +203,7 @@ def update_contact_information(supplier_id, contact_id):
     contact = ContactInformation.query.filter(
         ContactInformation.id == contact_id,
         ContactInformation.supplier_id == supplier_id,
-    ).first()
-
-    if contact is None:
-        abort(404, "contact_id '%d' not found" % contact_id)
+    ).first_or_404()
 
     json_has_required_keys(request_data, [
         'contactInformation', 'updated_by'
@@ -344,10 +338,7 @@ def register_interest_in_framework(supplier_id, framework_slug):
 
     supplier = Supplier.query.filter(
         Supplier.supplier_id == supplier_id
-    ).first()
-
-    if supplier is None:
-        abort(404, "supplier_id '{}' not found".format(supplier_id))
+    ).first_or_404()
 
     interest_record = SupplierFramework.query.filter(
         SupplierFramework.supplier_id == supplier_id,
@@ -389,10 +380,7 @@ def register_framework_interest(supplier_id, framework_slug):
 
     supplier = Supplier.query.filter(
         Supplier.supplier_id == supplier_id
-    ).first()
-
-    if supplier is None:
-        abort(404, "supplier_id '{}' not found".format(supplier_id))
+    ).first_or_404()
 
     interest_record = SupplierFramework.query.filter(
         SupplierFramework.supplier_id == supplier_id,
@@ -437,10 +425,7 @@ def update_supplier_framework_details(supplier_id, framework_slug):
 
     supplier = Supplier.query.filter(
         Supplier.supplier_id == supplier_id
-    ).first()
-
-    if supplier is None:
-        abort(404, "supplier_id '{}' not found".format(supplier_id))
+    ).first_or_404()
 
     json_payload = get_json_from_request()
     json_has_required_keys(json_payload, ["update"])

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -245,8 +245,10 @@ def update_contact_information(supplier_id, contact_id):
     return jsonify(contactInformation=contact.serialize())
 
 
+# TODO: deprecated - remove route once all frontend apps are using utils version 10.8.0 or higher
 @main.route('/suppliers/<supplier_id>/frameworks/<framework_slug>/declaration', methods=['GET'])
 def get_a_declaration(supplier_id, framework_slug):
+    current_app.logger.warning("Deprecated /suppliers/<supplier_id>/frameworks/<framework_slug>/declaration route")
     supplier_framework = SupplierFramework.find_by_supplier_and_framework(
         supplier_id, framework_slug
     )

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -239,7 +239,7 @@ def update_contact_information(supplier_id, contact_id):
     return jsonify(contactInformation=contact.serialize())
 
 
-# TODO: deprecated - remove route once all frontend apps are using utils version 10.8.0 or higher
+# TODO: deprecated - remove route once all frontend apps are using utils version 11.1.0 or higher
 @main.route('/suppliers/<supplier_id>/frameworks/<framework_slug>/declaration', methods=['GET'])
 def get_a_declaration(supplier_id, framework_slug):
     current_app.logger.warning("Deprecated /suppliers/<supplier_id>/frameworks/<framework_slug>/declaration route")
@@ -323,7 +323,7 @@ def get_supplier_framework_info(supplier_id, framework_slug):
     return jsonify(frameworkInterest=supplier_framework.serialize())
 
 
-# TODO: deprecated - remove route once all frontend apps are using utils version 10.8.0 or higher
+# TODO: deprecated - remove route once all frontend apps are using utils version 11.1.0 or higher
 @main.route('/suppliers/<supplier_id>/frameworks/<framework_slug>/interest', methods=['POST'])
 def register_interest_in_framework(supplier_id, framework_slug):
     current_app.logger.warning("Deprecated /suppliers/<supplier_id>/frameworks/<framework_slug>/interest route")

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -387,6 +387,11 @@ def register_framework_interest(supplier_id, framework_slug):
         SupplierFramework.framework_id == framework.id
     ).first()
 
+    json_payload = get_json_from_request()
+    json_payload.pop('update_details')
+    if json_payload:
+        abort(400, "This PUT endpoint does not take a payload.")
+
     if interest_record:
         return jsonify(frameworkInterest=interest_record.serialize()), 200
 

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -316,6 +316,17 @@ def get_registered_frameworks(supplier_id):
     return jsonify(frameworks=slugs)
 
 
+@main.route('/suppliers/<supplier_id>/frameworks/<framework_slug>', methods=['GET'])
+def get_supplier_framework_info(supplier_id, framework_slug):
+    supplier_framework = SupplierFramework.find_by_supplier_and_framework(
+        supplier_id, framework_slug
+    )
+    if supplier_framework is None:
+        abort(404)
+
+    return jsonify(frameworkInterest=supplier_framework.serialize())
+
+
 # TODO: deprecated - remove route once all frontend apps are using utils version 10.8.0 or higher
 @main.route('/suppliers/<supplier_id>/frameworks/<framework_slug>/interest', methods=['POST'])
 def register_interest_in_framework(supplier_id, framework_slug):

--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -56,10 +56,7 @@ def list_users():
     if email_address:
         user = user_query.filter(
             User.email_address == email_address.lower()
-        ).first()
-
-        if not user:
-            abort(404, "No user with email_address '{}'".format(email_address))
+        ).first_or_404()
 
         return jsonify(
             users=[user.serialize()],

--- a/app/models.py
+++ b/app/models.py
@@ -283,7 +283,6 @@ class SupplierFramework(db.Model):
         return {
             "supplierId": self.supplier_id,
             "frameworkSlug": self.framework.slug,
-            "questionAnswers": self.declaration,
             "declaration": self.declaration,
             "onFramework": self.on_framework,
             "agreementReturned": self.agreement_returned

--- a/app/models.py
+++ b/app/models.py
@@ -260,6 +260,8 @@ class SupplierFramework(db.Model):
                              db.ForeignKey('frameworks.id'),
                              primary_key=True)
     declaration = db.Column(JSON)
+    on_framework = db.Column(db.Boolean, nullable=True)
+    agreement_returned = db.Column(db.Boolean, nullable=True)
 
     supplier = db.relationship(Supplier, lazy='joined', innerjoin=True)
     framework = db.relationship(Framework, lazy='joined', innerjoin=True)
@@ -283,6 +285,8 @@ class SupplierFramework(db.Model):
             "frameworkSlug": self.framework.slug,
             "questionAnswers": self.declaration,
             "declaration": self.declaration,
+            "onFramework": self.on_framework,
+            "agreementReturned": self.agreement_returned
         }
 
 

--- a/migrations/versions/360_add_pass_fail_returned.py
+++ b/migrations/versions/360_add_pass_fail_returned.py
@@ -1,0 +1,28 @@
+""" Add columns to supplier_frameworks to indicate
+    Pass/Fail and whether a Framework Agreement has
+    been returned.
+
+Revision ID: 360_add_pass_fail_returned
+Revises: 340
+Create Date: 2015-10-23 16:25:02.068155
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '360_add_pass_fail_returned'
+down_revision = '340'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+
+    op.add_column('supplier_frameworks', sa.Column('agreement_returned', sa.Boolean(), nullable=True))
+    op.add_column('supplier_frameworks', sa.Column('on_framework', sa.Boolean(), nullable=True))
+
+
+def downgrade():
+
+    op.drop_column('supplier_frameworks', 'on_framework')
+    op.drop_column('supplier_frameworks', 'agreement_returned')

--- a/migrations/versions/360_add_pass_fail_returned.py
+++ b/migrations/versions/360_add_pass_fail_returned.py
@@ -3,14 +3,14 @@
     been returned.
 
 Revision ID: 360_add_pass_fail_returned
-Revises: 340
+Revises: 350_migrate_interested_suppliers
 Create Date: 2015-10-23 16:25:02.068155
 
 """
 
 # revision identifiers, used by Alembic.
 revision = '360_add_pass_fail_returned'
-down_revision = '340'
+down_revision = '350_migrate_interested_suppliers'
 
 from alembic import op
 import sqlalchemy as sa

--- a/tests/app/test_users.py
+++ b/tests/app/test_users.py
@@ -917,12 +917,7 @@ class TestUsersGet(BaseApplicationTest):
     def test_returns_404_for_nonexistent_email_address(self):
         non_existent_email = "jbond@mi6.biz"
         response = self.client.get("/users?email_address={}".format(non_existent_email))
-        data = json.loads(response.get_data())["error"]
         assert_equal(response.status_code, 404)
-        assert_equal(
-            data,
-            "No user with email_address 'jbond@mi6.biz'".format(non_existent_email)
-        )
 
     def test_returns_400_for_non_int_supplier_id(self):
         bad_supplier_id = 'not_an_integer'

--- a/tests/app/views/test_suppliers.py
+++ b/tests/app/views/test_suppliers.py
@@ -1080,7 +1080,7 @@ class TestRegisterFrameworkInterest(BaseApplicationTest):
             db.session.commit()
 
     def register_interest(self, supplier_id, framework_slug, user='interested@example.com'):
-        return self.client.post(
+        return self.client.put(
             '/suppliers/{}/frameworks/{}'.format(supplier_id, framework_slug),
             data=json.dumps(
                 {
@@ -1175,6 +1175,13 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest):
             framework_enum_vals = db.session.execute("SELECT enum_range(NULL::framework_enum);").first()[0]
             if 'dos' not in str(framework_enum_vals):
                 self.bootstrap_dos()
+            self.client.put(
+                '/suppliers/0/frameworks/digital-outcomes-and-specialists',
+                data=json.dumps(
+                    {
+                        'update_details': {'updated_by': 'interested@example.com'}
+                    }),
+                content_type='application/json')
 
             answers = SupplierFramework(
                 supplier_id=0, framework_id=2,
@@ -1218,8 +1225,6 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest):
         assert_equal(response.status_code, 404)
 
     def test_adding_supplier_has_passed(self):
-        self.supplier_framework_update(0, 'digital-outcomes-and-specialists')
-
         response = self.supplier_framework_update(
             0,
             'digital-outcomes-and-specialists',
@@ -1233,8 +1238,6 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest):
         assert_equal(data['frameworkInterest']['agreementReturned'], False)
 
     def test_adding_supplier_has_not_passed(self):
-        self.supplier_framework_update(0, 'digital-outcomes-and-specialists')
-
         response = self.supplier_framework_update(
             0,
             'digital-outcomes-and-specialists',
@@ -1247,8 +1250,6 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest):
         assert_equal(data['frameworkInterest']['onFramework'], False)
 
     def test_adding_that_agreement_has_been_returned(self):
-        self.supplier_framework_update(0, 'digital-outcomes-and-specialists')
-
         response = self.supplier_framework_update(
             0,
             'digital-outcomes-and-specialists',
@@ -1261,8 +1262,6 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest):
         assert_equal(data['frameworkInterest']['agreementReturned'], True)
 
     def test_changing_from_failed_to_passed(self):
-        self.supplier_framework_update(0, 'digital-outcomes-and-specialists')
-
         response = self.supplier_framework_update(
             0,
             'digital-outcomes-and-specialists',
@@ -1284,8 +1283,6 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest):
         assert_equal(data['frameworkInterest']['agreementReturned'], False)
 
     def test_changing_from_passed_to_failed(self):
-        self.supplier_framework_update(0, 'digital-outcomes-and-specialists')
-
         response = self.supplier_framework_update(
             0,
             'digital-outcomes-and-specialists',
@@ -1307,7 +1304,6 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest):
         assert_equal(data['frameworkInterest']['agreementReturned'], False)
 
     def test_pass_fail_update_creates_audit_event(self):
-        self.supplier_framework_update(0, 'digital-outcomes-and-specialists')
         self.supplier_framework_update(
             0,
             'digital-outcomes-and-specialists',

--- a/tests/app/views/test_suppliers.py
+++ b/tests/app/views/test_suppliers.py
@@ -1210,7 +1210,7 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest):
             data=json.dumps(
                 {
                     'update_details': {'updated_by': 'interested@example.com'},
-                    'update': update
+                    'frameworkInterest': update
                 }),
             content_type='application/json')
 

--- a/tests/app/views/test_suppliers.py
+++ b/tests/app/views/test_suppliers.py
@@ -1084,8 +1084,7 @@ class TestRegisterFrameworkInterest(BaseApplicationTest):
             '/suppliers/{}/frameworks/{}'.format(supplier_id, framework_slug),
             data=json.dumps(
                 {
-                    'update_details': {'updated_by': user},
-                    'update': {}
+                    'update_details': {'updated_by': user}
                 }),
             content_type='application/json')
 
@@ -1132,6 +1131,21 @@ class TestRegisterFrameworkInterest(BaseApplicationTest):
             data = json.loads(response2.get_data())
             assert_equal(data['frameworkInterest']['supplierId'], 1)
             assert_equal(data['frameworkInterest']['frameworkSlug'], 'digital-outcomes-and-specialists')
+
+    def test_can_not_send_payload_to_register_interest_endpoint(self):
+        with self.app.app_context():
+            response = self.client.put(
+                '/suppliers/1/frameworks/digital-outcomes-and-specialists',
+                data=json.dumps(
+                    {
+                        'update_details': {'updated_by': 'interested@example.com'},
+                        'update': {'agreementReturned': True}
+                    }),
+                content_type='application/json')
+
+            assert_equal(response.status_code, 400)
+            data = json.loads(response.get_data())
+            assert_equal(data['error'], 'This PUT endpoint does not take a payload.')
 
     def test_register_interest_creates_audit_event(self):
         self.register_interest(1, 'digital-outcomes-and-specialists')


### PR DESCRIPTION
This is the API part of this story: https://www.pivotaltracker.com/story/show/106103948

Adds two new columns to the `supplier_frameworks` table and an endpoint for updating values in them.

**Note to self: Migration sequence numbers will probably need updating by the time this is ready to merge**