### PR TITLE
Add new statuses to frameworks

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -55,7 +55,7 @@ class Framework(db.Model):
     __tablename__ = 'frameworks'
 
     STATUSES = [
-        'pending', 'open', 'live', 'expired'
+        'coming', 'open', 'pending', 'standstill', 'live', 'expired'
     ]
 
     id = db.Column(db.Integer, primary_key=True)

--- a/app/models.py
+++ b/app/models.py
@@ -63,9 +63,9 @@ class Framework(db.Model):
     name = db.Column(db.String(255), nullable=False)
     framework = db.Column(db.Enum('gcloud', name='frameworks_enum'),
                           index=True, nullable=False)
-    status = db.Column(db.Enum(STATUSES, name='framework_status_enum'),
+    status = db.Column(db.String(),
                        index=True, nullable=False,
-                       server_default='pending')
+                       default='pending')
     lots = db.relationship(
         Lot, secondary=framework_lots,
         lazy='joined', innerjoin=False,
@@ -87,6 +87,13 @@ class Framework(db.Model):
             'status': self.status,
             'lots': [lot.serialize() for lot in self.lots],
         }
+
+    @validates('status')
+    def validates_status(self, key, value):
+        if value not in self.STATUSES:
+            raise ValidationError("Invalid status value '{}'".format(value))
+
+        return value
 
     def __repr__(self):
         return '<{}: {}>'.format(self.__class__.__name__, self.name)

--- a/app/utils.py
+++ b/app/utils.py
@@ -50,6 +50,11 @@ def json_has_required_keys(data, keys):
         abort(400, "Invalid JSON must have '%s' keys" % list(missing_keys))
 
 
+def json_only_has_required_keys(data, keys):
+    if set(keys) != set(data.keys()):
+        abort(400, "Invalid JSON must only have {} keys".format(keys))
+
+
 def drop_foreign_fields(json_object, list_of_keys):
     json_object = json_object.copy()
     for key in list_of_keys:

--- a/migrations/versions/370_use_sqlalchemy_validator.py
+++ b/migrations/versions/370_use_sqlalchemy_validator.py
@@ -1,0 +1,48 @@
+"""Use SQLAlchemy validator instead of enum for framework status
+
+Revision ID: 370
+Revises: 360_add_pass_fail_returned
+Create Date: 2015-10-29 13:44:17.371767
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '370_use_sqlalchemy_validator'
+down_revision = '360_add_pass_fail_returned'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+
+    op.execute("""
+        ALTER TABLE frameworks ALTER COLUMN status
+        TYPE character varying USING status::character varying
+    """)
+
+    op.execute("""
+        ALTER TABLE frameworks ALTER COLUMN status DROP DEFAULT
+    """)
+
+    op.execute("""
+        DROP TYPE framework_status_enum
+    """)
+
+
+def downgrade():
+
+    op.execute("""
+        CREATE TYPE framework_status_enum AS ENUM (
+            'coming', 'open', 'pending', 'standstill', 'live', 'expired'
+        )
+    """)
+
+    op.execute("""
+        ALTER TABLE frameworks ALTER COLUMN status TYPE framework_status_enum
+        USING status::framework_status_enum
+    """)
+
+    op.execute("""
+        ALTER TABLE frameworks ALTER COLUMN status SET DEFAULT 'pending'
+    """)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ SQLAlchemy==1.0.5
 SQLAlchemy-Utils==0.30.5
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.3#egg=python-json-logger==v0.1.3
-git+https://github.com/alphagov/digitalmarketplace-utils.git@8.1.2#egg=digitalmarketplace-utils==8.1.2
+git+https://github.com/alphagov/digitalmarketplace-utils.git@11.3.0#egg=digitalmarketplace-utils==11.3.0
 
 # For schema validation
 jsonschema==2.3.0

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -185,7 +185,6 @@ class BaseApplicationTest(object):
         old_level = db.session.connection().connection.isolation_level
         db.session.connection().connection.set_isolation_level(0)
         db.session.execute("ALTER TYPE framework_enum ADD VALUE 'dos' AFTER 'gcloud';")
-        db.session.execute("ALTER TYPE framework_status_enum ADD VALUE 'coming' BEFORE 'pending';")
         db.session.connection().connection.set_isolation_level(old_level)
 
         framework = Framework(

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -32,7 +32,7 @@ def test_should_not_return_password_on_user():
 
 def test_framework_should_not_accept_invalid_status():
     app = create_app('test')
-    with app.app_context(), assert_raises(DataError):
+    with app.app_context(), assert_raises(ValidationError):
         f = Framework(
             name='foo',
             slug='foo',


### PR DESCRIPTION
### coming ⇢ open ⇢ pending ⇢ standstill ⇢ live ⇢ expired

--

- "coming" replaces "pending" as the state before a framework is open for suppliers to make their applications
- "pending" moves in the order to reflect that it is the stage between a supplier applying and CCS telling suppliers if they're successful
- "standstill" is a new state which is in between suppliers being told if they're successful and their services being live on the marketplace