### PR TITLE
Add Digital Outcomes and Specialists to frameworks

### DIFF
--- a/migrations/versions/420_dos_is_coming.py
+++ b/migrations/versions/420_dos_is_coming.py
@@ -1,0 +1,34 @@
+"""DOS is coming
+
+Revision ID: 420
+Revises: 410_remove_empty_drafts
+Create Date: 2015-11-16 14:10:35.814066
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '420'
+down_revision = '410_remove_empty_drafts'
+
+from alembic import op
+import sqlalchemy as sa
+from app.models import Framework
+
+
+def upgrade():
+    op.execute("COMMIT")
+    op.execute("ALTER TYPE framework_enum ADD VALUE IF NOT EXISTS 'dos' after 'gcloud'")
+
+    framework = Framework.query.filter(Framework.slug == 'digital-outcomes-and-specialists').first()
+
+    if not framework:
+        op.execute("""
+            INSERT INTO frameworks (name, framework, status, slug)
+                values('Digital Outcomes and Specialists', 'dos', 'coming', 'digital-outcomes-and-specialists')
+        """)
+
+
+def downgrade():
+    op.execute("""
+        DELETE FROM frameworks where slug='digital-outcomes-and-specialists'
+    """)

--- a/migrations/versions/420_dos_is_coming.py
+++ b/migrations/versions/420_dos_is_coming.py
@@ -11,17 +11,17 @@ revision = '420'
 down_revision = '410_remove_empty_drafts'
 
 from alembic import op
-import sqlalchemy as sa
-from app.models import Framework
 
 
 def upgrade():
     op.execute("COMMIT")
     op.execute("ALTER TYPE framework_enum ADD VALUE IF NOT EXISTS 'dos' after 'gcloud'")
 
-    framework = Framework.query.filter(Framework.slug == 'digital-outcomes-and-specialists').first()
+    conn = op.get_bind()
+    res = conn.execute("SELECT * FROM frameworks WHERE slug = 'digital-outcomes-and-specialists'")
+    results = res.fetchall()
 
-    if not framework:
+    if not results:
         op.execute("""
             INSERT INTO frameworks (name, framework, status, slug)
                 values('Digital Outcomes and Specialists', 'dos', 'coming', 'digital-outcomes-and-specialists')


### PR DESCRIPTION
Depends on:
- [x] https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/187 being merged **and** deployed through to production

--

This commit checks to see if:
- the framework exists in the enum before trying to add it
- the framework exists in the table before trying to add

This means that it won’t fall over on environments where DOS has already been created (eg local dev machines, preview).

The downgrade will fail if data associated with a framework has been created (eg a supplier has registered interest). We made this trade off because:
- can rollback production if anything goes wrong if we deploy this
- no framework-related data will be created on production until the framework is open—by which time it will be way too late to rollback this far

_Paired with @TheDoubleK_