### PR TITLE
Sort and normalise json schemas

### DIFF
--- a/json_schemas/contact-information.json
+++ b/json_schemas/contact-information.json
@@ -1,24 +1,6 @@
 {
-  "title": "G6 Contact Information Schema",
-  "type": "object",
   "additionalProperties": false,
   "properties": {
-    "id": {
-      "type": "integer"
-    },
-    "website": {
-      "type": "string"
-    },
-    "contactName": {
-      "type": "string"
-    },
-    "email": {
-      "type": "string",
-      "format": "email"
-    },
-    "phoneNumber": {
-      "type": "string"
-    },
     "address1": {
       "type": "string"
     },
@@ -28,15 +10,33 @@
     "city": {
       "type": "string"
     },
+    "contactName": {
+      "type": "string"
+    },
     "country": {
       "type": "string"
     },
+    "email": {
+      "format": "email",
+      "type": "string"
+    },
+    "id": {
+      "type": "integer"
+    },
+    "phoneNumber": {
+      "type": "string"
+    },
     "postcode": {
+      "type": "string"
+    },
+    "website": {
       "type": "string"
     }
   },
   "required": [
     "contactName",
     "email"
-  ]
+  ],
+  "title": "G6 Contact Information Schema",
+  "type": "object"
 }

--- a/json_schemas/new-supplier.json
+++ b/json_schemas/new-supplier.json
@@ -1,47 +1,47 @@
 {
-  "title": "Supplier Schema",
   "$schema": "http://json-schema.org/schema#",
-  "type": "object",
   "additionalProperties": false,
   "properties": {
-    "name": {
+    "clients": {
+      "items": {
+        "type": "string"
+      },
+      "maxItems": 10,
+      "minItems": 0,
+      "type": "array"
+    },
+    "companiesHouseNumber": {
+      "maxLength": 8,
+      "minLength": 8,
       "type": "string"
+    },
+    "contactInformation": {
+      "items": {
+        "$ref": "file:json_schemas/contact-information.json"
+      },
+      "minItems": 1,
+      "type": "array"
     },
     "description": {
       "type": "string"
     },
-    "contactInformation": {
-      "type": "array",
-      "items": {
-        "$ref": "file:json_schemas/contact-information.json"
-      },
-      "minItems": 1
-    },
     "dunsNumber": {
-      "type": "string",
-      "pattern": "^[0-9]+$"
+      "pattern": "^[0-9]+$",
+      "type": "string"
     },
     "eSourcingId": {
-      "type": "string",
-      "pattern": "^[0-9]+$"
+      "pattern": "^[0-9]+$",
+      "type": "string"
     },
-    "companiesHouseNumber": {
-      "type": "string",
-      "minLength": 8,
-      "maxLength": 8
-    },
-    "clients": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      },
-      "minItems": 0,
-      "maxItems": 10
+    "name": {
+      "type": "string"
     }
   },
   "required": [
-    "name",
+    "contactInformation",
     "dunsNumber",
-    "contactInformation"
-  ]
+    "name"
+  ],
+  "title": "Supplier Schema",
+  "type": "object"
 }

--- a/json_schemas/services-digital-outcomes-and-specialists-digital-outcomes.json
+++ b/json_schemas/services-digital-outcomes-and-specialists-digital-outcomes.json
@@ -1,14 +1,10 @@
 {
-  "title":"Digital Outcomes and Specialists Digital outcomes Service Schema",
-  "$schema":"http://json-schema.org/schema#",
-  "type":"object",
-
+  "$schema": "http://json-schema.org/schema#",
   "additionalProperties": true,
-
-  "properties": {
-  },
+  "properties": {},
   "required": [
     "outcomesSupplierInformation"
-  ]
-
+  ],
+  "title": "Digital Outcomes and Specialists Digital outcomes Service Schema",
+  "type": "object"
 }

--- a/json_schemas/services-digital-outcomes-and-specialists-digital-specialists.json
+++ b/json_schemas/services-digital-outcomes-and-specialists-digital-specialists.json
@@ -1,14 +1,10 @@
 {
-  "title":"Digital Outcomes and Specialists Digital specialists Service Schema",
-  "$schema":"http://json-schema.org/schema#",
-  "type":"object",
-
+  "$schema": "http://json-schema.org/schema#",
   "additionalProperties": true,
-
-  "properties": {
-  },
+  "properties": {},
   "required": [
     "specialistsSupplierInformation"
-  ]
-
+  ],
+  "title": "Digital Outcomes and Specialists Digital specialists Service Schema",
+  "type": "object"
 }

--- a/json_schemas/services-digital-outcomes-and-specialists-user-research-participants.json
+++ b/json_schemas/services-digital-outcomes-and-specialists-user-research-participants.json
@@ -1,10 +1,7 @@
 {
-  "title":"Digital Outcomes and Specialists User research participants Service Schema",
-  "$schema":"http://json-schema.org/schema#",
-  "type":"object",
-
+  "$schema": "http://json-schema.org/schema#",
   "additionalProperties": true,
-
-  "properties": {
-  }
+  "properties": {},
+  "title": "Digital Outcomes and Specialists User research participants Service Schema",
+  "type": "object"
 }

--- a/json_schemas/services-digital-outcomes-and-specialists-user-research-studios.json
+++ b/json_schemas/services-digital-outcomes-and-specialists-user-research-studios.json
@@ -1,18 +1,16 @@
 {
-  "title":"Digital Outcomes and Specialists User research studios Service Schema",
-  "$schema":"http://json-schema.org/schema#",
-  "type":"object",
-
+  "$schema": "http://json-schema.org/schema#",
   "additionalProperties": true,
-
   "properties": {
-    "serviceName":{
-      "type":"string",
-      "minLength":1,
-      "maxLength":100
+    "serviceName": {
+      "maxLength": 100,
+      "minLength": 1,
+      "type": "string"
     }
   },
   "required": [
     "serviceName"
-  ]
+  ],
+  "title": "Digital Outcomes and Specialists User research studios Service Schema",
+  "type": "object"
 }

--- a/json_schemas/services-g-cloud-4.json
+++ b/json_schemas/services-g-cloud-4.json
@@ -1,203 +1,294 @@
 {
-  "title": "G4 Services Schema",
   "$schema": "http://json-schema.org/schema#",
-  "type": "object",
   "additionalProperties": false,
   "properties": {
-    "title": {
-      "type": "string"
-    },
-    "serviceName": {
-      "type": "string"
-    },
-    "serviceSummary": {
-      "type": "string"
-    },
-    "serviceBenefits": {
-      "type": "array",
-      "maxItems": 10,
-      "items": {
-        "type": "string"
-      }
-    },
-    "serviceFeatures": {
-      "type": "array",
-      "maxItems": 10,
-      "items": {
-        "type": "string"
-      }
-    },
-    "serviceDefinitionDocumentURL": {
-      "type": "string",
-      "format": "uri"
-    },
-    "termsAndConditionsDocumentURL": {
-      "type": "string",
-      "format": "uri"
-    },
-    "pricingDocumentURL": {
-      "type": "string",
-      "format": "uri"
-    },
-    "sfiaRateDocumentURL": {
-      "type": "string",
-      "format": "uri"
-    },
     "additionalDocumentURLs": {
-      "type": "array",
-      "uniqueItems": true,
       "items": {
-        "type": "string",
-        "format": "uri"
-      }
+        "format": "uri",
+        "type": "string"
+      },
+      "type": "array",
+      "uniqueItems": true
     },
-    "minimumContractPeriod": {
-      "enum": ["hour", "day", "month", "year", "other"]
+    "apiAccess": {
+      "type": "boolean"
+    },
+    "dataBackupRecovery": {
+      "type": "boolean"
+    },
+    "dataExtractionRemoval": {
+      "type": "boolean"
+    },
+    "datacentreTier": {
+      "type": "string"
+    },
+    "datacentresEUCode": {
+      "type": "boolean"
+    },
+    "educationPricing": {
+      "type": "boolean"
+    },
+    "elasticCloud": {
+      "type": "boolean"
     },
     "freeOption": {
       "type": "boolean"
     },
-    "trialOption": {
+    "guaranteedResources": {
       "type": "boolean"
     },
-    "terminationCost": {
+    "minimumContractPeriod": {
+      "enum": [
+        "hour",
+        "day",
+        "month",
+        "year",
+        "other"
+      ]
+    },
+    "networksConnected": {
+      "items": {
+        "enum": [
+          "Internet",
+          "Public Services Network (PSN)",
+          "Government Secure intranet (GSi)",
+          "Police National Network (PNN)",
+          "New NHS Network (N3)",
+          "Joint Academic Network (JANET)",
+          "Other"
+        ]
+      },
+      "maxItems": 7,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "openSource": {
+      "type": "boolean"
+    },
+    "openStandardsSupported": {
+      "type": "boolean"
+    },
+    "persistentStorage": {
       "type": "boolean"
     },
     "priceMin": {
       "type": "number"
     },
+    "priceString": {
+      "type": "string"
+    },
     "priceUnit": {
       "type": "string"
     },
-    "priceString": {
+    "pricingDocumentURL": {
+      "format": "uri",
+      "type": "string"
+    },
+    "selfServiceProvisioning": {
+      "type": "boolean"
+    },
+    "serviceBenefits": {
+      "items": {
+        "type": "string"
+      },
+      "maxItems": 10,
+      "type": "array"
+    },
+    "serviceDefinitionDocumentURL": {
+      "format": "uri",
+      "type": "string"
+    },
+    "serviceFeatures": {
+      "items": {
+        "type": "string"
+      },
+      "maxItems": 10,
+      "type": "array"
+    },
+    "serviceName": {
+      "type": "string"
+    },
+    "serviceOffboarding": {
+      "type": "boolean"
+    },
+    "serviceOnboarding": {
+      "type": "boolean"
+    },
+    "serviceSummary": {
       "type": "string"
     },
     "serviceTypes": {
       "oneOf": [
         {
           "id": "SaaS - G4",
-          "type": "array",
-          "uniqueItems": true,
-          "maxItems": 25,
           "items": {
-            "enum": ["Accessibility", "Agile Tools", "Analytics", "Antispam / CAPTCHA", "Asset Management", "Content Management Systems (CMS)", "Customer Relationship Management (CRM)", "Data Visualisation", "EDRM / Collaboration", "Email", "End User Device (EUD)", "Enterprise Resource Planning", "Forms", "Gamification", "Geographic Search", "Identity", "Learning Management Systems (LMS)", "Office Productivity", "Polls/Surveys", "Search", "Service Monitoring", "Simulation & Training", "Un-listed", "User Alerts"]
-          }
+            "enum": [
+              "Accessibility",
+              "Agile Tools",
+              "Analytics",
+              "Antispam / CAPTCHA",
+              "Asset Management",
+              "Content Management Systems (CMS)",
+              "Customer Relationship Management (CRM)",
+              "Data Visualisation",
+              "EDRM / Collaboration",
+              "Email",
+              "End User Device (EUD)",
+              "Enterprise Resource Planning",
+              "Forms",
+              "Gamification",
+              "Geographic Search",
+              "Identity",
+              "Learning Management Systems (LMS)",
+              "Office Productivity",
+              "Polls/Surveys",
+              "Search",
+              "Service Monitoring",
+              "Simulation & Training",
+              "Un-listed",
+              "User Alerts"
+            ]
+          },
+          "maxItems": 25,
+          "type": "array",
+          "uniqueItems": true
         },
         {
           "id": "SaaS - Updated to G6",
-          "type": "array",
-          "uniqueItems": true,
-          "maxItems": 25,
           "items": {
-            "enum": ["Accounting and finance", "Business intelligence and analytics", "Collaboration", "Customer relationship management (CRM)", "Creative and design", "Data management", "Electronic document and records management (EDRM)", "Energy and environment", "Healthcare", "Human resources and employee management", "IT management", "Legal", "Libraries", "Marketing", "Operations management", "Project management and planning", "Sales", "Schools and education", "Security", "Software development tools", "Telecoms", "Transport and logistics"]
-          }
+            "enum": [
+              "Accounting and finance",
+              "Business intelligence and analytics",
+              "Collaboration",
+              "Customer relationship management (CRM)",
+              "Creative and design",
+              "Data management",
+              "Electronic document and records management (EDRM)",
+              "Energy and environment",
+              "Healthcare",
+              "Human resources and employee management",
+              "IT management",
+              "Legal",
+              "Libraries",
+              "Marketing",
+              "Operations management",
+              "Project management and planning",
+              "Sales",
+              "Schools and education",
+              "Security",
+              "Software development tools",
+              "Telecoms",
+              "Transport and logistics"
+            ]
+          },
+          "maxItems": 25,
+          "type": "array",
+          "uniqueItems": true
         },
         {
           "id": "PaaS - G4",
-          "type": "array",
-          "uniqueItems": true,
-          "maxItems": 25,
           "items": {
-            "enum": ["Application Deployment", "Components"]
-          }
+            "enum": [
+              "Application Deployment",
+              "Components"
+            ]
+          },
+          "maxItems": 25,
+          "type": "array",
+          "uniqueItems": true
         },
         {
           "id": "IaaS - G4",
-          "type": "array",
-          "uniqueItems": true,
-          "maxItems": 25,
           "items": {
-            "enum": ["Compute", "Content Delivery Network (CDN)", "Storage", "Other"]
-          }
+            "enum": [
+              "Compute",
+              "Content Delivery Network (CDN)",
+              "Storage",
+              "Other"
+            ]
+          },
+          "maxItems": 25,
+          "type": "array",
+          "uniqueItems": true
         },
         {
           "id": "SCS - G4",
-          "type": "array",
-          "uniqueItems": true,
-          "maxItems": 25,
           "items": {
-            "enum": ["Business Analysis", "Deployment", "Design and Development", "Design Authority", "Enterprise Architecture", "Helpdesk", "Onboarding services", "Project Management, Programme Management and Governance", "Project Specification and Selection", "Service Integration and Management Services (SIAM)", "Service Management", "Software Support", "Specialist Cloud Services", "Transition Management", "User Management"]
-             
-          }
+            "enum": [
+              "Business Analysis",
+              "Deployment",
+              "Design and Development",
+              "Design Authority",
+              "Enterprise Architecture",
+              "Helpdesk",
+              "Onboarding services",
+              "Project Management, Programme Management and Governance",
+              "Project Specification and Selection",
+              "Service Integration and Management Services (SIAM)",
+              "Service Management",
+              "Software Support",
+              "Specialist Cloud Services",
+              "Transition Management",
+              "User Management"
+            ]
+          },
+          "maxItems": 25,
+          "type": "array",
+          "uniqueItems": true
         },
         {
           "id": "SCS - Updated to G6",
-          "type": "array",
-          "uniqueItems": true,
-          "maxItems": 25,
           "items": {
-            "enum": ["Implementation", "Ongoing Support", "Planning", "Testing", "Training"]
-          }
+            "enum": [
+              "Implementation",
+              "Ongoing Support",
+              "Planning",
+              "Testing",
+              "Training"
+            ]
+          },
+          "maxItems": 25,
+          "type": "array",
+          "uniqueItems": true
         }
       ]
     },
-    "educationPricing": {
-      "type": "boolean"
-    },
-    "networksConnected": {
-      "type": "array",
-      "uniqueItems": true,
-      "maxItems": 7,
-      "items": {
-        "enum": ["Internet", "Public Services Network (PSN)", "Government Secure intranet (GSi)", "Police National Network (PNN)", "New NHS Network (N3)", "Joint Academic Network (JANET)", "Other"]
-      }
-    },
-    "apiAccess": {
-      "type": "boolean"
-    },
-    "elasticCloud": {
-      "type": "boolean"
-    },
-    "guaranteedResources": {
-      "type": "boolean"
-    },
-    "persistentStorage": {
-      "type": "boolean"
-    },
-    "openStandardsSupported": {
-      "type": "boolean"
-    },
-    "openSource": {
-      "type": "boolean"
-    },
-    "serviceOnboarding": {
-      "type": "boolean"
-    },
-    "serviceOffboarding": {
-      "type": "boolean"
-    },
-    "dataExtractionRemoval": {
-      "type": "boolean"
-    },
-    "datacentresEUCode": {
-      "type": "boolean"
-    },
-    "datacentreTier": {
+    "sfiaRateDocumentURL": {
+      "format": "uri",
       "type": "string"
     },
-    "dataBackupRecovery": {
-      "type": "boolean"
-    },
-    "selfServiceProvisioning": {
-      "type": "boolean"
-    },
     "supportForThirdParties": {
+      "type": "boolean"
+    },
+    "terminationCost": {
+      "type": "boolean"
+    },
+    "termsAndConditionsDocumentURL": {
+      "format": "uri",
+      "type": "string"
+    },
+    "title": {
+      "type": "string"
+    },
+    "trialOption": {
       "type": "boolean"
     }
   },
   "required": [
-    "title",
+    "freeOption",
+    "minimumContractPeriod",
+    "priceMin",
+    "priceString",
+    "priceUnit",
+    "pricingDocumentURL",
+    "serviceDefinitionDocumentURL",
     "serviceName",
     "serviceSummary",
-    "serviceDefinitionDocumentURL",
-    "termsAndConditionsDocumentURL",
-    "pricingDocumentURL",
-    "minimumContractPeriod",
-    "freeOption",
-    "trialOption",
     "terminationCost",
-    "priceMin",
-    "priceUnit",
-    "priceString"
-  ]
+    "termsAndConditionsDocumentURL",
+    "title",
+    "trialOption"
+  ],
+  "title": "G4 Services Schema",
+  "type": "object"
 }

--- a/json_schemas/services-g-cloud-5.json
+++ b/json_schemas/services-g-cloud-5.json
@@ -1,225 +1,336 @@
 {
-  "title": "G5 Services Schema",
   "$schema": "http://json-schema.org/schema#",
-  "type": "object",
   "additionalProperties": false,
   "properties": {
-    "title": {
-      "type": "string"
-    },
-    "serviceName":{
-      "type":"string",
-      "minLength":1,
-      "maxLength":200
-    },
-    "serviceSummary":{
-      "type":"string",
-      "maxLength":10000
-    },
-    "serviceBenefits":{
-      "type":"array",
-      "minItems":1,
-      "maxItems":10,
-      "items":{
-        "type":"string",
-        "maxLength":120,
-        "pattern":"^(?:\\S+\\s+){0,9}\\S+$"
-      }
-    },
-    "serviceFeatures":{
-      "type":"array",
-      "minItems":1,
-      "maxItems":10,
-      "items":{
-        "type":"string",
-        "maxLength":120,
-        "pattern":"^(?:\\S+\\s+){0,9}\\S+$"
-      }
-    },
-    "serviceDefinitionDocumentURL": {
-      "type": "string",
-      "format": "uri"
-    },
-    "termsAndConditionsDocumentURL": {
-      "type": "string",
-      "format": "uri"
-    },
-    "pricingDocumentURL": {
-      "type": "string",
-      "format": "uri"
-    },
-    "sfiaRateDocumentURL": {
-      "type": "string",
-      "format": "uri"
-    },
     "additionalDocumentURLs": {
-      "type": "array",
-      "uniqueItems": true,
       "items": {
-        "type": "string",
-        "format": "uri"
-      }
-    },
-    "minimumContractPeriod": {
-      "enum": [
-        "hour", "day", "month", "year", "other",
-        "Hour", "Day", "Month", "Year", "Other"
-      ]
-    },
-    "freeOption": {
-      "type": "boolean"
-    },
-    "trialOption": {
-      "type": "boolean"
-    },
-    "terminationCost": {
-      "type": "boolean"
-    },
-    "priceMin":{
-      "type":"string",
-      "pattern": "^\\d+(?:\\.\\d{1,5})?$"
-    },
-    "priceMax":{
-      "type": "string",
-      "pattern": "^$|^\\d+(?:\\.\\d{1,5})?$"
-    },
-    "priceUnit": {
-      "type": "string"
-    },
-    "priceString": {
-      "type": "string"
-    },
-    "priceInterval": {
-      "enum": ["", "Second", "Minute", "Hour", "Day", "Week", "Month", "Quarter", "6 months", "Year"]
-    },
-    "vatIncluded": {
-      "type": "boolean"
-    },
-    "serviceTypes": {
-      "oneOf": [
-        {
-          "id": "SaaS - G5",
-          "type": "array",
-          "uniqueItems": true,
-          "maxItems": 25,
-          "items": {
-            "enum": ["Accessibility", "Agile Tools", "Analytics", "Antispam / CAPTCHA", "Asset Management", "Content Management Systems (CMS)", "Customer Relationship Management (CRM)", "Data Visualisation", "EDRM / Collaboration", "Email", "End User Device (EUD)", "Enterprise Resource Planning", "Forms", "Gamification", "Geographic Search", "Identity", "Learning Management Systems (LMS)", "Office Productivity", "Polls/Surveys", "Search", "Service Monitoring", "Simulation & Training", "Un-listed", "User Alerts"]
-          }
-        },
-        {
-          "id": "SaaS - Updated to G6",
-          "type": "array",
-          "uniqueItems": true,
-          "maxItems": 25,
-          "items": {
-            "enum": ["Accounting and finance", "Business intelligence and analytics", "Collaboration", "Customer relationship management (CRM)", "Creative and design", "Data management", "Electronic document and records management (EDRM)", "Energy and environment", "Healthcare", "Human resources and employee management", "IT management", "Legal", "Libraries", "Marketing", "Operations management", "Project management and planning", "Sales", "Schools and education", "Security", "Software development tools", "Telecoms", "Transport and logistics"]
-          }
-        },
-        {
-          "id": "PaaS - G5",
-          "type": "array",
-          "uniqueItems": true,
-          "maxItems": 25,
-          "items": {
-            "enum": ["Application Deployment", "Components"]
-          }
-        },
-        {
-          "id": "IaaS - G5",
-          "type": "array",
-          "uniqueItems": true,
-          "maxItems": 25,
-          "items": {
-            "enum": ["Compute", "Content Delivery Network (CDN)", "Storage", "Other"]
-          }
-        },
-        {
-          "id": "SCS - G5",
-          "type": "array",
-          "uniqueItems": true,
-          "maxItems": 25,
-          "items": {
-            "enum": ["Business Analysis", "Data quality", "Data recovery, conversion and migration", "Data storage consultancy", "Deployment", "Design and Development", "Design Authority", "eDiscovery", "Digital archiving", "Enterprise Architecture", "Helpdesk", "Information Management and Digital Continuity", "Onboarding services", "Project Management, Programme Management and Governance", "Project Specification and Selection", "Service Integration and Management Services (SIAM)", "Service Management", "Software Support", "Specialist Cloud Services", "Transition Management", "User Management"]
-          }
-        },
-        {
-          "id": "SCS - Updated to G6",
-          "type": "array",
-          "uniqueItems": true,
-          "maxItems": 25,
-          "items": {
-            "enum": ["Implementation", "Ongoing Support", "Planning", "Testing", "Training"]
-          }
-        }
-      ]
-    },
-    "educationPricing": {
-      "type": "boolean"
-    },
-    "networksConnected": {
+        "format": "uri",
+        "type": "string"
+      },
       "type": "array",
-      "uniqueItems": true,
-      "maxItems": 7,
-      "items": {
-        "enum": ["Internet", "Public Services Network (PSN)", "Government Secure intranet (GSi)", "Police National Network (PNN)", "New NHS Network (N3)", "Joint Academic Network (JANET)", "Other"]
-      }
+      "uniqueItems": true
     },
     "apiAccess": {
       "type": "boolean"
     },
-    "elasticCloud": {
-      "type": "boolean"
-    },
-    "guaranteedResources": {
-      "type": "boolean"
-    },
-    "persistentStorage": {
-      "type": "boolean"
-    },
-    "openStandardsSupported": {
-      "type": "boolean"
-    },
-    "openSource": {
-      "type": "boolean"
-    },
-    "serviceOnboarding": {
-      "type": "boolean"
-    },
-    "serviceOffboarding": {
+    "dataBackupRecovery": {
       "type": "boolean"
     },
     "dataExtractionRemoval": {
       "type": "boolean"
     },
-    "datacentresEUCode": {
-      "type": "boolean"
-    },
     "datacentreTier": {
       "type": "string"
     },
-    "dataBackupRecovery": {
+    "datacentresEUCode": {
       "type": "boolean"
+    },
+    "educationPricing": {
+      "type": "boolean"
+    },
+    "elasticCloud": {
+      "type": "boolean"
+    },
+    "freeOption": {
+      "type": "boolean"
+    },
+    "guaranteedResources": {
+      "type": "boolean"
+    },
+    "minimumContractPeriod": {
+      "enum": [
+        "hour",
+        "day",
+        "month",
+        "year",
+        "other",
+        "Hour",
+        "Day",
+        "Month",
+        "Year",
+        "Other"
+      ]
+    },
+    "networksConnected": {
+      "items": {
+        "enum": [
+          "Internet",
+          "Public Services Network (PSN)",
+          "Government Secure intranet (GSi)",
+          "Police National Network (PNN)",
+          "New NHS Network (N3)",
+          "Joint Academic Network (JANET)",
+          "Other"
+        ]
+      },
+      "maxItems": 7,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "openSource": {
+      "type": "boolean"
+    },
+    "openStandardsSupported": {
+      "type": "boolean"
+    },
+    "persistentStorage": {
+      "type": "boolean"
+    },
+    "priceInterval": {
+      "enum": [
+        "",
+        "Second",
+        "Minute",
+        "Hour",
+        "Day",
+        "Week",
+        "Month",
+        "Quarter",
+        "6 months",
+        "Year"
+      ]
+    },
+    "priceMax": {
+      "pattern": "^$|^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "priceMin": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "priceString": {
+      "type": "string"
+    },
+    "priceUnit": {
+      "type": "string"
+    },
+    "pricingDocumentURL": {
+      "format": "uri",
+      "type": "string"
     },
     "selfServiceProvisioning": {
       "type": "boolean"
     },
+    "serviceBenefits": {
+      "items": {
+        "maxLength": 120,
+        "pattern": "^(?:\\S+\\s+){0,9}\\S+$",
+        "type": "string"
+      },
+      "maxItems": 10,
+      "minItems": 1,
+      "type": "array"
+    },
+    "serviceDefinitionDocumentURL": {
+      "format": "uri",
+      "type": "string"
+    },
+    "serviceFeatures": {
+      "items": {
+        "maxLength": 120,
+        "pattern": "^(?:\\S+\\s+){0,9}\\S+$",
+        "type": "string"
+      },
+      "maxItems": 10,
+      "minItems": 1,
+      "type": "array"
+    },
+    "serviceName": {
+      "maxLength": 200,
+      "minLength": 1,
+      "type": "string"
+    },
+    "serviceOffboarding": {
+      "type": "boolean"
+    },
+    "serviceOnboarding": {
+      "type": "boolean"
+    },
+    "serviceSummary": {
+      "maxLength": 10000,
+      "type": "string"
+    },
+    "serviceTypes": {
+      "oneOf": [
+        {
+          "id": "SaaS - G5",
+          "items": {
+            "enum": [
+              "Accessibility",
+              "Agile Tools",
+              "Analytics",
+              "Antispam / CAPTCHA",
+              "Asset Management",
+              "Content Management Systems (CMS)",
+              "Customer Relationship Management (CRM)",
+              "Data Visualisation",
+              "EDRM / Collaboration",
+              "Email",
+              "End User Device (EUD)",
+              "Enterprise Resource Planning",
+              "Forms",
+              "Gamification",
+              "Geographic Search",
+              "Identity",
+              "Learning Management Systems (LMS)",
+              "Office Productivity",
+              "Polls/Surveys",
+              "Search",
+              "Service Monitoring",
+              "Simulation & Training",
+              "Un-listed",
+              "User Alerts"
+            ]
+          },
+          "maxItems": 25,
+          "type": "array",
+          "uniqueItems": true
+        },
+        {
+          "id": "SaaS - Updated to G6",
+          "items": {
+            "enum": [
+              "Accounting and finance",
+              "Business intelligence and analytics",
+              "Collaboration",
+              "Customer relationship management (CRM)",
+              "Creative and design",
+              "Data management",
+              "Electronic document and records management (EDRM)",
+              "Energy and environment",
+              "Healthcare",
+              "Human resources and employee management",
+              "IT management",
+              "Legal",
+              "Libraries",
+              "Marketing",
+              "Operations management",
+              "Project management and planning",
+              "Sales",
+              "Schools and education",
+              "Security",
+              "Software development tools",
+              "Telecoms",
+              "Transport and logistics"
+            ]
+          },
+          "maxItems": 25,
+          "type": "array",
+          "uniqueItems": true
+        },
+        {
+          "id": "PaaS - G5",
+          "items": {
+            "enum": [
+              "Application Deployment",
+              "Components"
+            ]
+          },
+          "maxItems": 25,
+          "type": "array",
+          "uniqueItems": true
+        },
+        {
+          "id": "IaaS - G5",
+          "items": {
+            "enum": [
+              "Compute",
+              "Content Delivery Network (CDN)",
+              "Storage",
+              "Other"
+            ]
+          },
+          "maxItems": 25,
+          "type": "array",
+          "uniqueItems": true
+        },
+        {
+          "id": "SCS - G5",
+          "items": {
+            "enum": [
+              "Business Analysis",
+              "Data quality",
+              "Data recovery, conversion and migration",
+              "Data storage consultancy",
+              "Deployment",
+              "Design and Development",
+              "Design Authority",
+              "eDiscovery",
+              "Digital archiving",
+              "Enterprise Architecture",
+              "Helpdesk",
+              "Information Management and Digital Continuity",
+              "Onboarding services",
+              "Project Management, Programme Management and Governance",
+              "Project Specification and Selection",
+              "Service Integration and Management Services (SIAM)",
+              "Service Management",
+              "Software Support",
+              "Specialist Cloud Services",
+              "Transition Management",
+              "User Management"
+            ]
+          },
+          "maxItems": 25,
+          "type": "array",
+          "uniqueItems": true
+        },
+        {
+          "id": "SCS - Updated to G6",
+          "items": {
+            "enum": [
+              "Implementation",
+              "Ongoing Support",
+              "Planning",
+              "Testing",
+              "Training"
+            ]
+          },
+          "maxItems": 25,
+          "type": "array",
+          "uniqueItems": true
+        }
+      ]
+    },
+    "sfiaRateDocumentURL": {
+      "format": "uri",
+      "type": "string"
+    },
     "supportForThirdParties": {
+      "type": "boolean"
+    },
+    "terminationCost": {
+      "type": "boolean"
+    },
+    "termsAndConditionsDocumentURL": {
+      "format": "uri",
+      "type": "string"
+    },
+    "title": {
+      "type": "string"
+    },
+    "trialOption": {
+      "type": "boolean"
+    },
+    "vatIncluded": {
       "type": "boolean"
     }
   },
   "required": [
-    "title",
+    "freeOption",
+    "minimumContractPeriod",
+    "priceMin",
+    "priceString",
+    "priceUnit",
+    "pricingDocumentURL",
+    "serviceDefinitionDocumentURL",
     "serviceName",
     "serviceSummary",
-    "serviceDefinitionDocumentURL",
-    "termsAndConditionsDocumentURL",
-    "pricingDocumentURL",
-    "minimumContractPeriod",
-    "freeOption",
-    "trialOption",
     "terminationCost",
-    "priceMin",
-    "priceUnit",
-    "priceString"
-  ]
+    "termsAndConditionsDocumentURL",
+    "title",
+    "trialOption"
+  ],
+  "title": "G5 Services Schema",
+  "type": "object"
 }

--- a/json_schemas/services-g-cloud-6-iaas.json
+++ b/json_schemas/services-g-cloud-6-iaas.json
@@ -1,164 +1,8 @@
 {
-  "title": "G6 Submissions IaaS Schema",
   "$schema": "http://json-schema.org/schema#",
-  "type": "object",
   "additionalProperties": false,
   "properties": {
-    "title": {
-      "type": "string"
-    },
-    "serviceTypes": {
-      "type": "array",
-      "uniqueItems": true,
-      "maxItems": 2,
-      "items": {
-        "enum": ["Compute", "Storage"]
-      }
-    },
-    "serviceName":{
-      "type":"string",
-      "minLength":1,
-      "maxLength":100
-    },
-    "serviceSummary":{
-      "type":"string",
-      "maxLength":500,
-      "pattern":"^(?:\\S+\\s+){0,49}\\S+$"
-    },
-    "serviceBenefits":{
-      "type":"array",
-      "minItems":1,
-      "maxItems":10,
-      "items":{
-        "type":"string",
-        "maxLength":120,
-        "pattern":"^(?:\\S+\\s+){0,9}\\S+$"
-      }
-    },
-    "serviceFeatures":{
-      "type":"array",
-      "minItems":1,
-      "maxItems":10,
-      "items":{
-        "type":"string",
-        "maxLength":120,
-        "pattern":"^(?:\\S+\\s+){0,9}\\S+$"
-      }
-    },
-    "serviceDefinitionDocument": {
-      "type": "string"
-    },
-    "serviceDefinitionDocumentURL": {
-      "type": "string",
-      "format": "uri"
-    },
-    "termsAndConditionsDocument": {
-      "type": "string"
-    },
-    "termsAndConditionsDocumentURL": {
-      "type": "string",
-      "format": "uri"
-    },
-    "minimumContractPeriod": {
-      "enum": ["Hour", "Day", "Month", "Year", "Other"]
-    },
-    "terminationCost": {
-      "type": "boolean"
-    },
-    "priceMin":{
-      "type":"string",
-      "pattern": "^\\d+(?:\\.\\d{1,5})?$"
-    },
-    "priceMax":{
-      "type": "string",
-      "pattern": "^$|^\\d+(?:\\.\\d{1,5})?$"
-    },
-    "priceUnit": {
-      "enum": ["Unit", "Person", "Licence", "User", "Device", "Instance", "Server", "Virtual machine", "Transaction", "Megabyte", "Gigabyte", "Terabyte"]
-    },
-    "priceInterval": {
-      "enum": ["", "Second", "Minute", "Hour", "Day", "Week", "Month", "Quarter", "6 months", "Year"]
-    },
-    "priceString": {
-      "type": "string"
-    },
-    "vatIncluded": {
-      "type": "boolean"
-    },
-    "educationPricing": {
-      "type": "boolean"
-    },
-    "trialOption": {
-      "type": "boolean"
-    },
-    "freeOption": {
-      "type": "boolean"
-    },
-    "pricingDocument": {
-      "type": "string"
-    },
-    "pricingDocumentURL": {
-      "type": "string",
-      "format": "uri"
-    },
-    "sfiaRateDocument": {
-      "type": "string"
-    },
-    "sfiaRateDocumentURL": {
-      "type": "string",
-      "format": "uri"
-    },
-    "openStandardsSupported": {
-      "type": "boolean"
-    },
-    "supportForThirdParties": {
-      "type": "boolean"
-    },
-    "supportAvailability": {
-      "type": "string"
-    },
-    "supportResponseTime": {
-      "type": "string"
-    },
-    "incidentEscalation": {
-      "type": "boolean"
-    },
-    "supportTypes": {
-      "type": "array",
-      "uniqueItems": true,
-      "maxItems": 5,
-      "items": {
-        "enum": ["Service desk", "Email", "Phone", "Live chat", "Onsite"]
-      }
-    },
-    "serviceOnboarding": {
-      "type": "boolean"
-    },
-    "serviceOffboarding": {
-      "type": "boolean"
-    },
     "analyticsAvailable": {
-      "type": "boolean"
-    },
-    "elasticCloud": {
-      "type": "boolean"
-    },
-    "guaranteedResources": {
-      "type": "boolean"
-    },
-    "persistentStorage": {
-      "type": "boolean"
-    },
-    "selfServiceProvisioning": {
-      "type": "boolean"
-    },
-    "provisioningTime": {
-      "type": "string"
-    },
-    "deprovisioningTime": {
-      "type": "string"
-    },
-    "openSource": {
       "type": "boolean"
     },
     "apiAccess": {
@@ -167,48 +11,99 @@
     "apiType": {
       "type": "string"
     },
-    "networksConnected": {
-      "type": "array",
-      "uniqueItems": true,
-      "maxItems": 7,
-      "items": {
-        "enum": ["Internet", "Public Services Network (PSN)", "Government Secure intranet (GSi)", "Police National Network (PNN)", "New NHS Network (N3)", "Joint Academic Network (JANET)", "Other"]
-      }
+    "auditInformationProvided": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "enum": [
+            "None",
+            "Data made available",
+            "Data made available by negotiation"
+          ]
+        }
+      },
+      "type": "object"
     },
-    "supportedBrowsers": {
-      "type": "array",
-      "uniqueItems": true,
-      "maxItems": 9,
-      "items": {
-        "enum": ["Internet Explorer 6", "Internet Explorer 7", "Internet Explorer 8", "Internet Explorer 9", "Internet Explorer 10+", "Firefox", "Chrome", "Safari", "Opera"]
-      }
+    "changeImpactAssessment": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
     },
-    "offlineWorking": {
-      "type": "boolean"
+    "cloudDeploymentModel": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Contractual commitment",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "enum": [
+            "Public cloud",
+            "Community cloud",
+            "Private cloud",
+            "Hybrid cloud"
+          ]
+        }
+      },
+      "type": "object"
     },
