### PR TITLE
Add supplierName to SupplierFramework

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -319,6 +319,7 @@ class SupplierFramework(db.Model):
             agreement_returned_at = agreement_returned_at.strftime(DATETIME_FORMAT)
         return dict({
             "supplierId": self.supplier_id,
+            "supplierName": self.supplier.name,
             "frameworkSlug": self.framework.slug,
             "declaration": self.declaration,
             "onFramework": self.on_framework,

--- a/tests/app/views/test_suppliers.py
+++ b/tests/app/views/test_suppliers.py
@@ -1093,7 +1093,8 @@ class TestGetSupplierFrameworks(BaseApplicationTest):
                         'supplierId': 1,
                         'drafts_count': 1,
                         'complete_drafts_count': 1,
-                        'services_count': 0
+                        'services_count': 0,
+                        'supplierName': 'Supplier 1',
                     }
                 ]
             }
@@ -1116,7 +1117,8 @@ class TestGetSupplierFrameworks(BaseApplicationTest):
                         'supplierId': 2,
                         'drafts_count': 0,
                         'complete_drafts_count': 0,
-                        'services_count': 1
+                        'services_count': 1,
+                        'supplierName': 'Supplier 2',
                     }
                 ]
             }


### PR DESCRIPTION
Add the supplierName to the serialised version of SupplierFramework.
This is needed particularly for the admin app where we list suppliers
that have uploaded framework agreements.