### PR TITLE
[WIP]

### DIFF
--- a/app/validation.py
+++ b/app/validation.py
@@ -141,6 +141,9 @@ def get_validation_errors(validator_name, json_data,
         elif error.validator == 'required':
             key = re.search(r'\'(.*)\'', error.message).group(1)
             error_map[key] = 'answer_required'
+        elif error.validator == 'anyOf':
+            if error.validator_value[0].get('title'):
+                form_errors.append('{}_required'.format(error.validator_value[0].get('title')))
         else:
             form_errors.append(error.message)
     if form_errors:

--- a/app/validation.py
+++ b/app/validation.py
@@ -138,8 +138,9 @@ def get_validation_errors(validator_name, json_data,
             error_map[key] = _translate_json_schema_error(
                 key, error.validator, error.validator_value, error.message
             )
-        elif error.validator == 'required':
-            key = re.search(r'\'(.*)\'', error.message).group(1)
+        elif error.validator in ['required', 'dependencies']:
+            regex = r'\'(\w+)\' is a dependency of \'(\w+)\'' if error.validator == 'dependencies' else r'\'(.*)\''
+            key = re.search(regex, error.message).group(1)
             error_map[key] = 'answer_required'
         elif error.validator == 'anyOf':
             if error.validator_value[0].get('title'):

--- a/app/validation.py
+++ b/app/validation.py
@@ -64,7 +64,8 @@ def get_validator(schema_name, enforce_required=True, required_fields=None):
         schema['required'] = [
             field for field in schema.get('required', [])
             if field in required_fields
-            ]
+        ]
+        schema.pop('anyOf', None)
     return validator_for(schema)(schema, format_checker=FORMAT_CHECKER)
 
 

--- a/app/validation.py
+++ b/app/validation.py
@@ -235,10 +235,13 @@ def _translate_json_schema_error(key, validator, validator_value, message):
             return 'answer_required'
 
     elif validator == 'pattern':
-        if key in ['priceMin', 'priceMax']:
-            return 'not_money_format'
-        else:
-            return 'under_{}_words'.format(_get_word_count(validator_value))
+        # Since error messages are now specified in the manifests, we can (in the future) generalise the returned
+        # string and just show the correct message
+        for price_str in ['priceMin', 'priceMax', 'PriceMin', 'PriceMax']:
+            if price_str in key:
+                return 'not_money_format'
+
+        return 'under_{}_words'.format(_get_word_count(validator_value))
 
     elif validator == 'enum' and key == 'priceUnit':
         return 'no_unit_specified'

--- a/app/validation.py
+++ b/app/validation.py
@@ -1,6 +1,7 @@
 import json
 import re
 import os
+import copy
 from decimal import Decimal
 
 from flask import abort
@@ -60,7 +61,7 @@ def get_validator(schema_name, enforce_required=True, required_fields=None):
     if enforce_required:
         schema = _SCHEMAS[schema_name]
     else:
-        schema = _SCHEMAS[schema_name].copy()
+        schema = copy.deepcopy(_SCHEMAS[schema_name])
         schema['required'] = [
             field for field in schema.get('required', [])
             if field in required_fields

--- a/example_listings/DOS-LOT1.json
+++ b/example_listings/DOS-LOT1.json
@@ -1,5 +1,0 @@
-{
-  "supplierId": 1,
-  "lot": "digital-outcomes",
-  "dataProtocols": true
-}

--- a/example_listings/DOS-digital-specialist.json
+++ b/example_listings/DOS-digital-specialist.json
@@ -1,0 +1,16 @@
+{
+  "id": 1,
+  "supplierId": 1,
+  "lot": "digital-specialists",
+  "lotName": "Digital Specialists",
+  "agileCoachLocations": [
+    "London"
+  ],
+  "agileCoachPriceMax": "200",
+  "agileCoachPriceMin": "100",
+  "bespokeSystemInformation": true,
+  "dataProtocols": true,
+  "helpGovernmentImproveServices": true,
+  "openSourceLicence": true,
+  "openStandardsPrinciples": true
+}

--- a/json_schemas/services-digital-outcomes-and-specialists-digital-outcomes.json
+++ b/json_schemas/services-digital-outcomes-and-specialists-digital-outcomes.json
@@ -1,6 +1,56 @@
 {
   "$schema": "http://json-schema.org/schema#",
   "additionalProperties": false,
+  "anyOf": [
+    {
+      "required": [
+        "deliveryTypes"
+      ],
+      "title": "capability"
+    },
+    {
+      "required": [
+        "performanceAnalysisTypes"
+      ],
+      "title": "capability"
+    },
+    {
+      "required": [
+        "securityTypes"
+      ],
+      "title": "capability"
+    },
+    {
+      "required": [
+        "softwareDevelopmentTypes"
+      ],
+      "title": "capability"
+    },
+    {
+      "required": [
+        "supportAndOperationsTypes"
+      ],
+      "title": "capability"
+    },
+    {
+      "required": [
+        "testingAndAuditingTypes"
+      ],
+      "title": "capability"
+    },
+    {
+      "required": [
+        "userExperienceAndDesignTypes"
+      ],
+      "title": "capability"
+    },
+    {
+      "required": [
+        "userResearchTypes"
+      ],
+      "title": "capability"
+    }
+  ],
   "properties": {
     "bespokeSystemInformation": {
       "type": "boolean"
@@ -11,14 +61,14 @@
     "deliveryTypes": {
       "items": {
         "enum": [
-          "Service management",
-          "Product management",
-          "Project management",
-          "Programme management",
-          "Business analysis",
-          "Agile coaching / training",
+          "Agile coaching and training",
           "Agile delivery",
-          "Digital communication / engagement"
+          "Business analysis",
+          "Digital communication and engagement",
+          "Product management",
+          "Programme management",
+          "Project management",
+          "Service management"
         ]
       },
       "maxItems": 8,
@@ -38,6 +88,7 @@
     "outcomesLocations": {
       "items": {
         "enum": [
+          "Off-site",
           "Scotland",
           "North East England",
           "North West England",
@@ -52,7 +103,7 @@
           "Northern Ireland"
         ]
       },
-      "maxItems": 12,
+      "maxItems": 13,
       "minItems": 1,
       "type": "array",
       "uniqueItems": true
@@ -60,14 +111,14 @@
     "performanceAnalysisTypes": {
       "items": {
         "enum": [
+          "A/B and multivariate testing",
           "Data analysis",
-          "Web analytics",
           "Data cleansing",
           "Data visualisation",
-          "Statistical modelling",
-          "Performance reporting",
           "Performance frameworks",
-          "A/B and multivariate testing"
+          "Performance reporting",
+          "Statistical modelling",
+          "Web analytics"
         ]
       },
       "maxItems": 8,
@@ -78,17 +129,18 @@
     "securityTypes": {
       "items": {
         "enum": [
-          "CLAS / CESG certification",
-          "THC (Pen) Testing",
-          "Threat modelling",
+          "CESG information assurance certification",
+          "Firewall audit",
+          "Incident response and forensics",
+          "Infrastructure review",
           "Risk management",
-          "Incident response / forensics",
           "Security policy",
-          "Firewall review / audit",
-          "Infrastructure review"
+          "IT health check",
+          "Threat modelling",
+          "Vulnerability and penetration testing"
         ]
       },
-      "maxItems": 8,
+      "maxItems": 9,
       "minItems": 1,
       "type": "array",
       "uniqueItems": true
@@ -96,22 +148,22 @@
     "softwareDevelopmentTypes": {
       "items": {
         "enum": [
-          "Frontend web application development",
-          "Web application development",
-          "Desktop application development",
-          "Mobile application development",
-          "Geographic information systems (GIS) development",
-          "Database development (Relational/Document/XML/Graph/RDF/Key Value)",
-          "Cloud-based service development",
           "API development",
-          "Game development",
-          "Message Queues",
-          "Search",
+          "Cloud-based service development",
+          "Content management system",
           "Customer relationship management",
-          "Content management system (Wordpress/Drupal)",
-          "Systems Integration",
-          "Mainframe (Cobol / etc)",
-          "Machine learning"
+          "Database development",
+          "Desktop application development",
+          "Frontend web application development",
+          "Game development",
+          "Geographic information systems (GIS) development",
+          "Machine learning",
+          "Mainframe",
+          "Message queues",
+          "Mobile application development",
+          "Search",
+          "Systems integration",
+          "Web application development"
         ]
       },
       "maxItems": 16,
@@ -122,15 +174,15 @@
     "supportAndOperationsTypes": {
       "items": {
         "enum": [
+          "Customer support",
+          "Firewall management",
           "Hosting",
-          "Tooling (continuous integration / deployment tools)",
           "Incident management",
           "Monitoring",
-          "Systems administration",
-          "Customer support",
-          "Technical service desk",
           "Network administration",
-          "Firewall management"
+          "Systems administration",
+          "Service desk",
+          "Tooling"
         ]
       },
       "maxItems": 9,
@@ -141,13 +193,13 @@
     "testingAndAuditingTypes": {
       "items": {
         "enum": [
-          "Load/Performance testing",
           "Accessibility testing",
-          "Application testing (Automated/Exploratory)",
-          "Software auditing",
-          "System auditing",
+          "Application testing",
+          "Data auditing",
+          "Load and performance testing",
           "Process auditing",
-          "Data auditing"
+          "Software auditing",
+          "System auditing"
         ]
       },
       "maxItems": 7,
@@ -158,17 +210,19 @@
     "userExperienceAndDesignTypes": {
       "items": {
         "enum": [
-          "Interaction design",
-          "User experience and design strategy",
-          "Information architecture",
-          "Prototyping",
+          "Accessibility",
           "Animation",
           "Brand development",
+          "Content design and copywriting",
           "Cross-platform design",
-          "Content design / copywriting"
+          "Information architecture",
+          "Interaction design",
+          "Prototyping",
+          "Service design",
+          "User experience and design strategy"
         ]
       },
-      "maxItems": 8,
+      "maxItems": 10,
       "minItems": 1,
       "type": "array",
       "uniqueItems": true
@@ -176,12 +230,12 @@
     "userResearchTypes": {
       "items": {
         "enum": [
-          "User needs and insights",
-          "User journey mapping",
           "Creating personas",
-          "Usability testing",
           "Quantitative research",
-          "Surveys"
+          "Surveys",
+          "Usability testing",
+          "User journey mapping",
+          "User needs and insights"
         ]
       },
       "maxItems": 6,
@@ -193,18 +247,10 @@
   "required": [
     "bespokeSystemInformation",
     "dataProtocols",
-    "deliveryTypes",
     "helpGovernmentImproveServices",
     "openSourceLicence",
     "openStandardsPrinciples",
-    "outcomesLocations",
-    "performanceAnalysisTypes",
-    "securityTypes",
-    "softwareDevelopmentTypes",
-    "supportAndOperationsTypes",
-    "testingAndAuditingTypes",
-    "userExperienceAndDesignTypes",
-    "userResearchTypes"
+    "outcomesLocations"
   ],
   "title": "Digital Outcomes and Specialists Digital outcomes Service Schema",
   "type": "object"

--- a/json_schemas/services-digital-outcomes-and-specialists-digital-specialists.json
+++ b/json_schemas/services-digital-outcomes-and-specialists-digital-specialists.json
@@ -1,6 +1,330 @@
 {
   "$schema": "http://json-schema.org/schema#",
   "additionalProperties": false,
+  "anyOf": [
+    {
+      "required": [
+        "agileCoachLocations",
+        "agileCoachPriceMax",
+        "agileCoachPriceMin"
+      ],
+      "title": "specialist"
+    },
+    {
+      "required": [
+        "businessAnalystLocations",
+        "businessAnalystPriceMax",
+        "businessAnalystPriceMin"
+      ],
+      "title": "specialist"
+    },
+    {
+      "required": [
+        "communicationsManagerLocations",
+        "communicationsManagerPriceMax",
+        "communicationsManagerPriceMin"
+      ],
+      "title": "specialist"
+    },
+    {
+      "required": [
+        "contentDesignerLocations",
+        "contentDesignerPriceMax",
+        "contentDesignerPriceMin"
+      ],
+      "title": "specialist"
+    },
+    {
+      "required": [
+        "deliveryManagerLocations",
+        "deliveryManagerPriceMax",
+        "deliveryManagerPriceMin"
+      ],
+      "title": "specialist"
+    },
+    {
+      "required": [
+        "designerLocations",
+        "designerPriceMax",
+        "designerPriceMin"
+      ],
+      "title": "specialist"
+    },
+    {
+      "required": [
+        "developerLocations",
+        "developerPriceMax",
+        "developerPriceMin"
+      ],
+      "title": "specialist"
+    },
+    {
+      "required": [
+        "performanceAnalystLocations",
+        "performanceAnalystPriceMax",
+        "performanceAnalystPriceMin"
+      ],
+      "title": "specialist"
+    },
+    {
+      "required": [
+        "portfolioManagerLocations",
+        "portfolioManagerPriceMax",
+        "portfolioManagerPriceMin"
+      ],
+      "title": "specialist"
+    },
+    {
+      "required": [
+        "productManagerLocations",
+        "productManagerPriceMax",
+        "productManagerPriceMin"
+      ],
+      "title": "specialist"
+    },
+    {
+      "required": [
+        "programmeManagerLocations",
+        "programmeManagerPriceMax",
+        "programmeManagerPriceMin"
+      ],
+      "title": "specialist"
+    },
+    {
+      "required": [
+        "securityConsultantLocations",
+        "securityConsultantPriceMax",
+        "securityConsultantPriceMin"
+      ],
+      "title": "specialist"
+    },
+    {
+      "required": [
+        "serviceManagerLocations",
+        "serviceManagerPriceMax",
+        "serviceManagerPriceMin"
+      ],
+      "title": "specialist"
+    },
+    {
+      "required": [
+        "technicalArchitectLocations",
+        "technicalArchitectPriceMax",
+        "technicalArchitectPriceMin"
+      ],
+      "title": "specialist"
+    },
+    {
+      "required": [
+        "userResearcherLocations",
+        "userResearcherPriceMax",
+        "userResearcherPriceMin"
+      ],
+      "title": "specialist"
+    },
+    {
+      "required": [
+        "webOperationsLocations",
+        "webOperationsPriceMax",
+        "webOperationsPriceMin"
+      ],
+      "title": "specialist"
+    }
+  ],
+  "dependencies": {
+    "agileCoachLocations": [
+      "agileCoachPriceMax",
+      "agileCoachPriceMin"
+    ],
+    "agileCoachPriceMax": [
+      "agileCoachLocations",
+      "agileCoachPriceMin"
+    ],
+    "agileCoachPriceMin": [
+      "agileCoachLocations",
+      "agileCoachPriceMax"
+    ],
+    "businessAnalystLocations": [
+      "businessAnalystPriceMax",
+      "businessAnalystPriceMin"
+    ],
+    "businessAnalystPriceMax": [
+      "businessAnalystLocations",
+      "businessAnalystPriceMin"
+    ],
+    "businessAnalystPriceMin": [
+      "businessAnalystLocations",
+      "businessAnalystPriceMax"
+    ],
+    "communicationsManagerLocations": [
+      "communicationsManagerPriceMax",
+      "communicationsManagerPriceMin"
+    ],
+    "communicationsManagerPriceMax": [
+      "communicationsManagerLocations",
+      "communicationsManagerPriceMin"
+    ],
+    "communicationsManagerPriceMin": [
+      "communicationsManagerLocations",
+      "communicationsManagerPriceMax"
+    ],
+    "contentDesignerLocations": [
+      "contentDesignerPriceMax",
+      "contentDesignerPriceMin"
+    ],
+    "contentDesignerPriceMax": [
+      "contentDesignerLocations",
+      "contentDesignerPriceMin"
+    ],
+    "contentDesignerPriceMin": [
+      "contentDesignerLocations",
+      "contentDesignerPriceMax"
+    ],
+    "deliveryManagerLocations": [
+      "deliveryManagerPriceMax",
+      "deliveryManagerPriceMin"
+    ],
+    "deliveryManagerPriceMax": [
+      "deliveryManagerLocations",
+      "deliveryManagerPriceMin"
+    ],
+    "deliveryManagerPriceMin": [
+      "deliveryManagerLocations",
+      "deliveryManagerPriceMax"
+    ],
+    "designerLocations": [
+      "designerPriceMax",
+      "designerPriceMin"
+    ],
+    "designerPriceMax": [
+      "designerLocations",
+      "designerPriceMin"
+    ],
+    "designerPriceMin": [
+      "designerLocations",
+      "designerPriceMax"
+    ],
+    "developerLocations": [
+      "developerPriceMax",
+      "developerPriceMin"
+    ],
+    "developerPriceMax": [
+      "developerLocations",
+      "developerPriceMin"
+    ],
+    "developerPriceMin": [
+      "developerLocations",
+      "developerPriceMax"
+    ],
+    "performanceAnalystLocations": [
+      "performanceAnalystPriceMax",
+      "performanceAnalystPriceMin"
+    ],
+    "performanceAnalystPriceMax": [
+      "performanceAnalystLocations",
+      "performanceAnalystPriceMin"
+    ],
+    "performanceAnalystPriceMin": [
+      "performanceAnalystLocations",
+      "performanceAnalystPriceMax"
+    ],
+    "portfolioManagerLocations": [
+      "portfolioManagerPriceMax",
+      "portfolioManagerPriceMin"
+    ],
+    "portfolioManagerPriceMax": [
+      "portfolioManagerLocations",
+      "portfolioManagerPriceMin"
+    ],
+    "portfolioManagerPriceMin": [
+      "portfolioManagerLocations",
+      "portfolioManagerPriceMax"
+    ],
+    "productManagerLocations": [
+      "productManagerPriceMax",
+      "productManagerPriceMin"
+    ],
+    "productManagerPriceMax": [
+      "productManagerLocations",
+      "productManagerPriceMin"
+    ],
+    "productManagerPriceMin": [
+      "productManagerLocations",
+      "productManagerPriceMax"
+    ],
+    "programmeManagerLocations": [
+      "programmeManagerPriceMax",
+      "programmeManagerPriceMin"
+    ],
+    "programmeManagerPriceMax": [
+      "programmeManagerLocations",
+      "programmeManagerPriceMin"
+    ],
+    "programmeManagerPriceMin": [
+      "programmeManagerLocations",
+      "programmeManagerPriceMax"
+    ],
+    "securityConsultantLocations": [
+      "securityConsultantPriceMax",
+      "securityConsultantPriceMin"
+    ],
+    "securityConsultantPriceMax": [
+      "securityConsultantLocations",
+      "securityConsultantPriceMin"
+    ],
+    "securityConsultantPriceMin": [
+      "securityConsultantLocations",
+      "securityConsultantPriceMax"
+    ],
+    "serviceManagerLocations": [
+      "serviceManagerPriceMax",
+      "serviceManagerPriceMin"
+    ],
+    "serviceManagerPriceMax": [
+      "serviceManagerLocations",
+      "serviceManagerPriceMin"
+    ],
+    "serviceManagerPriceMin": [
+      "serviceManagerLocations",
+      "serviceManagerPriceMax"
+    ],
+    "technicalArchitectLocations": [
+      "technicalArchitectPriceMax",
+      "technicalArchitectPriceMin"
+    ],
+    "technicalArchitectPriceMax": [
+      "technicalArchitectLocations",
+      "technicalArchitectPriceMin"
+    ],
+    "technicalArchitectPriceMin": [
+      "technicalArchitectLocations",
+      "technicalArchitectPriceMax"
+    ],
+    "userResearcherLocations": [
+      "userResearcherPriceMax",
+      "userResearcherPriceMin"
+    ],
+    "userResearcherPriceMax": [
+      "userResearcherLocations",
+      "userResearcherPriceMin"
+    ],
+    "userResearcherPriceMin": [
+      "userResearcherLocations",
+      "userResearcherPriceMax"
+    ],
+    "webOperationsLocations": [
+      "webOperationsPriceMax",
+      "webOperationsPriceMin"
+    ],
+    "webOperationsPriceMax": [
+      "webOperationsLocations",
+      "webOperationsPriceMin"
+    ],
+    "webOperationsPriceMin": [
+      "webOperationsLocations",
+      "webOperationsPriceMax"
+    ]
+  },
   "properties": {
     "agileCoachLocations": {
       "items": {
@@ -24,12 +348,21 @@
       "type": "array",
       "uniqueItems": true
     },
+    "agileCoachPriceMax": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "agileCoachPriceMin": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
     "bespokeSystemInformation": {
       "type": "boolean"
     },
     "businessAnalystLocations": {
       "items": {
         "enum": [
+          "Off-site",
           "Scotland",
           "North East England",
           "North West England",
@@ -44,14 +377,23 @@
           "Northern Ireland"
         ]
       },
-      "maxItems": 12,
+      "maxItems": 13,
       "minItems": 1,
       "type": "array",
       "uniqueItems": true
+    },
+    "businessAnalystPriceMax": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "businessAnalystPriceMin": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
     },
     "communicationsManagerLocations": {
       "items": {
         "enum": [
+          "Off-site",
           "Scotland",
           "North East England",
           "North West England",
@@ -66,14 +408,23 @@
           "Northern Ireland"
         ]
       },
-      "maxItems": 12,
+      "maxItems": 13,
       "minItems": 1,
       "type": "array",
       "uniqueItems": true
     },
+    "communicationsManagerPriceMax": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "communicationsManagerPriceMin": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
     "contentDesignerLocations": {
       "items": {
         "enum": [
+          "Off-site",
           "Scotland",
           "North East England",
           "North West England",
@@ -88,10 +439,18 @@
           "Northern Ireland"
         ]
       },
-      "maxItems": 12,
+      "maxItems": 13,
       "minItems": 1,
       "type": "array",
       "uniqueItems": true
+    },
+    "contentDesignerPriceMax": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "contentDesignerPriceMin": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
     },
     "dataProtocols": {
       "type": "boolean"
@@ -99,6 +458,7 @@
     "deliveryManagerLocations": {
       "items": {
         "enum": [
+          "Off-site",
           "Scotland",
           "North East England",
           "North West England",
@@ -113,14 +473,23 @@
           "Northern Ireland"
         ]
       },
-      "maxItems": 12,
+      "maxItems": 13,
       "minItems": 1,
       "type": "array",
       "uniqueItems": true
+    },
+    "deliveryManagerPriceMax": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "deliveryManagerPriceMin": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
     },
     "designerLocations": {
       "items": {
         "enum": [
+          "Off-site",
           "Scotland",
           "North East England",
           "North West England",
@@ -135,14 +504,23 @@
           "Northern Ireland"
         ]
       },
-      "maxItems": 12,
+      "maxItems": 13,
       "minItems": 1,
       "type": "array",
       "uniqueItems": true
     },
+    "designerPriceMax": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "designerPriceMin": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
     "developerLocations": {
       "items": {
         "enum": [
+          "Off-site",
           "Scotland",
           "North East England",
           "North West England",
@@ -157,10 +535,18 @@
           "Northern Ireland"
         ]
       },
-      "maxItems": 12,
+      "maxItems": 13,
       "minItems": 1,
       "type": "array",
       "uniqueItems": true
+    },
+    "developerPriceMax": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "developerPriceMin": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
     },
     "helpGovernmentImproveServices": {
       "type": "boolean"
@@ -174,6 +560,7 @@
     "performanceAnalystLocations": {
       "items": {
         "enum": [
+          "Off-site",
           "Scotland",
           "North East England",
           "North West England",
@@ -188,14 +575,23 @@
           "Northern Ireland"
         ]
       },
-      "maxItems": 12,
+      "maxItems": 13,
       "minItems": 1,
       "type": "array",
       "uniqueItems": true
+    },
+    "performanceAnalystPriceMax": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "performanceAnalystPriceMin": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
     },
     "portfolioManagerLocations": {
       "items": {
         "enum": [
+          "Off-site",
           "Scotland",
           "North East England",
           "North West England",
@@ -210,52 +606,23 @@
           "Northern Ireland"
         ]
       },
-      "maxItems": 12,
+      "maxItems": 13,
       "minItems": 1,
       "type": "array",
       "uniqueItems": true
     },
-    "priceInterval": {
-      "enum": [
-        "",
-        "Second",
-        "Minute",
-        "Hour",
-        "Day",
-        "Week",
-        "Month",
-        "Quarter",
-        "6 months",
-        "Year"
-      ]
-    },
-    "priceMax": {
-      "pattern": "^$|^\\d+(?:\\.\\d{1,5})?$",
-      "type": "string"
-    },
-    "priceMin": {
+    "portfolioManagerPriceMax": {
       "pattern": "^\\d+(?:\\.\\d{1,5})?$",
       "type": "string"
     },
-    "priceUnit": {
-      "enum": [
-        "Unit",
-        "Person",
-        "Licence",
-        "User",
-        "Device",
-        "Instance",
-        "Server",
-        "Virtual machine",
-        "Transaction",
-        "Megabyte",
-        "Gigabyte",
-        "Terabyte"
-      ]
+    "portfolioManagerPriceMin": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
     },
     "productManagerLocations": {
       "items": {
         "enum": [
+          "Off-site",
           "Scotland",
           "North East England",
           "North West England",
@@ -270,14 +637,23 @@
           "Northern Ireland"
         ]
       },
-      "maxItems": 12,
+      "maxItems": 13,
       "minItems": 1,
       "type": "array",
       "uniqueItems": true
+    },
+    "productManagerPriceMax": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "productManagerPriceMin": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
     },
     "programmeManagerLocations": {
       "items": {
         "enum": [
+          "Off-site",
           "Scotland",
           "North East England",
           "North West England",
@@ -292,14 +668,23 @@
           "Northern Ireland"
         ]
       },
-      "maxItems": 12,
+      "maxItems": 13,
       "minItems": 1,
       "type": "array",
       "uniqueItems": true
+    },
+    "programmeManagerPriceMax": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "programmeManagerPriceMin": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
     },
     "securityConsultantLocations": {
       "items": {
         "enum": [
+          "Off-site",
           "Scotland",
           "North East England",
           "North West England",
@@ -314,14 +699,23 @@
           "Northern Ireland"
         ]
       },
-      "maxItems": 12,
+      "maxItems": 13,
       "minItems": 1,
       "type": "array",
       "uniqueItems": true
+    },
+    "securityConsultantPriceMax": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "securityConsultantPriceMin": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
     },
     "serviceManagerLocations": {
       "items": {
         "enum": [
+          "Off-site",
           "Scotland",
           "North East England",
           "North West England",
@@ -336,14 +730,23 @@
           "Northern Ireland"
         ]
       },
-      "maxItems": 12,
+      "maxItems": 13,
       "minItems": 1,
       "type": "array",
       "uniqueItems": true
+    },
+    "serviceManagerPriceMax": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "serviceManagerPriceMin": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
     },
     "technicalArchitectLocations": {
       "items": {
         "enum": [
+          "Off-site",
           "Scotland",
           "North East England",
           "North West England",
@@ -358,14 +761,23 @@
           "Northern Ireland"
         ]
       },
-      "maxItems": 12,
+      "maxItems": 13,
       "minItems": 1,
       "type": "array",
       "uniqueItems": true
+    },
+    "technicalArchitectPriceMax": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "technicalArchitectPriceMin": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
     },
     "userResearcherLocations": {
       "items": {
         "enum": [
+          "Off-site",
           "Scotland",
           "North East England",
           "North West England",
@@ -380,14 +792,23 @@
           "Northern Ireland"
         ]
       },
-      "maxItems": 12,
+      "maxItems": 13,
       "minItems": 1,
       "type": "array",
       "uniqueItems": true
     },
+    "userResearcherPriceMax": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "userResearcherPriceMin": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
     "webOperationsLocations": {
       "items": {
         "enum": [
+          "Off-site",
           "Scotland",
           "North East England",
           "North West England",
@@ -402,50 +823,26 @@
           "Northern Ireland"
         ]
       },
-      "maxItems": 12,
+      "maxItems": 13,
       "minItems": 1,
       "type": "array",
       "uniqueItems": true
+    },
+    "webOperationsPriceMax": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "webOperationsPriceMin": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
     }
   },
   "required": [
-    "agileCoachDayRate",
-    "agileCoachLocations",
     "bespokeSystemInformation",
-    "businessAnalystDayRate",
-    "businessAnalystLocations",
-    "communicationsManagerDayRate",
-    "communicationsManagerLocations",
-    "contentDesignerDayRate",
-    "contentDesignerLocations",
     "dataProtocols",
-    "deliveryManagerDayRate",
-    "deliveryManagerLocations",
-    "designerDayRate",
-    "designerLocations",
-    "developerDayRate",
-    "developerLocations",
     "helpGovernmentImproveServices",
     "openSourceLicence",
-    "openStandardsPrinciples",
-    "performanceAnalystDayRate",
-    "performanceAnalystLocations",
-    "portfolioManagerDayRate",
-    "portfolioManagerLocations",
-    "productManagerDayRate",
-    "productManagerLocations",
-    "programmeManagerDayRate",
-    "programmeManagerLocations",
-    "securityConsultantDayRate",
-    "securityConsultantLocations",
-    "serviceManagerDayRate",
-    "serviceManagerLocations",
-    "technicalArchitectDayRate",
-    "technicalArchitectLocations",
-    "userResearcherDayRate",
-    "userResearcherLocations",
-    "webOperationsDayRate",
-    "webOperationsLocations"
+    "openStandardsPrinciples"
   ],
   "title": "Digital Outcomes and Specialists Digital specialists Service Schema",
   "type": "object"


### PR DESCRIPTION
WIP because I haven't tested this with the frontend supplier app yet.  I'll do some of that and then remove the tag.

--

This pull request:

- Adds the new schemas
- Changes how validating works in a few places
- Tests things

#### Adds the new schemas

We've got what seem to be the final DOS schemas with 'anyOf's and 'dependencies' and all that other fun stuff, so now the API is validating against the right things :+1: 

#### Changes how validating works in a few places

- process `dependencies` errors
 - If a key that's part of a group is included without the rest of the group, the schema will fail to validate with an error that's not very helpful
   -  (ie, adding `developerLocations
- anyof
- pricing 
- drop anyOf