### PR TITLE
Add frameworkStatus to service response

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -467,7 +467,7 @@ class ServiceTableMixin(object):
         data = drop_foreign_fields(value, [
             'id', 'status',
             'supplierId', 'supplierName',
-            'frameworkSlug', 'frameworkName',
+            'frameworkSlug', 'frameworkName', 'frameworkStatus',
             'lot', 'lotName',
             'updatedAt', 'createdAt', 'links'
         ])
@@ -489,6 +489,7 @@ class ServiceTableMixin(object):
             'supplierName': self.supplier.name,
             'frameworkSlug': self.framework.slug,
             'frameworkName': self.framework.name,
+            'frameworkStatus': self.framework.status,
             'lot': self.lot.slug,
             'lotName': self.lot.name,
             'updatedAt': self.updated_at.strftime(DATETIME_FORMAT),

--- a/tests/app/views/test_services.py
+++ b/tests/app/views/test_services.py
@@ -1748,3 +1748,10 @@ class TestGetService(BaseApplicationTest):
         data = json.loads(response.get_data())
         assert_equal(data['services']['supplierId'], 1)
         assert_equal(data['services']['supplierName'], u'Supplier 1')
+
+    def test_get_service_returns_framework_info(self):
+        response = self.client.get('/services/123-published-456')
+        data = json.loads(response.get_data())
+        assert_equal(data['services']['frameworkSlug'], 'g-cloud-6')
+        assert_equal(data['services']['frameworkName'], u'G-Cloud 6')
+        assert_equal(data['services']['frameworkStatus'], u'live')


### PR DESCRIPTION
This is required so that frontends can decide whether or not to show a service. Once this change is merged and the buyer frontend is updated to make use of it then the get service endpoint can be changed to always return services regardless of framework status.