-    "supportedDevices": {
-      "type": "array",
-      "uniqueItems": true,
-      "maxItems": 4,
-      "items": {
-        "enum": ["PC", "Mac", "Smartphone", "Tablet"]
-      }
+    "configurationTracking": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
     },
-    "vendorCertifications": {
-      "type": "array",
-      "maxItems": 10,
-      "items": {
-        "type": "string"
-      }
-    },
-    "datacentresEUCode": {
-      "type": "boolean"
-    },
-    "datacentresSpecifyLocation": {
-      "type": "boolean"
-    },
-    "datacentreTier": {
-      "type": "string"
+    "dataAtRestProtections": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion",
+            "Independent testing of implementation",
+            "CESG-assured components"
+          ]
+        },
+        "value": {
+          "items": {
+            "enum": [
+              "CPA Foundation-grade assured components",
+              "FIPS-assured encryption",
+              "Other encryption",
+              "Secure containers, racks or cages",
+              "Physical access control",
+              "No protection"
+            ]
+          },
+          "maxItems": 6,
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "type": "object"
     },
     "dataBackupRecovery": {
       "type": "boolean"
@@ -216,720 +111,1175 @@
     "dataExtractionRemoval": {
       "type": "boolean"
     },
-    "dataProtectionBetweenUserAndService": {
-      "type": "object",
+    "dataManagementLocations": {
       "properties": {
-        "value": {
-          "type": "array",
-          "uniqueItems": true,
-          "maxItems": 6,
-          "items": {
-            "enum": ["Encrypted PSN service", "PSN service", "CPA Foundation VPN Gateway", "VPN using TLS, version 1.2 or later", "VPN using legacy SSL or TLS", "No encryption"]
-          }
-        },
         "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation", "CESG-assured components"]
-        }
-      }
-    },
-    "dataProtectionWithinService": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "array",
-          "uniqueItems": true,
-          "maxItems": 6,
-          "items": {
-            "enum": ["VPN using TLS, version 1.2 or later", "VPN using legacy SSL or TLS", "VLAN", "Bonded fibre optic connections", "Other network protection", "No encryption"]
-          }
+          "enum": [
+            "Service provider assertion",
+            "Contractual commitment",
+            "Independent validation of assertion"
+          ]
         },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation", "CESG-assured components"]
+        "value": {
+          "items": {
+            "enum": [
+              "UK",
+              "EU",
+              "USA - Safe Harbor",
+              "Other countries with data protection treaties",
+              "Rest of world"
+            ]
+          },
+          "maxItems": 5,
+          "type": "array",
+          "uniqueItems": true
         }
-      }
+      },
+      "type": "object"
     },
     "dataProtectionBetweenServices": {
-      "type": "object",
       "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion",
+            "Independent testing of implementation",
+            "CESG-assured components"
+          ]
+        },
         "value": {
-          "type": "array",
-          "uniqueItems": true,
+          "items": {
+            "enum": [
+              "Encrypted PSN service",
+              "PSN service",
+              "CPA Foundation VPN Gateway",
+              "VPN using TLS, version 1.2 or later",
+              "VPN using legacy SSL or TLS",
+              "No encryption"
+            ]
+          },
           "maxItems": 6,
-          "items": {
-            "enum": ["Encrypted PSN service", "PSN service", "CPA Foundation VPN Gateway", "VPN using TLS, version 1.2 or later", "VPN using legacy SSL or TLS", "No encryption"]
-          }
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation", "CESG-assured components"]
-        }
-      }
-    },
-    "datacentreLocations": {
-      "type": "object",
-      "properties": {
-        "value": {
           "type": "array",
-          "uniqueItems": true,
-          "maxItems": 5,
+          "uniqueItems": true
+        }
+      },
+      "type": "object"
+    },
+    "dataProtectionBetweenUserAndService": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion",
+            "Independent testing of implementation",
+            "CESG-assured components"
+          ]
+        },
+        "value": {
           "items": {
-            "enum": ["UK", "EU", "USA - Safe Harbor", "Other countries with data protection treaties", "Rest of world"]
-          }
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]
-        }
-      }
-    },
-    "dataManagementLocations": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "array",
-          "uniqueItems": true,
-          "maxItems": 5,
-          "items": {
-            "enum": ["UK", "EU", "USA - Safe Harbor", "Other countries with data protection treaties", "Rest of world"]
-          }
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]
-        }
-      }
-    },
-    "legalJurisdiction": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "enum": ["UK", "EU", "USA - Safe Harbor", "Other countries with data protection treaties", "Rest of world"]
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]
-        }
-      }
-    },
-    "datacentreProtectionDisclosure": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]
-        }
-      }
-    },
-    "dataAtRestProtections": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "array",
-          "uniqueItems": true,
+            "enum": [
+              "Encrypted PSN service",
+              "PSN service",
+              "CPA Foundation VPN Gateway",
+              "VPN using TLS, version 1.2 or later",
+              "VPN using legacy SSL or TLS",
+              "No encryption"
+            ]
+          },
           "maxItems": 6,
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "type": "object"
+    },
+    "dataProtectionWithinService": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion",
+            "Independent testing of implementation",
+            "CESG-assured components"
+          ]
+        },
+        "value": {
           "items": {
-            "enum": ["CPA Foundation-grade assured components", "FIPS-assured encryption", "Other encryption", "Secure containers, racks or cages", "Physical access control", "No protection"]
-          }
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation", "CESG-assured components"]
+            "enum": [
+              "VPN using TLS, version 1.2 or later",
+              "VPN using legacy SSL or TLS",
+              "VLAN",
+              "Bonded fibre optic connections",
+              "Other network protection",
+              "No encryption"
+            ]
+          },
+          "maxItems": 6,
+          "type": "array",
+          "uniqueItems": true
         }
-      }
-    },
-    "dataSecureDeletion": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "enum": ["CPA Foundation-grade erasure product", "CESG or CPNI-approved erasure process", "Other secure erasure process", "Other erasure process"]
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation", "CESG-assured components"]
-        }
-      }
-    },
-    "dataStorageMediaDisposal": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "enum": ["CESG-assured destruction service (CAS(T))", "CPA Foundation-assured product", "CPNI-approved destruction service", "BS EN 151713:2009-compliant destruction", "CESG or CPNI-approved erasure process", "Other secure erasure process", "Other destruction/erasure process"]
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion", "Independent testing of implementation", "CESG-assured components"]
-        }
-      }
-    },
-    "dataSecureEquipmentDisposal": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion", "CESG-assured components"]
-        }
-      }
+      },
+      "type": "object"
     },
     "dataRedundantEquipmentAccountsRevoked": {
-      "type": "object",
       "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Contractual commitment",
+            "Independent validation of assertion"
+          ]
+        },
         "value": {
           "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]
         }
-      }
+      },
+      "type": "object"
     },
-    "serviceAvailabilityPercentage": {
-      "type": "object",
+    "dataSecureDeletion": {
       "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion",
+            "Independent testing of implementation",
+            "CESG-assured components"
+          ]
+        },
         "value": {
-          "type": "number"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]
+          "enum": [
+            "CPA Foundation-grade erasure product",
+            "CESG or CPNI-approved erasure process",
+            "Other secure erasure process",
+            "Other erasure process"
+          ]
         }
-      }
+      },
+      "type": "object"
     },
-    "cloudDeploymentModel": {
-      "type": "object",
+    "dataSecureEquipmentDisposal": {
       "properties": {
-        "value": {
-          "enum": ["Public cloud", "Community cloud", "Private cloud", "Hybrid cloud"]
-        },
         "assurance": {
-          "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]
-        }
-      }
-    },
-    "otherConsumers": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "enum": ["No other consumer", "Only government consumers", "A specific consumer group, eg Police, Defence or Health", "Anyone - public"]
+          "enum": [
+            "Service provider assertion",
+            "Contractual commitment",
+            "Independent validation of assertion",
+            "CESG-assured components"
+          ]
         },
-        "assurance": {
-          "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]
-        }
-      }
-    },
-    "servicesSeparation": {
-      "type": "object",
-      "properties": {
         "value": {
           "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent testing of implementation", "Assurance of service design", "CESG-assured components"]
         }
-      }
+      },
+      "type": "object"
     },
-    "servicesManagementSeparation": {
-      "type": "object",
+    "dataStorageMediaDisposal": {
       "properties": {
-        "value": {
-          "type": "boolean"
-        },
         "assurance": {
-          "enum": ["Service provider assertion", "Independent testing of implementation", "Assurance of service design", "CESG-assured components"]
-        }
-      }
-    },
-    "governanceFramework": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
+          "enum": [
+            "Service provider assertion",
+            "Contractual commitment",
+            "Independent validation of assertion",
+            "Independent testing of implementation",
+            "CESG-assured components"
+          ]
         },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      }
-    },
-    "configurationTracking": {
-      "type": "object",
-      "properties": {
         "value": {
-          "type": "boolean"
+          "enum": [
+            "CESG-assured destruction service (CAS(T))",
+            "CPA Foundation-assured product",
+            "CPNI-approved destruction service",
+            "BS EN 151713:2009-compliant destruction",
+            "CESG or CPNI-approved erasure process",
+            "Other secure erasure process",
+            "Other destruction/erasure process"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "datacentreLocations": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Contractual commitment",
+            "Independent validation of assertion"
+          ]
         },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      }
-    },
-    "changeImpactAssessment": {
-      "type": "object",
-      "properties": {
         "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      }
-    },
-    "vulnerabilityAssessment": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      }
-    },
-    "vulnerabilityMonitoring": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      }
-    },
-    "vulnerabilityMitigationPrioritisation": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      }
-    },
-    "vulnerabilityTracking": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      }
-    },
-    "vulnerabilityTimescales": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      }
-    },
-    "eventMonitoring": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      }
-    },
-    "incidentManagementProcess": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      }
-    },
-    "incidentManagementReporting": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      }
-    },
-    "incidentDefinitionPublished": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      }
-    },
-    "personnelSecurityChecks": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "array",
-          "uniqueItems": true,
-          "maxItems": 4,
           "items": {
-            "enum": ["Security clearance national vetting (SC)", "Baseline personnel security standard (BPSS)", "Background checks in accordance with BS7858:2012", "Employment checks"]
-          }
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      }
-    },
-    "secureDevelopment": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      }
-    },
-    "secureDesign": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      }
-    },
-    "secureConfigurationManagement": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      }
-    },
-    "thirdPartyDataSharingInformation": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      }
-    },
-    "thirdPartySecurityRequirements": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      }
-    },
-    "thirdPartyRiskAssessment": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      }
-    },
-    "thirdPartyComplianceMonitoring": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      }
-    },
-    "hardwareSoftwareVerification": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      }
-    },
-    "userAuthenticateManagement": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation"]
-        }
-      }
-    },
-    "userAuthenticateSupport": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation"]
-        }
-      }
-    },
-    "userAccessControlManagement": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation"]
-        }
-      }
-    },
-    "restrictAdministratorPermissions": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation"]
-        }
-      }
-    },
-    "managementInterfaceProtection": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation"]
-        }
-      }
-    },
-    "identityAuthenticationControls": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "array",
-          "uniqueItems": true,
-          "maxItems": 7,
-          "items": {
-            "enum": ["Username and two-factor authentication", "Username and TLS client certificate", "Authentication federation", "Limited access over dedicated link, enterprise or community network", "Username and password", "Username and strong password/passphrase enforcement", "Other mechanism"]
-          }
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent testing of implementation", "CESG-assured components"]
-        }
-      }
-    },
-    "onboardingGuidance": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      }
-    },
-    "interconnectionMethods": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "array",
-          "uniqueItems": true,
-          "maxItems": 4,
-          "items": {
-            "enum": ["Encrypted PSN service", "PSN service", "Private WAN", "Internet"]
-          }
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      }
-    },
-    "serviceManagementModel": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "array",
-          "uniqueItems": true,
+            "enum": [
+              "UK",
+              "EU",
+              "USA - Safe Harbor",
+              "Other countries with data protection treaties",
+              "Rest of world"
+            ]
+          },
           "maxItems": 5,
-          "items": {
-            "enum": ["Dedicated devices on a segregated network", "Dedicated devices for community service management", "Dedicated devices for multiple community service management", "Service management via bastion hosts", "Direct service management"]
-          }
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
+          "type": "array",
+          "uniqueItems": true
         }
-      }
+      },
+      "type": "object"
     },
-    "auditInformationProvided": {
-      "type": "object",
+    "datacentreProtectionDisclosure": {
       "properties": {
-        "value": {
-          "enum": ["None", "Data made available", "Data made available by negotiation"]
-        },
         "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
+          "enum": [
+            "Service provider assertion",
+            "Contractual commitment",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
         }
-      }
+      },
+      "type": "object"
+    },
+    "datacentreTier": {
+      "type": "string"
+    },
+    "datacentresEUCode": {
+      "type": "boolean"
+    },
+    "datacentresSpecifyLocation": {
+      "type": "boolean"
+    },
+    "deprovisioningTime": {
+      "type": "string"
     },
     "deviceAccessMethod": {
-      "type": "object",
       "properties": {
-        "value": {
-          "type": "array",
-          "uniqueItems": true,
-          "maxItems": 3,
-          "items": {
-            "enum": ["Corporate/enterprise devices", "Partner devices", "Unknown devices"]
-          }
-        },
         "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "items": {
+            "enum": [
+              "Corporate/enterprise devices",
+              "Partner devices",
+              "Unknown devices"
+            ]
+          },
+          "maxItems": 3,
+          "type": "array",
+          "uniqueItems": true
         }
-      }
+      },
+      "type": "object"
+    },
+    "educationPricing": {
+      "type": "boolean"
+    },
+    "elasticCloud": {
+      "type": "boolean"
+    },
+    "eventMonitoring": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "freeOption": {
+      "type": "boolean"
+    },
+    "governanceFramework": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "guaranteedResources": {
+      "type": "boolean"
+    },
+    "hardwareSoftwareVerification": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "identityAuthenticationControls": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent testing of implementation",
+            "CESG-assured components"
+          ]
+        },
+        "value": {
+          "items": {
+            "enum": [
+              "Username and two-factor authentication",
+              "Username and TLS client certificate",
+              "Authentication federation",
+              "Limited access over dedicated link, enterprise or community network",
+              "Username and password",
+              "Username and strong password/passphrase enforcement",
+              "Other mechanism"
+            ]
+          },
+          "maxItems": 7,
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "type": "object"
+    },
+    "incidentDefinitionPublished": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "incidentEscalation": {
+      "type": "boolean"
+    },
+    "incidentManagementProcess": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "incidentManagementReporting": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "interconnectionMethods": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "items": {
+            "enum": [
+              "Encrypted PSN service",
+              "PSN service",
+              "Private WAN",
+              "Internet"
+            ]
+          },
+          "maxItems": 4,
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "type": "object"
+    },
+    "legalJurisdiction": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Contractual commitment",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "enum": [
+            "UK",
+            "EU",
+            "USA - Safe Harbor",
+            "Other countries with data protection treaties",
+            "Rest of world"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "managementInterfaceProtection": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion",
+            "Independent testing of implementation"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "minimumContractPeriod": {
+      "enum": [
+        "Hour",
+        "Day",
+        "Month",
+        "Year",
+        "Other"
+      ]
+    },
+    "networksConnected": {
+      "items": {
+        "enum": [
+          "Internet",
+          "Public Services Network (PSN)",
+          "Government Secure intranet (GSi)",
+          "Police National Network (PNN)",
+          "New NHS Network (N3)",
+          "Joint Academic Network (JANET)",
+          "Other"
+        ]
+      },
+      "maxItems": 7,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "offlineWorking": {
+      "type": "boolean"
+    },
+    "onboardingGuidance": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "openSource": {
+      "type": "boolean"
+    },
+    "openStandardsSupported": {
+      "type": "boolean"
+    },
+    "otherConsumers": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Contractual commitment",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "enum": [
+            "No other consumer",
+            "Only government consumers",
+            "A specific consumer group, eg Police, Defence or Health",
+            "Anyone - public"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "persistentStorage": {
+      "type": "boolean"
+    },
+    "personnelSecurityChecks": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "items": {
+            "enum": [
+              "Security clearance national vetting (SC)",
+              "Baseline personnel security standard (BPSS)",
+              "Background checks in accordance with BS7858:2012",
+              "Employment checks"
+            ]
+          },
+          "maxItems": 4,
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "type": "object"
+    },
+    "priceInterval": {
+      "enum": [
+        "",
+        "Second",
+        "Minute",
+        "Hour",
+        "Day",
+        "Week",
+        "Month",
+        "Quarter",
+        "6 months",
+        "Year"
+      ]
+    },
+    "priceMax": {
+      "pattern": "^$|^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "priceMin": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "priceString": {
+      "type": "string"
+    },
+    "priceUnit": {
+      "enum": [
+        "Unit",
+        "Person",
+        "Licence",
+        "User",
+        "Device",
+        "Instance",
+        "Server",
+        "Virtual machine",
+        "Transaction",
+        "Megabyte",
+        "Gigabyte",
+        "Terabyte"
+      ]
+    },
+    "pricingDocument": {
+      "type": "string"
+    },
+    "pricingDocumentURL": {
+      "format": "uri",
+      "type": "string"
+    },
+    "provisioningTime": {
+      "type": "string"
+    },
+    "restrictAdministratorPermissions": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion",
+            "Independent testing of implementation"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "secureConfigurationManagement": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "secureDesign": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "secureDevelopment": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "selfServiceProvisioning": {
+      "type": "boolean"
+    },
+    "serviceAvailabilityPercentage": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Contractual commitment",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "number"
+        }
+      },
+      "type": "object"
+    },
+    "serviceBenefits": {
+      "items": {
+        "maxLength": 120,
+        "pattern": "^(?:\\S+\\s+){0,9}\\S+$",
+        "type": "string"
+      },
+      "maxItems": 10,
+      "minItems": 1,
+      "type": "array"
     },
     "serviceConfigurationGuidance": {
-      "type": "object",
       "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion",
+            "Independent testing of implementation"
+          ]
+        },
         "value": {
           "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation"]
         }
-      }
+      },
+      "type": "object"
+    },
+    "serviceDefinitionDocument": {
+      "type": "string"
+    },
+    "serviceDefinitionDocumentURL": {
+      "format": "uri",
+      "type": "string"
+    },
+    "serviceFeatures": {
+      "items": {
+        "maxLength": 120,
+        "pattern": "^(?:\\S+\\s+){0,9}\\S+$",
+        "type": "string"
+      },
+      "maxItems": 10,
+      "minItems": 1,
+      "type": "array"
+    },
+    "serviceManagementModel": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "items": {
+            "enum": [
+              "Dedicated devices on a segregated network",
+              "Dedicated devices for community service management",
+              "Dedicated devices for multiple community service management",
+              "Service management via bastion hosts",
+              "Direct service management"
+            ]
+          },
+          "maxItems": 5,
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "type": "object"
+    },
+    "serviceName": {
+      "maxLength": 100,
+      "minLength": 1,
+      "type": "string"
+    },
+    "serviceOffboarding": {
+      "type": "boolean"
+    },
+    "serviceOnboarding": {
+      "type": "boolean"
+    },
+    "serviceSummary": {
+      "maxLength": 500,
+      "pattern": "^(?:\\S+\\s+){0,49}\\S+$",
+      "type": "string"
+    },
+    "serviceTypes": {
+      "items": {
+        "enum": [
+          "Compute",
+          "Storage"
+        ]
+      },
+      "maxItems": 2,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "servicesManagementSeparation": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent testing of implementation",
+            "Assurance of service design",
+            "CESG-assured components"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "servicesSeparation": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent testing of implementation",
+            "Assurance of service design",
+            "CESG-assured components"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "sfiaRateDocument": {
+      "type": "string"
+    },
+    "sfiaRateDocumentURL": {
+      "format": "uri",
+      "type": "string"
+    },
+    "supportAvailability": {
+      "type": "string"
+    },
+    "supportForThirdParties": {
+      "type": "boolean"
+    },
+    "supportResponseTime": {
+      "type": "string"
+    },
+    "supportTypes": {
+      "items": {
+        "enum": [
+          "Service desk",
+          "Email",
+          "Phone",
+          "Live chat",
+          "Onsite"
+        ]
+      },
+      "maxItems": 5,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "supportedBrowsers": {
+      "items": {
+        "enum": [
+          "Internet Explorer 6",
+          "Internet Explorer 7",
+          "Internet Explorer 8",
+          "Internet Explorer 9",
+          "Internet Explorer 10+",
+          "Firefox",
+          "Chrome",
+          "Safari",
+          "Opera"
+        ]
+      },
+      "maxItems": 9,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "supportedDevices": {
+      "items": {
+        "enum": [
+          "PC",
+          "Mac",
+          "Smartphone",
+          "Tablet"
+        ]
+      },
+      "maxItems": 4,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "terminationCost": {
+      "type": "boolean"
+    },
+    "termsAndConditionsDocument": {
+      "type": "string"
+    },
+    "termsAndConditionsDocumentURL": {
+      "format": "uri",
+      "type": "string"
+    },
+    "thirdPartyComplianceMonitoring": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "thirdPartyDataSharingInformation": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "thirdPartyRiskAssessment": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "thirdPartySecurityRequirements": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "title": {
+      "type": "string"
     },
     "trainingProvided": {
-      "type": "object",
       "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
         "value": {
           "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "type": "object"
+    },
+    "trialOption": {
+      "type": "boolean"
+    },
+    "userAccessControlManagement": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion",
+            "Independent testing of implementation"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "userAuthenticateManagement": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion",
+            "Independent testing of implementation"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "userAuthenticateSupport": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion",
+            "Independent testing of implementation"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "vatIncluded": {
+      "type": "boolean"
+    },
+    "vendorCertifications": {
+      "items": {
+        "type": "string"
+      },
+      "maxItems": 10,
+      "type": "array"
+    },
+    "vulnerabilityAssessment": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "vulnerabilityMitigationPrioritisation": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "vulnerabilityMonitoring": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "vulnerabilityTimescales": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "vulnerabilityTracking": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
     }
   },
   "required": [
-    "title",
-    "serviceTypes",
-    "serviceName",
-    "serviceSummary",
-    "serviceBenefits",
-    "serviceFeatures",
-    "serviceDefinitionDocument",
-    "serviceDefinitionDocumentURL",
-    "termsAndConditionsDocument",
-    "termsAndConditionsDocumentURL",
-    "minimumContractPeriod",
-    "terminationCost",
-    "priceMin",
-    "priceUnit",
-    "priceString",
-    "vatIncluded",
-    "educationPricing",
-    "trialOption",
-    "freeOption",
-    "pricingDocument",
-    "pricingDocumentURL",
-    "openStandardsSupported",
-    "supportForThirdParties",
-    "supportAvailability",
-    "supportResponseTime",
-    "incidentEscalation",
-    "supportTypes",
-    "serviceOnboarding",
-    "serviceOffboarding",
     "analyticsAvailable",
-    "elasticCloud",
-    "guaranteedResources",
-    "persistentStorage",
-    "selfServiceProvisioning",
-    "provisioningTime",
-    "deprovisioningTime",
-    "openSource",
     "apiAccess",
-    "networksConnected",
-    "supportedBrowsers",
-    "offlineWorking",
-    "supportedDevices",
-    "datacentresEUCode",
-    "datacentresSpecifyLocation",
-    "datacentreTier",
+    "auditInformationProvided",
+    "changeImpactAssessment",
+    "cloudDeploymentModel",
+    "configurationTracking",
+    "dataAtRestProtections",
     "dataBackupRecovery",
     "dataExtractionRemoval",
+    "dataManagementLocations",
+    "dataProtectionBetweenServices",
     "dataProtectionBetweenUserAndService",
     "dataProtectionWithinService",
-    "dataProtectionBetweenServices",
-    "datacentreLocations",
-    "dataManagementLocations",
-    "legalJurisdiction",
-    "datacentreProtectionDisclosure",
-    "dataAtRestProtections",
-    "dataSecureDeletion",
-    "dataStorageMediaDisposal",
-    "dataSecureEquipmentDisposal",
     "dataRedundantEquipmentAccountsRevoked",
-    "serviceAvailabilityPercentage",
-    "cloudDeploymentModel",
-    "otherConsumers",
-    "servicesSeparation",
-    "servicesManagementSeparation",
-    "governanceFramework",
-    "configurationTracking",
-    "changeImpactAssessment",
-    "vulnerabilityAssessment",
-    "vulnerabilityMonitoring",
-    "vulnerabilityMitigationPrioritisation",
-    "vulnerabilityTracking",
-    "vulnerabilityTimescales",
+    "dataSecureDeletion",
+    "dataSecureEquipmentDisposal",
+    "dataStorageMediaDisposal",
+    "datacentreLocations",
+    "datacentreProtectionDisclosure",
+    "datacentreTier",
+    "datacentresEUCode",
+    "datacentresSpecifyLocation",
+    "deprovisioningTime",
+    "deviceAccessMethod",
+    "educationPricing",
+    "elasticCloud",
     "eventMonitoring",
+    "freeOption",
+    "governanceFramework",
+    "guaranteedResources",
+    "identityAuthenticationControls",
+    "incidentDefinitionPublished",
+    "incidentEscalation",
     "incidentManagementProcess",
     "incidentManagementReporting",
-    "incidentDefinitionPublished",
+    "interconnectionMethods",
+    "legalJurisdiction",
+    "managementInterfaceProtection",
+    "minimumContractPeriod",
+    "networksConnected",
+    "offlineWorking",
+    "onboardingGuidance",
+    "openSource",
+    "openStandardsSupported",
+    "otherConsumers",
+    "persistentStorage",
     "personnelSecurityChecks",
-    "secureDevelopment",
-    "secureDesign",
+    "priceMin",
+    "priceString",
+    "priceUnit",
+    "pricingDocument",
+    "pricingDocumentURL",
+    "provisioningTime",
+    "restrictAdministratorPermissions",
     "secureConfigurationManagement",
-    "thirdPartyDataSharingInformation",
-    "thirdPartySecurityRequirements",
-    "thirdPartyRiskAssessment",
+    "secureDesign",
+    "secureDevelopment",
+    "selfServiceProvisioning",
+    "serviceAvailabilityPercentage",
+    "serviceBenefits",
+    "serviceConfigurationGuidance",
+    "serviceDefinitionDocument",
+    "serviceDefinitionDocumentURL",
+    "serviceFeatures",
+    "serviceManagementModel",
+    "serviceName",
+    "serviceOffboarding",
+    "serviceOnboarding",
+    "serviceSummary",
+    "serviceTypes",
+    "servicesManagementSeparation",
+    "servicesSeparation",
+    "supportAvailability",
+    "supportForThirdParties",
+    "supportResponseTime",
+    "supportTypes",
+    "supportedBrowsers",
+    "supportedDevices",
+    "terminationCost",
+    "termsAndConditionsDocument",
+    "termsAndConditionsDocumentURL",
     "thirdPartyComplianceMonitoring",
+    "thirdPartyDataSharingInformation",
+    "thirdPartyRiskAssessment",
+    "thirdPartySecurityRequirements",
+    "title",
+    "trainingProvided",
+    "trialOption",
+    "userAccessControlManagement",
     "userAuthenticateManagement",
     "userAuthenticateSupport",
-    "userAccessControlManagement",
-    "restrictAdministratorPermissions",
-    "managementInterfaceProtection",
-    "identityAuthenticationControls",
-    "onboardingGuidance",
-    "interconnectionMethods",
-    "serviceManagementModel",
-    "auditInformationProvided",
-    "deviceAccessMethod",
-    "serviceConfigurationGuidance",
-    "trainingProvided"
-  ]
+    "vatIncluded",
+    "vulnerabilityAssessment",
+    "vulnerabilityMitigationPrioritisation",
+    "vulnerabilityMonitoring",
+    "vulnerabilityTimescales",
+    "vulnerabilityTracking"
+  ],
+  "title": "G6 Submissions IaaS Schema",
+  "type": "object"
 }

--- a/json_schemas/services-g-cloud-6-paas.json
+++ b/json_schemas/services-g-cloud-6-paas.json
@@ -1,156 +1,8 @@
 {
-  "title": "G6 Submissions PaaS Schema",
   "$schema": "http://json-schema.org/schema#",
-  "type": "object",
   "additionalProperties": false,
   "properties": {
-    "title": {
-      "type": "string"
-    },
-    "serviceName":{
-      "type":"string",
-      "minLength":1,
-      "maxLength":100
-    },
-    "serviceSummary":{
-      "type":"string",
-      "maxLength":500,
-      "pattern":"^(?:\\S+\\s+){0,49}\\S+$"
-    },
-    "serviceBenefits":{
-      "type":"array",
-      "minItems":1,
-      "maxItems":10,
-      "items":{
-        "type":"string",
-        "maxLength":120,
-        "pattern":"^(?:\\S+\\s+){0,9}\\S+$"
-      }
-    },
-    "serviceFeatures":{
-      "type":"array",
-      "minItems":1,
-      "maxItems":10,
-      "items":{
-        "type":"string",
-        "maxLength":120,
-        "pattern":"^(?:\\S+\\s+){0,9}\\S+$"
-      }
-    },
-    "serviceDefinitionDocument": {
-      "type": "string"
-    },
-    "serviceDefinitionDocumentURL": {
-      "type": "string",
-      "format": "uri"
-    },
-    "termsAndConditionsDocument": {
-      "type": "string"
-    },
-    "termsAndConditionsDocumentURL": {
-      "type": "string",
-      "format": "uri"
-    },
-    "minimumContractPeriod": {
-      "enum": ["Hour", "Day", "Month", "Year", "Other"]
-    },
-    "terminationCost": {
-      "type": "boolean"
-    },
-    "priceMin":{
-      "type":"string",
-      "pattern": "^\\d+(?:\\.\\d{1,5})?$"
-    },
-    "priceMax":{
-      "type": "string",
-      "pattern": "^$|^\\d+(?:\\.\\d{1,5})?$"
-    },
-    "priceUnit": {
-      "enum": ["Unit", "Person", "Licence", "User", "Device", "Instance", "Server", "Virtual machine", "Transaction", "Megabyte", "Gigabyte", "Terabyte"]
-    },
-    "priceInterval": {
-      "enum": ["", "Second", "Minute", "Hour", "Day", "Week", "Month", "Quarter", "6 months", "Year"]
-    },
-    "priceString": {
-      "type": "string"
-    },
-    "vatIncluded": {
-      "type": "boolean"
-    },
-    "educationPricing": {
-      "type": "boolean"
-    },
-    "trialOption": {
-      "type": "boolean"
-    },
-    "freeOption": {
-      "type": "boolean"
-    },
-    "pricingDocument": {
-      "type": "string"
-    },
-    "pricingDocumentURL": {
-      "type": "string",
-      "format": "uri"
-    },
-    "sfiaRateDocument": {
-      "type": "string"
-    },
-    "sfiaRateDocumentURL": {
-      "type": "string",
-      "format": "uri"
-    },
-    "openStandardsSupported": {
-      "type": "boolean"
-    },
-    "supportForThirdParties": {
-      "type": "boolean"
-    },
-    "supportAvailability": {
-      "type": "string"
-    },
-    "supportResponseTime": {
-      "type": "string"
-    },
-    "incidentEscalation": {
-      "type": "boolean"
-    },
-    "supportTypes": {
-      "type": "array",
-      "uniqueItems": true,
-      "maxItems": 5,
-      "items": {
-        "enum": ["Service desk", "Email", "Phone", "Live chat", "Onsite"]
-      }
-    },
-    "serviceOnboarding": {
-      "type": "boolean"
-    },
-    "serviceOffboarding": {
-      "type": "boolean"
-    },
     "analyticsAvailable": {
-      "type": "boolean"
-    },
-    "elasticCloud": {
-      "type": "boolean"
-    },
-    "guaranteedResources": {
-      "type": "boolean"
-    },
-    "persistentStorage": {
-      "type": "boolean"
-    },
-    "selfServiceProvisioning": {
-      "type": "boolean"
-    },
-    "provisioningTime": {
-      "type": "string"
-    },
-    "deprovisioningTime": {
-      "type": "string"
-    },
-    "openSource": {
       "type": "boolean"
     },
     "apiAccess": {
@@ -159,48 +11,99 @@
     "apiType": {
       "type": "string"
     },
-    "networksConnected": {
-      "type": "array",
-      "uniqueItems": true,
-      "maxItems": 7,
-      "items": {
-        "enum": ["Internet", "Public Services Network (PSN)", "Government Secure intranet (GSi)", "Police National Network (PNN)", "New NHS Network (N3)", "Joint Academic Network (JANET)", "Other"]
-      }
+    "auditInformationProvided": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "enum": [
+            "None",
+            "Data made available",
+            "Data made available by negotiation"
+          ]
+        }
+      },
+      "type": "object"
     },
-    "supportedBrowsers": {
-      "type": "array",
-      "uniqueItems": true,
-      "maxItems": 9,
-      "items": {
-        "enum": ["Internet Explorer 6", "Internet Explorer 7", "Internet Explorer 8", "Internet Explorer 9", "Internet Explorer 10+", "Firefox", "Chrome", "Safari", "Opera"]
-      }
+    "changeImpactAssessment": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
     },
-    "offlineWorking": {
-      "type": "boolean"
+    "cloudDeploymentModel": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Contractual commitment",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "enum": [
+            "Public cloud",
+            "Community cloud",
+            "Private cloud",
+            "Hybrid cloud"
+          ]
+        }
+      },
+      "type": "object"
     },
