### PR TITLE
Adding a description to hashpw

### DIFF
--- a/json_schemas/users.json
+++ b/json_schemas/users.json
@@ -25,7 +25,8 @@
       "type": "integer"
     },
     "hashpw": {
-      "type": "boolean"
+      "type": "boolean",
+      "description": "set to False to skip password hashing"
     }
   },
   "required": [


### PR DESCRIPTION
For a human reader, `hashpw` is ambiguous. `hashpw` being true could mean "the password in this payload has already been hashed" or it could mean "the password in this payload needs to be hashed". Similarly, it being false could mean "the supplied password has not been hashed" or it could mean "don't hash this password, I've already done it".

Adding a brief description in the JSON schema makes it clear what the purpose of it is. Found this because I tried to create a user following the schema and ended up with a test user in the DB with a cleartext password.