### PR TITLE
[#107188798] Remove keys from draft services if updated values are None

### DIFF
--- a/app/main/views/drafts.py
+++ b/app/main/views/drafts.py
@@ -86,6 +86,7 @@ def edit_draft_service(draft_id):
     ).first_or_404()
 
     draft.update_from_json(update_json)
+    draft.purge_nulls()
     validate_service_data(draft, enforce_required=False, required_fields=page_questions)
 
     audit = AuditEvent(

--- a/app/main/views/drafts.py
+++ b/app/main/views/drafts.py
@@ -86,7 +86,6 @@ def edit_draft_service(draft_id):
     ).first_or_404()
 
     draft.update_from_json(update_json)
-    draft.purge_nulls()
     validate_service_data(draft, enforce_required=False, required_fields=page_questions)
 
     audit = AuditEvent(

--- a/app/models.py
+++ b/app/models.py
@@ -511,6 +511,9 @@ class ServiceTableMixin(object):
         self.data = current_data
         self.updated_at = datetime.utcnow()
 
+    def purge_nulls(self):
+        self.data = dict((k, v) for k, v in self.data.iteritems() if v is not None)
+
 
 class Service(db.Model, ServiceTableMixin):
     __tablename__ = 'services'

--- a/app/models.py
+++ b/app/models.py
@@ -3,7 +3,7 @@ from datetime import datetime
 
 from flask import current_app
 from flask_sqlalchemy import BaseQuery
-
+from six import iteritems
 from sqlalchemy import asc
 from sqlalchemy import func
 from sqlalchemy.dialects.postgresql import JSON
@@ -512,7 +512,7 @@ class ServiceTableMixin(object):
         self.updated_at = datetime.utcnow()
 
     def purge_nulls(self):
-        self.data = dict((k, v) for k, v in self.data.iteritems() if v is not None)
+        self.data = dict((k, v) for k, v in iteritems(self.data) if v is not None)
 
 
 class Service(db.Model, ServiceTableMixin):

--- a/app/models.py
+++ b/app/models.py
@@ -3,7 +3,6 @@ from datetime import datetime
 
 from flask import current_app
 from flask_sqlalchemy import BaseQuery
-from six import iteritems
 from sqlalchemy import asc
 from sqlalchemy import func
 from sqlalchemy.dialects.postgresql import JSON
@@ -15,7 +14,7 @@ from sqlalchemy_utils import generic_relationship
 from dmutils.formats import DATETIME_FORMAT
 
 from . import db
-from .utils import link, url_for, strip_whitespace_from_data, drop_foreign_fields
+from .utils import link, url_for, strip_whitespace_from_data, drop_foreign_fields, purge_nulls_from_data
 from .validation import is_valid_service_id
 
 
@@ -474,6 +473,7 @@ class ServiceTableMixin(object):
         ])
 
         data = strip_whitespace_from_data(data)
+        data = purge_nulls_from_data(data)
 
         return data
 
@@ -510,9 +510,6 @@ class ServiceTableMixin(object):
 
         self.data = current_data
         self.updated_at = datetime.utcnow()
-
-    def purge_nulls(self):
-        self.data = dict((k, v) for k, v in iteritems(self.data) if v is not None)
 
 
 class Service(db.Model, ServiceTableMixin):

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,6 +1,6 @@
 from flask import url_for as base_url_for
 from flask import abort, request
-from six import string_types
+from six import iteritems, string_types
 from werkzeug.exceptions import BadRequest
 
 
@@ -91,3 +91,7 @@ def strip_whitespace_from_data(data):
             # Strip whitespace from strings
             data[key] = value.strip()
     return data
+
+
+def purge_nulls_from_data(data):
+    return dict((k, v) for k, v in iteritems(data) if v is not None)

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 
 from nose.tools import assert_equal, assert_raises
-from sqlalchemy.exc import DataError
 
 from app import db, create_app
 from app.models import User, Framework, Service, ValidationError
@@ -120,26 +119,3 @@ class TestServices(BaseApplicationTest):
             services = Service.query.has_statuses('published', 'disabled')
 
             assert_equal(services.count(), 2)
-
-    def test_purge_nulls(self):
-        service_with_nulls = {
-            'serviceName': 'Service with nulls',
-            'empty': None,
-            'serviceSummary': None,
-            'price': 'Not a lot'
-        }
-        same_service_without_nulls = {
-            'serviceName': 'Service with nulls',
-            'price': 'Not a lot'
-        }
-        with self.app.app_context():
-            self.setup_dummy_suppliers(2)
-            self.setup_dummy_service("1234567890123456", data=service_with_nulls)
-
-            service = Service.query.filter(
-                Service.service_id == "1234567890123456"
-            ).first()
-
-            assert_equal(service.data, service_with_nulls)
-            service.purge_nulls()
-            assert_equal(service.data, same_service_without_nulls)

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -120,3 +120,26 @@ class TestServices(BaseApplicationTest):
             services = Service.query.has_statuses('published', 'disabled')
 
             assert_equal(services.count(), 2)