-    "supportedDevices": {
-      "type": "array",
-      "uniqueItems": true,
-      "maxItems": 4,
-      "items": {
-        "enum": ["PC", "Mac", "Smartphone", "Tablet"]
-      }
+    "configurationTracking": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
     },
-    "vendorCertifications": {
-      "type": "array",
-      "maxItems": 10,
-      "items": {
-        "type": "string"
-      }
-    },
-    "datacentresEUCode": {
-      "type": "boolean"
-    },
-    "datacentresSpecifyLocation": {
-      "type": "boolean"
-    },
-    "datacentreTier": {
-      "type": "string"
+    "dataAtRestProtections": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion",
+            "Independent testing of implementation",
+            "CESG-assured components"
+          ]
+        },
+        "value": {
+          "items": {
+            "enum": [
+              "CPA Foundation-grade assured components",
+              "FIPS-assured encryption",
+              "Other encryption",
+              "Secure containers, racks or cages",
+              "Physical access control",
+              "No protection"
+            ]
+          },
+          "maxItems": 6,
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "type": "object"
     },
     "dataBackupRecovery": {
       "type": "boolean"
@@ -208,719 +111,1163 @@
     "dataExtractionRemoval": {
       "type": "boolean"
     },
-    "dataProtectionBetweenUserAndService": {
-      "type": "object",
+    "dataManagementLocations": {
       "properties": {
-        "value": {
-          "type": "array",
-          "uniqueItems": true,
-          "maxItems": 6,
-          "items": {
-            "enum": ["Encrypted PSN service", "PSN service", "CPA Foundation VPN Gateway", "VPN using TLS, version 1.2 or later", "VPN using legacy SSL or TLS", "No encryption"]
-          }
-        },
         "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation", "CESG-assured components"]
-        }
-      }
-    },
-    "dataProtectionWithinService": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "array",
-          "uniqueItems": true,
-          "maxItems": 6,
-          "items": {
-            "enum": ["VPN using TLS, version 1.2 or later", "VPN using legacy SSL or TLS", "VLAN", "Bonded fibre optic connections", "Other network protection", "No encryption"]
-          }
+          "enum": [
+            "Service provider assertion",
+            "Contractual commitment",
+            "Independent validation of assertion"
+          ]
         },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation", "CESG-assured components"]
+        "value": {
+          "items": {
+            "enum": [
+              "UK",
+              "EU",
+              "USA - Safe Harbor",
+              "Other countries with data protection treaties",
+              "Rest of world"
+            ]
+          },
+          "maxItems": 5,
+          "type": "array",
+          "uniqueItems": true
         }
-      }
+      },
+      "type": "object"
     },
     "dataProtectionBetweenServices": {
-      "type": "object",
       "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion",
+            "Independent testing of implementation",
+            "CESG-assured components"
+          ]
+        },
         "value": {
-          "type": "array",
-          "uniqueItems": true,
+          "items": {
+            "enum": [
+              "Encrypted PSN service",
+              "PSN service",
+              "CPA Foundation VPN Gateway",
+              "VPN using TLS, version 1.2 or later",
+              "VPN using legacy SSL or TLS",
+              "No encryption"
+            ]
+          },
           "maxItems": 6,
-          "items": {
-            "enum": ["Encrypted PSN service", "PSN service", "CPA Foundation VPN Gateway", "VPN using TLS, version 1.2 or later", "VPN using legacy SSL or TLS", "No encryption"]
-          }
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation", "CESG-assured components"]
-        }
-      }
-    },
-    "datacentreLocations": {
-      "type": "object",
-      "properties": {
-        "value": {
           "type": "array",
-          "uniqueItems": true,
-          "maxItems": 5,
+          "uniqueItems": true
+        }
+      },
+      "type": "object"
+    },
+    "dataProtectionBetweenUserAndService": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion",
+            "Independent testing of implementation",
+            "CESG-assured components"
+          ]
+        },
+        "value": {
           "items": {
-            "enum": ["UK", "EU", "USA - Safe Harbor", "Other countries with data protection treaties", "Rest of world"]
-          }
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]
-        }
-      }
-    },
-    "dataManagementLocations": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "array",
-          "uniqueItems": true,
-          "maxItems": 5,
-          "items": {
-            "enum": ["UK", "EU", "USA - Safe Harbor", "Other countries with data protection treaties", "Rest of world"]
-          }
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]
-        }
-      }
-    },
-    "legalJurisdiction": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "enum": ["UK", "EU", "USA - Safe Harbor", "Other countries with data protection treaties", "Rest of world"]
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]
-        }
-      }
-    },
-    "datacentreProtectionDisclosure": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]
-        }
-      }
-    },
-    "dataAtRestProtections": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "array",
-          "uniqueItems": true,
+            "enum": [
+              "Encrypted PSN service",
+              "PSN service",
+              "CPA Foundation VPN Gateway",
+              "VPN using TLS, version 1.2 or later",
+              "VPN using legacy SSL or TLS",
+              "No encryption"
+            ]
+          },
           "maxItems": 6,
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "type": "object"
+    },
+    "dataProtectionWithinService": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion",
+            "Independent testing of implementation",
+            "CESG-assured components"
+          ]
+        },
+        "value": {
           "items": {
-            "enum": ["CPA Foundation-grade assured components", "FIPS-assured encryption", "Other encryption", "Secure containers, racks or cages", "Physical access control", "No protection"]
-          }
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation", "CESG-assured components"]
+            "enum": [
+              "VPN using TLS, version 1.2 or later",
+              "VPN using legacy SSL or TLS",
+              "VLAN",
+              "Bonded fibre optic connections",
+              "Other network protection",
+              "No encryption"
+            ]
+          },
+          "maxItems": 6,
+          "type": "array",
+          "uniqueItems": true
         }
-      }
-    },
-    "dataSecureDeletion": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "enum": ["CPA Foundation-grade erasure product", "CESG or CPNI-approved erasure process", "Other secure erasure process", "Other erasure process"]
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation", "CESG-assured components"]
-        }
-      }
-    },
-    "dataStorageMediaDisposal": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "enum": ["CESG-assured destruction service (CAS(T))", "CPA Foundation-assured product", "CPNI-approved destruction service", "BS EN 151713:2009-compliant destruction", "CESG or CPNI-approved erasure process", "Other secure erasure process", "Other destruction/erasure process"]
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion", "Independent testing of implementation", "CESG-assured components"]
-        }
-      }
-    },
-    "dataSecureEquipmentDisposal": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion", "CESG-assured components"]
-        }
-      }
+      },
+      "type": "object"
     },
     "dataRedundantEquipmentAccountsRevoked": {
-      "type": "object",
       "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Contractual commitment",
+            "Independent validation of assertion"
+          ]
+        },
         "value": {
           "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]
         }
-      }
+      },
+      "type": "object"
     },
-    "serviceAvailabilityPercentage": {
-      "type": "object",
+    "dataSecureDeletion": {
       "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion",
+            "Independent testing of implementation",
+            "CESG-assured components"
+          ]
+        },
         "value": {
-          "type": "number"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]
+          "enum": [
+            "CPA Foundation-grade erasure product",
+            "CESG or CPNI-approved erasure process",
+            "Other secure erasure process",
+            "Other erasure process"
+          ]
         }
-      }
+      },
+      "type": "object"
     },
-    "cloudDeploymentModel": {
-      "type": "object",
+    "dataSecureEquipmentDisposal": {
       "properties": {
-        "value": {
-          "enum": ["Public cloud", "Community cloud", "Private cloud", "Hybrid cloud"]
-        },
         "assurance": {
-          "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]
-        }
-      }
-    },
-    "otherConsumers": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "enum": ["No other consumer", "Only government consumers", "A specific consumer group, eg Police, Defence or Health", "Anyone - public"]
+          "enum": [
+            "Service provider assertion",
+            "Contractual commitment",
+            "Independent validation of assertion",
+            "CESG-assured components"
+          ]
         },
-        "assurance": {
-          "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]
-        }
-      }
-    },
-    "servicesSeparation": {
-      "type": "object",
-      "properties": {
         "value": {
           "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent testing of implementation", "Assurance of service design", "CESG-assured components"]
         }
-      }
+      },
+      "type": "object"
     },
-    "servicesManagementSeparation": {
-      "type": "object",
+    "dataStorageMediaDisposal": {
       "properties": {
-        "value": {
-          "type": "boolean"
-        },
         "assurance": {
-          "enum": ["Service provider assertion", "Independent testing of implementation", "Assurance of service design", "CESG-assured components"]
-        }
-      }
-    },
-    "governanceFramework": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
+          "enum": [
+            "Service provider assertion",
+            "Contractual commitment",
+            "Independent validation of assertion",
+            "Independent testing of implementation",
+            "CESG-assured components"
+          ]
         },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      }
-    },
-    "configurationTracking": {
-      "type": "object",
-      "properties": {
         "value": {
-          "type": "boolean"
+          "enum": [
+            "CESG-assured destruction service (CAS(T))",
+            "CPA Foundation-assured product",
+            "CPNI-approved destruction service",
+            "BS EN 151713:2009-compliant destruction",
+            "CESG or CPNI-approved erasure process",
+            "Other secure erasure process",
+            "Other destruction/erasure process"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "datacentreLocations": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Contractual commitment",
+            "Independent validation of assertion"
+          ]
         },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      }
-    },
-    "changeImpactAssessment": {
-      "type": "object",
-      "properties": {
         "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      }
-    },
-    "vulnerabilityAssessment": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      }
-    },
-    "vulnerabilityMonitoring": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      }
-    },
-    "vulnerabilityMitigationPrioritisation": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      }
-    },
-    "vulnerabilityTracking": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      }
-    },
-    "vulnerabilityTimescales": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      }
-    },
-    "eventMonitoring": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      }
-    },
-    "incidentManagementProcess": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      }
-    },
-    "incidentManagementReporting": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      }
-    },
-    "incidentDefinitionPublished": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      }
-    },
-    "personnelSecurityChecks": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "array",
-          "uniqueItems": true,
-          "maxItems": 4,
           "items": {
-            "enum": ["Security clearance national vetting (SC)", "Baseline personnel security standard (BPSS)", "Background checks in accordance with BS7858:2012", "Employment checks"]
-          }
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      }
-    },
-    "secureDevelopment": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      }
-    },
-    "secureDesign": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      }
-    },
-    "secureConfigurationManagement": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      }
-    },
-    "thirdPartyDataSharingInformation": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      }
-    },
-    "thirdPartySecurityRequirements": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      }
-    },
-    "thirdPartyRiskAssessment": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      }
-    },
-    "thirdPartyComplianceMonitoring": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      }
-    },
-    "hardwareSoftwareVerification": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      }
-    },
-    "userAuthenticateManagement": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation"]
-        }
-      }
-    },
-    "userAuthenticateSupport": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation"]
-        }
-      }
-    },
-    "userAccessControlManagement": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation"]
-        }
-      }
-    },
-    "restrictAdministratorPermissions": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation"]
-        }
-      }
-    },
-    "managementInterfaceProtection": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation"]
-        }
-      }
-    },
-    "identityAuthenticationControls": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "array",
-          "uniqueItems": true,
-          "maxItems": 7,
-          "items": {
-            "enum": ["Username and two-factor authentication", "Username and TLS client certificate", "Authentication federation", "Limited access over dedicated link, enterprise or community network", "Username and password", "Username and strong password/passphrase enforcement", "Other mechanism"]
-          }
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent testing of implementation", "CESG-assured components"]
-        }
-      }
-    },
-    "onboardingGuidance": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      }
-    },
-    "interconnectionMethods": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "array",
-          "uniqueItems": true,
-          "maxItems": 4,
-          "items": {
-            "enum": ["Encrypted PSN service", "PSN service", "Private WAN", "Internet"]
-          }
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      }
-    },
-    "serviceManagementModel": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "array",
-          "uniqueItems": true,
+            "enum": [
+              "UK",
+              "EU",
+              "USA - Safe Harbor",
+              "Other countries with data protection treaties",
+              "Rest of world"
+            ]
+          },
           "maxItems": 5,
-          "items": {
-            "enum": ["Dedicated devices on a segregated network", "Dedicated devices for community service management", "Dedicated devices for multiple community service management", "Service management via bastion hosts", "Direct service management"]
-          }
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
+          "type": "array",
+          "uniqueItems": true
         }
-      }
+      },
+      "type": "object"
     },
-    "auditInformationProvided": {
-      "type": "object",
+    "datacentreProtectionDisclosure": {
       "properties": {
-        "value": {
-          "enum": ["None", "Data made available", "Data made available by negotiation"]
-        },
         "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
+          "enum": [
+            "Service provider assertion",
+            "Contractual commitment",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
         }
-      }
+      },
+      "type": "object"
+    },
+    "datacentreTier": {
+      "type": "string"
+    },
+    "datacentresEUCode": {
+      "type": "boolean"
+    },
+    "datacentresSpecifyLocation": {
+      "type": "boolean"
+    },
+    "deprovisioningTime": {
+      "type": "string"
     },
     "deviceAccessMethod": {
-      "type": "object",
       "properties": {
-        "value": {
-          "type": "array",
-          "uniqueItems": true,
-          "maxItems": 3,
-          "items": {
-            "enum": ["Corporate/enterprise devices", "Partner devices", "Unknown devices"]
-          }
-        },
         "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "items": {
+            "enum": [
+              "Corporate/enterprise devices",
+              "Partner devices",
+              "Unknown devices"
+            ]
+          },
+          "maxItems": 3,
+          "type": "array",
+          "uniqueItems": true
         }
-      }
+      },
+      "type": "object"
+    },
+    "educationPricing": {
+      "type": "boolean"
+    },
+    "elasticCloud": {
+      "type": "boolean"
+    },
+    "eventMonitoring": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "freeOption": {
+      "type": "boolean"
+    },
+    "governanceFramework": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "guaranteedResources": {
+      "type": "boolean"
+    },
+    "hardwareSoftwareVerification": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "identityAuthenticationControls": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent testing of implementation",
+            "CESG-assured components"
+          ]
+        },
+        "value": {
+          "items": {
+            "enum": [
+              "Username and two-factor authentication",
+              "Username and TLS client certificate",
+              "Authentication federation",
+              "Limited access over dedicated link, enterprise or community network",
+              "Username and password",
+              "Username and strong password/passphrase enforcement",
+              "Other mechanism"
+            ]
+          },
+          "maxItems": 7,
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "type": "object"
+    },
+    "incidentDefinitionPublished": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "incidentEscalation": {
+      "type": "boolean"
+    },
+    "incidentManagementProcess": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "incidentManagementReporting": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "interconnectionMethods": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "items": {
+            "enum": [
+              "Encrypted PSN service",
+              "PSN service",
+              "Private WAN",
+              "Internet"
+            ]
+          },
+          "maxItems": 4,
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "type": "object"
+    },
+    "legalJurisdiction": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Contractual commitment",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "enum": [
+            "UK",
+            "EU",
+            "USA - Safe Harbor",
+            "Other countries with data protection treaties",
+            "Rest of world"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "managementInterfaceProtection": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion",
+            "Independent testing of implementation"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "minimumContractPeriod": {
+      "enum": [
+        "Hour",
+        "Day",
+        "Month",
+        "Year",
+        "Other"
+      ]
+    },
+    "networksConnected": {
+      "items": {
+        "enum": [
+          "Internet",
+          "Public Services Network (PSN)",
+          "Government Secure intranet (GSi)",
+          "Police National Network (PNN)",
+          "New NHS Network (N3)",
+          "Joint Academic Network (JANET)",
+          "Other"
+        ]
+      },
+      "maxItems": 7,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "offlineWorking": {
+      "type": "boolean"
+    },
+    "onboardingGuidance": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "openSource": {
+      "type": "boolean"
+    },
+    "openStandardsSupported": {
+      "type": "boolean"
+    },
+    "otherConsumers": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Contractual commitment",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "enum": [
+            "No other consumer",
+            "Only government consumers",
+            "A specific consumer group, eg Police, Defence or Health",
+            "Anyone - public"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "persistentStorage": {
+      "type": "boolean"
+    },
+    "personnelSecurityChecks": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "items": {
+            "enum": [
+              "Security clearance national vetting (SC)",
+              "Baseline personnel security standard (BPSS)",
+              "Background checks in accordance with BS7858:2012",
+              "Employment checks"
+            ]
+          },
+          "maxItems": 4,
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "type": "object"
+    },
+    "priceInterval": {
+      "enum": [
+        "",
+        "Second",
+        "Minute",
+        "Hour",
+        "Day",
+        "Week",
+        "Month",
+        "Quarter",
+        "6 months",
+        "Year"
+      ]
+    },
+    "priceMax": {
+      "pattern": "^$|^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "priceMin": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "priceString": {
+      "type": "string"
+    },
+    "priceUnit": {
+      "enum": [
+        "Unit",
+        "Person",
+        "Licence",
+        "User",
+        "Device",
+        "Instance",
+        "Server",
+        "Virtual machine",
+        "Transaction",
+        "Megabyte",
+        "Gigabyte",
+        "Terabyte"
+      ]
+    },
+    "pricingDocument": {
+      "type": "string"
+    },
+    "pricingDocumentURL": {
+      "format": "uri",
+      "type": "string"
+    },
+    "provisioningTime": {
+      "type": "string"
+    },
+    "restrictAdministratorPermissions": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion",
+            "Independent testing of implementation"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "secureConfigurationManagement": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "secureDesign": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "secureDevelopment": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "selfServiceProvisioning": {
+      "type": "boolean"
+    },
+    "serviceAvailabilityPercentage": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Contractual commitment",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "number"
+        }
+      },
+      "type": "object"
+    },
+    "serviceBenefits": {
+      "items": {
+        "maxLength": 120,
+        "pattern": "^(?:\\S+\\s+){0,9}\\S+$",
+        "type": "string"
+      },
+      "maxItems": 10,
+      "minItems": 1,
+      "type": "array"
     },
     "serviceConfigurationGuidance": {
-      "type": "object",
       "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion",
+            "Independent testing of implementation"
+          ]
+        },
         "value": {
           "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation"]
         }
-      }
+      },
+      "type": "object"
+    },
+    "serviceDefinitionDocument": {
+      "type": "string"
+    },
+    "serviceDefinitionDocumentURL": {
+      "format": "uri",
+      "type": "string"
+    },
+    "serviceFeatures": {
+      "items": {
+        "maxLength": 120,
+        "pattern": "^(?:\\S+\\s+){0,9}\\S+$",
+        "type": "string"
+      },
+      "maxItems": 10,
+      "minItems": 1,
+      "type": "array"
+    },
+    "serviceManagementModel": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "items": {
+            "enum": [
+              "Dedicated devices on a segregated network",
+              "Dedicated devices for community service management",
+              "Dedicated devices for multiple community service management",
+              "Service management via bastion hosts",
+              "Direct service management"
+            ]
+          },
+          "maxItems": 5,
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "type": "object"
+    },
+    "serviceName": {
+      "maxLength": 100,
+      "minLength": 1,
+      "type": "string"
+    },
+    "serviceOffboarding": {
+      "type": "boolean"
+    },
+    "serviceOnboarding": {
+      "type": "boolean"
+    },
+    "serviceSummary": {
+      "maxLength": 500,
+      "pattern": "^(?:\\S+\\s+){0,49}\\S+$",
+      "type": "string"
+    },
+    "servicesManagementSeparation": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent testing of implementation",
+            "Assurance of service design",
+            "CESG-assured components"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "servicesSeparation": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent testing of implementation",
+            "Assurance of service design",
+            "CESG-assured components"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "sfiaRateDocument": {
+      "type": "string"
+    },
+    "sfiaRateDocumentURL": {
+      "format": "uri",
+      "type": "string"
+    },
+    "supportAvailability": {
+      "type": "string"
+    },
+    "supportForThirdParties": {
+      "type": "boolean"
+    },
+    "supportResponseTime": {
+      "type": "string"
+    },
+    "supportTypes": {
+      "items": {
+        "enum": [
+          "Service desk",
+          "Email",
+          "Phone",
+          "Live chat",
+          "Onsite"
+        ]
+      },
+      "maxItems": 5,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "supportedBrowsers": {
+      "items": {
+        "enum": [
+          "Internet Explorer 6",
+          "Internet Explorer 7",
+          "Internet Explorer 8",
+          "Internet Explorer 9",
+          "Internet Explorer 10+",
+          "Firefox",
+          "Chrome",
+          "Safari",
+          "Opera"
+        ]
+      },
+      "maxItems": 9,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "supportedDevices": {
+      "items": {
+        "enum": [
+          "PC",
+          "Mac",
+          "Smartphone",
+          "Tablet"
+        ]
+      },
+      "maxItems": 4,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "terminationCost": {
+      "type": "boolean"
+    },
+    "termsAndConditionsDocument": {
+      "type": "string"
+    },
+    "termsAndConditionsDocumentURL": {
+      "format": "uri",
+      "type": "string"
+    },
+    "thirdPartyComplianceMonitoring": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "thirdPartyDataSharingInformation": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "thirdPartyRiskAssessment": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "thirdPartySecurityRequirements": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "title": {
+      "type": "string"
     },
     "trainingProvided": {
-      "type": "object",
       "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
         "value": {
           "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "type": "object"
+    },
+    "trialOption": {
+      "type": "boolean"
+    },
+    "userAccessControlManagement": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion",
+            "Independent testing of implementation"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "userAuthenticateManagement": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion",
+            "Independent testing of implementation"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "userAuthenticateSupport": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion",
+            "Independent testing of implementation"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "vatIncluded": {
+      "type": "boolean"
+    },
+    "vendorCertifications": {
+      "items": {
+        "type": "string"
+      },
+      "maxItems": 10,
+      "type": "array"
+    },
+    "vulnerabilityAssessment": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "vulnerabilityMitigationPrioritisation": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "vulnerabilityMonitoring": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "vulnerabilityTimescales": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "vulnerabilityTracking": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
     }
   },
   "required": [
-    "title",
-    "serviceName",
-    "serviceSummary",
-    "serviceBenefits",
-    "serviceFeatures",
-    "serviceDefinitionDocument",
-    "serviceDefinitionDocumentURL",
-    "termsAndConditionsDocument",
-    "termsAndConditionsDocumentURL",
-    "minimumContractPeriod",
-    "terminationCost",
-    "priceMin",
-    "priceUnit",
-    "priceString",
-    "vatIncluded",
-    "educationPricing",
-    "trialOption",
-    "freeOption",
-    "pricingDocument",
-    "pricingDocumentURL",
-    "openStandardsSupported",
-    "supportForThirdParties",
-    "supportAvailability",
-    "supportResponseTime",
-    "incidentEscalation",
-    "supportTypes",
-    "serviceOnboarding",
-    "serviceOffboarding",
     "analyticsAvailable",
-    "elasticCloud",
-    "guaranteedResources",
-    "persistentStorage",
-    "selfServiceProvisioning",
-    "provisioningTime",
-    "deprovisioningTime",
-    "openSource",
     "apiAccess",
-    "networksConnected",
-    "supportedBrowsers",
-    "offlineWorking",
-    "supportedDevices",
-    "datacentresEUCode",
-    "datacentresSpecifyLocation",
-    "datacentreTier",
+    "auditInformationProvided",
+    "changeImpactAssessment",
+    "cloudDeploymentModel",
+    "configurationTracking",
+    "dataAtRestProtections",
     "dataBackupRecovery",
     "dataExtractionRemoval",
+    "dataManagementLocations",
+    "dataProtectionBetweenServices",
     "dataProtectionBetweenUserAndService",
     "dataProtectionWithinService",
-    "dataProtectionBetweenServices",
-    "datacentreLocations",
-    "dataManagementLocations",
-    "legalJurisdiction",
-    "datacentreProtectionDisclosure",
-    "dataAtRestProtections",
-    "dataSecureDeletion",
-    "dataStorageMediaDisposal",
-    "dataSecureEquipmentDisposal",
     "dataRedundantEquipmentAccountsRevoked",
-    "serviceAvailabilityPercentage",
-    "cloudDeploymentModel",
-    "otherConsumers",
-    "servicesSeparation",
-    "servicesManagementSeparation",
-    "governanceFramework",
-    "configurationTracking",
-    "changeImpactAssessment",
-    "vulnerabilityAssessment",
-    "vulnerabilityMonitoring",
-    "vulnerabilityMitigationPrioritisation",
-    "vulnerabilityTracking",
-    "vulnerabilityTimescales",
+    "dataSecureDeletion",
+    "dataSecureEquipmentDisposal",
+    "dataStorageMediaDisposal",
+    "datacentreLocations",
+    "datacentreProtectionDisclosure",
+    "datacentreTier",
+    "datacentresEUCode",
+    "datacentresSpecifyLocation",
+    "deprovisioningTime",
+    "deviceAccessMethod",
+    "educationPricing",
+    "elasticCloud",
     "eventMonitoring",
+    "freeOption",
+    "governanceFramework",
+    "guaranteedResources",
+    "identityAuthenticationControls",
+    "incidentDefinitionPublished",
+    "incidentEscalation",
     "incidentManagementProcess",
     "incidentManagementReporting",
-    "incidentDefinitionPublished",
+    "interconnectionMethods",
+    "legalJurisdiction",
+    "managementInterfaceProtection",
+    "minimumContractPeriod",
+    "networksConnected",
+    "offlineWorking",
+    "onboardingGuidance",
+    "openSource",
+    "openStandardsSupported",
+    "otherConsumers",
+    "persistentStorage",
     "personnelSecurityChecks",
-    "secureDevelopment",
-    "secureDesign",
+    "priceMin",
+    "priceString",
+    "priceUnit",
+    "pricingDocument",
+    "pricingDocumentURL",
+    "provisioningTime",
+    "restrictAdministratorPermissions",
     "secureConfigurationManagement",
-    "thirdPartyDataSharingInformation",
-    "thirdPartySecurityRequirements",
-    "thirdPartyRiskAssessment",
+    "secureDesign",
+    "secureDevelopment",
+    "selfServiceProvisioning",
+    "serviceAvailabilityPercentage",
+    "serviceBenefits",
+    "serviceConfigurationGuidance",
+    "serviceDefinitionDocument",
+    "serviceDefinitionDocumentURL",
+    "serviceFeatures",
+    "serviceManagementModel",
+    "serviceName",
+    "serviceOffboarding",
+    "serviceOnboarding",
+    "serviceSummary",
+    "servicesManagementSeparation",
+    "servicesSeparation",
+    "supportAvailability",
+    "supportForThirdParties",
+    "supportResponseTime",
+    "supportTypes",
+    "supportedBrowsers",
+    "supportedDevices",
+    "terminationCost",
+    "termsAndConditionsDocument",
+    "termsAndConditionsDocumentURL",
     "thirdPartyComplianceMonitoring",
+    "thirdPartyDataSharingInformation",
+    "thirdPartyRiskAssessment",
+    "thirdPartySecurityRequirements",
+    "title",
+    "trainingProvided",
+    "trialOption",
+    "userAccessControlManagement",
     "userAuthenticateManagement",
     "userAuthenticateSupport",
-    "userAccessControlManagement",
-    "restrictAdministratorPermissions",
-    "managementInterfaceProtection",
-    "identityAuthenticationControls",
-    "onboardingGuidance",
-    "interconnectionMethods",
-    "serviceManagementModel",
-    "auditInformationProvided",
-    "deviceAccessMethod",
-    "serviceConfigurationGuidance",
-    "trainingProvided"
-  ]
+    "vatIncluded",
+    "vulnerabilityAssessment",
+    "vulnerabilityMitigationPrioritisation",
+    "vulnerabilityMonitoring",
+    "vulnerabilityTimescales",
+    "vulnerabilityTracking"
+  ],
+  "title": "G6 Submissions PaaS Schema",
+  "type": "object"
 }

