### PR TITLE
Remove drafts with no serviceName

### DIFF
--- a/migrations/versions/410_remove_empty_drafts.py
+++ b/migrations/versions/410_remove_empty_drafts.py
@@ -1,0 +1,23 @@
+"""Remove empty drafts
+
+Revision ID: 410_remove_empty_drafts
+Revises: 400_drop_agreement_returned
+Create Date: 2015-11-09 11:41:00.000000
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '410_remove_empty_drafts'
+down_revision = '400_drop_agreement_returned'
+
+from alembic import op
+
+
+def upgrade():
+    op.execute("""
+        DELETE FROM draft_services WHERE (data->>'serviceName') is NULL;
+    """)
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
NOTE: 
 - I have already created a snapshot of the current prod database `before-deleting-empty-drafts-9-11-2015`
 - I have tested the `DELETE` query locally and it does the job.

In production we have 1237 draft services from 806 suppliers that only have a lot selected but no other data.

These have never been counted or shown to suppliers, but with the new lot changes for DOS they will be counted in G-7 draft services.

This removes these lot-only drafts so that draft counts will remain the same once the latest changes to supplier frontend go out.