### PR TITLE
Add supplier frameworks endpoint

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -299,6 +299,15 @@ def get_registered_frameworks(supplier_id):
     return jsonify(frameworks=slugs)
 
 
+@main.route('/suppliers/<supplier_id>/frameworks', methods=['GET'])
+def get_supplier_frameworks_info(supplier_id):
+    supplier_framework = SupplierFramework.query.filter(
+        SupplierFramework.supplier_id == supplier_id
+    )
+
+    return jsonify(frameworkInterest=[framework.serialize() for framework in supplier_framework])
+
+
 @main.route('/suppliers/<supplier_id>/frameworks/<framework_slug>', methods=['GET'])
 def get_supplier_framework_info(supplier_id, framework_slug):
     supplier_framework = SupplierFramework.find_by_supplier_and_framework(

--- a/migrations/versions/380_add_supplierframework_records_for_g5_g6_.py
+++ b/migrations/versions/380_add_supplierframework_records_for_g5_g6_.py
@@ -7,7 +7,7 @@ Create Date: 2015-11-02 16:27:01.538066
 """
 
 # revision identifiers, used by Alembic.
-revision = '380'
+revision = '380_add_supplierframework'
 down_revision = '370_use_sqlalchemy_validator'
 
 from alembic import op

--- a/migrations/versions/380_add_supplierframework_records_for_g5_g6_.py
+++ b/migrations/versions/380_add_supplierframework_records_for_g5_g6_.py
@@ -1,0 +1,30 @@
+"""Add SupplierFramework records for G5, G6 suppliers
+
+Revision ID: 380
+Revises: 370_use_sqlalchemy_validator
+Create Date: 2015-11-02 16:27:01.538066
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '380'
+down_revision = '370_use_sqlalchemy_validator'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.execute("""
+        INSERT INTO supplier_frameworks
+            (supplier_id, framework_id)
+        SELECT DISTINCT supplier_id, framework_id
+            FROM services
+                WHERE framework_id in (1, 3)
+    """)
+
+
+def downgrade():
+    op.execute("""
+        DELETE from supplier_frameworks WHERE framework_id in (1, 3)
+    """)

--- a/tests/app/views/test_suppliers.py
+++ b/tests/app/views/test_suppliers.py
@@ -1024,6 +1024,47 @@ class TestPostSupplier(BaseApplicationTest, JSONUpdateTestMixin):
         assert_true('duplicate key value violates unique constraint "ix_suppliers_duns_number"' in data['message'])
 
 
+class TestGetSupplierFrameworks(BaseApplicationTest):
+    def setup(self):
+        super(TestGetSupplierFrameworks, self).setup()
+
+        with self.app.app_context():
+
+            db.session.add(
+                Supplier(supplier_id=1, name=u"Supplier 1")
+            )
+            db.session.add(
+                SupplierFramework(
+                    supplier_id=1,
+                    framework_id=1,
+                    declaration={},
+                    agreement_returned=False,
+                    on_framework=False
+                )
+            )
+            db.session.commit()
+
+    def test_register_interest(self):
+        response = self.client.get('/suppliers/1/frameworks')
+        data = json.loads(response.get_data())
+        assert_equal(response.status_code, 200)
+        assert_equal(
+            data,
+            {
+                'frameworkInterest': [
+                    {
+                        'agreementReturned': False,
+                        'onFramework': False,
+                        'declaration': {},
+                        'frameworkSlug': 'g-cloud-6',
+                        'onFramework': False,
+                        'supplierId': 1
+                    }
+                ]
+            }
+        )
+
+
 class TestRegisterFrameworkInterest(BaseApplicationTest):
     def setup(self):
         super(TestRegisterFrameworkInterest, self).setup()

--- a/tests/app/views/test_suppliers.py
+++ b/tests/app/views/test_suppliers.py
@@ -3,7 +3,7 @@ from nose.tools import assert_equal, assert_in, assert_is_not_none, assert_true
 
 from app import db
 from app.models import Supplier, ContactInformation, AuditEvent, \
-    SupplierFramework, Framework
+    SupplierFramework, Framework, DraftService, Service
 from ..helpers import BaseApplicationTest, JSONUpdateTestMixin
 from random import randint
 
@@ -1030,21 +1030,52 @@ class TestGetSupplierFrameworks(BaseApplicationTest):
 
         with self.app.app_context():
 
-            db.session.add(
-                Supplier(supplier_id=1, name=u"Supplier 1")
-            )
-            db.session.add(
+            db.session.add_all([
+                Supplier(supplier_id=1, name=u"Supplier 1"),
+                Supplier(supplier_id=2, name=u"Supplier 2"),
+                Supplier(supplier_id=3, name=u"Supplier 2"),
                 SupplierFramework(
                     supplier_id=1,
                     framework_id=1,
                     declaration={},
                     agreement_returned=False,
                     on_framework=False
+                ),
+                SupplierFramework(
+                    supplier_id=2,
+                    framework_id=1,
+                    declaration={},
+                    agreement_returned=False,
+                    on_framework=False
+                ),
+                DraftService(
+                    framework_id=1,
+                    lot_id=1,
+                    service_id="0987654321",
+                    supplier_id=1,
+                    data={},
+                    status='not-submitted'
+                ),
+                DraftService(
+                    framework_id=1,
+                    lot_id=2,
+                    service_id="1234567890",
+                    supplier_id=1,
+                    data={},
+                    status='submitted'
+                ),
+                Service(
+                    framework_id=1,
+                    lot_id=2,
+                    service_id="1234567890",
+                    supplier_id=2,
+                    data={},
+                    status='published'
                 )
-            )
+            ])
             db.session.commit()
 
-    def test_register_interest(self):
+    def test_supplier_with_drafts(self):
         response = self.client.get('/suppliers/1/frameworks')
         data = json.loads(response.get_data())
         assert_equal(response.status_code, 200)
@@ -1057,12 +1088,52 @@ class TestGetSupplierFrameworks(BaseApplicationTest):
                         'onFramework': False,
                         'declaration': {},
                         'frameworkSlug': 'g-cloud-6',
-                        'onFramework': False,
-                        'supplierId': 1
+                        'supplierId': 1,
+                        'drafts_count': 1,
+                        'complete_drafts_count': 1,
+                        'services_count': 0
                     }
                 ]
             }
         )