--- a/json_schemas/services-g-cloud-6-saas.json
+++ b/json_schemas/services-g-cloud-6-saas.json
@@ -1,169 +1,9 @@
 {
-  "title": "G6 Submissions SaaS Schema",
   "$schema": "http://json-schema.org/schema#",
-  "type": "object",
   "additionalProperties": false,
   "properties": {
-    "title": {
-      "type": "string"
-    },
-    "serviceTypes": {
-      "type": "array",
-      "uniqueItems": true,
-      "maxItems": 22,
-      "items": {
-        "enum": ["Accounting and finance", "Business intelligence and analytics", "Collaboration", "Creative and design", "Customer relationship management (CRM)", "Data management", "Electronic document and records management (EDRM)", "Energy and environment", "Healthcare", "Human resources and employee management", "IT management", "Legal", "Libraries", "Marketing", "Operations management", "Project management and planning", "Sales", "Schools and education", "Security", "Software development tools", "Telecoms", "Transport and logistics"]
-      }
-    },
-    "serviceName":{
-      "type":"string",
-      "minLength":1,
-      "maxLength":100
-    },
-    "serviceSummary":{
-      "type":"string",
-      "maxLength":500,
-      "pattern":"^(?:\\S+\\s+){0,49}\\S+$"
-    },
-    "serviceBenefits":{
-      "type":"array",
-      "minItems":1,
-      "maxItems":10,
-      "items":{
-        "type":"string",
-        "maxLength":120,
-        "pattern":"^(?:\\S+\\s+){0,9}\\S+$"
-      }
-    },
-    "serviceFeatures":{
-      "type":"array",
-      "minItems":1,
-      "maxItems":10,
-      "items":{
-        "type":"string",
-        "maxLength":120,
-        "pattern":"^(?:\\S+\\s+){0,9}\\S+$"
-      }
-    },
-    "serviceDefinitionDocument": {
-      "type": "string"
-    },
-    "serviceDefinitionDocumentURL": {
-      "type": "string",
-      "format": "uri"
-    },
-    "termsAndConditionsDocument": {
-      "type": "string"
-    },
-    "termsAndConditionsDocumentURL": {
-      "type": "string",
-      "format": "uri"
-    },
-    "minimumContractPeriod": {
-      "enum": ["Hour", "Day", "Month", "Year", "Other"]
-    },
-    "priceMin":{
-      "type":"string",
-      "pattern": "^\\d+(?:\\.\\d{1,5})?$"
-    },
-    "priceMax":{
-      "type": "string",
-      "pattern": "^$|^\\d+(?:\\.\\d{1,5})?$"
-    },
-    "priceUnit": {
-      "enum": ["Unit", "Person", "Licence", "User", "Device", "Instance", "Server", "Virtual machine", "Transaction", "Megabyte", "Gigabyte", "Terabyte"]
-    },
-    "priceInterval": {
-      "enum": ["", "Second", "Minute", "Hour", "Day", "Week", "Month", "Quarter", "6 months", "Year"]
-    },
-    "priceString": {
-      "type": "string"
-    },
-    "vatIncluded": {
-      "type": "boolean"
-    },
-    "educationPricing": {
-      "type": "boolean"
-    },
-    "trialOption": {
-      "type": "boolean"
-    },
-    "freeOption": {
-      "type": "boolean"
-    },
-    "pricingDocument": {
-      "type": "string"
-    },
-    "pricingDocumentURL": {
-      "type": "string",
-      "format": "uri"
-    },
-    "sfiaRateDocument": {
-      "type": "string"
-    },
-    "sfiaRateDocumentURL": {
-      "type": "string",
-      "format": "uri"
-    },
-    "openStandardsSupported": {
-      "type": "boolean"
-    },
-    "supportForThirdParties": {
-      "type": "boolean"
-    },
-    "supportAvailability": {
-      "type": "string"
-    },
-    "supportResponseTime": {
-      "type": "string"
-    },
-    "incidentEscalation": {
-      "type": "boolean"
-    },
-    "supportTypes": {
-      "type": "array",
-      "uniqueItems": true,
-      "maxItems": 5,
-      "items": {
-        "enum": ["Service desk", "Email", "Phone", "Live chat", "Onsite"]
-      }
-    },
-    "serviceOnboarding": {
-      "type": "boolean"
-    },
-    "serviceOffboarding": {
-      "type": "boolean"
-    },
     "analyticsAvailable": {
       "type": "boolean"
-    },
-    "elasticCloud": {
-      "type": "boolean"
-    },
-    "guaranteedResources": {
-      "type": "boolean"
-    },
-    "persistentStorage": {
-      "type": "boolean"
-    },
-    "selfServiceProvisioning": {
-      "type": "boolean"
-    },
-    "provisioningTime": {
-      "type": "string"
-    },
-    "deprovisioningTime": {
-      "type": "string"
-    },
-    "openSource": {
-      "type": "boolean"
-    },
-    "codeLibraryLanguages": {
-      "type": "array",
-      "maxItems": 10,
-      "items": {
-        "type": "string"
-      }
     },
     "apiAccess": {
       "type": "boolean"
@@ -171,55 +11,92 @@
     "apiType": {
       "type": "string"
     },
-    "networksConnected": {
-      "type": "array",
-      "uniqueItems": true,
-      "maxItems": 7,
-      "items": {
-        "enum": ["Internet", "Public Services Network (PSN)", "Government Secure intranet (GSi)", "Police National Network (PNN)", "New NHS Network (N3)", "Joint Academic Network (JANET)", "Other"]
-      }
+    "auditInformationProvided": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "enum": [
+            "None",
+            "Data made available",
+            "Data made available by negotiation"
+          ]
+        }
+      },
+      "type": "object"
     },
-    "supportedBrowsers": {
-      "type": "array",
-      "uniqueItems": true,
-      "maxItems": 9,
-      "items": {
-        "enum": ["Internet Explorer 6", "Internet Explorer 7", "Internet Explorer 8", "Internet Explorer 9", "Internet Explorer 10+", "Firefox", "Chrome", "Safari", "Opera"]
-      }
+    "changeImpactAssessment": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
     },
-    "offlineWorking": {
-      "type": "boolean"
+    "cloudDeploymentModel": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Contractual commitment",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "enum": [
+            "Public cloud",
+            "Community cloud",
+            "Private cloud",
+            "Hybrid cloud"
+          ]
+        }
+      },
+      "type": "object"
     },
-    "supportedDevices": {
-      "type": "array",
-      "uniqueItems": true,
-      "maxItems": 4,
-      "items": {
-        "enum": ["PC", "Mac", "Smartphone", "Tablet"]
-      }
-    },
-    "vendorCertifications": {
-      "type": "array",
-      "maxItems": 10,
+    "codeLibraryLanguages": {
       "items": {
         "type": "string"
-      }
-    },
-    "identityStandards": {
-      "type": "array",
+      },
       "maxItems": 10,
-      "items": {
-        "type": "string"
-      }
+      "type": "array"
     },
-    "datacentresEUCode": {
-      "type": "boolean"
-    },
-    "datacentresSpecifyLocation": {
-      "type": "boolean"
-    },
-    "datacentreTier": {
-      "type": "string"
+    "dataAtRestProtections": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion",
+            "Independent testing of implementation",
+            "CESG-assured components"
+          ]
+        },
+        "value": {
+          "items": {
+            "enum": [
+              "CPA Foundation-grade assured components",
+              "FIPS-assured encryption",
+              "Other encryption",
+              "Secure containers, racks or cages",
+              "Physical access control",
+              "No protection"
+            ]
+          },
+          "maxItems": 6,
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "type": "object"
     },
     "dataBackupRecovery": {
       "type": "boolean"
@@ -227,573 +104,994 @@
     "dataExtractionRemoval": {
       "type": "boolean"
     },
-    "dataProtectionBetweenUserAndService": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "array",
-          "uniqueItems": true,
-          "maxItems": 6,
-          "items": {
-            "enum": ["Encrypted PSN service", "PSN service", "CPA Foundation VPN Gateway", "VPN using TLS, version 1.2 or later", "VPN using legacy SSL or TLS", "No encryption"]
-          }
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation", "CESG-assured components"]
-        }
-      }
-    },
-    "datacentreLocations": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "array",
-          "uniqueItems": true,
-          "maxItems": 5,
-          "items": {
-            "enum": ["UK", "EU", "USA - Safe Harbor", "Other countries with data protection treaties", "Rest of world"]
-          }
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]
-        }
-      }
-    },
     "dataManagementLocations": {
-      "type": "object",
       "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Contractual commitment",
+            "Independent validation of assertion"
+          ]
+        },
         "value": {
-          "type": "array",
-          "uniqueItems": true,
+          "items": {
+            "enum": [
+              "UK",
+              "EU",
+              "USA - Safe Harbor",
+              "Other countries with data protection treaties",
+              "Rest of world"
+            ]
+          },
           "maxItems": 5,
-          "items": {
-            "enum": ["UK", "EU", "USA - Safe Harbor", "Other countries with data protection treaties", "Rest of world"]
-          }
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]
-        }
-      }
-    },
-    "legalJurisdiction": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "enum": ["UK", "EU", "USA - Safe Harbor", "Other countries with data protection treaties", "Rest of world"]
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]
-        }
-      }
-    },
-    "datacentreProtectionDisclosure": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]
-        }
-      }
-    },
-    "dataAtRestProtections": {
-      "type": "object",
-      "properties": {
-        "value": {
           "type": "array",
-          "uniqueItems": true,
-          "maxItems": 6,
-          "items": {
-            "enum": ["CPA Foundation-grade assured components", "FIPS-assured encryption", "Other encryption", "Secure containers, racks or cages", "Physical access control", "No protection"]
-          }
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation", "CESG-assured components"]
+          "uniqueItems": true
         }
-      }
+      },
+      "type": "object"
+    },
+    "dataProtectionBetweenUserAndService": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion",
+            "Independent testing of implementation",
+            "CESG-assured components"
+          ]
+        },
+        "value": {
+          "items": {
+            "enum": [
+              "Encrypted PSN service",
+              "PSN service",
+              "CPA Foundation VPN Gateway",
+              "VPN using TLS, version 1.2 or later",
+              "VPN using legacy SSL or TLS",
+              "No encryption"
+            ]
+          },
+          "maxItems": 6,
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "type": "object"
     },
     "dataSecureDeletion": {
-      "type": "object",
       "properties": {
-        "value": {
-          "enum": ["CPA Foundation-grade erasure product", "CESG or CPNI-approved erasure process", "Other secure erasure process", "Other erasure process"]
-        },
         "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation", "CESG-assured components"]
-        }
-      }
-    },
-    "serviceAvailabilityPercentage": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "number"
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion",
+            "Independent testing of implementation",
+            "CESG-assured components"
+          ]
         },
-        "assurance": {
-          "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]
-        }
-      }
-    },
-    "cloudDeploymentModel": {
-      "type": "object",
-      "properties": {
         "value": {
-          "enum": ["Public cloud", "Community cloud", "Private cloud", "Hybrid cloud"]
+          "enum": [
+            "CPA Foundation-grade erasure product",
+            "CESG or CPNI-approved erasure process",
+            "Other secure erasure process",
+            "Other erasure process"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "datacentreLocations": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Contractual commitment",
+            "Independent validation of assertion"
+          ]
         },
-        "assurance": {
-          "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]
-        }
-      }
-    },
-    "otherConsumers": {
-      "type": "object",
-      "properties": {
         "value": {
-          "enum": ["No other consumer", "Only government consumers", "A specific consumer group, eg Police, Defence or Health", "Anyone - public"]
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]
-        }
-      }
-    },
-    "servicesSeparation": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent testing of implementation", "Assurance of service design", "CESG-assured components"]
-        }
-      }
-    },
-    "servicesManagementSeparation": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent testing of implementation", "Assurance of service design", "CESG-assured components"]
-        }
-      }
-    },
-    "governanceFramework": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      }
-    },
-    "changeImpactAssessment": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      }
-    },
-    "vulnerabilityAssessment": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      }
-    },
-    "vulnerabilityMonitoring": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      }
-    },
-    "vulnerabilityMitigationPrioritisation": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      }
-    },
-    "vulnerabilityTracking": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      }
-    },
-    "vulnerabilityTimescales": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      }
-    },
-    "eventMonitoring": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      }
-    },
-    "incidentManagementProcess": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      }
-    },
-    "incidentManagementReporting": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      }
-    },
-    "incidentDefinitionPublished": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      }
-    },
-    "personnelSecurityChecks": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "array",
-          "uniqueItems": true,
-          "maxItems": 4,
           "items": {
-            "enum": ["Security clearance national vetting (SC)", "Baseline personnel security standard (BPSS)", "Background checks in accordance with BS7858:2012", "Employment checks"]
-          }
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      }
-    },
-    "secureDevelopment": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      }
-    },
-    "secureDesign": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      }
-    },
-    "secureConfigurationManagement": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      }
-    },
-    "thirdPartyDataSharingInformation": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      }
-    },
-    "thirdPartySecurityRequirements": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      }
-    },
-    "thirdPartyRiskAssessment": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      }
-    },
-    "thirdPartyComplianceMonitoring": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      }
-    },
-    "userAuthenticateManagement": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation"]
-        }
-      }
-    },
-    "userAuthenticateSupport": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation"]
-        }
-      }
-    },
-    "userAccessControlManagement": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation"]
-        }
-      }
-    },
-    "restrictAdministratorPermissions": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation"]
-        }
-      }
-    },
-    "identityAuthenticationControls": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "array",
-          "uniqueItems": true,
-          "maxItems": 7,
-          "items": {
-            "enum": ["Username and two-factor authentication", "Username and TLS client certificate", "Authentication federation", "Limited access over dedicated link, enterprise or community network", "Username and password", "Username and strong password/passphrase enforcement", "Other mechanism"]
-          }
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent testing of implementation", "CESG-assured components"]
-        }
-      }
-    },
-    "serviceManagementModel": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "array",
-          "uniqueItems": true,
+            "enum": [
+              "UK",
+              "EU",
+              "USA - Safe Harbor",
+              "Other countries with data protection treaties",
+              "Rest of world"
+            ]
+          },
           "maxItems": 5,
-          "items": {
-            "enum": ["Dedicated devices on a segregated network", "Dedicated devices for community service management", "Dedicated devices for multiple community service management", "Service management via bastion hosts", "Direct service management"]
-          }
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
+          "type": "array",
+          "uniqueItems": true
         }
-      }
+      },
+      "type": "object"
     },
-    "auditInformationProvided": {
-      "type": "object",
+    "datacentreProtectionDisclosure": {
       "properties": {
-        "value": {
-          "enum": ["None", "Data made available", "Data made available by negotiation"]
-        },
         "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
+          "enum": [
+            "Service provider assertion",
+            "Contractual commitment",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
         }
-      }
+      },
+      "type": "object"
+    },
+    "datacentreTier": {
+      "type": "string"
+    },
+    "datacentresEUCode": {
+      "type": "boolean"
+    },
+    "datacentresSpecifyLocation": {
+      "type": "boolean"
+    },
+    "deprovisioningTime": {
+      "type": "string"
     },
     "deviceAccessMethod": {
-      "type": "object",
       "properties": {
-        "value": {
-          "type": "array",
-          "uniqueItems": true,
-          "maxItems": 3,
-          "items": {
-            "enum": ["Corporate/enterprise devices", "Partner devices", "Unknown devices"]
-          }
-        },
         "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "items": {
+            "enum": [
+              "Corporate/enterprise devices",
+              "Partner devices",
+              "Unknown devices"
+            ]
+          },
+          "maxItems": 3,
+          "type": "array",
+          "uniqueItems": true
         }
-      }
+      },
+      "type": "object"
     },
-    "trainingProvided": {
-      "type": "object",
+    "educationPricing": {
+      "type": "boolean"
+    },
+    "elasticCloud": {
+      "type": "boolean"
+    },
+    "eventMonitoring": {
       "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
         "value": {
           "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
-      }
+      },
+      "type": "object"
+    },
+    "freeOption": {
+      "type": "boolean"
+    },
+    "governanceFramework": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "guaranteedResources": {
+      "type": "boolean"
+    },
+    "identityAuthenticationControls": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent testing of implementation",
+            "CESG-assured components"
+          ]
+        },
+        "value": {
+          "items": {
+            "enum": [
+              "Username and two-factor authentication",
+              "Username and TLS client certificate",
+              "Authentication federation",
+              "Limited access over dedicated link, enterprise or community network",
+              "Username and password",
+              "Username and strong password/passphrase enforcement",
+              "Other mechanism"
+            ]
+          },
+          "maxItems": 7,
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "type": "object"
+    },
+    "identityStandards": {
+      "items": {
+        "type": "string"
+      },
+      "maxItems": 10,
+      "type": "array"
+    },
+    "incidentDefinitionPublished": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "incidentEscalation": {
+      "type": "boolean"
+    },
+    "incidentManagementProcess": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "incidentManagementReporting": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "legalJurisdiction": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Contractual commitment",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "enum": [
+            "UK",
+            "EU",
+            "USA - Safe Harbor",
+            "Other countries with data protection treaties",
+            "Rest of world"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "minimumContractPeriod": {
+      "enum": [
+        "Hour",
+        "Day",
+        "Month",
+        "Year",
+        "Other"
+      ]
+    },
+    "networksConnected": {
+      "items": {
+        "enum": [
+          "Internet",
+          "Public Services Network (PSN)",
+          "Government Secure intranet (GSi)",
+          "Police National Network (PNN)",
+          "New NHS Network (N3)",
+          "Joint Academic Network (JANET)",
+          "Other"
+        ]
+      },
+      "maxItems": 7,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "offlineWorking": {
+      "type": "boolean"
+    },
+    "openSource": {
+      "type": "boolean"
+    },
+    "openStandardsSupported": {
+      "type": "boolean"
+    },
+    "otherConsumers": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Contractual commitment",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "enum": [
+            "No other consumer",
+            "Only government consumers",
+            "A specific consumer group, eg Police, Defence or Health",
+            "Anyone - public"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "persistentStorage": {
+      "type": "boolean"
+    },
+    "personnelSecurityChecks": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "items": {
+            "enum": [
+              "Security clearance national vetting (SC)",
+              "Baseline personnel security standard (BPSS)",
+              "Background checks in accordance with BS7858:2012",
+              "Employment checks"
+            ]
+          },
+          "maxItems": 4,
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "type": "object"
+    },
+    "priceInterval": {
+      "enum": [
+        "",
+        "Second",
+        "Minute",
+        "Hour",
+        "Day",
+        "Week",
+        "Month",
+        "Quarter",
+        "6 months",
+        "Year"
+      ]
+    },
+    "priceMax": {
+      "pattern": "^$|^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "priceMin": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "priceString": {
+      "type": "string"
+    },
+    "priceUnit": {
+      "enum": [
+        "Unit",
+        "Person",
+        "Licence",
+        "User",
+        "Device",
+        "Instance",
+        "Server",
+        "Virtual machine",
+        "Transaction",
+        "Megabyte",
+        "Gigabyte",
+        "Terabyte"
+      ]
+    },
+    "pricingDocument": {
+      "type": "string"
+    },
+    "pricingDocumentURL": {
+      "format": "uri",
+      "type": "string"
+    },
+    "provisioningTime": {
+      "type": "string"
+    },
+    "restrictAdministratorPermissions": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion",
+            "Independent testing of implementation"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "secureConfigurationManagement": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "secureDesign": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "secureDevelopment": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "selfServiceProvisioning": {
+      "type": "boolean"
+    },
+    "serviceAvailabilityPercentage": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Contractual commitment",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "number"
+        }
+      },
+      "type": "object"
+    },
+    "serviceBenefits": {
+      "items": {
+        "maxLength": 120,
+        "pattern": "^(?:\\S+\\s+){0,9}\\S+$",
+        "type": "string"
+      },
+      "maxItems": 10,
+      "minItems": 1,
+      "type": "array"
+    },
+    "serviceDefinitionDocument": {
+      "type": "string"
+    },
+    "serviceDefinitionDocumentURL": {
+      "format": "uri",
+      "type": "string"
+    },
+    "serviceFeatures": {
+      "items": {
+        "maxLength": 120,
+        "pattern": "^(?:\\S+\\s+){0,9}\\S+$",
+        "type": "string"
+      },
+      "maxItems": 10,
+      "minItems": 1,
+      "type": "array"
+    },
+    "serviceManagementModel": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "items": {
+            "enum": [
+              "Dedicated devices on a segregated network",
+              "Dedicated devices for community service management",
+              "Dedicated devices for multiple community service management",
+              "Service management via bastion hosts",
+              "Direct service management"
+            ]
+          },
+          "maxItems": 5,
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "type": "object"
+    },
+    "serviceName": {
+      "maxLength": 100,
+      "minLength": 1,
+      "type": "string"
+    },
+    "serviceOffboarding": {
+      "type": "boolean"
+    },
+    "serviceOnboarding": {
+      "type": "boolean"
+    },
+    "serviceSummary": {
+      "maxLength": 500,
+      "pattern": "^(?:\\S+\\s+){0,49}\\S+$",
+      "type": "string"
+    },
+    "serviceTypes": {
+      "items": {
+        "enum": [
+          "Accounting and finance",
+          "Business intelligence and analytics",
+          "Collaboration",
+          "Creative and design",
+          "Customer relationship management (CRM)",
+          "Data management",
+          "Electronic document and records management (EDRM)",
+          "Energy and environment",
+          "Healthcare",
+          "Human resources and employee management",
+          "IT management",
+          "Legal",
+          "Libraries",
+          "Marketing",
+          "Operations management",
+          "Project management and planning",
+          "Sales",
+          "Schools and education",
+          "Security",
+          "Software development tools",
+          "Telecoms",
+          "Transport and logistics"
+        ]
+      },
+      "maxItems": 22,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "servicesManagementSeparation": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent testing of implementation",
+            "Assurance of service design",
+            "CESG-assured components"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "servicesSeparation": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent testing of implementation",
+            "Assurance of service design",
+            "CESG-assured components"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "sfiaRateDocument": {
+      "type": "string"
+    },
+    "sfiaRateDocumentURL": {
+      "format": "uri",
+      "type": "string"
+    },
+    "supportAvailability": {
+      "type": "string"
+    },
+    "supportForThirdParties": {
+      "type": "boolean"
+    },
+    "supportResponseTime": {
+      "type": "string"
+    },
+    "supportTypes": {
+      "items": {
+        "enum": [
+          "Service desk",
+          "Email",
+          "Phone",
+          "Live chat",
+          "Onsite"
+        ]
+      },
+      "maxItems": 5,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "supportedBrowsers": {
+      "items": {
+        "enum": [
+          "Internet Explorer 6",
+          "Internet Explorer 7",
+          "Internet Explorer 8",
+          "Internet Explorer 9",
+          "Internet Explorer 10+",
+          "Firefox",
+          "Chrome",
+          "Safari",
+          "Opera"
+        ]
+      },
+      "maxItems": 9,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "supportedDevices": {
+      "items": {
+        "enum": [
+          "PC",
+          "Mac",
+          "Smartphone",
+          "Tablet"
+        ]
+      },
+      "maxItems": 4,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "termsAndConditionsDocument": {
+      "type": "string"
+    },
+    "termsAndConditionsDocumentURL": {
+      "format": "uri",
+      "type": "string"
+    },
+    "thirdPartyComplianceMonitoring": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "thirdPartyDataSharingInformation": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "thirdPartyRiskAssessment": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "thirdPartySecurityRequirements": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "title": {
+      "type": "string"
+    },
+    "trainingProvided": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "trialOption": {
+      "type": "boolean"
+    },
+    "userAccessControlManagement": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion",
+            "Independent testing of implementation"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "userAuthenticateManagement": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion",
+            "Independent testing of implementation"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "userAuthenticateSupport": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion",
+            "Independent testing of implementation"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "vatIncluded": {
+      "type": "boolean"
+    },
+    "vendorCertifications": {
+      "items": {
+        "type": "string"
+      },
+      "maxItems": 10,
+      "type": "array"
+    },
+    "vulnerabilityAssessment": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "vulnerabilityMitigationPrioritisation": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "vulnerabilityMonitoring": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "vulnerabilityTimescales": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "vulnerabilityTracking": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
     }
   },
   "required": [
-    "title",
-    "serviceTypes",
-    "serviceName",
-    "serviceSummary",
-    "serviceBenefits",
-    "serviceFeatures",
-    "serviceDefinitionDocument",
-    "serviceDefinitionDocumentURL",
-    "termsAndConditionsDocument",
-    "termsAndConditionsDocumentURL",
-    "minimumContractPeriod",
-    "priceMin",
-    "priceUnit",
-    "priceString",
-    "vatIncluded",
-    "educationPricing",
-    "trialOption",
-    "freeOption",
-    "pricingDocument",
-    "pricingDocumentURL",
-    "openStandardsSupported",
-    "supportForThirdParties",
-    "supportAvailability",
-    "supportResponseTime",
-    "incidentEscalation",
-    "supportTypes",
-    "serviceOnboarding",
-    "serviceOffboarding",
     "analyticsAvailable",
-    "elasticCloud",
-    "guaranteedResources",
-    "persistentStorage",
-    "selfServiceProvisioning",
-    "provisioningTime",
-    "deprovisioningTime",
-    "openSource",
     "apiAccess",
-    "networksConnected",
-    "supportedBrowsers",
-    "offlineWorking",
-    "supportedDevices",
-    "datacentresEUCode",
-    "datacentresSpecifyLocation",
-    "datacentreTier",
+    "auditInformationProvided",
+    "changeImpactAssessment",
+    "cloudDeploymentModel",
+    "dataAtRestProtections",
     "dataBackupRecovery",
     "dataExtractionRemoval",
-    "dataProtectionBetweenUserAndService",
-    "datacentreLocations",
     "dataManagementLocations",
-    "legalJurisdiction",
-    "datacentreProtectionDisclosure",
-    "dataAtRestProtections",
+    "dataProtectionBetweenUserAndService",
     "dataSecureDeletion",
-    "serviceAvailabilityPercentage",
-    "cloudDeploymentModel",
-    "otherConsumers",
-    "servicesSeparation",
-    "servicesManagementSeparation",
-    "governanceFramework",
-    "changeImpactAssessment",
-    "vulnerabilityAssessment",
-    "vulnerabilityMonitoring",
-    "vulnerabilityMitigationPrioritisation",
-    "vulnerabilityTracking",
-    "vulnerabilityTimescales",
+    "datacentreLocations",
+    "datacentreProtectionDisclosure",
+    "datacentreTier",
+    "datacentresEUCode",
+    "datacentresSpecifyLocation",
+    "deprovisioningTime",
+    "deviceAccessMethod",
+    "educationPricing",
+    "elasticCloud",
     "eventMonitoring",
+    "freeOption",
+    "governanceFramework",
+    "guaranteedResources",
+    "identityAuthenticationControls",
+    "incidentDefinitionPublished",
+    "incidentEscalation",
     "incidentManagementProcess",
     "incidentManagementReporting",
-    "incidentDefinitionPublished",
+    "legalJurisdiction",
+    "minimumContractPeriod",
+    "networksConnected",
+    "offlineWorking",
+    "openSource",
+    "openStandardsSupported",
+    "otherConsumers",
+    "persistentStorage",
     "personnelSecurityChecks",
-    "secureDevelopment",
-    "secureDesign",
+    "priceMin",
+    "priceString",
+    "priceUnit",
+    "pricingDocument",
+    "pricingDocumentURL",
+    "provisioningTime",
+    "restrictAdministratorPermissions",
     "secureConfigurationManagement",
-    "thirdPartyDataSharingInformation",
-    "thirdPartySecurityRequirements",
-    "thirdPartyRiskAssessment",
+    "secureDesign",
+    "secureDevelopment",
+    "selfServiceProvisioning",
+    "serviceAvailabilityPercentage",
+    "serviceBenefits",
+    "serviceDefinitionDocument",
+    "serviceDefinitionDocumentURL",
+    "serviceFeatures",
+    "serviceManagementModel",
+    "serviceName",
+    "serviceOffboarding",
+    "serviceOnboarding",
+    "serviceSummary",
+    "serviceTypes",
+    "servicesManagementSeparation",
+    "servicesSeparation",
+    "supportAvailability",
+    "supportForThirdParties",
+    "supportResponseTime",
+    "supportTypes",
+    "supportedBrowsers",
+    "supportedDevices",
+    "termsAndConditionsDocument",
+    "termsAndConditionsDocumentURL",
     "thirdPartyComplianceMonitoring",
+    "thirdPartyDataSharingInformation",
+    "thirdPartyRiskAssessment",
+    "thirdPartySecurityRequirements",
+    "title",
+    "trainingProvided",
+    "trialOption",
+    "userAccessControlManagement",
     "userAuthenticateManagement",
     "userAuthenticateSupport",
-    "userAccessControlManagement",
-    "restrictAdministratorPermissions",
-    "identityAuthenticationControls",
-    "serviceManagementModel",
-    "auditInformationProvided",
-    "deviceAccessMethod",
-    "trainingProvided"
-  ]
+    "vatIncluded",
+    "vulnerabilityAssessment",
+    "vulnerabilityMitigationPrioritisation",
+    "vulnerabilityMonitoring",
+    "vulnerabilityTimescales",
+    "vulnerabilityTracking"
+  ],
+  "title": "G6 Submissions SaaS Schema",
+  "type": "object"
 }

