### PR TITLE
Add framework.clarification_questions_open flag

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -39,11 +39,11 @@ def update_framework(framework_slug):
 
     json_payload = get_json_from_request()
     json_has_required_keys(json_payload, ['frameworks', 'updated_by'])
-    json_only_has_required_keys(json_payload['frameworks'], ['status', 'clarification_questions_open'])
+    json_only_has_required_keys(json_payload['frameworks'], ['status', 'clarificationQuestionsOpen'])
 
     try:
         framework.status = json_payload['frameworks']['status']
-        framework.clarification_questions_open = json_payload['frameworks']['clarification_questions_open']
+        framework.clarification_questions_open = json_payload['frameworks']['clarificationQuestionsOpen']
         db.session.add(framework)
         db.session.add(
             AuditEvent(

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -39,10 +39,11 @@ def update_framework(framework_slug):
 
     json_payload = get_json_from_request()
     json_has_required_keys(json_payload, ['frameworks', 'updated_by'])
-    json_only_has_required_keys(json_payload['frameworks'], ['status'])
+    json_only_has_required_keys(json_payload['frameworks'], ['status', 'clarification_questions_open'])
 
     try:
         framework.status = json_payload['frameworks']['status']
+        framework.clarification_questions_open = json_payload['frameworks']['clarification_questions_open']
         db.session.add(framework)
         db.session.add(
             AuditEvent(

--- a/app/models.py
+++ b/app/models.py
@@ -46,7 +46,8 @@ class Lot(db.Model):
             'id': self.id,
             'slug': self.slug,
             'name': self.name,
-            'one_service_limit': self.one_service_limit,
+            'one_service_limit': self.one_service_limit,  # TODO deprecated
+            'oneServiceLimit': self.one_service_limit,
         }
 
 
@@ -86,7 +87,7 @@ class Framework(db.Model):
             'slug': self.slug,
             'framework': self.framework,
             'status': self.status,
-            'clarification_questions_open': self.clarification_questions_open,
+            'clarificationQuestionsOpen': self.clarification_questions_open,
             'lots': [lot.serialize() for lot in self.lots],
         }
 

--- a/app/models.py
+++ b/app/models.py
@@ -65,6 +65,7 @@ class Framework(db.Model):
     status = db.Column(db.String(),
                        index=True, nullable=False,
                        default='pending')
+    clarification_questions_open = db.Column(db.Boolean, nullable=False, default=False)
     lots = db.relationship(
         Lot, secondary=framework_lots,
         lazy='joined', innerjoin=False,
@@ -85,6 +86,7 @@ class Framework(db.Model):
             'slug': self.slug,
             'framework': self.framework,
             'status': self.status,
+            'clarification_questions_open': self.clarification_questions_open,
             'lots': [lot.serialize() for lot in self.lots],
         }
 

--- a/migrations/versions/440_add_framework_clarification_questions_.py
+++ b/migrations/versions/440_add_framework_clarification_questions_.py
@@ -1,0 +1,30 @@
+"""Add framework clarification_questions_open flag
+
+Revision ID: 440
+Revises: 430
+Create Date: 2015-11-25 16:49:45.258601
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '440'
+down_revision = '430'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('frameworks', sa.Column('clarification_questions_open', sa.Boolean(), nullable=True))
+    op.execute("""
+        UPDATE frameworks SET clarification_questions_open = (CASE status
+               WHEN 'open' THEN 't'
+               ELSE 'f'
+               END
+              )::boolean
+    """)
+    op.alter_column('frameworks', 'clarification_questions_open', existing_type=sa.Boolean(), nullable=False)
+
+
+def downgrade():
+    op.drop_column('frameworks', 'clarification_questions_open')

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ SQLAlchemy==1.0.5
 SQLAlchemy-Utils==0.30.5
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.3#egg=python-json-logger==v0.1.3
-git+https://github.com/alphagov/digitalmarketplace-utils.git@11.3.0#egg=digitalmarketplace-utils==11.3.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@15.3.0#egg=digitalmarketplace-utils==15.3.0
 
 # For schema validation
 jsonschema==2.5.1

--- a/tests/app/views/test_frameworks.py
+++ b/tests/app/views/test_frameworks.py
@@ -20,7 +20,7 @@ class TestListFrameworks(BaseApplicationTest):
             assert_equal(len(data['frameworks']),
                          len(Framework.query.all()))
             assert_equal(sorted(data['frameworks'][0].keys()),
-                         ['clarification_questions_open', 'framework', 'id', 'lots', 'name', 'slug', 'status'])
+                         ['clarificationQuestionsOpen', 'framework', 'id', 'lots', 'name', 'slug', 'status'])
 
 
 class TestGetFramework(BaseApplicationTest):
@@ -39,10 +39,14 @@ class TestGetFramework(BaseApplicationTest):
 
         data = json.loads(response.get_data())
         assert_equal(data['frameworks']['lots'], [
-            {u'id': 1, u'name': u'Software as a Service', u'one_service_limit': False, u'slug': u'saas'},
-            {u'id': 2, u'name': u'Platform as a Service', u'one_service_limit': False, u'slug': u'paas'},
-            {u'id': 3, u'name': u'Infrastructure as a Service', u'one_service_limit': False, u'slug': u'iaas'},
-            {u'id': 4, u'name': u'Specialist Cloud Services', u'one_service_limit': False, u'slug': u'scs'}
+            {u'id': 1, u'name': u'Software as a Service',
+             u'one_service_limit': False, u'oneServiceLimit': False, u'slug': u'saas'},
+            {u'id': 2, u'name': u'Platform as a Service',
+             u'one_service_limit': False, u'oneServiceLimit': False, u'slug': u'paas'},
+            {u'id': 3, u'name': u'Infrastructure as a Service',
+             u'one_service_limit': False, u'oneServiceLimit': False, u'slug': u'iaas'},
+            {u'id': 4, u'name': u'Specialist Cloud Services',
+             u'one_service_limit': False, u'oneServiceLimit': False, u'slug': u'scs'}
         ])
 
     def test_a_404_is_raised_if_it_does_not_exist(self):
@@ -75,7 +79,7 @@ class TestUpdateFramework(BaseApplicationTest):
             response = self.client.post('/frameworks/example',
                                         data=json.dumps({'frameworks': {
                                             'status': 'expired',
-                                            'clarification_questions_open': False,
+                                            'clarificationQuestionsOpen': False,
                                         }, 'updated_by': 'example user'}),
                                         content_type="application/json")
 

--- a/tests/app/views/test_frameworks.py
+++ b/tests/app/views/test_frameworks.py
@@ -20,7 +20,7 @@ class TestListFrameworks(BaseApplicationTest):
             assert_equal(len(data['frameworks']),
                          len(Framework.query.all()))
             assert_equal(sorted(data['frameworks'][0].keys()),
-                         ['framework', 'id', 'lots', 'name', 'slug', 'status'])
+                         ['clarification_questions_open', 'framework', 'id', 'lots', 'name', 'slug', 'status'])
 
 
 class TestGetFramework(BaseApplicationTest):
@@ -73,12 +73,17 @@ class TestUpdateFramework(BaseApplicationTest):
     def test_framework_updated(self):
         with self.app.app_context():
             response = self.client.post('/frameworks/example',
-                                        data=json.dumps({'frameworks': {'status': 'expired'},
-                                                         'updated_by': 'example user'}),
+                                        data=json.dumps({'frameworks': {
+                                            'status': 'expired',
+                                            'clarification_questions_open': False,
+                                        }, 'updated_by': 'example user'}),
                                         content_type="application/json")
 
             assert response.status_code == 200
-            assert Framework.query.filter(Framework.slug == 'example').first().status == "expired"
+
+            framework = Framework.query.filter(Framework.slug == 'example').first()
+            assert framework.status == "expired"
+            assert not framework.clarification_questions_open
 
     def test_returns_404_on_non_existent_framework(self):
         with self.app.app_context():


### PR DESCRIPTION
Part of [#107995312](https://www.pivotaltracker.com/story/show/107995312)

Flag tels supplier frontend if clarification questions are open for
the framework. Can be updated at the same time as the framework status.

Migration sets the flag to 'false' for all existing non-open frameworks
and to 'true' for open frameworks.