+
+    def test_supplier_with_service(self):
+        response = self.client.get('/suppliers/2/frameworks')
+        data = json.loads(response.get_data())
+        assert_equal(response.status_code, 200)
+        assert_equal(
+            data,
+            {
+                'frameworkInterest': [
+                    {
+                        'agreementReturned': False,
+                        'onFramework': False,
+                        'declaration': {},
+                        'frameworkSlug': 'g-cloud-6',
+                        'supplierId': 2,
+                        'drafts_count': 0,
+                        'complete_drafts_count': 0,
+                        'services_count': 1
+                    }
+                ]
+            }
+        )
+
+    def test_supplier_with_no_drafts_or_services(self):
+        response = self.client.get('/suppliers/3/frameworks')
+        data = json.loads(response.get_data())
+        assert_equal(response.status_code, 200)
+        assert_equal(
+            data,
+            {
+                'frameworkInterest': []
+            }
+        )
+
+    def test_supplier_that_doesnt_exist(self):
+        response = self.client.get('/suppliers/4/frameworks')
+        data = json.loads(response.get_data())
+        assert_equal(response.status_code, 404)
 
 
 class TestRegisterFrameworkInterest(BaseApplicationTest):


### PR DESCRIPTION
## Get frameworks that a supplier has interacted from `/suppliers/1/frameworks`

This commit adds an endpoint to list the `supplier_frameworks` table.

For any framework from G-Cloud 7 onwards, this table has an entry when a supplier does stuff like register interest, answer declaration questions, etc


## Add service counts to `/suppliers/1/frameworks` response

For each framework that a supplier has interacted with, this commit adds:
- count of published services
- count of submitted draft services
- count of draft draft services

It doesn’t add this for the individual framework endpoint because we don’t have a use case for this yet.


## Add SupplierFramework entry for all G5/6 suppliers

G-Cloud 5 and 6 suppliers have 'interacted' with a framework, it just wasn’t on our system. So we should retroactively record this interaction.

If we *don’t* do this then it means 3 API queries:
- get all frameworks
- get all frameworks for a supplier
- get frameworks with a supplier’s services
- …and much munging

And things would get even more complicated when G6 and G7 are both live.

_Paired with @allait_