### PR TITLE
Re-add nose as requirements

### DIFF
--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -4,3 +4,4 @@ pep8==1.5.7
 requests-mock==0.6.0
 mock==1.0.1
 freezegun==0.3.4
+nose==1.3.6


### PR DESCRIPTION
Nose deprecated, however some old tests are still using this and it needs to be kept as a requirment
in the meantime.