--- a/json_schemas/services-g-cloud-6-scs.json
+++ b/json_schemas/services-g-cloud-6-scs.json
@@ -1,160 +1,201 @@
 {
-   "title": "G6 Submissions SCS Schema",
-   "$schema": "http://json-schema.org/schema#",
-   "type": "object",
-   "additionalProperties": false,
-   "properties": {
-      "title": {
-         "type": "string"
+  "$schema": "http://json-schema.org/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "educationPricing": {
+      "type": "boolean"
+    },
+    "incidentEscalation": {
+      "type": "boolean"
+    },
+    "minimumContractPeriod": {
+      "enum": [
+        "Hour",
+        "Day",
+        "Month",
+        "Year",
+        "Other"
+      ]
+    },
+    "priceInterval": {
+      "enum": [
+        "",
+        "Second",
+        "Minute",
+        "Hour",
+        "Day",
+        "Week",
+        "Month",
+        "Quarter",
+        "6 months",
+        "Year"
+      ]
+    },
+    "priceMax": {
+      "pattern": "^$|^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "priceMin": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "priceString": {
+      "type": "string"
+    },
+    "priceUnit": {
+      "enum": [
+        "Unit",
+        "Person",
+        "Licence",
+        "User",
+        "Device",
+        "Instance",
+        "Server",
+        "Virtual machine",
+        "Transaction",
+        "Megabyte",
+        "Gigabyte",
+        "Terabyte"
+      ]
+    },
+    "pricingDocument": {
+      "type": "string"
+    },
+    "pricingDocumentURL": {
+      "format": "uri",
+      "type": "string"
+    },
+    "serviceBenefits": {
+      "items": {
+        "maxLength": 120,
+        "pattern": "^(?:\\S+\\s+){0,9}\\S+$",
+        "type": "string"
       },
-      "serviceTypes": {
-         "type": "array",
-         "uniqueItems": true,
-         "maxItems": 5,
-         "items": {
-            "enum": ["Implementation", "Ongoing support", "Planning", "Testing", "Training"]
-         }
+      "maxItems": 10,
+      "minItems": 1,
+      "type": "array"
+    },
+    "serviceDefinitionDocument": {
+      "type": "string"
+    },
+    "serviceDefinitionDocumentURL": {
+      "format": "uri",
+      "type": "string"
+    },
+    "serviceFeatures": {
+      "items": {
+        "maxLength": 120,
+        "pattern": "^(?:\\S+\\s+){0,9}\\S+$",
+        "type": "string"
       },
-      "serviceName":{
-        "type":"string",
-        "minLength":1,
-        "maxLength":100
+      "maxItems": 10,
+      "minItems": 1,
+      "type": "array"
+    },
+    "serviceName": {
+      "maxLength": 100,
+      "minLength": 1,
+      "type": "string"
+    },
+    "serviceSummary": {
+      "maxLength": 500,
+      "pattern": "^(?:\\S+\\s+){0,49}\\S+$",
+      "type": "string"
+    },
+    "serviceTypes": {
+      "items": {
+        "enum": [
+          "Implementation",
+          "Ongoing support",
+          "Planning",
+          "Testing",
+          "Training"
+        ]
       },
-      "serviceSummary":{
-        "type":"string",
-        "maxLength":500,
-        "pattern":"^(?:\\S+\\s+){0,49}\\S+$"
+      "maxItems": 5,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "sfiaRateDocument": {
+      "type": "string"
+    },
+    "sfiaRateDocumentURL": {
+      "format": "uri",
+      "type": "string"
+    },
+    "supportAvailability": {
+      "type": "string"
+    },
+    "supportForThirdParties": {
+      "type": "boolean"
+    },
+    "supportResponseTime": {
+      "type": "string"
+    },
+    "supportTypes": {
+      "items": {
+        "enum": [
+          "Service desk",
+          "Email",
+          "Phone",
+          "Live chat",
+          "Onsite"
+        ]
       },
-      "serviceBenefits":{
-        "type":"array",
-        "minItems":1,
-        "maxItems":10,
-        "items":{
-          "type":"string",
-          "maxLength":120,
-          "pattern":"^(?:\\S+\\s+){0,9}\\S+$"
-        }
+      "maxItems": 5,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "terminationCost": {
+      "type": "boolean"
+    },
+    "termsAndConditionsDocument": {
+      "type": "string"
+    },
+    "termsAndConditionsDocumentURL": {
+      "format": "uri",
+      "type": "string"
+    },
+    "title": {
+      "type": "string"
+    },
+    "vatIncluded": {
+      "type": "boolean"
+    },
+    "vendorCertifications": {
+      "items": {
+        "type": "string"
       },
-      "serviceFeatures":{
-        "type":"array",
-        "minItems":1,
-        "maxItems":10,
-        "items":{
-          "type":"string",
-          "maxLength":120,
-          "pattern":"^(?:\\S+\\s+){0,9}\\S+$"
-        }
-      },
-      "serviceDefinitionDocument": {
-         "type": "string"
-      },
-      "serviceDefinitionDocumentURL": {
-         "type": "string",
-         "format": "uri"
-      },
-      "termsAndConditionsDocument": {
-         "type": "string"
-      },
-      "termsAndConditionsDocumentURL": {
-         "type": "string",
-        "format": "uri"
-      },
-      "minimumContractPeriod": {
-         "enum": ["Hour", "Day", "Month", "Year", "Other"]
-      },
-      "terminationCost": {
-         "type": "boolean"
-      },
-      "priceMin":{
-        "type":"string",
-        "pattern": "^\\d+(?:\\.\\d{1,5})?$"
-      },
-      "priceMax":{
-        "type": "string",
-        "pattern": "^$|^\\d+(?:\\.\\d{1,5})?$"
-      },
-      "priceUnit": {
-         "enum": [
-           "Unit", "Person", "Licence", "User", "Device", "Instance", "Server", "Virtual machine", "Transaction", "Megabyte", "Gigabyte", "Terabyte"]
-      },
-      "priceInterval": {
-         "enum": ["", "Second", "Minute", "Hour", "Day", "Week", "Month", "Quarter", "6 months", "Year"]
-      },
-      "priceString": {
-         "type": "string"
-      },
-      "vatIncluded": {
-         "type": "boolean"
-      },
-      "educationPricing": {
-         "type": "boolean"
-      },
-      "pricingDocument": {
-         "type": "string"
-      },
-      "pricingDocumentURL": {
-         "type": "string",
-         "format": "uri"
-      },
-      "sfiaRateDocument": {
-         "type": "string"
-      },
-      "sfiaRateDocumentURL": {
-         "type": "string",
-         "format": "uri"
-      },
-      "supportForThirdParties": {
-         "type": "boolean"
-      },
-      "supportAvailability": {
-         "type": "string"
-      },
-      "supportResponseTime": {
-         "type": "string"
-      },
-      "incidentEscalation": {
-         "type": "boolean"
-      },
-      "supportTypes": {
-         "type": "array",
-         "uniqueItems": true,
-         "maxItems": 5,
-         "items": {
-            "enum": ["Service desk", "Email", "Phone", "Live chat", "Onsite"]
-         }
-      },
-      "vendorCertifications": {
-         "type": "array",
-         "maxItems": 10,
-         "items": {
-            "type": "string"
-         }
-      }
-   },
-   "required": [
-      "title",
-      "serviceTypes",
-      "serviceName",
-      "serviceSummary",
-      "serviceBenefits",
-      "serviceFeatures",
-      "serviceDefinitionDocument",
-      "serviceDefinitionDocumentURL",
-      "termsAndConditionsDocument",
-      "termsAndConditionsDocumentURL",
-      "minimumContractPeriod",
-      "terminationCost",
-      "priceMin",
-      "priceUnit",
-      "priceString",
-      "vatIncluded",
-      "educationPricing",
-      "pricingDocument",
-      "pricingDocumentURL",
-      "supportForThirdParties",
-      "supportAvailability",
-      "supportResponseTime",
-      "incidentEscalation",
-      "supportTypes"
-   ]
+      "maxItems": 10,
+      "type": "array"
+    }
+  },
+  "required": [
+    "educationPricing",
+    "incidentEscalation",
+    "minimumContractPeriod",
+    "priceMin",
+    "priceString",
+    "priceUnit",
+    "pricingDocument",
+    "pricingDocumentURL",
+    "serviceBenefits",
+    "serviceDefinitionDocument",
+    "serviceDefinitionDocumentURL",
+    "serviceFeatures",
+    "serviceName",
+    "serviceSummary",
+    "serviceTypes",
+    "supportAvailability",
+    "supportForThirdParties",
+    "supportResponseTime",
+    "supportTypes",
+    "terminationCost",
+    "termsAndConditionsDocument",
+    "termsAndConditionsDocumentURL",
+    "title",
+    "vatIncluded"
+  ],
+  "title": "G6 Submissions SCS Schema",
+  "type": "object"
 }

--- a/json_schemas/services-g-cloud-7-iaas.json
+++ b/json_schemas/services-g-cloud-7-iaas.json
@@ -1,74 +1,816 @@
 {
-  "title":"G-Cloud 7 IaaS Service Schema",
-  "$schema":"http://json-schema.org/schema#",
-  "type":"object",
-  "additionalProperties":false,
-  "properties":{
-    "serviceDefinitionDocumentURL":{
-      "type":"string",
-      "format":"uri"
+  "$schema": "http://json-schema.org/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "analyticsAvailable": {
+      "type": "boolean"
     },
-    "termsAndConditionsDocumentURL":{
-      "type":"string",
-      "format":"uri"
+    "apiAccess": {
+      "type": "boolean"
     },
-    "pricingDocumentURL":{
-      "type":"string",
-      "format":"uri"
+    "apiType": {
+      "maxLength": 200,
+      "pattern": "^$|(^(?:\\S+\\s+){0,19}\\S+$)",
+      "type": "string"
     },
-    "sfiaRateDocumentURL":{
-      "type":"string",
-      "format":"uri"
+    "auditInformationProvided": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "enum": [
+            "None",
+            "Data made available",
+            "Data made available by negotiation"
+          ]
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
     },
-    "serviceName":{
-      "type":"string",
-      "minLength":1,
-      "maxLength":100
+    "changeImpactAssessment": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
     },
-    "serviceSummary":{
-      "type":"string",
-      "maxLength":500,
-      "pattern":"^(?:\\S+\\s+){0,49}\\S+$",
-      "minLength":1
+    "cloudDeploymentModel": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Contractual commitment",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "enum": [
+            "Public cloud",
+            "Community cloud",
+            "Private cloud",
+            "Hybrid cloud"
+          ]
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
     },
-    "serviceTypes":{
-      "type":"array",
-      "uniqueItems":true,
-      "maxItems":2,
-      "items":{
-        "enum":["Compute", "Storage"]
-      }
+    "configurationTracking": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
     },
-    "serviceFeatures":{
-      "type":"array",
-      "minItems":1,
-      "maxItems":10,
-      "items":{
-        "type":"string",
-        "maxLength":100,
-        "pattern":"^(?:\\S+\\s+){0,9}\\S+$"
-      }
+    "dataAtRestProtections": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion",
+            "Independent testing of implementation",
+            "CESG-assured components"
+          ]
+        },
+        "value": {
+          "items": {
+            "enum": [
+              "CPA Foundation-grade assured components",
+              "FIPS-assured encryption",
+              "Other encryption",
+              "Secure containers, racks or cages",
+              "Physical access control",
+              "No protection"
+            ]
+          },
+          "maxItems": 6,
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
     },
-    "serviceBenefits":{
-      "type":"array",
-      "minItems":1,
-      "maxItems":10,
-      "items":{
-        "type":"string",
-        "maxLength":100,
-        "pattern":"^(?:\\S+\\s+){0,9}\\S+$"
-      }
+    "dataBackupRecovery": {
+      "type": "boolean"
     },
-    "priceMin":{
-      "type":"string",
-      "pattern": "^\\d+(?:\\.\\d{1,5})?$"
+    "dataExtractionRemoval": {
+      "type": "boolean"
     },
-    "priceMax":{
-      "type": "string",
-      "pattern": "^$|^\\d+(?:\\.\\d{1,5})?$"
+    "dataManagementLocations": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Contractual commitment",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "items": {
+            "enum": [
+              "UK",
+              "EU",
+              "USA - Safe Harbor",
+              "Other countries with data protection treaties",
+              "Rest of world"
+            ]
+          },
+          "maxItems": 5,
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
     },
-    "priceUnit":{
-      "enum":[
+    "dataProtectionBetweenServices": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion",
+            "Independent testing of implementation",
+            "CESG-assured components"
+          ]
+        },
+        "value": {
+          "items": {
+            "enum": [
+              "Encrypted PSN service",
+              "PSN service",
+              "CPA Foundation VPN Gateway",
+              "VPN using TLS, version 1.2 or later",
+              "VPN using legacy SSL or TLS",
+              "No encryption"
+            ]
+          },
+          "maxItems": 6,
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "dataProtectionBetweenUserAndService": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion",
+            "Independent testing of implementation",
+            "CESG-assured components"
+          ]
+        },
+        "value": {
+          "items": {
+            "enum": [
+              "Encrypted PSN service",
+              "PSN service",
+              "CPA Foundation VPN Gateway",
+              "VPN using TLS, version 1.2 or later",
+              "VPN using legacy SSL or TLS",
+              "No encryption"
+            ]
+          },
+          "maxItems": 6,
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "dataProtectionWithinService": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion",
+            "Independent testing of implementation",
+            "CESG-assured components"
+          ]
+        },
+        "value": {
+          "items": {
+            "enum": [
+              "VPN using TLS, version 1.2 or later",
+              "VPN using legacy SSL or TLS",
+              "VLAN",
+              "Bonded fibre optic connections",
+              "Other network protection",
+              "No encryption"
+            ]
+          },
+          "maxItems": 6,
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "dataRedundantEquipmentAccountsRevoked": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Contractual commitment",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "dataSecureDeletion": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion",
+            "Independent testing of implementation",
+            "CESG-assured components"
+          ]
+        },
+        "value": {
+          "enum": [
+            "CPA Foundation-grade erasure product",
+            "CESG or CPNI-approved erasure process",
+            "Other secure erasure process",
+            "Other erasure process"
+          ]
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "dataSecureEquipmentDisposal": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Contractual commitment",
+            "Independent validation of assertion",
+            "CESG-assured components"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "dataStorageMediaDisposal": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Contractual commitment",
+            "Independent validation of assertion",
+            "Independent testing of implementation",
+            "CESG-assured components"
+          ]
+        },
+        "value": {
+          "enum": [
+            "CESG-assured destruction service (CAS(T))",
+            "CPA Foundation-assured product",
+            "CPNI-approved destruction service",
+            "BS EN 151713:2009-compliant destruction",
+            "CESG or CPNI-approved erasure process",
+            "Other secure erasure process",
+            "Other destruction/erasure process"
+          ]
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "datacentreLocations": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Contractual commitment",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "items": {
+            "enum": [
+              "UK",
+              "EU",
+              "USA - Safe Harbor",
+              "Other countries with data protection treaties",
+              "Rest of world"
+            ]
+          },
+          "maxItems": 5,
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "datacentreProtectionDisclosure": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Contractual commitment",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "datacentreTier": {
+      "enum": [
+        "TIA-942 Tier 1",
+        "TIA-942 Tier 2",
+        "TIA-942 Tier 3",
+        "TIA-942 Tier 4",
+        "Uptime Institute Tier 1",
+        "Uptime Institute Tier 2",
+        "Uptime Institute Tier 3",
+        "Uptime Institute Tier 4",
+        "None of the above"
+      ]
+    },
+    "datacentresEUCode": {
+      "type": "boolean"
+    },
+    "datacentresSpecifyLocation": {
+      "type": "boolean"
+    },
+    "deprovisioningTime": {
+      "maxLength": 200,
+      "minLength": 1,
+      "pattern": "^(?:\\S+\\s+){0,19}\\S+$",
+      "type": "string"
+    },
+    "deviceAccessMethod": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "items": {
+            "enum": [
+              "Corporate/enterprise devices",
+              "Partner devices",
+              "Unknown devices"
+            ]
+          },
+          "maxItems": 3,
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "educationPricing": {
+      "type": "boolean"
+    },
+    "elasticCloud": {
+      "type": "boolean"
+    },
+    "eventMonitoring": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "freeOption": {
+      "type": "boolean"
+    },
+    "governanceFramework": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "guaranteedResources": {
+      "type": "boolean"
+    },
+    "hardwareSoftwareVerification": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "identityAuthenticationControls": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent testing of implementation",
+            "CESG-assured components"
+          ]
+        },
+        "value": {
+          "items": {
+            "enum": [
+              "Username and two-factor authentication",
+              "Username and TLS client certificate",
+              "Authentication federation",
+              "Limited access over dedicated link, enterprise or community network",
+              "Username and password",
+              "Username and strong password/passphrase enforcement",
+              "Other mechanism"
+            ]
+          },
+          "maxItems": 7,
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "incidentDefinitionPublished": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "incidentEscalation": {
+      "type": "boolean"
+    },
+    "incidentManagementProcess": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "incidentManagementReporting": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "interconnectionMethods": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "items": {
+            "enum": [
+              "Encrypted PSN service",
+              "PSN service",
+              "Private WAN",
+              "Internet"
+            ]
+          },
+          "maxItems": 4,
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "legalJurisdiction": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Contractual commitment",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "enum": [
+            "UK",
+            "EU",
+            "USA - Safe Harbor",
+            "Other countries with data protection treaties",
+            "Rest of world"
+          ]
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "managementInterfaceProtection": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion",
+            "Independent testing of implementation"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "minimumContractPeriod": {
+      "enum": [
+        "Hour",
+        "Day",
+        "Month",
+        "Year",
+        "Other"
+      ]
+    },
+    "networksConnected": {
+      "items": {
+        "enum": [
+          "Internet",
+          "Public Services Network (PSN)",
+          "Government Secure intranet (GSi)",
+          "Police National Network (PNN)",
+          "New NHS Network (N3)",
+          "Joint Academic Network (JANET)",
+          "Other"
+        ]
+      },
+      "maxItems": 7,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "offlineWorking": {
+      "type": "boolean"
+    },
+    "onboardingGuidance": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "openSource": {
+      "type": "boolean"
+    },
+    "openStandardsSupported": {
+      "type": "boolean"
+    },
+    "otherConsumers": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Contractual commitment",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "enum": [
+            "No other consumer",
+            "Only government consumers",
+            "A specific consumer group, eg Police, Defence or Health",
+            "Anyone - public"
+          ]
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "persistentStorage": {
+      "type": "boolean"
+    },
+    "personnelSecurityChecks": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "items": {
+            "enum": [
+              "Security clearance national vetting (SC)",
+              "Baseline personnel security standard (BPSS)",
+              "Background checks in accordance with BS7858:2012",
+              "Employment checks"
+            ]
+          },
+          "maxItems": 4,
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "priceInterval": {
+      "enum": [
+        "",
+        "Second",
+        "Minute",
+        "Hour",
+        "Day",
+        "Week",
+        "Month",
+        "Quarter",
+        "6 months",
+        "Year"
+      ]
+    },
+    "priceMax": {
+      "pattern": "^$|^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "priceMin": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "priceUnit": {
+      "enum": [
         "Unit",
         "Person",
         "Licence",
@@ -83,950 +825,674 @@
         "Terabyte"
       ]
     },
-    "priceInterval":{
-      "enum":[
-        "",
-        "Second",
-        "Minute",
-        "Hour",
-        "Day",
-        "Week",
-        "Month",
-        "Quarter",
-        "6 months",
-        "Year"
-      ]
+    "pricingDocumentURL": {
+      "format": "uri",
+      "type": "string"
     },
-    "vatIncluded":{
-      "type":"boolean"
+    "provisioningTime": {
+      "maxLength": 200,
+      "minLength": 1,
+      "pattern": "^(?:\\S+\\s+){0,19}\\S+$",
+      "type": "string"
     },
-    "educationPricing":{
-      "type":"boolean"
+    "restrictAdministratorPermissions": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion",
+            "Independent testing of implementation"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
     },
-    "trialOption": {
+    "secureConfigurationManagement": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "secureDesign": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "secureDevelopment": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "selfServiceProvisioning": {
       "type": "boolean"
     },
-    "freeOption": {
+    "serviceAvailabilityPercentage": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Contractual commitment",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "exclusiveMaximum": true,
+          "maximum": 100,
+          "minimum": 0,
+          "type": "number"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "serviceBenefits": {
+      "items": {
+        "maxLength": 100,
+        "pattern": "^(?:\\S+\\s+){0,9}\\S+$",
+        "type": "string"
+      },
+      "maxItems": 10,
+      "minItems": 1,
+      "type": "array"
+    },
+    "serviceConfigurationGuidance": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion",
+            "Independent testing of implementation"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "serviceDefinitionDocumentURL": {
+      "format": "uri",
+      "type": "string"
+    },
+    "serviceFeatures": {
+      "items": {
+        "maxLength": 100,
+        "pattern": "^(?:\\S+\\s+){0,9}\\S+$",
+        "type": "string"
+      },
+      "maxItems": 10,
+      "minItems": 1,
+      "type": "array"
+    },
+    "serviceManagementModel": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "items": {
+            "enum": [
+              "Dedicated devices on a segregated network",
+              "Dedicated devices for community service management",
+              "Dedicated devices for multiple community service management",
+              "Service management via bastion hosts",
+              "Direct service management"
+            ]
+          },
+          "maxItems": 5,
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "serviceName": {
+      "maxLength": 100,
+      "minLength": 1,
+      "type": "string"
+    },
+    "serviceOffboarding": {
       "type": "boolean"
     },
-    "terminationCost":{
-      "type":"boolean"
+    "serviceOnboarding": {
+      "type": "boolean"
     },
-    "minimumContractPeriod":{
-      "enum":[
-        "Hour",
-        "Day",
-        "Month",
-        "Year",
-        "Other"
-      ]
+    "serviceSummary": {
+      "maxLength": 500,
+      "minLength": 1,
+      "pattern": "^(?:\\S+\\s+){0,49}\\S+$",
+      "type": "string"
     },
-    "supportTypes":{
-      "type":"array",
-      "uniqueItems":true,
-      "minItems":1,
-      "maxItems":5,
-      "items":{
-        "enum":[
+    "serviceTypes": {
+      "items": {
+        "enum": [
+          "Compute",
+          "Storage"
+        ]
+      },
+      "maxItems": 2,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "servicesManagementSeparation": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent testing of implementation",
+            "Assurance of service design",
+            "CESG-assured components"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "servicesSeparation": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent testing of implementation",
+            "Assurance of service design",
+            "CESG-assured components"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "sfiaRateDocumentURL": {
+      "format": "uri",
+      "type": "string"
+    },
+    "supportAvailability": {
+      "maxLength": 200,
+      "minLength": 1,
+      "pattern": "^(?:\\S+\\s+){0,19}\\S+$",
+      "type": "string"
+    },
+    "supportForThirdParties": {
+      "type": "boolean"
+    },
+    "supportResponseTime": {
+      "maxLength": 200,
+      "minLength": 1,
+      "pattern": "^(?:\\S+\\s+){0,19}\\S+$",
+      "type": "string"
+    },
+    "supportTypes": {
+      "items": {
+        "enum": [
           "Service desk",
           "Email",
           "Phone",
           "Live chat",
           "Onsite"
         ]
-      }
-    },
-    "supportForThirdParties":{
-      "type":"boolean"
-    },
-    "supportAvailability":{
-      "type":"string",
-      "maxLength":200,
-      "pattern":"^(?:\\S+\\s+){0,19}\\S+$",
-      "minLength":1
-    },
-    "supportResponseTime":{
-      "type":"string",
-      "maxLength":200,
-      "pattern":"^(?:\\S+\\s+){0,19}\\S+$",
-      "minLength":1
-    },
-    "incidentEscalation":{
-      "type":"boolean"
-    },
-    "openStandardsSupported": {
-      "type": "boolean"
-    },
-    "serviceOnboarding": {
-      "type": "boolean"
-    },
-    "serviceOffboarding": {
-      "type": "boolean"
-    },
-    "analyticsAvailable": {
-      "type": "boolean"
-    },
-    "elasticCloud": {
-      "type": "boolean"
-    },
-    "guaranteedResources": {
-      "type": "boolean"
-    },
-    "persistentStorage": {
-      "type": "boolean"
-    },
-    "selfServiceProvisioning": {
-      "type": "boolean"
-    },
-    "provisioningTime": {
-      "type": "string",
-      "maxLength":200,
-      "pattern":"^(?:\\S+\\s+){0,19}\\S+$",
-      "minLength":1
-    },
-    "deprovisioningTime": {
-      "type": "string",
-      "maxLength":200,
-      "pattern":"^(?:\\S+\\s+){0,19}\\S+$",
-      "minLength":1
-    },
-    "openSource": {
-      "type": "boolean"
-    },
-    "apiAccess": {
-      "type": "boolean"
-    },
-    "apiType": {
-      "type": "string",
-      "maxLength":200,
-      "pattern":"^$|(^(?:\\S+\\s+){0,19}\\S+$)"
-    },
-    "networksConnected": {
+      },
+      "maxItems": 5,
+      "minItems": 1,
       "type": "array",
-      "uniqueItems": true,
-      "maxItems": 7,
-      "items": {
-        "enum": ["Internet", "Public Services Network (PSN)", "Government Secure intranet (GSi)", "Police National Network (PNN)", "New NHS Network (N3)", "Joint Academic Network (JANET)", "Other"]
-      }
+      "uniqueItems": true
     },
     "supportedBrowsers": {
-      "type": "array",
-      "uniqueItems": true,
-      "maxItems": 9,
       "items": {
-        "enum": ["Internet Explorer 6", "Internet Explorer 7", "Internet Explorer 8", "Internet Explorer 9", "Internet Explorer 10+", "Firefox", "Chrome", "Safari", "Opera"]
-      }
-    },
-    "offlineWorking": {
-      "type": "boolean"
+        "enum": [
+          "Internet Explorer 6",
+          "Internet Explorer 7",
+          "Internet Explorer 8",
+          "Internet Explorer 9",
+          "Internet Explorer 10+",
+          "Firefox",
+          "Chrome",
+          "Safari",
+          "Opera"
+        ]
+      },
+      "maxItems": 9,
+      "type": "array",
+      "uniqueItems": true
     },
     "supportedDevices": {
-      "type": "array",
-      "uniqueItems": true,
-      "maxItems": 4,
       "items": {
-        "enum": ["PC", "Mac", "Smartphone", "Tablet"]
-      }
+        "enum": [
+          "PC",
+          "Mac",
+          "Smartphone",
+          "Tablet"
+        ]
+      },
+      "maxItems": 4,
+      "type": "array",
+      "uniqueItems": true
     },
-    "vendorCertifications":{
-      "type":"array",
-      "maxItems":10,
-      "items":{
-        "type":"string",
-        "maxLength":100,
-        "pattern":"^(?:\\S+\\s+){0,9}\\S+$"
-      }
-    },
-    "datacentresEUCode": {
+    "terminationCost": {
       "type": "boolean"
     },
-    "datacentresSpecifyLocation": {
-      "type": "boolean"
-    },
-    "datacentreTier": {
-      "enum":[
-        "TIA-942 Tier 1",
-        "TIA-942 Tier 2",
-        "TIA-942 Tier 3",
-        "TIA-942 Tier 4",
-        "Uptime Institute Tier 1",
-        "Uptime Institute Tier 2",
-        "Uptime Institute Tier 3",
-        "Uptime Institute Tier 4",
-        "None of the above"
-      ]
-    },
-    "dataBackupRecovery": {
-      "type": "boolean"
-    },
-    "dataExtractionRemoval": {
-      "type": "boolean"
-    },
-    "dataProtectionBetweenUserAndService": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "array",
-          "uniqueItems": true,
-          "maxItems": 6,
-          "items": {
-            "enum": ["Encrypted PSN service", "PSN service", "CPA Foundation VPN Gateway", "VPN using TLS, version 1.2 or later", "VPN using legacy SSL or TLS", "No encryption"]
-          }
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation", "CESG-assured components"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "dataProtectionWithinService": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "array",
-          "uniqueItems": true,
-          "maxItems": 6,
-          "items": {
-            "enum": ["VPN using TLS, version 1.2 or later", "VPN using legacy SSL or TLS", "VLAN", "Bonded fibre optic connections", "Other network protection", "No encryption"]
-          }
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation", "CESG-assured components"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "dataProtectionBetweenServices": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "array",
-          "uniqueItems": true,
-          "maxItems": 6,
-          "items": {
-            "enum": ["Encrypted PSN service", "PSN service", "CPA Foundation VPN Gateway", "VPN using TLS, version 1.2 or later", "VPN using legacy SSL or TLS", "No encryption"]
-          }
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation", "CESG-assured components"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "datacentreLocations": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "array",
-          "uniqueItems": true,
-          "maxItems": 5,
-          "items": {
-            "enum": ["UK", "EU", "USA - Safe Harbor", "Other countries with data protection treaties", "Rest of world"]
-          }
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "dataManagementLocations": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "array",
-          "uniqueItems": true,
-          "maxItems": 5,
-          "items": {
-            "enum": ["UK", "EU", "USA - Safe Harbor", "Other countries with data protection treaties", "Rest of world"]
-          }
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "legalJurisdiction": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "enum": ["UK", "EU", "USA - Safe Harbor", "Other countries with data protection treaties", "Rest of world"]
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "datacentreProtectionDisclosure": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "dataAtRestProtections": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "array",
-          "uniqueItems": true,
-          "maxItems": 6,
-          "items": {
-            "enum": ["CPA Foundation-grade assured components", "FIPS-assured encryption", "Other encryption", "Secure containers, racks or cages", "Physical access control", "No protection"]
-          }
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation", "CESG-assured components"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "dataSecureDeletion": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "enum": ["CPA Foundation-grade erasure product", "CESG or CPNI-approved erasure process", "Other secure erasure process", "Other erasure process"]
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation", "CESG-assured components"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "dataStorageMediaDisposal": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "enum": ["CESG-assured destruction service (CAS(T))", "CPA Foundation-assured product", "CPNI-approved destruction service", "BS EN 151713:2009-compliant destruction", "CESG or CPNI-approved erasure process", "Other secure erasure process", "Other destruction/erasure process"]
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion", "Independent testing of implementation", "CESG-assured components"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "dataSecureEquipmentDisposal": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion", "CESG-assured components"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "dataRedundantEquipmentAccountsRevoked": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "serviceAvailabilityPercentage": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "number",
-          "minimum": 0,
-          "maximum": 100,
-          "exclusiveMaximum": true
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "cloudDeploymentModel": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "enum": ["Public cloud", "Community cloud", "Private cloud", "Hybrid cloud"]
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "otherConsumers": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "enum": ["No other consumer", "Only government consumers", "A specific consumer group, eg Police, Defence or Health", "Anyone - public"]
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "servicesSeparation": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent testing of implementation", "Assurance of service design", "CESG-assured components"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "servicesManagementSeparation": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent testing of implementation", "Assurance of service design", "CESG-assured components"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "governanceFramework": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "configurationTracking": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "changeImpactAssessment": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "vulnerabilityAssessment": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "vulnerabilityMonitoring": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "vulnerabilityMitigationPrioritisation": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "vulnerabilityTracking": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "vulnerabilityTimescales": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "eventMonitoring": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "incidentManagementProcess": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "incidentManagementReporting": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "incidentDefinitionPublished": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "personnelSecurityChecks": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "array",
-          "uniqueItems": true,
-          "maxItems": 4,
-          "items": {
-            "enum": ["Security clearance national vetting (SC)", "Baseline personnel security standard (BPSS)", "Background checks in accordance with BS7858:2012", "Employment checks"]
-          }
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "secureDevelopment": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "secureDesign": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "secureConfigurationManagement": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "thirdPartyDataSharingInformation": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "thirdPartySecurityRequirements": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "thirdPartyRiskAssessment": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
+    "termsAndConditionsDocumentURL": {
+      "format": "uri",
+      "type": "string"
     },
     "thirdPartyComplianceMonitoring": {
-      "type": "object",
       "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
         "value": {
           "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
       },
-      "required": ["value", "assurance"]
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
     },
-    "hardwareSoftwareVerification": {
-      "type": "object",
+    "thirdPartyDataSharingInformation": {
       "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
         "value": {
           "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
       },
-      "required": ["value", "assurance"]
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
     },
-    "userAuthenticateManagement": {
-      "type": "object",
+    "thirdPartyRiskAssessment": {
       "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
         "value": {
           "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation"]
         }
       },
-      "required": ["value", "assurance"]
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
     },
-    "userAuthenticateSupport": {
-      "type": "object",
+    "thirdPartySecurityRequirements": {
       "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
         "value": {
           "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation"]
         }
       },
-      "required": ["value", "assurance"]
-    },
-    "userAccessControlManagement": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "restrictAdministratorPermissions": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "managementInterfaceProtection": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "identityAuthenticationControls": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "array",
-          "uniqueItems": true,
-          "maxItems": 7,
-          "items": {
-            "enum": ["Username and two-factor authentication", "Username and TLS client certificate", "Authentication federation", "Limited access over dedicated link, enterprise or community network", "Username and password", "Username and strong password/passphrase enforcement", "Other mechanism"]
-          }
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent testing of implementation", "CESG-assured components"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "onboardingGuidance": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "interconnectionMethods": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "array",
-          "uniqueItems": true,
-          "maxItems": 4,
-          "items": {
-            "enum": ["Encrypted PSN service", "PSN service", "Private WAN", "Internet"]
-          }
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "serviceManagementModel": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "array",
-          "uniqueItems": true,
-          "maxItems": 5,
-          "items": {
-            "enum": ["Dedicated devices on a segregated network", "Dedicated devices for community service management", "Dedicated devices for multiple community service management", "Service management via bastion hosts", "Direct service management"]
-          }
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "auditInformationProvided": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "enum": ["None", "Data made available", "Data made available by negotiation"]
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "deviceAccessMethod": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "array",
-          "uniqueItems": true,
-          "maxItems": 3,
-          "items": {
-            "enum": ["Corporate/enterprise devices", "Partner devices", "Unknown devices"]
-          }
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "serviceConfigurationGuidance": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation"]
-        }
-      },
-      "required": ["value", "assurance"]
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
     },
     "trainingProvided": {
-      "type": "object",
       "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
         "value": {
           "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
       },
-      "required": ["value", "assurance"]
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "trialOption": {
+      "type": "boolean"
+    },
+    "userAccessControlManagement": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion",
+            "Independent testing of implementation"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "userAuthenticateManagement": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion",
+            "Independent testing of implementation"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "userAuthenticateSupport": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion",
+            "Independent testing of implementation"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "vatIncluded": {
+      "type": "boolean"
+    },
+    "vendorCertifications": {
+      "items": {
+        "maxLength": 100,
+        "pattern": "^(?:\\S+\\s+){0,9}\\S+$",
+        "type": "string"
+      },
+      "maxItems": 10,
+      "type": "array"
+    },
+    "vulnerabilityAssessment": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "vulnerabilityMitigationPrioritisation": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "vulnerabilityMonitoring": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "vulnerabilityTimescales": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "vulnerabilityTracking": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
     }
   },
-  "required":[
-    "serviceDefinitionDocumentURL",
-    "termsAndConditionsDocumentURL",
-    "pricingDocumentURL",
-    "serviceName",
-    "serviceSummary",
-    "serviceTypes",
-    "serviceFeatures",
-    "serviceBenefits",
-    "priceMin",
-    "priceUnit",
-    "vatIncluded",
-    "educationPricing",
-    "trialOption",
-    "freeOption",
-    "terminationCost",
-    "minimumContractPeriod",
-    "supportTypes",
-    "supportForThirdParties",
-    "supportAvailability",
-    "supportResponseTime",
-    "incidentEscalation",
-    "openStandardsSupported",
-    "serviceOnboarding",
-    "serviceOffboarding",
+  "required": [
     "analyticsAvailable",
-    "elasticCloud",
-    "guaranteedResources",
-    "persistentStorage",
-    "selfServiceProvisioning",
-    "provisioningTime",
-    "deprovisioningTime",
-    "openSource",
     "apiAccess",
-    "networksConnected",
-    "supportedBrowsers",
-    "offlineWorking",
-    "supportedDevices",
-    "datacentresEUCode",
-    "datacentresSpecifyLocation",
-    "datacentreTier",
+    "auditInformationProvided",
+    "changeImpactAssessment",
+    "cloudDeploymentModel",
+    "configurationTracking",
+    "dataAtRestProtections",
     "dataBackupRecovery",
     "dataExtractionRemoval",
+    "dataManagementLocations",
+    "dataProtectionBetweenServices",
     "dataProtectionBetweenUserAndService",
     "dataProtectionWithinService",
-    "dataProtectionBetweenServices",
-    "datacentreLocations",
-    "dataManagementLocations",
-    "legalJurisdiction",
-    "datacentreProtectionDisclosure",
-    "dataAtRestProtections",
-    "dataSecureDeletion",
-    "dataStorageMediaDisposal",
-    "dataSecureEquipmentDisposal",
     "dataRedundantEquipmentAccountsRevoked",
-    "serviceAvailabilityPercentage",
-    "cloudDeploymentModel",
-    "otherConsumers",
-    "servicesSeparation",
-    "servicesManagementSeparation",
-    "governanceFramework",
-    "configurationTracking",
-    "changeImpactAssessment",
-    "vulnerabilityAssessment",
-    "vulnerabilityMonitoring",
-    "vulnerabilityMitigationPrioritisation",
-    "vulnerabilityTracking",
-    "vulnerabilityTimescales",
+    "dataSecureDeletion",
+    "dataSecureEquipmentDisposal",
+    "dataStorageMediaDisposal",
+    "datacentreLocations",
+    "datacentreProtectionDisclosure",
+    "datacentreTier",
+    "datacentresEUCode",
+    "datacentresSpecifyLocation",
+    "deprovisioningTime",
+    "deviceAccessMethod",
+    "educationPricing",
+    "elasticCloud",
     "eventMonitoring",
+    "freeOption",
+    "governanceFramework",
+    "guaranteedResources",
+    "hardwareSoftwareVerification",
+    "identityAuthenticationControls",
+    "incidentDefinitionPublished",
+    "incidentEscalation",
     "incidentManagementProcess",
     "incidentManagementReporting",
-    "incidentDefinitionPublished",
+    "interconnectionMethods",
+    "legalJurisdiction",
+    "managementInterfaceProtection",
+    "minimumContractPeriod",
+    "networksConnected",
+    "offlineWorking",
+    "onboardingGuidance",
+    "openSource",
+    "openStandardsSupported",
+    "otherConsumers",
+    "persistentStorage",
     "personnelSecurityChecks",
-    "secureDevelopment",
-    "secureDesign",
+    "priceMin",
+    "priceUnit",
+    "pricingDocumentURL",
+    "provisioningTime",
+    "restrictAdministratorPermissions",
     "secureConfigurationManagement",
-    "thirdPartyDataSharingInformation",
-    "thirdPartySecurityRequirements",
-    "thirdPartyRiskAssessment",
+    "secureDesign",
+    "secureDevelopment",
+    "selfServiceProvisioning",
+    "serviceAvailabilityPercentage",
+    "serviceBenefits",
+    "serviceConfigurationGuidance",
+    "serviceDefinitionDocumentURL",
+    "serviceFeatures",
+    "serviceManagementModel",
+    "serviceName",
+    "serviceOffboarding",
+    "serviceOnboarding",
+    "serviceSummary",
+    "serviceTypes",
+    "servicesManagementSeparation",
+    "servicesSeparation",
+    "supportAvailability",
+    "supportForThirdParties",
+    "supportResponseTime",
+    "supportTypes",
+    "supportedBrowsers",
+    "supportedDevices",
+    "terminationCost",
+    "termsAndConditionsDocumentURL",
     "thirdPartyComplianceMonitoring",
-    "hardwareSoftwareVerification",
+    "thirdPartyDataSharingInformation",
+    "thirdPartyRiskAssessment",
+    "thirdPartySecurityRequirements",
+    "trainingProvided",
+    "trialOption",
+    "userAccessControlManagement",
     "userAuthenticateManagement",
     "userAuthenticateSupport",
-    "userAccessControlManagement",
-    "restrictAdministratorPermissions",
-    "managementInterfaceProtection",
-    "identityAuthenticationControls",
-    "onboardingGuidance",
-    "interconnectionMethods",
-    "serviceManagementModel",
-    "auditInformationProvided",
-    "deviceAccessMethod",
-    "serviceConfigurationGuidance",
-    "trainingProvided"
-
-  ]
+    "vatIncluded",
+    "vulnerabilityAssessment",
+    "vulnerabilityMitigationPrioritisation",
+    "vulnerabilityMonitoring",
+    "vulnerabilityTimescales",
+    "vulnerabilityTracking"
+  ],
+  "title": "G-Cloud 7 IaaS Service Schema",
+  "type": "object"
 }

--- a/json_schemas/services-g-cloud-7-iaas.json
+++ b/json_schemas/services-g-cloud-7-iaas.json
@@ -10,6 +10,7 @@
     },
     "apiType": {
       "maxLength": 200,
+      "minLength": 0,
       "pattern": "^$|(^(?:\\S+\\s+){0,19}\\S+$)",
       "type": "string"
     },
@@ -117,6 +118,7 @@
             ]
           },
           "maxItems": 6,
