### PR TITLE
Return 410 for services on expired frameworks

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -187,9 +187,14 @@ def import_service(service_id):
 def get_service(service_id):
     service = Service.query.filter(
         Service.service_id == service_id
-    ).framework_is_live().first_or_404()
+    ).first_or_404()
 
-    return jsonify(services=service.serialize())
+    if service.framework.status == 'live':
+        return jsonify(services=service.serialize())
+    elif service.framework.status == 'expired':
+        abort(410)
+    else:
+        abort(404)
 
 
 @main.route('/archived-services/<int:archived_service_id>', methods=['GET'])

--- a/tests/app/views/test_services.py
+++ b/tests/app/views/test_services.py
@@ -1741,7 +1741,7 @@ class TestGetService(BaseApplicationTest):
 
     def test_get_expired_service(self):
         response = self.client.get('/services/123-expired-456')
-        assert_equal(404, response.status_code)
+        assert_equal(410, response.status_code)
 
     def test_get_service_returns_supplier_info(self):
         response = self.client.get('/services/123-published-456')


### PR DESCRIPTION
When the G-Cloud 5 framework expires, we should return 410 ("Gone") rather than 404s for G5 service pages.

See: https://www.pivotaltracker.com/story/show/107382498

This is related to, but not dependent on: https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/185