### PR TITLE
Replace validation message rewrites with validator type checks

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ git+https://github.com/madzak/python-json-logger.git@v0.1.3#egg=python-json-logg
 git+https://github.com/alphagov/digitalmarketplace-utils.git@11.3.0#egg=digitalmarketplace-utils==11.3.0
 
 # For schema validation
-jsonschema==2.3.0
+jsonschema==2.5.1
 rfc3987==1.3.4
 strict-rfc3339==0.5
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -363,10 +363,16 @@ def test_assurance_only_causes_validation_error():
     assert "answer_required" in errs['serviceAvailabilityPercentage']
 
 
+def test_non_number_value_causes_validation_error():
+    data = load_example_listing("G6-PaaS")
+    data.update({'serviceAvailabilityPercentage': {"value": "a99.9", "assurance": "Service provider assertion"}})
+    errs = get_validation_errors("services-g-cloud-7-paas", data)
+    assert "not_a_number" in errs['serviceAvailabilityPercentage']
+
+
 def test_value_only_causes_validation_error():
     data = load_example_listing("G6-PaaS")
-    data.update({'serviceAvailabilityPercentage':
-                {"value": 99.9}})
+    data.update({'serviceAvailabilityPercentage': {"value": 99.9}})
     errs = get_validation_errors("services-g-cloud-7-paas", data)
     assert "assurance_required" in errs['serviceAvailabilityPercentage']
 


### PR DESCRIPTION
Instead of matching validation messages returned by the jsonschema
we use additional properties set on the ValidationError to replace
the message with the content validator name.

Some of the checks map directly from JSON schema validator to the
content validators, others require additional checks.

"required" and word count are the only ones that rely on substring
matching, since they don't expose any other values that could be
used instead (required for Draft v4 doesn't return the name of the
missing property, only the full list of required properties, so we
have to match the message text).