+          "minItems": 1,
           "type": "array",
           "uniqueItems": true
         }
@@ -153,6 +155,7 @@
             ]
           },
           "maxItems": 5,
+          "minItems": 1,
           "type": "array",
           "uniqueItems": true
         }
@@ -185,6 +188,7 @@
             ]
           },
           "maxItems": 6,
+          "minItems": 1,
           "type": "array",
           "uniqueItems": true
         }
@@ -217,6 +221,7 @@
             ]
           },
           "maxItems": 6,
+          "minItems": 1,
           "type": "array",
           "uniqueItems": true
         }
@@ -249,6 +254,7 @@
             ]
           },
           "maxItems": 6,
+          "minItems": 1,
           "type": "array",
           "uniqueItems": true
         }
@@ -372,6 +378,7 @@
             ]
           },
           "maxItems": 5,
+          "minItems": 1,
           "type": "array",
           "uniqueItems": true
         }
@@ -443,6 +450,7 @@
             ]
           },
           "maxItems": 3,
+          "minItems": 1,
           "type": "array",
           "uniqueItems": true
         }
@@ -541,6 +549,7 @@
             ]
           },
           "maxItems": 7,
+          "minItems": 1,
           "type": "array",
           "uniqueItems": true
         }
@@ -626,6 +635,7 @@
             ]
           },
           "maxItems": 4,
+          "minItems": 1,
           "type": "array",
           "uniqueItems": true
         }
@@ -702,6 +712,7 @@
         ]
       },
       "maxItems": 7,
+      "minItems": 1,
       "type": "array",
       "uniqueItems": true
     },
@@ -777,6 +788,7 @@
             ]
           },
           "maxItems": 4,
+          "minItems": 1,
           "type": "array",
           "uniqueItems": true
         }
@@ -995,6 +1007,7 @@
             ]
           },
           "maxItems": 5,
+          "minItems": 1,
           "type": "array",
           "uniqueItems": true
         }
@@ -1030,6 +1043,7 @@
         ]
       },
       "maxItems": 2,
+      "minItems": 1,
       "type": "array",
       "uniqueItems": true
     },
@@ -1122,6 +1136,7 @@
         ]
       },
       "maxItems": 9,
+      "minItems": 1,
       "type": "array",
       "uniqueItems": true
     },
@@ -1135,6 +1150,7 @@
         ]
       },
       "maxItems": 4,
+      "minItems": 1,
       "type": "array",
       "uniqueItems": true
     },
@@ -1305,6 +1321,7 @@
         "type": "string"
       },
       "maxItems": 10,
+      "minItems": 0,
       "type": "array"
     },
     "vulnerabilityAssessment": {

--- a/json_schemas/services-g-cloud-7-paas.json
+++ b/json_schemas/services-g-cloud-7-paas.json
@@ -10,6 +10,7 @@
     },
     "apiType": {
       "maxLength": 200,
+      "minLength": 0,
       "pattern": "^$|(^(?:\\S+\\s+){0,19}\\S+$)",
       "type": "string"
     },
@@ -117,6 +118,7 @@
             ]
           },
           "maxItems": 6,
+          "minItems": 1,
           "type": "array",
           "uniqueItems": true
         }
@@ -153,6 +155,7 @@
             ]
           },
           "maxItems": 5,
+          "minItems": 1,
           "type": "array",
           "uniqueItems": true
         }
@@ -185,6 +188,7 @@
             ]
           },
           "maxItems": 6,
+          "minItems": 1,
           "type": "array",
           "uniqueItems": true
         }
@@ -217,6 +221,7 @@
             ]
           },
           "maxItems": 6,
+          "minItems": 1,
           "type": "array",
           "uniqueItems": true
         }
@@ -249,6 +254,7 @@
             ]
           },
           "maxItems": 6,
+          "minItems": 1,
           "type": "array",
           "uniqueItems": true
         }
@@ -346,6 +352,10 @@
           ]
         }
       },
+      "required": [
+        "value",
+        "assurance"
+      ],
       "type": "object"
     },
     "datacentreLocations": {
@@ -368,6 +378,7 @@
             ]
           },
           "maxItems": 5,
+          "minItems": 1,
           "type": "array",
           "uniqueItems": true
         }
@@ -439,6 +450,7 @@
             ]
           },
           "maxItems": 3,
+          "minItems": 1,
           "type": "array",
           "uniqueItems": true
         }
@@ -537,6 +549,7 @@
             ]
           },
           "maxItems": 7,
+          "minItems": 1,
           "type": "array",
           "uniqueItems": true
         }
@@ -622,6 +635,7 @@
             ]
           },
           "maxItems": 4,
+          "minItems": 1,
           "type": "array",
           "uniqueItems": true
         }
@@ -698,6 +712,7 @@
         ]
       },
       "maxItems": 7,
+      "minItems": 1,
       "type": "array",
       "uniqueItems": true
     },
@@ -773,6 +788,7 @@
             ]
           },
           "maxItems": 4,
+          "minItems": 1,
           "type": "array",
           "uniqueItems": true
         }
@@ -991,6 +1007,7 @@
             ]
           },
           "maxItems": 5,
+          "minItems": 1,
           "type": "array",
           "uniqueItems": true
         }
@@ -1107,6 +1124,7 @@
         ]
       },
       "maxItems": 9,
+      "minItems": 1,
       "type": "array",
       "uniqueItems": true
     },
@@ -1120,6 +1138,7 @@
         ]
       },
       "maxItems": 4,
+      "minItems": 1,
       "type": "array",
       "uniqueItems": true
     },
@@ -1290,6 +1309,7 @@
         "type": "string"
       },
       "maxItems": 10,
+      "minItems": 0,
       "type": "array"
     },
     "vulnerabilityAssessment": {

--- a/json_schemas/services-g-cloud-7-paas.json
+++ b/json_schemas/services-g-cloud-7-paas.json
@@ -1,67 +1,812 @@
 {
-  "title":"G-Cloud 7 PaaS Service Schema",
-  "$schema":"http://json-schema.org/schema#",
-  "type":"object",
-  "additionalProperties":false,
-  "properties":{
-    "serviceDefinitionDocumentURL":{
-      "type":"string",
-      "format":"uri"
+  "$schema": "http://json-schema.org/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "analyticsAvailable": {
+      "type": "boolean"
     },
-    "termsAndConditionsDocumentURL":{
-      "type":"string",
-      "format":"uri"
+    "apiAccess": {
+      "type": "boolean"
     },
-    "pricingDocumentURL":{
-      "type":"string",
-      "format":"uri"
+    "apiType": {
+      "maxLength": 200,
+      "pattern": "^$|(^(?:\\S+\\s+){0,19}\\S+$)",
+      "type": "string"
     },
-    "sfiaRateDocumentURL":{
-      "type":"string",
-      "format":"uri"
+    "auditInformationProvided": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "enum": [
+            "None",
+            "Data made available",
+            "Data made available by negotiation"
+          ]
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
     },
-    "serviceName":{
-      "type":"string",
-      "minLength":1,
-      "maxLength":100
+    "changeImpactAssessment": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
     },
-    "serviceSummary":{
-      "type":"string",
-      "maxLength":500,
-      "pattern":"^(?:\\S+\\s+){0,49}\\S+$",
-      "minLength":1
-
+    "cloudDeploymentModel": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Contractual commitment",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "enum": [
+            "Public cloud",
+            "Community cloud",
+            "Private cloud",
+            "Hybrid cloud"
+          ]
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
     },
-    "serviceFeatures":{
-      "type":"array",
-      "minItems":1,
-      "maxItems":10,
-      "items":{
-        "type":"string",
-        "maxLength":100,
-        "pattern":"^(?:\\S+\\s+){0,9}\\S+$"
-      }
+    "configurationTracking": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
     },
-    "serviceBenefits":{
-      "type":"array",
-      "minItems":1,
-      "maxItems":10,
-      "items":{
-        "type":"string",
-        "maxLength":100,
-        "pattern":"^(?:\\S+\\s+){0,9}\\S+$"
-      }
+    "dataAtRestProtections": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion",
+            "Independent testing of implementation",
+            "CESG-assured components"
+          ]
+        },
+        "value": {
+          "items": {
+            "enum": [
+              "CPA Foundation-grade assured components",
+              "FIPS-assured encryption",
+              "Other encryption",
+              "Secure containers, racks or cages",
+              "Physical access control",
+              "No protection"
+            ]
+          },
+          "maxItems": 6,
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
     },
-    "priceMin":{
-      "type":"string",
-      "pattern": "^\\d+(?:\\.\\d{1,5})?$"
+    "dataBackupRecovery": {
+      "type": "boolean"
     },
-    "priceMax":{
-      "type": "string",
-      "pattern": "^$|^\\d+(?:\\.\\d{1,5})?$"
+    "dataExtractionRemoval": {
+      "type": "boolean"
     },
-    "priceUnit":{
-      "enum":[
+    "dataManagementLocations": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Contractual commitment",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "items": {
+            "enum": [
+              "UK",
+              "EU",
+              "USA - Safe Harbor",
+              "Other countries with data protection treaties",
+              "Rest of world"
+            ]
+          },
+          "maxItems": 5,
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "dataProtectionBetweenServices": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion",
+            "Independent testing of implementation",
+            "CESG-assured components"
+          ]
+        },
+        "value": {
+          "items": {
+            "enum": [
+              "Encrypted PSN service",
+              "PSN service",
+              "CPA Foundation VPN Gateway",
+              "VPN using TLS, version 1.2 or later",
+              "VPN using legacy SSL or TLS",
+              "No encryption"
+            ]
+          },
+          "maxItems": 6,
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "dataProtectionBetweenUserAndService": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion",
+            "Independent testing of implementation",
+            "CESG-assured components"
+          ]
+        },
+        "value": {
+          "items": {
+            "enum": [
+              "Encrypted PSN service",
+              "PSN service",
+              "CPA Foundation VPN Gateway",
+              "VPN using TLS, version 1.2 or later",
+              "VPN using legacy SSL or TLS",
+              "No encryption"
+            ]
+          },
+          "maxItems": 6,
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "dataProtectionWithinService": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion",
+            "Independent testing of implementation",
+            "CESG-assured components"
+          ]
+        },
+        "value": {
+          "items": {
+            "enum": [
+              "VPN using TLS, version 1.2 or later",
+              "VPN using legacy SSL or TLS",
+              "VLAN",
+              "Bonded fibre optic connections",
+              "Other network protection",
+              "No encryption"
+            ]
+          },
+          "maxItems": 6,
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "dataRedundantEquipmentAccountsRevoked": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Contractual commitment",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "dataSecureDeletion": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion",
+            "Independent testing of implementation",
+            "CESG-assured components"
+          ]
+        },
+        "value": {
+          "enum": [
+            "CPA Foundation-grade erasure product",
+            "CESG or CPNI-approved erasure process",
+            "Other secure erasure process",
+            "Other erasure process"
+          ]
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "dataSecureEquipmentDisposal": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Contractual commitment",
+            "Independent validation of assertion",
+            "CESG-assured components"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "dataStorageMediaDisposal": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Contractual commitment",
+            "Independent validation of assertion",
+            "Independent testing of implementation",
+            "CESG-assured components"
+          ]
+        },
+        "value": {
+          "enum": [
+            "CESG-assured destruction service (CAS(T))",
+            "CPA Foundation-assured product",
+            "CPNI-approved destruction service",
+            "BS EN 151713:2009-compliant destruction",
+            "CESG or CPNI-approved erasure process",
+            "Other secure erasure process",
+            "Other destruction/erasure process"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "datacentreLocations": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Contractual commitment",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "items": {
+            "enum": [
+              "UK",
+              "EU",
+              "USA - Safe Harbor",
+              "Other countries with data protection treaties",
+              "Rest of world"
+            ]
+          },
+          "maxItems": 5,
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "datacentreProtectionDisclosure": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Contractual commitment",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "datacentreTier": {
+      "enum": [
+        "TIA-942 Tier 1",
+        "TIA-942 Tier 2",
+        "TIA-942 Tier 3",
+        "TIA-942 Tier 4",
+        "Uptime Institute Tier 1",
+        "Uptime Institute Tier 2",
+        "Uptime Institute Tier 3",
+        "Uptime Institute Tier 4",
+        "None of the above"
+      ]
+    },
+    "datacentresEUCode": {
+      "type": "boolean"
+    },
+    "datacentresSpecifyLocation": {
+      "type": "boolean"
+    },
+    "deprovisioningTime": {
+      "maxLength": 200,
+      "minLength": 1,
+      "pattern": "^(?:\\S+\\s+){0,19}\\S+$",
+      "type": "string"
+    },
+    "deviceAccessMethod": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "items": {
+            "enum": [
+              "Corporate/enterprise devices",
+              "Partner devices",
+              "Unknown devices"
+            ]
+          },
+          "maxItems": 3,
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "educationPricing": {
+      "type": "boolean"
+    },
+    "elasticCloud": {
+      "type": "boolean"
+    },
+    "eventMonitoring": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "freeOption": {
+      "type": "boolean"
+    },
+    "governanceFramework": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "guaranteedResources": {
+      "type": "boolean"
+    },
+    "hardwareSoftwareVerification": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "identityAuthenticationControls": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent testing of implementation",
+            "CESG-assured components"
+          ]
+        },
+        "value": {
+          "items": {
+            "enum": [
+              "Username and two-factor authentication",
+              "Username and TLS client certificate",
+              "Authentication federation",
+              "Limited access over dedicated link, enterprise or community network",
+              "Username and password",
+              "Username and strong password/passphrase enforcement",
+              "Other mechanism"
+            ]
+          },
+          "maxItems": 7,
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "incidentDefinitionPublished": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "incidentEscalation": {
+      "type": "boolean"
+    },
+    "incidentManagementProcess": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "incidentManagementReporting": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "interconnectionMethods": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "items": {
+            "enum": [
+              "Encrypted PSN service",
+              "PSN service",
+              "Private WAN",
+              "Internet"
+            ]
+          },
+          "maxItems": 4,
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "legalJurisdiction": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Contractual commitment",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "enum": [
+            "UK",
+            "EU",
+            "USA - Safe Harbor",
+            "Other countries with data protection treaties",
+            "Rest of world"
+          ]
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "managementInterfaceProtection": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion",
+            "Independent testing of implementation"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "minimumContractPeriod": {
+      "enum": [
+        "Hour",
+        "Day",
+        "Month",
+        "Year",
+        "Other"
+      ]
+    },
+    "networksConnected": {
+      "items": {
+        "enum": [
+          "Internet",
+          "Public Services Network (PSN)",
+          "Government Secure intranet (GSi)",
+          "Police National Network (PNN)",
+          "New NHS Network (N3)",
+          "Joint Academic Network (JANET)",
+          "Other"
+        ]
+      },
+      "maxItems": 7,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "offlineWorking": {
+      "type": "boolean"
+    },
+    "onboardingGuidance": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "openSource": {
+      "type": "boolean"
+    },
+    "openStandardsSupported": {
+      "type": "boolean"
+    },
+    "otherConsumers": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Contractual commitment",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "enum": [
+            "No other consumer",
+            "Only government consumers",
+            "A specific consumer group, eg Police, Defence or Health",
+            "Anyone - public"
+          ]
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "persistentStorage": {
+      "type": "boolean"
+    },
+    "personnelSecurityChecks": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "items": {
+            "enum": [
+              "Security clearance national vetting (SC)",
+              "Baseline personnel security standard (BPSS)",
+              "Background checks in accordance with BS7858:2012",
+              "Employment checks"
+            ]
+          },
+          "maxItems": 4,
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "priceInterval": {
+      "enum": [
+        "",
+        "Second",
+        "Minute",
+        "Hour",
+        "Day",
+        "Week",
+        "Month",
+        "Quarter",
+        "6 months",
+        "Year"
+      ]
+    },
+    "priceMax": {
+      "pattern": "^$|^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "priceMin": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "priceUnit": {
+      "enum": [
         "Unit",
         "Person",
         "Licence",
@@ -76,947 +821,662 @@
         "Terabyte"
       ]
     },
