### PR TITLE
G7 launch

### DIFF
--- a/app/main/views/drafts.py
+++ b/app/main/views/drafts.py
@@ -227,10 +227,7 @@ def publish_draft_service(draft_id):
             Service.service_id == draft.service_id
         ).first_or_404()
 
-        service_from_draft = update_and_validate_service(
-            service,
-            draft.data)
-
+        service_from_draft = update_and_validate_service(service, draft.data)
     else:
         service_from_draft = create_service_from_draft(draft, "enabled")
 

--- a/app/main/views/drafts.py
+++ b/app/main/views/drafts.py
@@ -235,7 +235,7 @@ def publish_draft_service(draft_id):
 
         service_from_draft = update_and_validate_service(service, draft.data)
     else:
-        service_from_draft = create_service_from_draft(draft, "enabled")
+        service_from_draft = create_service_from_draft(draft, "published")
 
     commit_and_archive_service(service_from_draft, update_details,
                                AuditTypes.publish_draft_service,

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -189,12 +189,7 @@ def get_service(service_id):
         Service.service_id == service_id
     ).first_or_404()
 
-    if service.framework.status == 'live':
-        return jsonify(services=service.serialize())
-    elif service.framework.status == 'expired':
-        abort(410)
-    else:
-        abort(404)
+    return jsonify(services=service.serialize())
 
 
 @main.route('/archived-services/<int:archived_service_id>', methods=['GET'])

--- a/app/models.py
+++ b/app/models.py
@@ -631,6 +631,10 @@ class DraftService(db.Model, ServiceTableMixin):
         if self.service_id:
             data['serviceId'] = self.service_id
 
+        data['links']['publish'] = url_for('.publish_draft_service', draft_id=self.id)
+        data['links']['complete'] = url_for('.complete_draft_service', draft_id=self.id)
+        data['links']['copy'] = url_for('.copy_draft_service', draft_id=self.id)
+
         return data
 
     def get_link(self):

--- a/tests/app/views/test_drafts.py
+++ b/tests/app/views/test_drafts.py
@@ -742,9 +742,10 @@ class TestDraftServices(BaseApplicationTest):
         fetch = self.client.get('/draft-services/{}'.format(draft_id))
         assert_equal(fetch.status_code, 404)
 
-        # G-Cloud 7 service should not be visible yet
+        # G-Cloud 7 service should be visible from API
+        # (frontends hide them based on statuses)
         fetch2 = self.client.get('/services/{}'.format(new_service_id))
-        assert_equal(fetch2.status_code, 404)
+        assert_equal(fetch2.status_code, 200)
 
         # published should be visible when G7 goes live
         with self.app.app_context():

--- a/tests/app/views/test_services.py
+++ b/tests/app/views/test_services.py
@@ -1739,10 +1739,6 @@ class TestGetService(BaseApplicationTest):
         assert_equal(200, response.status_code)
         assert_equal("123-enabled-456", data['services']['id'])
 
-    def test_get_expired_service(self):
-        response = self.client.get('/services/123-expired-456')
-        assert_equal(410, response.status_code)
-
     def test_get_service_returns_supplier_info(self):
         response = self.client.get('/services/123-published-456')
         data = json.loads(response.get_data())


### PR DESCRIPTION
## Allow all services to be returned by API
Previously the buyer frontend expected the API to raise a 404 or 410 if the framework status was not valid. It now handles that itself by looking at the frameworkStatus so now the API can return all services it knows about.

## Test search API call on draft publishing
Test that the search API is called correctly during the draft publishing process. Services should only be indexed in the search API if the framework is live.

## Prevent draft deletion on publish submission
This change has been introduced to prevent drafts created through the submission process (submissions) from being deleted when they are published. In implementing this I have tightened up what actions can happen in various different states.

The `not-submitted` and `submitted` statuses are only possible on drafts that were created during the submissions process. They will not have a service ID until they are published. Because only submissions with the 'submitted' status can be published only they can have service IDs. When this kind of draft is published it is not deleted so as to preserve the submission.

The `enabled`, `disabled` and `published` statuses are inherited from the service model. Drafts can only have these statuses if they are created from an existing service. These drafts will always have a service ID. When this kind of draft is published it is deleted.