+
+    def test_purge_nulls(self):
+        service_with_nulls = {
+            'serviceName': 'Service with nulls',
+            'empty': None,
+            'serviceSummary': None,
+            'price': 'Not a lot'
+        }
+        same_service_without_nulls = {
+            'serviceName': 'Service with nulls',
+            'price': 'Not a lot'
+        }
+        with self.app.app_context():
+            self.setup_dummy_suppliers(2)
+            self.setup_dummy_service("1234567890123456", data=service_with_nulls)
+
+            service = Service.query.filter(
+                Service.service_id == "1234567890123456"
+            ).first()
+
+            assert_equal(service.data, service_with_nulls)
+            service.purge_nulls()
+            assert_equal(service.data, same_service_without_nulls)

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -1,4 +1,6 @@
 import pytest
+
+from nose.tools import assert_equal
 from werkzeug.exceptions import HTTPException
 
 from .helpers import BaseApplicationTest
@@ -7,7 +9,8 @@ from app.utils import (display_list,
                        strip_whitespace_from_data,
                        json_has_matching_id,
                        json_has_required_keys,
-                       link)
+                       link,
+                       purge_nulls_from_data)
 
 
 def test_link():
@@ -51,3 +54,17 @@ def test_strip_whitespace_from_data():
     after_strip = strip_whitespace_from_data(struct_with_list)
     for item in after_strip['eggs']:
         assert " " not in item
+
+
+def test_purge_nulls():
+    service_with_nulls = {
+        'serviceName': 'Service with nulls',
+        'empty': None,
+        'serviceSummary': None,
+        'price': 'Not a lot'
+    }
+    same_service_without_nulls = {
+        'serviceName': 'Service with nulls',
+        'price': 'Not a lot'
+    }
+    assert_equal(purge_nulls_from_data(service_with_nulls), same_service_without_nulls)

--- a/tests/app/views/test_drafts.py
+++ b/tests/app/views/test_drafts.py
@@ -370,6 +370,44 @@ class TestDraftServices(BaseApplicationTest):
             data['auditEvents'][2]['data']['draftId'], draft_id
         )
 
+    def test_update_draft_should_purge_keys_with_null_values(self):
+        res = self.client.post(
+            '/draft-services',
+            data=json.dumps(self.create_draft_json),
+            content_type='application/json')
+        data = json.loads(res.get_data())
+        draft_id = data['services']['id']
+
+        draft_update_json = self.updater_json.copy()
+        draft_update_json['services'] = {
+            'serviceName': "What a great service",
+            'serviceTypes': ['Implementation'],
+            'serviceBenefits': ['Tests pass']
+        }
+        res2 = self.client.post(
+            '/draft-services/{}'.format(draft_id),
+            data=json.dumps(draft_update_json),
+            content_type='application/json')
+        assert_equal(res2.status_code, 200)
+        data2 = json.loads(res2.get_data())['services']
+        assert('serviceName' in data2)
+        assert('serviceBenefits' in data2)
+        assert('serviceTypes' in data2)
+
+        draft_update_json['services'] = {
+            'serviceTypes': None,
+            'serviceBenefits': None
+        }
+        res3 = self.client.post(
+            '/draft-services/{}'.format(draft_id),
+            data=json.dumps(draft_update_json),
+            content_type='application/json')
+        assert_equal(res3.status_code, 200)
+        data3 = json.loads(res3.get_data())['services']
+        assert('serviceName' in data3)
+        assert('serviceBenefits' not in data3)
+        assert('serviceTypes' not in data3)
+
     def test_validation_errors_returned_for_invalid_update_of_new_draft(self):
         res = self.client.post(
             '/draft-services',

--- a/tests/app/views/test_services.py
+++ b/tests/app/views/test_services.py
@@ -1598,7 +1598,7 @@ class TestPutService(BaseApplicationTest, JSONUpdateTestMixin):
         payload = self.load_example_listing("G6-IaaS")
         payload['id'] = "1234567890123456"
 
-        payload['priceMin'] = None
+        payload['priceMin'] = 23.45
 
         response = self.client.put(
             '/services/1234567890123456',
@@ -1610,7 +1610,7 @@ class TestPutService(BaseApplicationTest, JSONUpdateTestMixin):
             content_type='application/json')
 
         assert_equal(response.status_code, 400)
-        assert_in("None is not of type", json.loads(response.get_data())['error']['priceMin'])
+        assert_in("23.45 is not of type", json.loads(response.get_data())['error']['priceMin'])
 
     def test_add_a_service_with_unknown_supplier_id(self):
         with self.app.app_context():


### PR DESCRIPTION
Required as part of this story: https://www.pivotaltracker.com/story/show/107188798

At the moment there is no way to remove keys from draft services.  This adds a step where keys that have their value set to `None` are removed from the draft service.

This is required to allow removal of specialist roles, etc. from DOS draft services.