-    "priceInterval":{
-      "enum":[
-        "",
-        "Second",
-        "Minute",
-        "Hour",
-        "Day",
-        "Week",
-        "Month",
-        "Quarter",
-        "6 months",
-        "Year"
-      ]
+    "pricingDocumentURL": {
+      "format": "uri",
+      "type": "string"
     },
-    "vatIncluded":{
-      "type":"boolean"
+    "provisioningTime": {
+      "maxLength": 200,
+      "minLength": 1,
+      "pattern": "^(?:\\S+\\s+){0,19}\\S+$",
+      "type": "string"
     },
-    "educationPricing":{
-      "type":"boolean"
+    "restrictAdministratorPermissions": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion",
+            "Independent testing of implementation"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
     },
-    "trialOption": {
+    "secureConfigurationManagement": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "secureDesign": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "secureDevelopment": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "selfServiceProvisioning": {
       "type": "boolean"
     },
-    "freeOption": {
+    "serviceAvailabilityPercentage": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Contractual commitment",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "exclusiveMaximum": true,
+          "maximum": 100,
+          "minimum": 0,
+          "type": "number"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "serviceBenefits": {
+      "items": {
+        "maxLength": 100,
+        "pattern": "^(?:\\S+\\s+){0,9}\\S+$",
+        "type": "string"
+      },
+      "maxItems": 10,
+      "minItems": 1,
+      "type": "array"
+    },
+    "serviceConfigurationGuidance": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion",
+            "Independent testing of implementation"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "serviceDefinitionDocumentURL": {
+      "format": "uri",
+      "type": "string"
+    },
+    "serviceFeatures": {
+      "items": {
+        "maxLength": 100,
+        "pattern": "^(?:\\S+\\s+){0,9}\\S+$",
+        "type": "string"
+      },
+      "maxItems": 10,
+      "minItems": 1,
+      "type": "array"
+    },
+    "serviceManagementModel": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "items": {
+            "enum": [
+              "Dedicated devices on a segregated network",
+              "Dedicated devices for community service management",
+              "Dedicated devices for multiple community service management",
+              "Service management via bastion hosts",
+              "Direct service management"
+            ]
+          },
+          "maxItems": 5,
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "serviceName": {
+      "maxLength": 100,
+      "minLength": 1,
+      "type": "string"
+    },
+    "serviceOffboarding": {
       "type": "boolean"
     },
-    "terminationCost":{
-      "type":"boolean"
+    "serviceOnboarding": {
+      "type": "boolean"
     },
-    "minimumContractPeriod":{
-      "enum":[
-        "Hour",
-        "Day",
-        "Month",
-        "Year",
-        "Other"
-      ]
+    "serviceSummary": {
+      "maxLength": 500,
+      "minLength": 1,
+      "pattern": "^(?:\\S+\\s+){0,49}\\S+$",
+      "type": "string"
     },
-    "supportTypes":{
-      "type":"array",
-      "uniqueItems":true,
-      "minItems":1,
-      "maxItems":5,
-      "items":{
-        "enum":[
+    "servicesManagementSeparation": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent testing of implementation",
+            "Assurance of service design",
+            "CESG-assured components"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "servicesSeparation": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent testing of implementation",
+            "Assurance of service design",
+            "CESG-assured components"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "sfiaRateDocumentURL": {
+      "format": "uri",
+      "type": "string"
+    },
+    "supportAvailability": {
+      "maxLength": 200,
+      "minLength": 1,
+      "pattern": "^(?:\\S+\\s+){0,19}\\S+$",
+      "type": "string"
+    },
+    "supportForThirdParties": {
+      "type": "boolean"
+    },
+    "supportResponseTime": {
+      "maxLength": 200,
+      "minLength": 1,
+      "pattern": "^(?:\\S+\\s+){0,19}\\S+$",
+      "type": "string"
+    },
+    "supportTypes": {
+      "items": {
+        "enum": [
           "Service desk",
           "Email",
           "Phone",
           "Live chat",
           "Onsite"
         ]
-      }
-    },
-    "supportForThirdParties":{
-      "type":"boolean"
-    },
-    "supportAvailability":{
-      "type":"string",
-      "maxLength":200,
-      "pattern":"^(?:\\S+\\s+){0,19}\\S+$",
-      "minLength":1
-    },
-    "supportResponseTime":{
-      "type":"string",
-      "maxLength":200,
-      "pattern":"^(?:\\S+\\s+){0,19}\\S+$",
-      "minLength":1
-    },
-    "incidentEscalation":{
-      "type":"boolean"
-    },
-    "openStandardsSupported": {
-      "type": "boolean"
-    },
-    "serviceOnboarding": {
-      "type": "boolean"
-    },
-    "serviceOffboarding": {
-      "type": "boolean"
-    },
-    "analyticsAvailable": {
-      "type": "boolean"
-    },
-    "elasticCloud": {
-      "type": "boolean"
-    },
-    "guaranteedResources": {
-      "type": "boolean"
-    },
-    "persistentStorage": {
-      "type": "boolean"
-    },
-    "selfServiceProvisioning": {
-      "type": "boolean"
-    },
-    "provisioningTime": {
-      "type": "string",
-      "maxLength":200,
-      "pattern":"^(?:\\S+\\s+){0,19}\\S+$",
-      "minLength":1
-    },
-    "deprovisioningTime": {
-      "type": "string",
-      "maxLength":200,
-      "pattern":"^(?:\\S+\\s+){0,19}\\S+$",
-      "minLength":1
-    },
-    "openSource": {
-      "type": "boolean"
-    },
-    "apiAccess": {
-      "type": "boolean"
-    },
-    "apiType": {
-      "type": "string",
-      "maxLength":200,
-      "pattern":"^$|(^(?:\\S+\\s+){0,19}\\S+$)"
-    },
-    "networksConnected": {
+      },
+      "maxItems": 5,
+      "minItems": 1,
       "type": "array",
-      "uniqueItems": true,
-      "maxItems": 7,
-      "items": {
-        "enum": ["Internet", "Public Services Network (PSN)", "Government Secure intranet (GSi)", "Police National Network (PNN)", "New NHS Network (N3)", "Joint Academic Network (JANET)", "Other"]
-      }
+      "uniqueItems": true
     },
     "supportedBrowsers": {
-      "type": "array",
-      "uniqueItems": true,
-      "maxItems": 9,
       "items": {
-        "enum": ["Internet Explorer 6", "Internet Explorer 7", "Internet Explorer 8", "Internet Explorer 9", "Internet Explorer 10+", "Firefox", "Chrome", "Safari", "Opera"]
-      }
-    },
-    "offlineWorking": {
-      "type": "boolean"
+        "enum": [
+          "Internet Explorer 6",
+          "Internet Explorer 7",
+          "Internet Explorer 8",
+          "Internet Explorer 9",
+          "Internet Explorer 10+",
+          "Firefox",
+          "Chrome",
+          "Safari",
+          "Opera"
+        ]
+      },
+      "maxItems": 9,
+      "type": "array",
+      "uniqueItems": true
     },
     "supportedDevices": {
-      "type": "array",
-      "uniqueItems": true,
+      "items": {
+        "enum": [
+          "PC",
+          "Mac",
+          "Smartphone",
+          "Tablet"
+        ]
+      },
       "maxItems": 4,
-      "items": {
-        "enum": ["PC", "Mac", "Smartphone", "Tablet"]
-      }
-    },
-    "vendorCertifications": {
       "type": "array",
-      "maxItems": 10,
-      "items": {
-        "type": "string",
-        "maxLength":100,
-        "pattern":"^(?:\\S+\\s+){0,9}\\S+$"
-      }
+      "uniqueItems": true
     },
-    "datacentresEUCode": {
+    "terminationCost": {
       "type": "boolean"
     },
-    "datacentresSpecifyLocation": {
-      "type": "boolean"
-    },
-    "datacentreTier": {
-      "enum":[
-        "TIA-942 Tier 1",
-        "TIA-942 Tier 2",
-        "TIA-942 Tier 3",
-        "TIA-942 Tier 4",
-        "Uptime Institute Tier 1",
-        "Uptime Institute Tier 2",
-        "Uptime Institute Tier 3",
-        "Uptime Institute Tier 4",
-        "None of the above"
-      ]
-    },
-    "dataBackupRecovery": {
-      "type": "boolean"
-    },
-    "dataExtractionRemoval": {
-      "type": "boolean"
-    },
-    "dataProtectionBetweenUserAndService": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "array",
-          "uniqueItems": true,
-          "maxItems": 6,
-          "items": {
-            "enum": ["Encrypted PSN service", "PSN service", "CPA Foundation VPN Gateway", "VPN using TLS, version 1.2 or later", "VPN using legacy SSL or TLS", "No encryption"]
-          }
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation", "CESG-assured components"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "dataProtectionWithinService": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "array",
-          "uniqueItems": true,
-          "maxItems": 6,
-          "items": {
-            "enum": ["VPN using TLS, version 1.2 or later", "VPN using legacy SSL or TLS", "VLAN", "Bonded fibre optic connections", "Other network protection", "No encryption"]
-          }
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation", "CESG-assured components"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "dataProtectionBetweenServices": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "array",
-          "uniqueItems": true,
-          "maxItems": 6,
-          "items": {
-            "enum": ["Encrypted PSN service", "PSN service", "CPA Foundation VPN Gateway", "VPN using TLS, version 1.2 or later", "VPN using legacy SSL or TLS", "No encryption"]
-          }
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation", "CESG-assured components"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "datacentreLocations": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "array",
-          "uniqueItems": true,
-          "maxItems": 5,
-          "items": {
-            "enum": ["UK", "EU", "USA - Safe Harbor", "Other countries with data protection treaties", "Rest of world"]
-          }
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "dataManagementLocations": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "array",
-          "uniqueItems": true,
-          "maxItems": 5,
-          "items": {
-            "enum": ["UK", "EU", "USA - Safe Harbor", "Other countries with data protection treaties", "Rest of world"]
-          }
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "legalJurisdiction": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "enum": ["UK", "EU", "USA - Safe Harbor", "Other countries with data protection treaties", "Rest of world"]
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "datacentreProtectionDisclosure": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "dataAtRestProtections": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "array",
-          "uniqueItems": true,
-          "maxItems": 6,
-          "items": {
-            "enum": ["CPA Foundation-grade assured components", "FIPS-assured encryption", "Other encryption", "Secure containers, racks or cages", "Physical access control", "No protection"]
-          }
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation", "CESG-assured components"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "dataSecureDeletion": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "enum": ["CPA Foundation-grade erasure product", "CESG or CPNI-approved erasure process", "Other secure erasure process", "Other erasure process"]
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation", "CESG-assured components"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "dataStorageMediaDisposal": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "enum": ["CESG-assured destruction service (CAS(T))", "CPA Foundation-assured product", "CPNI-approved destruction service", "BS EN 151713:2009-compliant destruction", "CESG or CPNI-approved erasure process", "Other secure erasure process", "Other destruction/erasure process"]
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion", "Independent testing of implementation", "CESG-assured components"]
-        }
-      }
-    },
-    "dataSecureEquipmentDisposal": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion", "CESG-assured components"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "dataRedundantEquipmentAccountsRevoked": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "serviceAvailabilityPercentage": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "number",
-          "minimum": 0,
-          "maximum": 100,
-          "exclusiveMaximum": true
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "cloudDeploymentModel": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "enum": ["Public cloud", "Community cloud", "Private cloud", "Hybrid cloud"]
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "otherConsumers": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "enum": ["No other consumer", "Only government consumers", "A specific consumer group, eg Police, Defence or Health", "Anyone - public"]
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "servicesSeparation": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent testing of implementation", "Assurance of service design", "CESG-assured components"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "servicesManagementSeparation": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent testing of implementation", "Assurance of service design", "CESG-assured components"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "governanceFramework": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "configurationTracking": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "changeImpactAssessment": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "vulnerabilityAssessment": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "vulnerabilityMonitoring": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "vulnerabilityMitigationPrioritisation": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "vulnerabilityTracking": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "vulnerabilityTimescales": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "eventMonitoring": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "incidentManagementProcess": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "incidentManagementReporting": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "incidentDefinitionPublished": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "personnelSecurityChecks": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "array",
-          "uniqueItems": true,
-          "maxItems": 4,
-          "items": {
-            "enum": ["Security clearance national vetting (SC)", "Baseline personnel security standard (BPSS)", "Background checks in accordance with BS7858:2012", "Employment checks"]
-          }
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "secureDevelopment": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "secureDesign": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "secureConfigurationManagement": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "thirdPartyDataSharingInformation": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "thirdPartySecurityRequirements": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "thirdPartyRiskAssessment": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
+    "termsAndConditionsDocumentURL": {
+      "format": "uri",
+      "type": "string"
     },
     "thirdPartyComplianceMonitoring": {
-      "type": "object",
       "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
         "value": {
           "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
       },
-      "required": ["value", "assurance"]
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
     },
-    "hardwareSoftwareVerification": {
-      "type": "object",
+    "thirdPartyDataSharingInformation": {
       "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
         "value": {
           "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
       },
-      "required": ["value", "assurance"]
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
     },
-    "userAuthenticateManagement": {
-      "type": "object",
+    "thirdPartyRiskAssessment": {
       "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
         "value": {
           "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation"]
         }
       },
-      "required": ["value", "assurance"]
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
     },
-    "userAuthenticateSupport": {
-      "type": "object",
+    "thirdPartySecurityRequirements": {
       "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
         "value": {
           "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation"]
         }
       },
-      "required": ["value", "assurance"]
-    },
-    "userAccessControlManagement": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "restrictAdministratorPermissions": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "managementInterfaceProtection": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "identityAuthenticationControls": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "array",
-          "uniqueItems": true,
-          "maxItems": 7,
-          "items": {
-            "enum": ["Username and two-factor authentication", "Username and TLS client certificate", "Authentication federation", "Limited access over dedicated link, enterprise or community network", "Username and password", "Username and strong password/passphrase enforcement", "Other mechanism"]
-          }
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent testing of implementation", "CESG-assured components"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "onboardingGuidance": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "interconnectionMethods": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "array",
-          "uniqueItems": true,
-          "maxItems": 4,
-          "items": {
-            "enum": ["Encrypted PSN service", "PSN service", "Private WAN", "Internet"]
-          }
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "serviceManagementModel": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "array",
-          "uniqueItems": true,
-          "maxItems": 5,
-          "items": {
-            "enum": ["Dedicated devices on a segregated network", "Dedicated devices for community service management", "Dedicated devices for multiple community service management", "Service management via bastion hosts", "Direct service management"]
-          }
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "auditInformationProvided": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "enum": ["None", "Data made available", "Data made available by negotiation"]
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "deviceAccessMethod": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "array",
-          "uniqueItems": true,
-          "maxItems": 3,
-          "items": {
-            "enum": ["Corporate/enterprise devices", "Partner devices", "Unknown devices"]
-          }
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "serviceConfigurationGuidance": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation"]
-        }
-      },
-      "required": ["value", "assurance"]
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
     },
     "trainingProvided": {
-      "type": "object",
       "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
         "value": {
           "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
       },
-      "required": ["value", "assurance"]
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "trialOption": {
+      "type": "boolean"
+    },
+    "userAccessControlManagement": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion",
+            "Independent testing of implementation"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "userAuthenticateManagement": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion",
+            "Independent testing of implementation"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "userAuthenticateSupport": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion",
+            "Independent testing of implementation"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "vatIncluded": {
+      "type": "boolean"
+    },
+    "vendorCertifications": {
+      "items": {
+        "maxLength": 100,
+        "pattern": "^(?:\\S+\\s+){0,9}\\S+$",
+        "type": "string"
+      },
+      "maxItems": 10,
+      "type": "array"
+    },
+    "vulnerabilityAssessment": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "vulnerabilityMitigationPrioritisation": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "vulnerabilityMonitoring": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "vulnerabilityTimescales": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "vulnerabilityTracking": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
     }
   },
   "required": [
-    "serviceDefinitionDocumentURL",
-    "termsAndConditionsDocumentURL",
-    "pricingDocumentURL",
-    "serviceName",
-    "serviceSummary",
-    "serviceFeatures",
-    "serviceBenefits",
-    "priceMin",
-    "priceUnit",
-    "vatIncluded",
-    "educationPricing",
-    "trialOption",
-    "freeOption",
-    "terminationCost",
-    "minimumContractPeriod",
-    "supportTypes",
-    "supportForThirdParties",
-    "supportAvailability",
-    "supportResponseTime",
-    "incidentEscalation",
-    "openStandardsSupported",
-    "serviceOnboarding",
-    "serviceOffboarding",
     "analyticsAvailable",
-    "elasticCloud",
-    "guaranteedResources",
-    "persistentStorage",
-    "selfServiceProvisioning",
-    "provisioningTime",
-    "deprovisioningTime",
-    "openSource",
     "apiAccess",
-    "networksConnected",
-    "supportedBrowsers",
-    "offlineWorking",
-    "supportedDevices",
-    "datacentresEUCode",
-    "datacentresSpecifyLocation",
-    "datacentreTier",
+    "auditInformationProvided",
+    "changeImpactAssessment",
+    "cloudDeploymentModel",
+    "configurationTracking",
+    "dataAtRestProtections",
     "dataBackupRecovery",
     "dataExtractionRemoval",
+    "dataManagementLocations",
+    "dataProtectionBetweenServices",
     "dataProtectionBetweenUserAndService",
     "dataProtectionWithinService",
-    "dataProtectionBetweenServices",
-    "datacentreLocations",
-    "dataManagementLocations",
-    "legalJurisdiction",
-    "datacentreProtectionDisclosure",
-    "dataAtRestProtections",
-    "dataSecureDeletion",
-    "dataStorageMediaDisposal",
-    "dataSecureEquipmentDisposal",
     "dataRedundantEquipmentAccountsRevoked",
-    "serviceAvailabilityPercentage",
-    "cloudDeploymentModel",
-    "otherConsumers",
-    "servicesSeparation",
-    "servicesManagementSeparation",
-    "governanceFramework",
-    "configurationTracking",
-    "changeImpactAssessment",
-    "vulnerabilityAssessment",
-    "vulnerabilityMonitoring",
-    "vulnerabilityMitigationPrioritisation",
-    "vulnerabilityTracking",
-    "vulnerabilityTimescales",
+    "dataSecureDeletion",
+    "dataSecureEquipmentDisposal",
+    "dataStorageMediaDisposal",
+    "datacentreLocations",
+    "datacentreProtectionDisclosure",
+    "datacentreTier",
+    "datacentresEUCode",
+    "datacentresSpecifyLocation",
+    "deprovisioningTime",
+    "deviceAccessMethod",
+    "educationPricing",
+    "elasticCloud",
     "eventMonitoring",
+    "freeOption",
+    "governanceFramework",
+    "guaranteedResources",
+    "hardwareSoftwareVerification",
+    "identityAuthenticationControls",
+    "incidentDefinitionPublished",
+    "incidentEscalation",
     "incidentManagementProcess",
     "incidentManagementReporting",
-    "incidentDefinitionPublished",
+    "interconnectionMethods",
+    "legalJurisdiction",
+    "managementInterfaceProtection",
+    "minimumContractPeriod",
+    "networksConnected",
+    "offlineWorking",
+    "onboardingGuidance",
+    "openSource",
+    "openStandardsSupported",
+    "otherConsumers",
+    "persistentStorage",
     "personnelSecurityChecks",
-    "secureDevelopment",
-    "secureDesign",
+    "priceMin",
+    "priceUnit",
+    "pricingDocumentURL",
+    "provisioningTime",
+    "restrictAdministratorPermissions",
     "secureConfigurationManagement",
-    "thirdPartyDataSharingInformation",
-    "thirdPartySecurityRequirements",
-    "thirdPartyRiskAssessment",
+    "secureDesign",
+    "secureDevelopment",
+    "selfServiceProvisioning",
+    "serviceAvailabilityPercentage",
+    "serviceBenefits",
+    "serviceConfigurationGuidance",
+    "serviceDefinitionDocumentURL",
+    "serviceFeatures",
+    "serviceManagementModel",
+    "serviceName",
+    "serviceOffboarding",
+    "serviceOnboarding",
+    "serviceSummary",
+    "servicesManagementSeparation",
+    "servicesSeparation",
+    "supportAvailability",
+    "supportForThirdParties",
+    "supportResponseTime",
+    "supportTypes",
+    "supportedBrowsers",
+    "supportedDevices",
+    "terminationCost",
+    "termsAndConditionsDocumentURL",
     "thirdPartyComplianceMonitoring",
-    "hardwareSoftwareVerification",
+    "thirdPartyDataSharingInformation",
+    "thirdPartyRiskAssessment",
+    "thirdPartySecurityRequirements",
+    "trainingProvided",
+    "trialOption",
+    "userAccessControlManagement",
     "userAuthenticateManagement",
     "userAuthenticateSupport",
-    "userAccessControlManagement",
-    "restrictAdministratorPermissions",
-    "managementInterfaceProtection",
-    "identityAuthenticationControls",
-    "onboardingGuidance",
-    "interconnectionMethods",
-    "serviceManagementModel",
-    "auditInformationProvided",
-    "deviceAccessMethod",
-    "serviceConfigurationGuidance",
-    "trainingProvided"
-  ]
+    "vatIncluded",
+    "vulnerabilityAssessment",
+    "vulnerabilityMitigationPrioritisation",
+    "vulnerabilityMonitoring",
+    "vulnerabilityTimescales",
+    "vulnerabilityTracking"
+  ],
+  "title": "G-Cloud 7 PaaS Service Schema",
+  "type": "object"
 }

--- a/json_schemas/services-g-cloud-7-saas.json
+++ b/json_schemas/services-g-cloud-7-saas.json
@@ -1,74 +1,601 @@
 {
-  "title":"G-Cloud 7 SaaS Service Schema",
-  "$schema":"http://json-schema.org/schema#",
-  "type":"object",
-  "additionalProperties":false,
-  "properties":{
-    "serviceDefinitionDocumentURL":{
-      "type":"string",
-      "format":"uri"
+  "$schema": "http://json-schema.org/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "analyticsAvailable": {
+      "type": "boolean"
     },
-    "termsAndConditionsDocumentURL":{
-      "type":"string",
-      "format":"uri"
+    "apiAccess": {
+      "type": "boolean"
     },
-    "pricingDocumentURL":{
-      "type":"string",
-      "format":"uri"
+    "apiType": {
+      "maxLength": 200,
+      "pattern": "^$|(^(?:\\S+\\s+){0,19}\\S+$)",
+      "type": "string"
     },
-    "sfiaRateDocumentURL":{
-      "type":"string",
-      "format":"uri"
+    "auditInformationProvided": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "enum": [
+            "None",
+            "Data made available",
+            "Data made available by negotiation"
+          ]
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
     },
-    "serviceName":{
-      "type":"string",
-      "minLength":1,
-      "maxLength":100
+    "changeImpactAssessment": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
     },
-    "serviceSummary":{
-      "type":"string",
-      "maxLength":500,
-      "pattern":"^(?:\\S+\\s+){0,49}\\S+$",
-      "minLength":1
+    "cloudDeploymentModel": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Contractual commitment",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "enum": [
+            "Public cloud",
+            "Community cloud",
+            "Private cloud",
+            "Hybrid cloud"
+          ]
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
     },
-    "serviceTypes":{
-      "type":"array",
-      "uniqueItems":true,
-      "maxItems":22,
-      "items":{
-        "enum":["Accounting and finance", "Business intelligence and analytics", "Collaboration", "Creative and design", "Customer relationship management (CRM)", "Data management", "Electronic document and records management (EDRM)", "Energy and environment", "Healthcare", "Human resources and employee management", "IT management", "Legal", "Libraries", "Marketing", "Operations management", "Project management and planning", "Sales", "Schools and education", "Security", "Software development tools", "Telecoms", "Transport and logistics"]
-      }
+    "codeLibraryLanguages": {
+      "items": {
+        "maxLength": 100,
+        "pattern": "^(?:\\S+\\s+){0,9}\\S+$",
+        "type": "string"
+      },
+      "maxItems": 10,
+      "type": "array"
     },
-    "serviceFeatures":{
-      "type":"array",
-      "minItems":1,
-      "maxItems":10,
-      "items":{
-        "type":"string",
-        "maxLength":100,
-        "pattern":"^(?:\\S+\\s+){0,9}\\S+$"
-      }
+    "dataAtRestProtections": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion",
+            "Independent testing of implementation",
+            "CESG-assured components"
+          ]
+        },
+        "value": {
+          "items": {
+            "enum": [
+              "CPA Foundation-grade assured components",
+              "FIPS-assured encryption",
+              "Other encryption",
+              "Secure containers, racks or cages",
+              "Physical access control",
+              "No protection"
+            ]
+          },
+          "maxItems": 6,
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
     },
-    "serviceBenefits":{
-      "type":"array",
-      "minItems":1,
-      "maxItems":10,
-      "items":{
-        "type":"string",
-        "maxLength":100,
-        "pattern":"^(?:\\S+\\s+){0,9}\\S+$"
-      }
+    "dataBackupRecovery": {
+      "type": "boolean"
     },
-    "priceMin":{
-      "type":"string",
-      "pattern": "^\\d+(?:\\.\\d{1,5})?$"
+    "dataExtractionRemoval": {
+      "type": "boolean"
     },
-    "priceMax":{
-      "type": "string",
-      "pattern": "^$|^\\d+(?:\\.\\d{1,5})?$"
+    "dataManagementLocations": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Contractual commitment",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "items": {
+            "enum": [
+              "UK",
+              "EU",
+              "USA - Safe Harbor",
+              "Other countries with data protection treaties",
+              "Rest of world"
+            ]
+          },
+          "maxItems": 5,
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
     },
-    "priceUnit":{
-      "enum":[
+    "dataProtectionBetweenUserAndService": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion",
+            "Independent testing of implementation",
+            "CESG-assured components"
+          ]
+        },
+        "value": {
+          "items": {
+            "enum": [
+              "Encrypted PSN service",
+              "PSN service",
+              "CPA Foundation VPN Gateway",
+              "VPN using TLS, version 1.2 or later",
+              "VPN using legacy SSL or TLS",
+              "No encryption"
+            ]
+          },
+          "maxItems": 6,
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "dataSecureDeletion": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion",
+            "Independent testing of implementation",
+            "CESG-assured components"
+          ]
+        },
+        "value": {
+          "enum": [
+            "CPA Foundation-grade erasure product",
+            "CESG or CPNI-approved erasure process",
+            "Other secure erasure process",
+            "Other erasure process"
+          ]
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "datacentreLocations": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Contractual commitment",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "items": {
+            "enum": [
+              "UK",
+              "EU",
+              "USA - Safe Harbor",
+              "Other countries with data protection treaties",
+              "Rest of world"
+            ]
+          },
+          "maxItems": 5,
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "datacentreProtectionDisclosure": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Contractual commitment",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "datacentreTier": {
+      "enum": [
+        "TIA-942 Tier 1",
+        "TIA-942 Tier 2",
+        "TIA-942 Tier 3",
+        "TIA-942 Tier 4",
+        "Uptime Institute Tier 1",
+        "Uptime Institute Tier 2",
+        "Uptime Institute Tier 3",
+        "Uptime Institute Tier 4",
+        "None of the above"
+      ]
+    },
+    "datacentresEUCode": {
+      "type": "boolean"
+    },
+    "datacentresSpecifyLocation": {
+      "type": "boolean"
+    },
+    "deprovisioningTime": {
+      "maxLength": 200,
+      "minLength": 1,
+      "pattern": "^(?:\\S+\\s+){0,19}\\S+$",
+      "type": "string"
+    },
+    "deviceAccessMethod": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "items": {
+            "enum": [
+              "Corporate/enterprise devices",
+              "Partner devices",
+              "Unknown devices"
+            ]
+          },
+          "maxItems": 3,
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "educationPricing": {
+      "type": "boolean"
+    },
+    "elasticCloud": {
+      "type": "boolean"
+    },
+    "eventMonitoring": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "freeOption": {
+      "type": "boolean"
+    },
+    "governanceFramework": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "guaranteedResources": {
+      "type": "boolean"
+    },
+    "identityAuthenticationControls": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent testing of implementation",
+            "CESG-assured components"
+          ]
+        },
+        "value": {
+          "items": {
+            "enum": [
+              "Username and two-factor authentication",
+              "Username and TLS client certificate",
+              "Authentication federation",
+              "Limited access over dedicated link, enterprise or community network",
+              "Username and password",
+              "Username and strong password/passphrase enforcement",
+              "Other mechanism"
+            ]
+          },
+          "maxItems": 7,
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "identityStandards": {
+      "items": {
+        "maxLength": 100,
+        "pattern": "^(?:\\S+\\s+){0,9}\\S+$",
+        "type": "string"
+      },
+      "maxItems": 10,
+      "type": "array"
+    },
+    "incidentDefinitionPublished": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "incidentEscalation": {
+      "type": "boolean"
+    },
+    "incidentManagementProcess": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "incidentManagementReporting": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "legalJurisdiction": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Contractual commitment",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "enum": [
+            "UK",
+            "EU",
+            "USA - Safe Harbor",
+            "Other countries with data protection treaties",
+            "Rest of world"
+          ]
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "minimumContractPeriod": {
+      "enum": [
+        "Hour",
+        "Day",
+        "Month",
+        "Year",
+        "Other"
+      ]
+    },
+    "networksConnected": {
+      "items": {
+        "enum": [
+          "Internet",
+          "Public Services Network (PSN)",
+          "Government Secure intranet (GSi)",
+          "Police National Network (PNN)",
+          "New NHS Network (N3)",
+          "Joint Academic Network (JANET)",
+          "Other"
+        ]
+      },
+      "maxItems": 7,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "offlineWorking": {
+      "type": "boolean"
+    },
+    "openSource": {
+      "type": "boolean"
+    },
+    "openStandardsSupported": {
+      "type": "boolean"
+    },
+    "otherConsumers": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Contractual commitment",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "enum": [
+            "No other consumer",
+            "Only government consumers",
+            "A specific consumer group, eg Police, Defence or Health",
+            "Anyone - public"
+          ]
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "persistentStorage": {
+      "type": "boolean"
+    },
+    "personnelSecurityChecks": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "items": {
+            "enum": [
+              "Security clearance national vetting (SC)",
+              "Baseline personnel security standard (BPSS)",
+              "Background checks in accordance with BS7858:2012",
+              "Employment checks"
+            ]
+          },
+          "maxItems": 4,
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "priceInterval": {
+      "enum": [
+        "",
+        "Second",
+        "Minute",
+        "Hour",
+        "Day",
+        "Week",
+        "Month",
+        "Quarter",
+        "6 months",
+        "Year"
+      ]
+    },
+    "priceMax": {
+      "pattern": "^$|^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "priceMin": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "priceUnit": {
+      "enum": [
         "Unit",
         "Person",
         "Licence",
@@ -83,805 +610,660 @@
         "Terabyte"
       ]
     },
