### PR TITLE
Don't allow copying a one_service_limit draft

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -1,7 +1,6 @@
 from flask import jsonify, abort, request
 from sqlalchemy.types import String
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.sql.expression import true, false
 from sqlalchemy import func, orm, case
 import datetime
 
@@ -172,10 +171,8 @@ def get_framework_interest(framework_slug):
 
     supplier_frameworks = SupplierFramework.query.filter(
         SupplierFramework.framework_id == framework.id
-    ).all()
+    ).order_by(SupplierFramework.supplier_id).all()
 
-    supplier_ids = []
-    for supplier_framework in supplier_frameworks:
-        supplier_ids.append(supplier_framework.supplier_id)
+    supplier_ids = [supplier_framework.supplier_id for supplier_framework in supplier_frameworks]
 
     return jsonify(interestedSuppliers=supplier_ids)

--- a/app/models.py
+++ b/app/models.py
@@ -605,6 +605,9 @@ class DraftService(db.Model, ServiceTableMixin):
         )
 
     def copy(self):
+        if self.lot.one_service_limit:
+            raise ValidationError("Cannot copy a '{}' draft".format(self.lot.slug))
+
         data = self.data.copy()
         name = data.get('serviceName', '')
         if len(name) <= 95:

--- a/app/models.py
+++ b/app/models.py
@@ -69,6 +69,7 @@ class Framework(db.Model):
     lots = db.relationship(
         Lot, secondary=framework_lots,
         lazy='joined', innerjoin=False,
+        order_by=Lot.id,
         backref='frameworks'
     )
 

--- a/tests/app/views/test_drafts.py
+++ b/tests/app/views/test_drafts.py
@@ -2,12 +2,11 @@ from tests.app.helpers import BaseApplicationTest
 from datetime import datetime
 from flask import json
 import mock
-from sqlalchemy.exc import IntegrityError
 from app.models import Supplier, ContactInformation, Service, Framework, \
     DraftService
 from app import db
 
-from nose.tools import assert_equal, assert_in, assert_raises, assert_false
+from nose.tools import assert_equal, assert_in, assert_false
 
 
 class TestDraftServices(BaseApplicationTest):
@@ -1267,6 +1266,18 @@ class TestDOSServices(BaseApplicationTest):
         data = json.loads(fetch.get_data())
         assert_equal(data['services']['dataProtocols'], False)
         assert_equal(data['services']['id'], draft_id)
+
+    def test_should_not_copy_one_service_limit_lot_draft(self):
+        draft = json.loads(self._post_dos_draft().get_data())
+
+        res = self.client.post(
+            '/draft-services/{}/copy'.format(draft['services']['id']),
+            data=json.dumps({"update_details": {"updated_by": "me"}}),
+            content_type="application/json")
+        data = json.loads(res.get_data())
+
+        assert_equal(res.status_code, 400)
+        assert_in("Cannot copy a 'digital-outcomes' draft", data['error'])
 
     def _post_dos_draft(self):
         res = self.client.post(


### PR DESCRIPTION
For lots that can only have one service per supplier there shouldn't
be a way to create additional services, so we return an error if the
copy draft endpoint was called.

Since there's no "Make a copy" button displayed for one-service lots
this requires no changes in the frontend apps.

### Add explicit order_by to Framework.lots
Lots should always be ordered by id since they could be used for
display.