### PR TITLE
Refactor error handling

### DIFF
--- a/app/authentication.py
+++ b/app/authentication.py
@@ -8,9 +8,9 @@ def requires_authentication():
         incoming_token = get_token_from_headers(request.headers)
 
         if not incoming_token:
-            abort(401)
+            abort(401, "Unauthorized; bearer token must be provided")
         if not token_is_valid(incoming_token):
-            abort(403, incoming_token)
+            abort(403, "Forbidden; invalid bearer token provided {}".format(incoming_token))
 
 
 def token_is_valid(incoming_token):

--- a/app/main/errors.py
+++ b/app/main/errors.py
@@ -9,31 +9,17 @@ def validatation_error(e):
     return jsonify(error=e.message), 400
 
 
-@main.app_errorhandler(400)
-def bad_request(e):
+def generic_error_handler(e):
     # TODO: log the error
-    return jsonify(error=e.description), 400
+    headers = []
+    error = e.description
+    if e.code == 401:
+        headers = [('WWW-Authenticate', 'Bearer')]
+    elif e.code == 500:
+        error = "Internal error"
+
+    return jsonify(error=error),  e.code, headers
 
 
-@main.app_errorhandler(401)
-def unauthorized(e):
-    error_message = "Unauthorized, bearer token must be provided"
-    return jsonify(error=error_message), 401, [('WWW-Authenticate', 'Bearer')]
-
-
-@main.app_errorhandler(403)
-def forbidden(e):
-    error_message = "Forbidden, invalid bearer token provided '{}'".format(
-        e.description)
-    return jsonify(error=error_message), 403
-
-
-@main.app_errorhandler(404)
-def page_not_found(e):
-    return jsonify(error=e.description or "Not found"), 404
-
-
-@main.app_errorhandler(500)
-def internal_server_error(e):
-    # TODO: log the error
-    return jsonify(error="Internal error"), 500
+for code in range(400, 599):
+    main.app_errorhandler(code)(generic_error_handler)


### PR DESCRIPTION
The bug this fixes is that we didn't have a handler for 409. I've
refactored how we do error handling so that it's generic for all HTTP
error codes.