### PR TITLE
Add validation errors to get draft response

### DIFF
--- a/app/main/views/drafts.py
+++ b/app/main/views/drafts.py
@@ -12,7 +12,8 @@ from ...service_utils import (
     validate_and_return_updater_request,
     update_and_validate_service, index_service,
     commit_and_archive_service, create_service_from_draft,
-    validate_and_return_related_objects, validate_service_data
+    validate_and_return_related_objects, validate_service_data,
+    get_service_validation_errors
 )
 
 from ...draft_utils import (
@@ -170,7 +171,8 @@ def fetch_draft_service(draft_id):
 
     return jsonify(
         services=draft.serialize(),
-        auditEvents=last_audit_event.serialize(include_user=True)
+        auditEvents=last_audit_event.serialize(include_user=True),
+        validationErrors=get_service_validation_errors(draft)
     )
 
 

--- a/app/service_utils.py
+++ b/app/service_utils.py
@@ -57,20 +57,27 @@ def update_and_validate_service(service, service_payload):
     return service
 
 
-def validate_service_data(service, enforce_required=True, required_fields=None):
+def _get_validator_name(service):
     if service.framework.slug in ['g-cloud-4', 'g-cloud-5']:
-        validator_name = 'services-{}'.format(service.framework.slug)
+        return 'services-{}'.format(service.framework.slug)
     else:
-        validator_name = 'services-{}-{}'.format(service.framework.slug, service.lot.slug)
+        return 'services-{}-{}'.format(service.framework.slug, service.lot.slug)
 
-    errs = get_validation_errors(
-        validator_name, service.data,
+
+def validate_service_data(service, enforce_required=True, required_fields=None):
+    errs = get_service_validation_errors(
+        service, enforce_required, required_fields)
+
+    if errs:
+        abort(400, errs)
+
+
+def get_service_validation_errors(service, enforce_required=True, required_fields=None):
+    return get_validation_errors(
+        _get_validator_name(service), service.data,
         enforce_required=enforce_required,
         required_fields=required_fields
     )
-    if errs:
-        abort(400, errs)
-    return
 
 
 def commit_and_archive_service(updated_service, update_details,

--- a/tests/app/views/test_drafts.py
+++ b/tests/app/views/test_drafts.py
@@ -476,6 +476,28 @@ class TestDraftServices(BaseApplicationTest):
         data = json.loads(res.get_data())
         assert_equal(data['services']['serviceId'], self.service_id)
 
+    def test_invalid_draft_should_have_validation_errors(self):
+        res = self.client.post(
+            '/draft-services',
+            data=json.dumps(self.create_draft_json),
+            content_type='application/json')
+        assert res.status_code == 201
+
+        data = json.loads(res.get_data())
+
+        res = self.client.get('/draft-services/{}'.format(data['services']['id']))
+        assert res.status_code == 200
+        data = json.loads(res.get_data())
+        assert data['validationErrors']
+
+    def test_valid_draft_should_have_no_validation_errors(self):
+        draft = self.create_draft_service()
+
+        res = self.client.get('/draft-services/{}'.format(draft['id']))
+        assert res.status_code == 200
+        data = json.loads(res.get_data())
+        assert not data['validationErrors']
+
     def test_should_404_on_fetch_a_draft_that_doesnt_exist(self):
         fetch = self.client.get('/draft-services/0000000000')
         assert_equal(fetch.status_code, 404)


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/108748808

Add a flag to the response when getting a single draft service showing whether the entire service is valid or not. This is useful for knowing when to show the 'mark as complete' button on the supplier frontend.