-    "priceInterval":{
-      "enum":[
-        "",
-        "Second",
-        "Minute",
-        "Hour",
-        "Day",
-        "Week",
-        "Month",
-        "Quarter",
-        "6 months",
-        "Year"
-      ]
+    "pricingDocumentURL": {
+      "format": "uri",
+      "type": "string"
     },
-    "vatIncluded":{
-      "type":"boolean"
+    "provisioningTime": {
+      "maxLength": 200,
+      "minLength": 1,
+      "pattern": "^(?:\\S+\\s+){0,19}\\S+$",
+      "type": "string"
     },
-    "educationPricing":{
-      "type":"boolean"
+    "restrictAdministratorPermissions": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion",
+            "Independent testing of implementation"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
     },
-    "trialOption": {
+    "secureConfigurationManagement": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "secureDesign": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "secureDevelopment": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "selfServiceProvisioning": {
       "type": "boolean"
     },
-    "freeOption": {
+    "serviceAvailabilityPercentage": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Contractual commitment",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "exclusiveMaximum": true,
+          "maximum": 100,
+          "minimum": 0,
+          "type": "number"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "serviceBenefits": {
+      "items": {
+        "maxLength": 100,
+        "pattern": "^(?:\\S+\\s+){0,9}\\S+$",
+        "type": "string"
+      },
+      "maxItems": 10,
+      "minItems": 1,
+      "type": "array"
+    },
+    "serviceDefinitionDocumentURL": {
+      "format": "uri",
+      "type": "string"
+    },
+    "serviceFeatures": {
+      "items": {
+        "maxLength": 100,
+        "pattern": "^(?:\\S+\\s+){0,9}\\S+$",
+        "type": "string"
+      },
+      "maxItems": 10,
+      "minItems": 1,
+      "type": "array"
+    },
+    "serviceManagementModel": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "items": {
+            "enum": [
+              "Dedicated devices on a segregated network",
+              "Dedicated devices for community service management",
+              "Dedicated devices for multiple community service management",
+              "Service management via bastion hosts",
+              "Direct service management"
+            ]
+          },
+          "maxItems": 5,
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "serviceName": {
+      "maxLength": 100,
+      "minLength": 1,
+      "type": "string"
+    },
+    "serviceOffboarding": {
       "type": "boolean"
     },
-    "minimumContractPeriod":{
-      "enum":[
-        "Hour",
-        "Day",
-        "Month",
-        "Year",
-        "Other"
-      ]
+    "serviceOnboarding": {
+      "type": "boolean"
     },
-    "supportTypes":{
-      "type":"array",
-      "uniqueItems":true,
-      "minItems":1,
-      "maxItems":5,
-      "items":{
-        "enum":[
+    "serviceSummary": {
+      "maxLength": 500,
+      "minLength": 1,
+      "pattern": "^(?:\\S+\\s+){0,49}\\S+$",
+      "type": "string"
+    },
+    "serviceTypes": {
+      "items": {
+        "enum": [
+          "Accounting and finance",
+          "Business intelligence and analytics",
+          "Collaboration",
+          "Creative and design",
+          "Customer relationship management (CRM)",
+          "Data management",
+          "Electronic document and records management (EDRM)",
+          "Energy and environment",
+          "Healthcare",
+          "Human resources and employee management",
+          "IT management",
+          "Legal",
+          "Libraries",
+          "Marketing",
+          "Operations management",
+          "Project management and planning",
+          "Sales",
+          "Schools and education",
+          "Security",
+          "Software development tools",
+          "Telecoms",
+          "Transport and logistics"
+        ]
+      },
+      "maxItems": 22,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "servicesManagementSeparation": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent testing of implementation",
+            "Assurance of service design",
+            "CESG-assured components"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "servicesSeparation": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent testing of implementation",
+            "Assurance of service design",
+            "CESG-assured components"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "sfiaRateDocumentURL": {
+      "format": "uri",
+      "type": "string"
+    },
+    "supportAvailability": {
+      "maxLength": 200,
+      "minLength": 1,
+      "pattern": "^(?:\\S+\\s+){0,19}\\S+$",
+      "type": "string"
+    },
+    "supportForThirdParties": {
+      "type": "boolean"
+    },
+    "supportResponseTime": {
+      "maxLength": 200,
+      "minLength": 1,
+      "pattern": "^(?:\\S+\\s+){0,19}\\S+$",
+      "type": "string"
+    },
+    "supportTypes": {
+      "items": {
+        "enum": [
           "Service desk",
           "Email",
           "Phone",
           "Live chat",
           "Onsite"
         ]
-      }
-    },
-    "supportForThirdParties":{
-      "type":"boolean"
-    },
-    "supportAvailability":{
-      "type":"string",
-      "maxLength":200,
-      "pattern":"^(?:\\S+\\s+){0,19}\\S+$",
-      "minLength":1
-    },
-    "supportResponseTime":{
-      "type":"string",
-      "maxLength":200,
-      "pattern":"^(?:\\S+\\s+){0,19}\\S+$",
-      "minLength":1
-    },
-    "incidentEscalation":{
-      "type":"boolean"
-    },
-    "openStandardsSupported": {
-      "type": "boolean"
-    },
-    "serviceOnboarding": {
-      "type": "boolean"
-    },
-    "serviceOffboarding": {
-      "type": "boolean"
-    },
-    "analyticsAvailable": {
-      "type": "boolean"
-    },
-    "elasticCloud": {
-      "type": "boolean"
-    },
-    "guaranteedResources": {
-      "type": "boolean"
-    },
-    "persistentStorage": {
-      "type": "boolean"
-    },
-    "selfServiceProvisioning": {
-      "type": "boolean"
-    },
-    "provisioningTime": {
-      "type": "string",
-      "maxLength":200,
-      "pattern":"^(?:\\S+\\s+){0,19}\\S+$",
-      "minLength":1
-    },
-    "deprovisioningTime": {
-      "type": "string",
-      "maxLength":200,
-      "pattern":"^(?:\\S+\\s+){0,19}\\S+$",
-      "minLength":1
-    },
-    "openSource": {
-      "type": "boolean"
-    },
-    "codeLibraryLanguages": {
+      },
+      "maxItems": 5,
+      "minItems": 1,
       "type": "array",
-      "maxItems": 10,
-      "items": {
-        "type": "string",
-        "maxLength":100,
-        "pattern":"^(?:\\S+\\s+){0,9}\\S+$"
-      }
-    },
-    "apiAccess": {
-      "type": "boolean"
-    },
-    "apiType": {
-      "type": "string",
-      "maxLength":200,
-      "pattern":"^$|(^(?:\\S+\\s+){0,19}\\S+$)"
-    },
-    "networksConnected": {
-      "type": "array",
-      "uniqueItems": true,
-      "maxItems": 7,
-      "items": {
-        "enum": ["Internet", "Public Services Network (PSN)", "Government Secure intranet (GSi)", "Police National Network (PNN)", "New NHS Network (N3)", "Joint Academic Network (JANET)", "Other"]
-      }
+      "uniqueItems": true
     },
     "supportedBrowsers": {
-      "type": "array",
-      "uniqueItems": true,
-      "maxItems": 9,
       "items": {
-        "enum": ["Internet Explorer 6", "Internet Explorer 7", "Internet Explorer 8", "Internet Explorer 9", "Internet Explorer 10+", "Firefox", "Chrome", "Safari", "Opera"]
-      }
-    },
-    "offlineWorking": {
-      "type": "boolean"
+        "enum": [
+          "Internet Explorer 6",
+          "Internet Explorer 7",
+          "Internet Explorer 8",
+          "Internet Explorer 9",
+          "Internet Explorer 10+",
+          "Firefox",
+          "Chrome",
+          "Safari",
+          "Opera"
+        ]
+      },
+      "maxItems": 9,
+      "type": "array",
+      "uniqueItems": true
     },
     "supportedDevices": {
-      "type": "array",
-      "uniqueItems": true,
+      "items": {
+        "enum": [
+          "PC",
+          "Mac",
+          "Smartphone",
+          "Tablet"
+        ]
+      },
       "maxItems": 4,
-      "items": {
-        "enum": ["PC", "Mac", "Smartphone", "Tablet"]
-      }
-    },
-    "vendorCertifications":{
-      "type":"array",
-      "maxItems":10,
-      "items":{
-        "type":"string",
-        "maxLength":100,
-        "pattern":"^(?:\\S+\\s+){0,9}\\S+$"
-      }
-    },
-    "identityStandards": {
       "type": "array",
-      "maxItems": 10,
-      "items": {
-        "type": "string",
-        "maxLength":100,
-        "pattern":"^(?:\\S+\\s+){0,9}\\S+$"
-      }
+      "uniqueItems": true
     },
-    "datacentresEUCode": {
-      "type": "boolean"
-    },
-    "datacentresSpecifyLocation": {
-      "type": "boolean"
-    },
-    "datacentreTier": {
-      "enum":[
-        "TIA-942 Tier 1",
-        "TIA-942 Tier 2",
-        "TIA-942 Tier 3",
-        "TIA-942 Tier 4",
-        "Uptime Institute Tier 1",
-        "Uptime Institute Tier 2",
-        "Uptime Institute Tier 3",
-        "Uptime Institute Tier 4",
-        "None of the above"
-      ]
-    },
-    "dataBackupRecovery": {
-      "type": "boolean"
-    },
-    "dataExtractionRemoval": {
-      "type": "boolean"
-    },
-    "dataProtectionBetweenUserAndService": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "array",
-          "uniqueItems": true,
-          "maxItems": 6,
-          "items": {
-            "enum": ["Encrypted PSN service", "PSN service", "CPA Foundation VPN Gateway", "VPN using TLS, version 1.2 or later", "VPN using legacy SSL or TLS", "No encryption"]
-          }
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation", "CESG-assured components"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "datacentreLocations": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "array",
-          "uniqueItems": true,
-          "maxItems": 5,
-          "items": {
-            "enum": ["UK", "EU", "USA - Safe Harbor", "Other countries with data protection treaties", "Rest of world"]
-          }
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "dataManagementLocations": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "array",
-          "uniqueItems": true,
-          "maxItems": 5,
-          "items": {
-            "enum": ["UK", "EU", "USA - Safe Harbor", "Other countries with data protection treaties", "Rest of world"]
-          }
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "legalJurisdiction": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "enum": ["UK", "EU", "USA - Safe Harbor", "Other countries with data protection treaties", "Rest of world"]
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "datacentreProtectionDisclosure": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "dataAtRestProtections": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "array",
-          "uniqueItems": true,
-          "maxItems": 6,
-          "items": {
-            "enum": ["CPA Foundation-grade assured components", "FIPS-assured encryption", "Other encryption", "Secure containers, racks or cages", "Physical access control", "No protection"]
-          }
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation", "CESG-assured components"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "dataSecureDeletion": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "enum": ["CPA Foundation-grade erasure product", "CESG or CPNI-approved erasure process", "Other secure erasure process", "Other erasure process"]
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation", "CESG-assured components"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "serviceAvailabilityPercentage": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "number",
-          "minimum": 0,
-          "maximum": 100,
-          "exclusiveMaximum": true
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "cloudDeploymentModel": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "enum": ["Public cloud", "Community cloud", "Private cloud", "Hybrid cloud"]
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "otherConsumers": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "enum": ["No other consumer", "Only government consumers", "A specific consumer group, eg Police, Defence or Health", "Anyone - public"]
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Contractual commitment", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "servicesSeparation": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent testing of implementation", "Assurance of service design", "CESG-assured components"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "servicesManagementSeparation": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent testing of implementation", "Assurance of service design", "CESG-assured components"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "governanceFramework": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "changeImpactAssessment": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "vulnerabilityAssessment": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "vulnerabilityMonitoring": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "vulnerabilityMitigationPrioritisation": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "vulnerabilityTracking": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "vulnerabilityTimescales": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "eventMonitoring": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "incidentManagementProcess": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "incidentManagementReporting": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "incidentDefinitionPublished": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "personnelSecurityChecks": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "array",
-          "uniqueItems": true,
-          "maxItems": 4,
-          "items": {
-            "enum": ["Security clearance national vetting (SC)", "Baseline personnel security standard (BPSS)", "Background checks in accordance with BS7858:2012", "Employment checks"]
-          }
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "secureDevelopment": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "secureDesign": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "secureConfigurationManagement": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "thirdPartyDataSharingInformation": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "thirdPartySecurityRequirements": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "thirdPartyRiskAssessment": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
+    "termsAndConditionsDocumentURL": {
+      "format": "uri",
+      "type": "string"
     },
     "thirdPartyComplianceMonitoring": {
-      "type": "object",
       "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
         "value": {
           "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
       },
-      "required": ["value", "assurance"]
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
     },
-    "userAuthenticateManagement": {
-      "type": "object",
+    "thirdPartyDataSharingInformation": {
       "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
         "value": {
           "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation"]
         }
       },
-      "required": ["value", "assurance"]
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
     },
-    "userAuthenticateSupport": {
-      "type": "object",
+    "thirdPartyRiskAssessment": {
       "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
         "value": {
           "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation"]
         }
       },
-      "required": ["value", "assurance"]
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
     },
-    "userAccessControlManagement": {
-      "type": "object",
+    "thirdPartySecurityRequirements": {
       "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
         "value": {
           "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation"]
         }
       },
-      "required": ["value", "assurance"]
-    },
-    "restrictAdministratorPermissions": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion", "Independent testing of implementation"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "identityAuthenticationControls": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "array",
-          "uniqueItems": true,
-          "maxItems": 7,
-          "items": {
-            "enum": ["Username and two-factor authentication", "Username and TLS client certificate", "Authentication federation", "Limited access over dedicated link, enterprise or community network", "Username and password", "Username and strong password/passphrase enforcement", "Other mechanism"]
-          }
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent testing of implementation", "CESG-assured components"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "serviceManagementModel": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "array",
-          "uniqueItems": true,
-          "maxItems": 5,
-          "items": {
-            "enum": ["Dedicated devices on a segregated network", "Dedicated devices for community service management", "Dedicated devices for multiple community service management", "Service management via bastion hosts", "Direct service management"]
-          }
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "auditInformationProvided": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "enum": ["None", "Data made available", "Data made available by negotiation"]
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
-    },
-    "deviceAccessMethod": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "array",
-          "uniqueItems": true,
-          "maxItems": 3,
-          "items": {
-            "enum": ["Corporate/enterprise devices", "Partner devices", "Unknown devices"]
-          }
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
-        }
-      },
-      "required": ["value", "assurance"]
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
     },
     "trainingProvided": {
-      "type": "object",
       "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
         "value": {
           "type": "boolean"
-        },
-        "assurance": {
-          "enum": ["Service provider assertion", "Independent validation of assertion"]
         }
       },
-      "required": ["value", "assurance"]
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "trialOption": {
+      "type": "boolean"
+    },
+    "userAccessControlManagement": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion",
+            "Independent testing of implementation"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "userAuthenticateManagement": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion",
+            "Independent testing of implementation"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "userAuthenticateSupport": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion",
+            "Independent testing of implementation"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "vatIncluded": {
+      "type": "boolean"
+    },
+    "vendorCertifications": {
+      "items": {
+        "maxLength": 100,
+        "pattern": "^(?:\\S+\\s+){0,9}\\S+$",
+        "type": "string"
+      },
+      "maxItems": 10,
+      "type": "array"
+    },
+    "vulnerabilityAssessment": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "vulnerabilityMitigationPrioritisation": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "vulnerabilityMonitoring": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "vulnerabilityTimescales": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
+    },
+    "vulnerabilityTracking": {
+      "properties": {
+        "assurance": {
+          "enum": [
+            "Service provider assertion",
+            "Independent validation of assertion"
+          ]
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "assurance"
+      ],
+      "type": "object"
     }
   },
   "required": [
-    "serviceDefinitionDocumentURL",
-    "termsAndConditionsDocumentURL",
-    "pricingDocumentURL",
-    "serviceName",
-    "serviceSummary",
-    "serviceTypes",
-    "serviceFeatures",
-    "serviceBenefits",
-    "priceMin",
-    "priceUnit",
-    "vatIncluded",
-    "educationPricing",
-    "trialOption",
-    "freeOption",
-    "minimumContractPeriod",
-    "supportTypes",
-    "supportForThirdParties",
-    "supportAvailability",
-    "supportResponseTime",
-    "incidentEscalation",
-    "openStandardsSupported",
-    "serviceOnboarding",
-    "serviceOffboarding",
     "analyticsAvailable",
-    "elasticCloud",
-    "guaranteedResources",
-    "persistentStorage",
-    "selfServiceProvisioning",
-    "provisioningTime",
-    "deprovisioningTime",
-    "openSource",
     "apiAccess",
-    "networksConnected",
-    "supportedBrowsers",
-    "offlineWorking",
-    "supportedDevices",
-    "datacentresEUCode",
-    "datacentresSpecifyLocation",
-    "datacentreTier",
+    "auditInformationProvided",
+    "changeImpactAssessment",
+    "cloudDeploymentModel",
+    "dataAtRestProtections",
     "dataBackupRecovery",
     "dataExtractionRemoval",
-    "dataProtectionBetweenUserAndService",
-    "datacentreLocations",
     "dataManagementLocations",
-    "legalJurisdiction",
-    "datacentreProtectionDisclosure",
-    "dataAtRestProtections",
+    "dataProtectionBetweenUserAndService",
     "dataSecureDeletion",
-    "serviceAvailabilityPercentage",
-    "cloudDeploymentModel",
-    "otherConsumers",
-    "servicesSeparation",
-    "servicesManagementSeparation",
-    "governanceFramework",
-    "changeImpactAssessment",
-    "vulnerabilityAssessment",
-    "vulnerabilityMonitoring",
-    "vulnerabilityMitigationPrioritisation",
-    "vulnerabilityTracking",
-    "vulnerabilityTimescales",
+    "datacentreLocations",
+    "datacentreProtectionDisclosure",
+    "datacentreTier",
+    "datacentresEUCode",
+    "datacentresSpecifyLocation",
+    "deprovisioningTime",
+    "deviceAccessMethod",
+    "educationPricing",
+    "elasticCloud",
     "eventMonitoring",
+    "freeOption",
+    "governanceFramework",
+    "guaranteedResources",
+    "identityAuthenticationControls",
+    "incidentDefinitionPublished",
+    "incidentEscalation",
     "incidentManagementProcess",
     "incidentManagementReporting",
-    "incidentDefinitionPublished",
+    "legalJurisdiction",
+    "minimumContractPeriod",
+    "networksConnected",
+    "offlineWorking",
+    "openSource",
+    "openStandardsSupported",
+    "otherConsumers",
+    "persistentStorage",
     "personnelSecurityChecks",
-    "secureDevelopment",
-    "secureDesign",
+    "priceMin",
+    "priceUnit",
+    "pricingDocumentURL",
+    "provisioningTime",
+    "restrictAdministratorPermissions",
     "secureConfigurationManagement",
-    "thirdPartyDataSharingInformation",
-    "thirdPartySecurityRequirements",
-    "thirdPartyRiskAssessment",
+    "secureDesign",
+    "secureDevelopment",
+    "selfServiceProvisioning",
+    "serviceAvailabilityPercentage",
+    "serviceBenefits",
+    "serviceDefinitionDocumentURL",
+    "serviceFeatures",
+    "serviceManagementModel",
+    "serviceName",
+    "serviceOffboarding",
+    "serviceOnboarding",
+    "serviceSummary",
+    "serviceTypes",
+    "servicesManagementSeparation",
+    "servicesSeparation",
+    "supportAvailability",
+    "supportForThirdParties",
+    "supportResponseTime",
+    "supportTypes",
+    "supportedBrowsers",
+    "supportedDevices",
+    "termsAndConditionsDocumentURL",
     "thirdPartyComplianceMonitoring",
+    "thirdPartyDataSharingInformation",
+    "thirdPartyRiskAssessment",
+    "thirdPartySecurityRequirements",
+    "trainingProvided",
+    "trialOption",
+    "userAccessControlManagement",
     "userAuthenticateManagement",
     "userAuthenticateSupport",
-    "userAccessControlManagement",
-    "restrictAdministratorPermissions",
-    "identityAuthenticationControls",
-    "serviceManagementModel",
-    "auditInformationProvided",
-    "deviceAccessMethod",
-    "trainingProvided"
-  ]
+    "vatIncluded",
+    "vulnerabilityAssessment",
+    "vulnerabilityMitigationPrioritisation",
+    "vulnerabilityMonitoring",
+    "vulnerabilityTimescales",
+    "vulnerabilityTracking"
+  ],
+  "title": "G-Cloud 7 SaaS Service Schema",
+  "type": "object"
 }

--- a/json_schemas/services-g-cloud-7-saas.json
+++ b/json_schemas/services-g-cloud-7-saas.json
@@ -10,6 +10,7 @@
     },
     "apiType": {
       "maxLength": 200,
+      "minLength": 0,
       "pattern": "^$|(^(?:\\S+\\s+){0,19}\\S+$)",
       "type": "string"
     },
@@ -84,6 +85,7 @@
         "type": "string"
       },
       "maxItems": 10,
+      "minItems": 0,
       "type": "array"
     },
     "dataAtRestProtections": {
@@ -108,6 +110,7 @@
             ]
           },
           "maxItems": 6,
+          "minItems": 1,
           "type": "array",
           "uniqueItems": true
         }
@@ -144,6 +147,7 @@
             ]
           },
           "maxItems": 5,
+          "minItems": 1,
           "type": "array",
           "uniqueItems": true
         }
@@ -176,6 +180,7 @@
             ]
           },
           "maxItems": 6,
+          "minItems": 1,
           "type": "array",
           "uniqueItems": true
         }
@@ -231,6 +236,7 @@
             ]
           },
           "maxItems": 5,
+          "minItems": 1,
           "type": "array",
           "uniqueItems": true
         }
@@ -302,6 +308,7 @@
             ]
           },
           "maxItems": 3,
+          "minItems": 1,
           "type": "array",
           "uniqueItems": true
         }
@@ -382,6 +389,7 @@
             ]
           },
           "maxItems": 7,
+          "minItems": 1,
           "type": "array",
           "uniqueItems": true
         }
@@ -399,6 +407,7 @@
         "type": "string"
       },
       "maxItems": 10,
+      "minItems": 0,
       "type": "array"
     },
     "incidentDefinitionPublished": {
@@ -505,6 +514,7 @@
         ]
       },
       "maxItems": 7,
+      "minItems": 1,
       "type": "array",
       "uniqueItems": true
     },
@@ -562,6 +572,7 @@
             ]
           },
           "maxItems": 4,
+          "minItems": 1,
           "type": "array",
           "uniqueItems": true
         }
@@ -761,6 +772,7 @@
             ]
           },
           "maxItems": 5,
+          "minItems": 1,
           "type": "array",
           "uniqueItems": true
         }
@@ -816,6 +828,7 @@
         ]
       },
       "maxItems": 22,
+      "minItems": 1,
       "type": "array",
       "uniqueItems": true
     },
@@ -908,6 +921,7 @@
         ]
       },
       "maxItems": 9,
+      "minItems": 1,
       "type": "array",
       "uniqueItems": true
     },
@@ -921,6 +935,7 @@
         ]
       },
       "maxItems": 4,
+      "minItems": 1,
       "type": "array",
       "uniqueItems": true
     },
@@ -1088,6 +1103,7 @@
         "type": "string"
       },
       "maxItems": 10,
+      "minItems": 0,
       "type": "array"
     },
     "vulnerabilityAssessment": {

--- a/json_schemas/services-g-cloud-7-scs.json
+++ b/json_schemas/services-g-cloud-7-scs.json
@@ -105,6 +105,7 @@
         ]
       },
       "maxItems": 5,
+      "minItems": 1,
       "type": "array",
       "uniqueItems": true
     },
@@ -159,6 +160,7 @@
         "type": "string"
       },
       "maxItems": 10,
+      "minItems": 0,
       "type": "array"
     }
   },

--- a/json_schemas/services-g-cloud-7-scs.json
+++ b/json_schemas/services-g-cloud-7-scs.json
@@ -1,80 +1,46 @@
 {
-  "title":"G-Cloud 7 SCS Service Schema",
-  "$schema":"http://json-schema.org/schema#",
-  "type":"object",
-  "additionalProperties":false,
-  "properties":{
-    "serviceDefinitionDocumentURL":{
-      "type":"string",
-      "format":"uri"
+  "$schema": "http://json-schema.org/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "educationPricing": {
+      "type": "boolean"
     },
-    "termsAndConditionsDocumentURL":{
-      "type":"string",
-      "format":"uri"
+    "incidentEscalation": {
+      "type": "boolean"
     },
-    "pricingDocumentURL":{
-      "type":"string",
-      "format":"uri"
+    "minimumContractPeriod": {
+      "enum": [
+        "Hour",
+        "Day",
+        "Month",
+        "Year",
+        "Other"
+      ]
     },
-    "sfiaRateDocumentURL":{
-      "type":"string",
-      "format":"uri"
+    "priceInterval": {
+      "enum": [
+        "",
+        "Second",
+        "Minute",
+        "Hour",
+        "Day",
+        "Week",
+        "Month",
+        "Quarter",
+        "6 months",
+        "Year"
+      ]
     },
-    "serviceName":{
-      "type":"string",
-      "minLength":1,
-      "maxLength":100
+    "priceMax": {
+      "pattern": "^$|^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
     },
-    "serviceSummary":{
-      "type":"string",
-      "maxLength":500,
-      "pattern":"^(?:\\S+\\s+){0,49}\\S+$",
-      "minLength":1
+    "priceMin": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
     },
-    "serviceTypes":{
-      "type":"array",
-      "uniqueItems":true,
-      "maxItems":5,
-      "items":{
-        "enum":[
-          "Implementation",
-          "Ongoing support",
-          "Planning",
-          "Testing",
-          "Training"
-        ]
-      }
-    },
-    "serviceFeatures":{
-      "type":"array",
-      "minItems":1,
-      "maxItems":10,
-      "items":{
-        "type":"string",
-        "maxLength":100,
-        "pattern":"^(?:\\S+\\s+){0,9}\\S+$"
-      }
-    },
-    "serviceBenefits":{
-      "type":"array",
-      "minItems":1,
-      "maxItems":10,
-      "items":{
-        "type":"string",
-        "maxLength":100,
-        "pattern":"^(?:\\S+\\s+){0,9}\\S+$"
-      }
-    },
-    "priceMin":{
-      "type":"string",
-      "pattern": "^\\d+(?:\\.\\d{1,5})?$"
-    },
-    "priceMax":{
-      "type": "string",
-      "pattern": "^$|^\\d+(?:\\.\\d{1,5})?$"
-    },
-    "priceUnit":{
-      "enum":[
+    "priceUnit": {
+      "enum": [
         "Unit",
         "Person",
         "Licence",
@@ -89,100 +55,134 @@
         "Terabyte"
       ]
     },
-    "priceInterval":{
-      "enum":[
-        "",
-        "Second",
-        "Minute",
-        "Hour",
-        "Day",
-        "Week",
-        "Month",
-        "Quarter",
-        "6 months",
-        "Year"
-      ]
+    "pricingDocumentURL": {
+      "format": "uri",
+      "type": "string"
     },
-    "vatIncluded":{
-      "type":"boolean"
+    "serviceBenefits": {
+      "items": {
+        "maxLength": 100,
+        "pattern": "^(?:\\S+\\s+){0,9}\\S+$",
+        "type": "string"
+      },
+      "maxItems": 10,
+      "minItems": 1,
+      "type": "array"
     },
-    "educationPricing":{
-      "type":"boolean"
+    "serviceDefinitionDocumentURL": {
+      "format": "uri",
+      "type": "string"
     },
-    "terminationCost":{
-      "type":"boolean"
+    "serviceFeatures": {
+      "items": {
+        "maxLength": 100,
+        "pattern": "^(?:\\S+\\s+){0,9}\\S+$",
+        "type": "string"
+      },
+      "maxItems": 10,
+      "minItems": 1,
+      "type": "array"
     },
-    "minimumContractPeriod":{
-      "enum":[
-        "Hour",
-        "Day",
-        "Month",
-        "Year",
-        "Other"
-      ]
+    "serviceName": {
+      "maxLength": 100,
+      "minLength": 1,
+      "type": "string"
     },
-    "supportTypes":{
-      "type":"array",
-      "uniqueItems":true,
-      "minItems":1,
-      "maxItems":5,
-      "items":{
-        "enum":[
+    "serviceSummary": {
+      "maxLength": 500,
+      "minLength": 1,
+      "pattern": "^(?:\\S+\\s+){0,49}\\S+$",
+      "type": "string"
+    },
+    "serviceTypes": {
+      "items": {
+        "enum": [
+          "Implementation",
+          "Ongoing support",
+          "Planning",
+          "Testing",
+          "Training"
+        ]
+      },
+      "maxItems": 5,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "sfiaRateDocumentURL": {
+      "format": "uri",
+      "type": "string"
+    },
+    "supportAvailability": {
+      "maxLength": 200,
+      "minLength": 1,
+      "pattern": "^(?:\\S+\\s+){0,19}\\S+$",
+      "type": "string"
+    },
+    "supportForThirdParties": {
+      "type": "boolean"
+    },
+    "supportResponseTime": {
+      "maxLength": 200,
+      "minLength": 1,
+      "pattern": "^(?:\\S+\\s+){0,19}\\S+$",
+      "type": "string"
+    },
+    "supportTypes": {
+      "items": {
+        "enum": [
           "Service desk",
           "Email",
           "Phone",
           "Live chat",
           "Onsite"
         ]
-      }
+      },
+      "maxItems": 5,
+      "minItems": 1,
+      "type": "array",
+      "uniqueItems": true
     },
-    "supportForThirdParties":{
-      "type":"boolean"
+    "terminationCost": {
+      "type": "boolean"
     },
-    "supportAvailability":{
-      "type":"string",
-      "maxLength":200,
-      "pattern":"^(?:\\S+\\s+){0,19}\\S+$",
-      "minLength":1
+    "termsAndConditionsDocumentURL": {
+      "format": "uri",
+      "type": "string"
     },
-    "supportResponseTime":{
-      "type":"string",
-      "maxLength":200,
-      "pattern":"^(?:\\S+\\s+){0,19}\\S+$",
-      "minLength":1
+    "vatIncluded": {
+      "type": "boolean"
     },
-    "incidentEscalation":{
-      "type":"boolean"
-    },
-    "vendorCertifications":{
-      "type":"array",
-      "maxItems":10,
-      "items":{
-        "type":"string",
-        "maxLength":100,
-        "pattern":"^(?:\\S+\\s+){0,9}\\S+$"
-      }
+    "vendorCertifications": {
+      "items": {
+        "maxLength": 100,
+        "pattern": "^(?:\\S+\\s+){0,9}\\S+$",
+        "type": "string"
+      },
+      "maxItems": 10,
+      "type": "array"
     }
   },
-  "required":[
-    "serviceDefinitionDocumentURL",
-    "termsAndConditionsDocumentURL",
+  "required": [
+    "educationPricing",
+    "incidentEscalation",
+    "minimumContractPeriod",
+    "priceMin",
+    "priceUnit",
     "pricingDocumentURL",
+    "serviceBenefits",
+    "serviceDefinitionDocumentURL",
+    "serviceFeatures",
     "serviceName",
     "serviceSummary",
     "serviceTypes",
-    "serviceFeatures",
-    "serviceBenefits",
-    "priceMin",
-    "priceUnit",
-    "vatIncluded",
-    "educationPricing",
-    "terminationCost",
-    "minimumContractPeriod",
-    "supportTypes",
-    "supportForThirdParties",
     "supportAvailability",
+    "supportForThirdParties",
     "supportResponseTime",
-    "incidentEscalation"
-  ]
+    "supportTypes",
+    "terminationCost",
+    "termsAndConditionsDocumentURL",
+    "vatIncluded"
+  ],
+  "title": "G-Cloud 7 SCS Service Schema",
+  "type": "object"
 }

--- a/json_schemas/services-update.json
+++ b/json_schemas/services-update.json
@@ -1,7 +1,5 @@
 {
-  "title": "API Updater Schema",
   "$schema": "http://json-schema.org/schema#",
-  "type": "object",
   "additionalProperties": true,
   "properties": {
     "updated_by": {
@@ -10,5 +8,7 @@
   },
   "required": [
     "updated_by"
-  ]
+  ],
+  "title": "API Updater Schema",
+  "type": "object"
 }

--- a/json_schemas/suppliers.json
+++ b/json_schemas/suppliers.json
@@ -1,49 +1,49 @@
 {
-  "title": "G6 Supplier Schema",
   "$schema": "http://json-schema.org/schema#",
-  "type": "object",
   "additionalProperties": false,
   "properties": {
+    "clients": {
+      "items": {
+        "type": "string"
+      },
+      "maxItems": 10,
+      "minItems": 0,
+      "type": "array"
+    },
+    "companiesHouseNumber": {
+      "maxLength": 8,
+      "minLength": 8,
+      "type": "string"
+    },
+    "contactInformation": {
+      "items": {
+        "$ref": "file:json_schemas/contact-information.json"
+      },
+      "minItems": 1,
+      "type": "array"
+    },
+    "description": {
+      "type": "string"
+    },
+    "dunsNumber": {
+      "pattern": "^[0-9]+$",
+      "type": "string"
+    },
+    "eSourcingId": {
+      "pattern": "^[0-9]+$",
+      "type": "string"
+    },
     "id": {
       "type": "integer"
     },
     "name": {
       "type": "string"
-    },
-    "description": {
-      "type": "string"
-    },
-    "contactInformation": {
-      "type": "array",
-      "items": {
-        "$ref": "file:json_schemas/contact-information.json"
-      },
-      "minItems": 1
-    },
-    "dunsNumber": {
-      "type": "string",
-      "pattern": "^[0-9]+$"
-    },
-    "eSourcingId": {
-      "type": "string",
-      "pattern": "^[0-9]+$"
-    },
-    "companiesHouseNumber": {
-      "type": "string",
-      "minLength": 8,
-      "maxLength": 8
-    },
-    "clients": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      },
-      "minItems": 0,
-      "maxItems": 10
     }
   },
   "required": [
     "id",
     "name"
-  ]
+  ],
+  "title": "G6 Supplier Schema",
+  "type": "object"
 }

--- a/json_schemas/users-auth.json
+++ b/json_schemas/users-auth.json
@@ -1,21 +1,21 @@
 {
-  "title": "API Updater Schema",
   "$schema": "http://json-schema.org/schema#",
-  "type": "object",
   "additionalProperties": false,
   "properties": {
     "emailAddress": {
-      "type": "string",
-      "pattern": "^[^@^\\s]+@[^@^\\.^\\s]+(\\.[^@^\\.^\\s]+)+$"
+      "pattern": "^[^@^\\s]+@[^@^\\.^\\s]+(\\.[^@^\\.^\\s]+)+$",
+      "type": "string"
     },
     "password": {
-      "type": "string",
       "maxLength": 255,
-      "minLength": 10
+      "minLength": 10,
+      "type": "string"
     }
   },
   "required": [
     "emailAddress",
     "password"
-  ]
+  ],
+  "title": "API Updater Schema",
+  "type": "object"
 }

--- a/json_schemas/users.json
+++ b/json_schemas/users.json
@@ -1,38 +1,44 @@
 {
-  "title": "API Updater Schema",
   "$schema": "http://json-schema.org/schema#",
-  "type": "object",
   "additionalProperties": false,
   "properties": {
-    "name": {
-      "type": "string",
-      "maxLength": 255,
-      "minLength": 1
-    },
     "emailAddress": {
-      "type": "string",
-      "pattern": "^[^@^\\s]+@[^@^\\.^\\s]+(\\.[^@^\\.^\\s]+)+$"
+      "pattern": "^[^@^\\s]+@[^@^\\.^\\s]+(\\.[^@^\\.^\\s]+)+$",
+      "type": "string"
+    },
+    "hashpw": {
+      "description": "set to False to skip password hashing",
+      "type": "boolean"
+    },
+    "name": {
+      "maxLength": 255,
+      "minLength": 1,
+      "type": "string"
     },
     "password": {
-      "type": "string",
       "maxLength": 255,
-      "minLength": 10
+      "minLength": 10,
+      "type": "string"
     },
     "role": {
-      "enum": ["buyer", "supplier", "admin", "admin-ccs-category", "admin-ccs-sourcing"]
+      "enum": [
+        "buyer",
+        "supplier",
+        "admin",
+        "admin-ccs-category",
+        "admin-ccs-sourcing"
+      ]
     },
     "supplierId": {
       "type": "integer"
-    },
-    "hashpw": {
-      "type": "boolean",
-      "description": "set to False to skip password hashing"
     }
   },
   "required": [
-    "name",
-    "role",
     "emailAddress",
-    "password"
-  ]
+    "name",
+    "password",
+    "role"
+  ],
+  "title": "API Updater Schema",
+  "type": "object"
 }


### PR DESCRIPTION
This opens up the way for the auto-generating schemas by sorting and normalising the existing schema files.

(Note: the commits are easier to review individually – the first commit reorders a lot of lines, but keeps the file contents the same, while the second one adds the output from the schema generation script that didn't match the current G7 schemas)

### Normalize and sort JSON schemas
Runs the JSON schema files through json.load and json.dump with
sorting keys and 'required' lists.

Files were changed by the following python script:

```python
for name in validation.SCHEMA_NAMES:
    with open('json_schemas/{}.json'.format(name)) as f:
        schema = json.load(f)
        if 'required' in schema:
            schema['required'].sort()
    with open('json_schemas/{}.json'.format(name), 'w') as fw:
        json.dump(schema, fw, sort_keys=True, indent=2, separators=(',', ': '))
```

### Update G-Cloud 7 schemas with autogenerated output from frameworks