### PR TITLE
[#107188910] Add Digital Services and Outcomes' Digital Services and Digital Outcomes schemas, make sure they validate correctly, and write some tests for them.

### DIFF
--- a/app/validation.py
+++ b/app/validation.py
@@ -237,9 +237,8 @@ def _translate_json_schema_error(key, validator, validator_value, message):
     elif validator == 'pattern':
         # Since error messages are now specified in the manifests, we can (in the future) generalise the returned
         # string and just show the correct message
-        for price_str in ['priceMin', 'priceMax', 'PriceMin', 'PriceMax']:
-            if price_str in key:
-                return 'not_money_format'
+        if key.endswith(('priceMin', 'priceMax', 'PriceMin', 'PriceMax')):
+            return 'not_money_format'
 
         return 'under_{}_words'.format(_get_word_count(validator_value))
 

--- a/app/validation.py
+++ b/app/validation.py
@@ -141,6 +141,9 @@ def get_validation_errors(validator_name, json_data,
         elif error.validator == 'required':
             key = re.search(r'\'(.*)\'', error.message).group(1)
             error_map[key] = 'answer_required'
+        elif error.validator == 'anyOf':
+            if error.validator_value[0].get('title'):
+                form_errors.append('{}_required'.format(error.validator_value[0].get('title')))
         else:
             form_errors.append(error.message)
     if form_errors:

--- a/app/validation.py
+++ b/app/validation.py
@@ -139,7 +139,7 @@ def get_validation_errors(validator_name, json_data,
                 key, error.validator, error.validator_value, error.message
             )
         elif error.validator in ['required', 'dependencies']:
-            regex = r'\'(\w+)\' is a dependency of \'(\w+)\'' if error.validator == 'dependencies' else r'\'(.*)\''
+            regex = r'u?\'(\w+)\' is a dependency of u?\'(\w+)\'' if error.validator == 'dependencies' else r'\'(.*)\''
             key = re.search(regex, error.message).group(1)
             error_map[key] = 'answer_required'
         elif error.validator == 'anyOf':

--- a/app/validation.py
+++ b/app/validation.py
@@ -138,8 +138,9 @@ def get_validation_errors(validator_name, json_data,
             error_map[key] = _translate_json_schema_error(
                 key, error.validator, error.validator_value, error.message
             )
-        elif error.validator == 'required':
-            key = re.search(r'\'(.*)\'', error.message).group(1)
+        elif error.validator in ['required', 'dependencies']:
+            regex = r'\'(\w+)\' is a dependency of \'(\w+)\'' if error.validator == 'dependencies' else r'\'(.*)\''
+            key = re.search(regex, error.message).group(1)
             error_map[key] = 'answer_required'
         elif error.validator == 'anyOf':
             if error.validator_value[0].get('title'):

--- a/app/validation.py
+++ b/app/validation.py
@@ -64,7 +64,8 @@ def get_validator(schema_name, enforce_required=True, required_fields=None):
         schema['required'] = [
             field for field in schema.get('required', [])
             if field in required_fields
-            ]
+        ]
+        schema.pop('anyOf', None)
     return validator_for(schema)(schema, format_checker=FORMAT_CHECKER)
 
 

--- a/app/validation.py
+++ b/app/validation.py
@@ -155,10 +155,26 @@ def get_validation_errors(validator_name, json_data,
 
 
 def min_price_less_than_max_price(error_map, json_data):
-    if 'priceMin' in json_data and json_data.get('priceMax'):
-        if 'priceMin' not in error_map and 'priceMax' not in error_map:
-            if Decimal(json_data['priceMin']) > Decimal(json_data['priceMax']):
-                return {'priceMax': 'max_less_than_min'}
+
+    def return_min_and_max_price_keys(json_data):
+        if 'priceMin' in json_data:
+            return 'priceMin', 'priceMax'
+
+        specialist_price_keys = [k for k in json_data.keys() if k.endswith(('PriceMin', 'PriceMax'))]
+        if specialist_price_keys:
+            return \
+                next((key for key in specialist_price_keys if key.endswith('PriceMin')), None), \
+                next((key for key in specialist_price_keys if key.endswith('PriceMax')), None)
+
+        return None, None
+
+    min_price_key, max_price_key = return_min_and_max_price_keys(json_data)
+
+    if min_price_key:
+        if min_price_key in json_data and json_data.get(max_price_key):
+            if min_price_key not in error_map and max_price_key not in error_map:
+                if Decimal(json_data[min_price_key]) > Decimal(json_data[max_price_key]):
+                    return {max_price_key: 'max_less_than_min'}
     return {}
 
 

--- a/app/validation.py
+++ b/app/validation.py
@@ -235,10 +235,13 @@ def _translate_json_schema_error(key, validator, validator_value, message):
             return 'answer_required'
 
     elif validator == 'pattern':
-        if key in ['priceMin', 'priceMax']:
-            return 'not_money_format'
-        else:
-            return 'under_{}_words'.format(_get_word_count(validator_value))
+        # Since error messages are now specified in the manifests, we can (in the future) generalise the returned
+        # string and just show the correct message
+        for price_str in ['priceMin', 'priceMax', 'PriceMin', 'PriceMax']:
+            if price_str in key:
+                return 'not_money_format'
+
+        return 'under_{}_words'.format(_get_word_count(validator_value))
 
     elif validator == 'enum' and key == 'priceUnit':
         return 'no_unit_specified'

--- a/app/validation.py
+++ b/app/validation.py
@@ -1,6 +1,7 @@
 import json
 import re
 import os
+import copy
 from decimal import Decimal
 
 from flask import abort
@@ -60,7 +61,7 @@ def get_validator(schema_name, enforce_required=True, required_fields=None):
     if enforce_required:
         schema = _SCHEMAS[schema_name]
     else:
-        schema = _SCHEMAS[schema_name].copy()
+        schema = copy.deepcopy(_SCHEMAS[schema_name])
         schema['required'] = [
             field for field in schema.get('required', [])
             if field in required_fields

--- a/example_listings/DOS-LOT1.json
+++ b/example_listings/DOS-LOT1.json
@@ -1,5 +1,0 @@
-{
-  "supplierId": 1,
-  "lot": "digital-outcomes",
-  "dataProtocols": true
-}

--- a/example_listings/DOS-digital-specialist.json
+++ b/example_listings/DOS-digital-specialist.json
@@ -11,6 +11,5 @@
   "bespokeSystemInformation": true,
   "dataProtocols": true,
   "helpGovernmentImproveServices": true,
-  "openSourceLicence": true,
   "openStandardsPrinciples": true
 }

--- a/example_listings/DOS-digital-specialist.json
+++ b/example_listings/DOS-digital-specialist.json
@@ -1,0 +1,16 @@
+{
+  "id": 1,
+  "supplierId": 1,
+  "lot": "digital-specialists",
+  "lotName": "Digital Specialists",
+  "agileCoachLocations": [
+    "London"
+  ],
+  "agileCoachPriceMax": "200",
+  "agileCoachPriceMin": "100",
+  "bespokeSystemInformation": true,
+  "dataProtocols": true,
+  "helpGovernmentImproveServices": true,
+  "openSourceLicence": true,
+  "openStandardsPrinciples": true
+}

--- a/json_schemas/services-digital-outcomes-and-specialists-digital-outcomes.json
+++ b/json_schemas/services-digital-outcomes-and-specialists-digital-outcomes.json
@@ -1,6 +1,56 @@
 {
   "$schema": "http://json-schema.org/schema#",
   "additionalProperties": false,
+  "anyOf": [
+    {
+      "required": [
+        "deliveryTypes"
+      ],
+      "title": "capability"
+    },
+    {
+      "required": [
+        "performanceAnalysisTypes"
+      ],
+      "title": "capability"
+    },
+    {
+      "required": [
+        "securityTypes"
+      ],
+      "title": "capability"
+    },
+    {
+      "required": [
+        "softwareDevelopmentTypes"
+      ],
+      "title": "capability"
+    },
+    {
+      "required": [
+        "supportAndOperationsTypes"
+      ],
+      "title": "capability"
+    },
+    {
+      "required": [
+        "testingAndAuditingTypes"
+      ],
+      "title": "capability"
+    },
+    {
+      "required": [
+        "userExperienceAndDesignTypes"
+      ],
+      "title": "capability"
+    },
+    {
+      "required": [
+        "userResearchTypes"
+      ],
+      "title": "capability"
+    }
+  ],
   "properties": {
     "bespokeSystemInformation": {
       "type": "boolean"
@@ -11,14 +61,14 @@
     "deliveryTypes": {
       "items": {
         "enum": [
-          "Service management",
-          "Product management",
-          "Project management",
-          "Programme management",
-          "Business analysis",
-          "Agile coaching / training",
+          "Agile coaching and training",
           "Agile delivery",
-          "Digital communication / engagement"
+          "Business analysis",
+          "Digital communication and engagement",
+          "Product management",
+          "Programme management",
+          "Project management",
+          "Service management"
         ]
       },
       "maxItems": 8,
@@ -38,6 +88,7 @@
     "outcomesLocations": {
       "items": {
         "enum": [
+          "Off-site",
           "Scotland",
           "North East England",
           "North West England",
@@ -52,7 +103,7 @@
           "Northern Ireland"
         ]
       },
-      "maxItems": 12,
+      "maxItems": 13,
       "minItems": 1,
       "type": "array",
       "uniqueItems": true
@@ -60,14 +111,14 @@
     "performanceAnalysisTypes": {
       "items": {
         "enum": [
+          "A/B and multivariate testing",
           "Data analysis",
-          "Web analytics",
           "Data cleansing",
           "Data visualisation",
-          "Statistical modelling",
-          "Performance reporting",
           "Performance frameworks",
-          "A/B and multivariate testing"
+          "Performance reporting",
+          "Statistical modelling",
+          "Web analytics"
         ]
       },
       "maxItems": 8,
@@ -78,17 +129,18 @@
     "securityTypes": {
       "items": {
         "enum": [
-          "CLAS / CESG certification",
-          "THC (Pen) Testing",
-          "Threat modelling",
+          "CESG information assurance certification",
+          "Firewall audit",
+          "Incident response and forensics",
+          "Infrastructure review",
           "Risk management",
-          "Incident response / forensics",
           "Security policy",
-          "Firewall review / audit",
-          "Infrastructure review"
+          "IT health check",
+          "Threat modelling",
+          "Vulnerability and penetration testing"
         ]
       },
-      "maxItems": 8,
+      "maxItems": 9,
       "minItems": 1,
       "type": "array",
       "uniqueItems": true
@@ -96,22 +148,22 @@
     "softwareDevelopmentTypes": {
       "items": {
         "enum": [
-          "Frontend web application development",
-          "Web application development",
-          "Desktop application development",
-          "Mobile application development",
-          "Geographic information systems (GIS) development",
-          "Database development (Relational/Document/XML/Graph/RDF/Key Value)",
-          "Cloud-based service development",
           "API development",
-          "Game development",
-          "Message Queues",
-          "Search",
+          "Cloud-based service development",
+          "Content management system",
           "Customer relationship management",
-          "Content management system (Wordpress/Drupal)",
-          "Systems Integration",
-          "Mainframe (Cobol / etc)",
-          "Machine learning"
+          "Database development",
+          "Desktop application development",
+          "Frontend web application development",
+          "Game development",
+          "Geographic information systems (GIS) development",
+          "Machine learning",
+          "Mainframe",
+          "Message queues",
+          "Mobile application development",
+          "Search",
+          "Systems integration",
+          "Web application development"
         ]
       },
       "maxItems": 16,
@@ -122,15 +174,15 @@
     "supportAndOperationsTypes": {
       "items": {
         "enum": [
+          "Customer support",
+          "Firewall management",
           "Hosting",
-          "Tooling (continuous integration / deployment tools)",
           "Incident management",
           "Monitoring",
-          "Systems administration",
-          "Customer support",
-          "Technical service desk",
           "Network administration",
-          "Firewall management"
+          "Systems administration",
+          "Service desk",
+          "Tooling"
         ]
       },
       "maxItems": 9,
@@ -141,13 +193,13 @@
     "testingAndAuditingTypes": {
       "items": {
         "enum": [
-          "Load/Performance testing",
           "Accessibility testing",
-          "Application testing (Automated/Exploratory)",
-          "Software auditing",
-          "System auditing",
+          "Application testing",
+          "Data auditing",
+          "Load and performance testing",
           "Process auditing",
-          "Data auditing"
+          "Software auditing",
+          "System auditing"
         ]
       },
       "maxItems": 7,
@@ -158,17 +210,19 @@
     "userExperienceAndDesignTypes": {
       "items": {
         "enum": [
-          "Interaction design",
-          "User experience and design strategy",
-          "Information architecture",
-          "Prototyping",
+          "Accessibility",
           "Animation",
           "Brand development",
+          "Content design and copywriting",
           "Cross-platform design",
-          "Content design / copywriting"
+          "Information architecture",
+          "Interaction design",
+          "Prototyping",
+          "Service design",
+          "User experience and design strategy"
         ]
       },
-      "maxItems": 8,
+      "maxItems": 10,
       "minItems": 1,
       "type": "array",
       "uniqueItems": true
@@ -176,12 +230,12 @@
     "userResearchTypes": {
       "items": {
         "enum": [
-          "User needs and insights",
-          "User journey mapping",
           "Creating personas",
-          "Usability testing",
           "Quantitative research",
-          "Surveys"
+          "Surveys",
+          "Usability testing",
+          "User journey mapping",
+          "User needs and insights"
         ]
       },
       "maxItems": 6,
@@ -193,18 +247,10 @@
   "required": [
     "bespokeSystemInformation",
     "dataProtocols",
-    "deliveryTypes",
     "helpGovernmentImproveServices",
     "openSourceLicence",
     "openStandardsPrinciples",
-    "outcomesLocations",
-    "performanceAnalysisTypes",
-    "securityTypes",
-    "softwareDevelopmentTypes",
-    "supportAndOperationsTypes",
-    "testingAndAuditingTypes",
-    "userExperienceAndDesignTypes",
-    "userResearchTypes"
+    "outcomesLocations"
   ],
   "title": "Digital Outcomes and Specialists Digital outcomes Service Schema",
   "type": "object"

--- a/json_schemas/services-digital-outcomes-and-specialists-digital-outcomes.json
+++ b/json_schemas/services-digital-outcomes-and-specialists-digital-outcomes.json
@@ -79,9 +79,6 @@
     "helpGovernmentImproveServices": {
       "type": "boolean"
     },
-    "openSourceLicence": {
-      "type": "boolean"
-    },
     "openStandardsPrinciples": {
       "type": "boolean"
     },
@@ -248,7 +245,6 @@
     "bespokeSystemInformation",
     "dataProtocols",
     "helpGovernmentImproveServices",
-    "openSourceLicence",
     "openStandardsPrinciples",
     "outcomesLocations"
   ],

--- a/json_schemas/services-digital-outcomes-and-specialists-digital-specialists.json
+++ b/json_schemas/services-digital-outcomes-and-specialists-digital-specialists.json
@@ -1,6 +1,330 @@
 {
   "$schema": "http://json-schema.org/schema#",
   "additionalProperties": false,
+  "anyOf": [
+    {
+      "required": [
+        "agileCoachLocations",
+        "agileCoachPriceMax",
+        "agileCoachPriceMin"
+      ],
+      "title": "specialist"
+    },
+    {
+      "required": [
+        "businessAnalystLocations",
+        "businessAnalystPriceMax",
+        "businessAnalystPriceMin"
+      ],
+      "title": "specialist"
+    },
+    {
+      "required": [
+        "communicationsManagerLocations",
+        "communicationsManagerPriceMax",
+        "communicationsManagerPriceMin"
+      ],
+      "title": "specialist"
+    },
+    {
+      "required": [
+        "contentDesignerLocations",
+        "contentDesignerPriceMax",
+        "contentDesignerPriceMin"
+      ],
+      "title": "specialist"
+    },
+    {
+      "required": [
+        "deliveryManagerLocations",
+        "deliveryManagerPriceMax",
+        "deliveryManagerPriceMin"
+      ],
+      "title": "specialist"
+    },
+    {
+      "required": [
+        "designerLocations",
+        "designerPriceMax",
+        "designerPriceMin"
+      ],
+      "title": "specialist"
+    },
+    {
+      "required": [
+        "developerLocations",
+        "developerPriceMax",
+        "developerPriceMin"
+      ],
+      "title": "specialist"
+    },
+    {
+      "required": [
+        "performanceAnalystLocations",
+        "performanceAnalystPriceMax",
+        "performanceAnalystPriceMin"
+      ],
+      "title": "specialist"
+    },
+    {
+      "required": [
+        "portfolioManagerLocations",
+        "portfolioManagerPriceMax",
+        "portfolioManagerPriceMin"
+      ],
+      "title": "specialist"
+    },
+    {
+      "required": [
+        "productManagerLocations",
+        "productManagerPriceMax",
+        "productManagerPriceMin"
+      ],
+      "title": "specialist"
+    },
+    {
+      "required": [
+        "programmeManagerLocations",
+        "programmeManagerPriceMax",
+        "programmeManagerPriceMin"
+      ],
+      "title": "specialist"
+    },
+    {
+      "required": [
+        "securityConsultantLocations",
+        "securityConsultantPriceMax",
+        "securityConsultantPriceMin"
+      ],
+      "title": "specialist"
+    },
+    {
+      "required": [
+        "serviceManagerLocations",
+        "serviceManagerPriceMax",
+        "serviceManagerPriceMin"
+      ],
+      "title": "specialist"
+    },
+    {
+      "required": [
+        "technicalArchitectLocations",
+        "technicalArchitectPriceMax",
+        "technicalArchitectPriceMin"
+      ],
+      "title": "specialist"
+    },
+    {
+      "required": [
+        "userResearcherLocations",
+        "userResearcherPriceMax",
+        "userResearcherPriceMin"
+      ],
+      "title": "specialist"
+    },
+    {
+      "required": [
+        "webOperationsLocations",
+        "webOperationsPriceMax",
+        "webOperationsPriceMin"
+      ],
+      "title": "specialist"
+    }
+  ],
+  "dependencies": {
+    "agileCoachLocations": [
+      "agileCoachPriceMax",
+      "agileCoachPriceMin"
+    ],
+    "agileCoachPriceMax": [
+      "agileCoachLocations",
+      "agileCoachPriceMin"
+    ],
+    "agileCoachPriceMin": [
+      "agileCoachLocations",
+      "agileCoachPriceMax"
+    ],
+    "businessAnalystLocations": [
+      "businessAnalystPriceMax",
+      "businessAnalystPriceMin"
+    ],
+    "businessAnalystPriceMax": [
+      "businessAnalystLocations",
+      "businessAnalystPriceMin"
+    ],
+    "businessAnalystPriceMin": [
+      "businessAnalystLocations",
+      "businessAnalystPriceMax"
+    ],
+    "communicationsManagerLocations": [
+      "communicationsManagerPriceMax",
+      "communicationsManagerPriceMin"
+    ],
+    "communicationsManagerPriceMax": [
+      "communicationsManagerLocations",
+      "communicationsManagerPriceMin"
+    ],
+    "communicationsManagerPriceMin": [
+      "communicationsManagerLocations",
+      "communicationsManagerPriceMax"
+    ],
+    "contentDesignerLocations": [
+      "contentDesignerPriceMax",
+      "contentDesignerPriceMin"
+    ],
+    "contentDesignerPriceMax": [
+      "contentDesignerLocations",
+      "contentDesignerPriceMin"
+    ],
+    "contentDesignerPriceMin": [
+      "contentDesignerLocations",
+      "contentDesignerPriceMax"
+    ],
+    "deliveryManagerLocations": [
+      "deliveryManagerPriceMax",
+      "deliveryManagerPriceMin"
+    ],
+    "deliveryManagerPriceMax": [
+      "deliveryManagerLocations",
+      "deliveryManagerPriceMin"
+    ],
+    "deliveryManagerPriceMin": [
+      "deliveryManagerLocations",
+      "deliveryManagerPriceMax"
+    ],
+    "designerLocations": [
+      "designerPriceMax",
+      "designerPriceMin"
+    ],
+    "designerPriceMax": [
+      "designerLocations",
+      "designerPriceMin"
+    ],
+    "designerPriceMin": [
+      "designerLocations",
+      "designerPriceMax"
+    ],
+    "developerLocations": [
+      "developerPriceMax",
+      "developerPriceMin"
+    ],
+    "developerPriceMax": [
+      "developerLocations",
+      "developerPriceMin"
+    ],
+    "developerPriceMin": [
+      "developerLocations",
+      "developerPriceMax"
+    ],
+    "performanceAnalystLocations": [
+      "performanceAnalystPriceMax",
+      "performanceAnalystPriceMin"
+    ],
+    "performanceAnalystPriceMax": [
+      "performanceAnalystLocations",
+      "performanceAnalystPriceMin"
+    ],
+    "performanceAnalystPriceMin": [
+      "performanceAnalystLocations",
+      "performanceAnalystPriceMax"
+    ],
+    "portfolioManagerLocations": [
+      "portfolioManagerPriceMax",
+      "portfolioManagerPriceMin"
+    ],
+    "portfolioManagerPriceMax": [
+      "portfolioManagerLocations",
+      "portfolioManagerPriceMin"
+    ],
+    "portfolioManagerPriceMin": [
+      "portfolioManagerLocations",
+      "portfolioManagerPriceMax"
+    ],
+    "productManagerLocations": [
+      "productManagerPriceMax",
+      "productManagerPriceMin"
+    ],
+    "productManagerPriceMax": [
+      "productManagerLocations",
+      "productManagerPriceMin"
+    ],
+    "productManagerPriceMin": [
+      "productManagerLocations",
+      "productManagerPriceMax"
+    ],
+    "programmeManagerLocations": [
+      "programmeManagerPriceMax",
+      "programmeManagerPriceMin"
+    ],
+    "programmeManagerPriceMax": [
+      "programmeManagerLocations",
+      "programmeManagerPriceMin"
+    ],
+    "programmeManagerPriceMin": [
+      "programmeManagerLocations",
+      "programmeManagerPriceMax"
+    ],
+    "securityConsultantLocations": [
+      "securityConsultantPriceMax",
+      "securityConsultantPriceMin"
+    ],
+    "securityConsultantPriceMax": [
+      "securityConsultantLocations",
+      "securityConsultantPriceMin"
+    ],
+    "securityConsultantPriceMin": [
+      "securityConsultantLocations",
+      "securityConsultantPriceMax"
+    ],
+    "serviceManagerLocations": [
+      "serviceManagerPriceMax",
+      "serviceManagerPriceMin"
+    ],
+    "serviceManagerPriceMax": [
+      "serviceManagerLocations",
+      "serviceManagerPriceMin"
+    ],
+    "serviceManagerPriceMin": [
+      "serviceManagerLocations",
+      "serviceManagerPriceMax"
+    ],
+    "technicalArchitectLocations": [
+      "technicalArchitectPriceMax",
+      "technicalArchitectPriceMin"
+    ],
+    "technicalArchitectPriceMax": [
+      "technicalArchitectLocations",
+      "technicalArchitectPriceMin"
+    ],
+    "technicalArchitectPriceMin": [
+      "technicalArchitectLocations",
+      "technicalArchitectPriceMax"
+    ],
+    "userResearcherLocations": [
+      "userResearcherPriceMax",
+      "userResearcherPriceMin"
+    ],
+    "userResearcherPriceMax": [
+      "userResearcherLocations",
+      "userResearcherPriceMin"
+    ],
+    "userResearcherPriceMin": [
+      "userResearcherLocations",
+      "userResearcherPriceMax"
+    ],
+    "webOperationsLocations": [
+      "webOperationsPriceMax",
+      "webOperationsPriceMin"
+    ],
+    "webOperationsPriceMax": [
+      "webOperationsLocations",
+      "webOperationsPriceMin"
+    ],
+    "webOperationsPriceMin": [
+      "webOperationsLocations",
+      "webOperationsPriceMax"
+    ]
+  },
   "properties": {
     "agileCoachLocations": {
       "items": {
@@ -24,12 +348,21 @@
       "type": "array",
       "uniqueItems": true
     },
+    "agileCoachPriceMax": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "agileCoachPriceMin": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
     "bespokeSystemInformation": {
       "type": "boolean"
     },
     "businessAnalystLocations": {
       "items": {
         "enum": [
+          "Off-site",
           "Scotland",
           "North East England",
           "North West England",
@@ -44,14 +377,23 @@
           "Northern Ireland"
         ]
       },
-      "maxItems": 12,
+      "maxItems": 13,
       "minItems": 1,
       "type": "array",
       "uniqueItems": true
+    },
+    "businessAnalystPriceMax": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "businessAnalystPriceMin": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
     },
     "communicationsManagerLocations": {
       "items": {
         "enum": [
+          "Off-site",
           "Scotland",
           "North East England",
           "North West England",
@@ -66,14 +408,23 @@
           "Northern Ireland"
         ]
       },
-      "maxItems": 12,
+      "maxItems": 13,
       "minItems": 1,
       "type": "array",
       "uniqueItems": true
     },
+    "communicationsManagerPriceMax": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "communicationsManagerPriceMin": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
     "contentDesignerLocations": {
       "items": {
         "enum": [
+          "Off-site",
           "Scotland",
           "North East England",
           "North West England",
@@ -88,10 +439,18 @@
           "Northern Ireland"
         ]
       },
-      "maxItems": 12,
+      "maxItems": 13,
       "minItems": 1,
       "type": "array",
       "uniqueItems": true
+    },
+    "contentDesignerPriceMax": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "contentDesignerPriceMin": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
     },
     "dataProtocols": {
       "type": "boolean"
@@ -99,6 +458,7 @@
     "deliveryManagerLocations": {
       "items": {
         "enum": [
+          "Off-site",
           "Scotland",
           "North East England",
           "North West England",
@@ -113,14 +473,23 @@
           "Northern Ireland"
         ]
       },
-      "maxItems": 12,
+      "maxItems": 13,
       "minItems": 1,
       "type": "array",
       "uniqueItems": true
+    },
+    "deliveryManagerPriceMax": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "deliveryManagerPriceMin": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
     },
     "designerLocations": {
       "items": {
         "enum": [
+          "Off-site",
           "Scotland",
           "North East England",
           "North West England",
@@ -135,14 +504,23 @@
           "Northern Ireland"
         ]
       },
-      "maxItems": 12,
+      "maxItems": 13,
       "minItems": 1,
       "type": "array",
       "uniqueItems": true
     },
+    "designerPriceMax": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "designerPriceMin": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
     "developerLocations": {
       "items": {
         "enum": [
+          "Off-site",
           "Scotland",
           "North East England",
           "North West England",
@@ -157,10 +535,18 @@
           "Northern Ireland"
         ]
       },
-      "maxItems": 12,
+      "maxItems": 13,
       "minItems": 1,
       "type": "array",
       "uniqueItems": true
+    },
+    "developerPriceMax": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "developerPriceMin": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
     },
     "helpGovernmentImproveServices": {
       "type": "boolean"
@@ -174,6 +560,7 @@
     "performanceAnalystLocations": {
       "items": {
         "enum": [
+          "Off-site",
           "Scotland",
           "North East England",
           "North West England",
@@ -188,14 +575,23 @@
           "Northern Ireland"
         ]
       },
-      "maxItems": 12,
+      "maxItems": 13,
       "minItems": 1,
       "type": "array",
       "uniqueItems": true
+    },
+    "performanceAnalystPriceMax": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "performanceAnalystPriceMin": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
     },
     "portfolioManagerLocations": {
       "items": {
         "enum": [
+          "Off-site",
           "Scotland",
           "North East England",
           "North West England",
@@ -210,52 +606,23 @@
           "Northern Ireland"
         ]
       },
-      "maxItems": 12,
+      "maxItems": 13,
       "minItems": 1,
       "type": "array",
       "uniqueItems": true
     },
-    "priceInterval": {
-      "enum": [
-        "",
-        "Second",
-        "Minute",
-        "Hour",
-        "Day",
-        "Week",
-        "Month",
-        "Quarter",
-        "6 months",
-        "Year"
-      ]
-    },
-    "priceMax": {
-      "pattern": "^$|^\\d+(?:\\.\\d{1,5})?$",
-      "type": "string"
-    },
-    "priceMin": {
+    "portfolioManagerPriceMax": {
       "pattern": "^\\d+(?:\\.\\d{1,5})?$",
       "type": "string"
     },
-    "priceUnit": {
-      "enum": [
-        "Unit",
-        "Person",
-        "Licence",
-        "User",
-        "Device",
-        "Instance",
-        "Server",
-        "Virtual machine",
-        "Transaction",
-        "Megabyte",
-        "Gigabyte",
-        "Terabyte"
-      ]
+    "portfolioManagerPriceMin": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
     },
     "productManagerLocations": {
       "items": {
         "enum": [
+          "Off-site",
           "Scotland",
           "North East England",
           "North West England",
@@ -270,14 +637,23 @@
           "Northern Ireland"
         ]
       },
-      "maxItems": 12,
+      "maxItems": 13,
       "minItems": 1,
       "type": "array",
       "uniqueItems": true
+    },
+    "productManagerPriceMax": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "productManagerPriceMin": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
     },
     "programmeManagerLocations": {
       "items": {
         "enum": [
+          "Off-site",
           "Scotland",
           "North East England",
           "North West England",
@@ -292,14 +668,23 @@
           "Northern Ireland"
         ]
       },
-      "maxItems": 12,
+      "maxItems": 13,
       "minItems": 1,
       "type": "array",
       "uniqueItems": true
+    },
+    "programmeManagerPriceMax": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "programmeManagerPriceMin": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
     },
     "securityConsultantLocations": {
       "items": {
         "enum": [
+          "Off-site",
           "Scotland",
           "North East England",
           "North West England",
@@ -314,14 +699,23 @@
           "Northern Ireland"
         ]
       },
-      "maxItems": 12,
+      "maxItems": 13,
       "minItems": 1,
       "type": "array",
       "uniqueItems": true
+    },
+    "securityConsultantPriceMax": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "securityConsultantPriceMin": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
     },
     "serviceManagerLocations": {
       "items": {
         "enum": [
+          "Off-site",
           "Scotland",
           "North East England",
           "North West England",
@@ -336,14 +730,23 @@
           "Northern Ireland"
         ]
       },
-      "maxItems": 12,
+      "maxItems": 13,
       "minItems": 1,
       "type": "array",
       "uniqueItems": true
+    },
+    "serviceManagerPriceMax": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "serviceManagerPriceMin": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
     },
     "technicalArchitectLocations": {
       "items": {
         "enum": [
+          "Off-site",
           "Scotland",
           "North East England",
           "North West England",
@@ -358,14 +761,23 @@
           "Northern Ireland"
         ]
       },
-      "maxItems": 12,
+      "maxItems": 13,
       "minItems": 1,
       "type": "array",
       "uniqueItems": true
+    },
+    "technicalArchitectPriceMax": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "technicalArchitectPriceMin": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
     },
     "userResearcherLocations": {
       "items": {
         "enum": [
+          "Off-site",
           "Scotland",
           "North East England",
           "North West England",
@@ -380,14 +792,23 @@
           "Northern Ireland"
         ]
       },
-      "maxItems": 12,
+      "maxItems": 13,
       "minItems": 1,
       "type": "array",
       "uniqueItems": true
     },
+    "userResearcherPriceMax": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "userResearcherPriceMin": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
     "webOperationsLocations": {
       "items": {
         "enum": [
+          "Off-site",
           "Scotland",
           "North East England",
           "North West England",
@@ -402,50 +823,26 @@
           "Northern Ireland"
         ]
       },
-      "maxItems": 12,
+      "maxItems": 13,
       "minItems": 1,
       "type": "array",
       "uniqueItems": true
+    },
+    "webOperationsPriceMax": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "webOperationsPriceMin": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
     }
   },
   "required": [
-    "agileCoachDayRate",
-    "agileCoachLocations",
     "bespokeSystemInformation",
-    "businessAnalystDayRate",
-    "businessAnalystLocations",
-    "communicationsManagerDayRate",
-    "communicationsManagerLocations",
-    "contentDesignerDayRate",
-    "contentDesignerLocations",
     "dataProtocols",
-    "deliveryManagerDayRate",
-    "deliveryManagerLocations",
-    "designerDayRate",
-    "designerLocations",
-    "developerDayRate",
-    "developerLocations",
     "helpGovernmentImproveServices",
     "openSourceLicence",
-    "openStandardsPrinciples",
-    "performanceAnalystDayRate",
-    "performanceAnalystLocations",
-    "portfolioManagerDayRate",
-    "portfolioManagerLocations",
-    "productManagerDayRate",
-    "productManagerLocations",
-    "programmeManagerDayRate",
-    "programmeManagerLocations",
-    "securityConsultantDayRate",
-    "securityConsultantLocations",
-    "serviceManagerDayRate",
-    "serviceManagerLocations",
-    "technicalArchitectDayRate",
-    "technicalArchitectLocations",
-    "userResearcherDayRate",
-    "userResearcherLocations",
-    "webOperationsDayRate",
-    "webOperationsLocations"
+    "openStandardsPrinciples"
   ],
   "title": "Digital Outcomes and Specialists Digital specialists Service Schema",
   "type": "object"

--- a/json_schemas/services-digital-outcomes-and-specialists-digital-specialists.json
+++ b/json_schemas/services-digital-outcomes-and-specialists-digital-specialists.json
@@ -329,6 +329,7 @@
     "agileCoachLocations": {
       "items": {
         "enum": [
+          "Off-site",
           "Scotland",
           "North East England",
           "North West England",
@@ -343,7 +344,7 @@
           "Northern Ireland"
         ]
       },
-      "maxItems": 12,
+      "maxItems": 13,
       "minItems": 1,
       "type": "array",
       "uniqueItems": true
@@ -549,9 +550,6 @@
       "type": "string"
     },
     "helpGovernmentImproveServices": {
-      "type": "boolean"
-    },
-    "openSourceLicence": {
       "type": "boolean"
     },
     "openStandardsPrinciples": {
@@ -841,7 +839,6 @@
     "bespokeSystemInformation",
     "dataProtocols",
     "helpGovernmentImproveServices",
-    "openSourceLicence",
     "openStandardsPrinciples"
   ],
   "title": "Digital Outcomes and Specialists Digital specialists Service Schema",

--- a/json_schemas/services-digital-outcomes-and-specialists-user-research-participants.json
+++ b/json_schemas/services-digital-outcomes-and-specialists-user-research-participants.json
@@ -25,10 +25,11 @@
           "London",
           "South East England",
           "West England",
-          "Northern Ireland"
+          "Northern Ireland",
+          "International (outside the UK)"
         ]
       },
-      "maxItems": 12,
+      "maxItems": 13,
       "minItems": 1,
       "type": "array",
       "uniqueItems": true

--- a/json_schemas/services-digital-outcomes-and-specialists-user-research-studios.json
+++ b/json_schemas/services-digital-outcomes-and-specialists-user-research-studios.json
@@ -3,18 +3,35 @@
   "additionalProperties": false,
   "properties": {
     "labAccessibility": {
+      "maxLength": 500,
+      "minLength": 1,
+      "pattern": "^(?:\\S+\\s+){0,49}\\S+$",
+      "type": "string"
+    },
+    "labAddressBuilding": {
+      "maxLength": 200,
+      "minLength": 1,
+      "pattern": "^(?:\\S+\\s+){0,19}\\S+$",
+      "type": "string"
+    },
+    "labAddressPostcode": {
+      "maxLength": 10,
       "minLength": 1,
       "type": "string"
     },
-    "labAddress": {
+    "labAddressTown": {
+      "maxLength": 200,
       "minLength": 1,
+      "pattern": "^(?:\\S+\\s+){0,19}\\S+$",
       "type": "string"
     },
     "labBabyChanging": {
       "type": "boolean"
     },
     "labCarPark": {
+      "maxLength": 500,
       "minLength": 1,
+      "pattern": "^(?:\\S+\\s+){0,49}\\S+$",
       "type": "string"
     },
     "labDesktopStreaming": {
@@ -45,11 +62,22 @@
         "Yes \u2013 for an additional cost"
       ]
     },
+    "labPriceMax": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "labPriceMin": {
+      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
     "labPublicTransport": {
+      "maxLength": 500,
       "minLength": 1,
+      "pattern": "^(?:\\S+\\s+){0,49}\\S+$",
       "type": "string"
     },
     "labSize": {
+      "maxLength": 100,
       "minLength": 1,
       "type": "string"
     },
@@ -91,44 +119,6 @@
         "Yes \u2013 for an additional cost"
       ]
     },
-    "priceInterval": {
-      "enum": [
-        "",
-        "Second",
-        "Minute",
-        "Hour",
-        "Day",
-        "Week",
-        "Month",
-        "Quarter",
-        "6 months",
-        "Year"
-      ]
-    },
-    "priceMax": {
-      "pattern": "^$|^\\d+(?:\\.\\d{1,5})?$",
-      "type": "string"
-    },
-    "priceMin": {
-      "pattern": "^\\d+(?:\\.\\d{1,5})?$",
-      "type": "string"
-    },
-    "priceUnit": {
-      "enum": [
-        "Unit",
-        "Person",
-        "Licence",
-        "User",
-        "Device",
-        "Instance",
-        "Server",
-        "Virtual machine",
-        "Transaction",
-        "Megabyte",
-        "Gigabyte",
-        "Terabyte"
-      ]
-    },
     "serviceName": {
       "maxLength": 100,
       "minLength": 1,
@@ -137,14 +127,17 @@
   },
   "required": [
     "labAccessibility",
-    "labAddress",
+    "labAddressBuilding",
+    "labAddressPostcode",
+    "labAddressTown",
     "labBabyChanging",
     "labCarPark",
     "labDesktopStreaming",
     "labDeviceStreaming",
     "labEyeTracking",
     "labHosting",
-    "labPrice",
+    "labPriceMax",
+    "labPriceMin",
     "labPublicTransport",
     "labSize",
     "labStreaming",

--- a/tests/app/views/test_drafts.py
+++ b/tests/app/views/test_drafts.py
@@ -1327,6 +1327,20 @@ class TestDOSServices(BaseApplicationTest):
             assert_equal(data['error'][key], 'not_money_format')
         assert_equal(update.status_code, 400)
 
+    def test_should_not_edit_draft_with_max_price_less_than_min_price(self):
+        res = self._post_dos_draft()
+        draft_id = json.loads(res.get_data())['services']['id']
+        update = self._edit_dos_draft(
+            draft_id=draft_id,
+            services={
+                "agileCoachPriceMin": '200',
+                "agileCoachPriceMax": '100'},
+            page_questions=[]
+        )
+        data = json.loads(update.get_data())
+        assert_equal(data['error']['agileCoachPriceMax'], 'max_less_than_min')
+        assert_equal(update.status_code, 400)
+
     def test_should_not_edit_draft_if_dependencies_missing(self):
         res = self._post_dos_draft()
         draft_id = json.loads(res.get_data())['services']['id']


### PR DESCRIPTION
**This pull request:**

- Adds the new schemas
- Changes how validating works in a few places
- Tests things

[>> Story in Pivotal](https://www.pivotaltracker.com/story/show/107188910)

***

#### Adds the new schemas

Now that we've got what seem to be the final DOS schemas, the API can start validating against the right things :+1: 

#### Changes how validating works in a few places

1.  Process `dependencies` errors
If a key that's part of a group is included without the rest of the group, the schema will fail to validate with a default `dependencies` error message that's not very helpful. The new behaviour is to processing the error the same way we do for `required` keys because the implications are the same.
 Adding `developerLocations` without any other developer-related keys will return 
  ```json
  `{ "error": { "developerPriceMin": "answer_required", "developerPriceMax": "answer_required" } }
  ```

2. Process `anyOf` errors
Similarly to the last thing, if a schema fails to validate because none of the `anyOf` groups are present (ie, we have no specialists or outcomes), a form error message is returned that our frontend will understand.  
Trying to mark as complete a digital-specialists service without any specialists will return
  ```json
  `{ "error": { "_form": "specialist_required" } }
  ```
Note that the `specialist` substring comes from [the `any_of` key in a multiquestion's manifest file](https://github.com/alphagov/digitalmarketplace-frameworks/blob/master/frameworks/digital-outcomes-and-specialists/questions/services/agileCoach.yml#L9).

3. Liberalise pricing check in `_translate_json_schema_error()`
Previously, we would previously only return a `not_money_format` if the failing key exactly matched `priceMin` or `priceMax`. 
Of course, now pricing keys in digital-specialists all look like `{specialistName}PriceMax` and `{specialistName}PriceMin`.  I've expanded the check to find all of our new pricing fields.

  - @allait pointed out that our manifest files ([for example](https://github.com/alphagov/digitalmarketplace-frameworks/blob/81a317c4d6bcf8f560e1cb1dcf9cd225801c6124/frameworks/digital-outcomes-and-specialists/questions/services/labAddressTown.yml#L14)) contain a message which describes the problem.  This arguably obviates the need for [our janky key detection](https://github.com/alphagov/digitalmarketplace-api/blob/master/app/validation.py#L232) anyway, since we could use a more general key (`incorrect_format_error`, maybe) for both cases and just return the corresponding message.

4. Drop `anyOf` fields when validating against a partial schema.
Our [`get_validator`](https://github.com/alphagov/digitalmarketplace-api/blob/master/app/validation.py#L57) function allows us to override the `required` fields with a passed-in subset of schema fields -- makes it easier to validate smaller bits of the schema at a time.  However, if we don't remove the `anyOf` keys, we're still validating against a bunch of stuff we probably don't care about.

#### More unit tests

Added more unit tests.
Specifically: 
 - :white_check_mark: Can still successfully edit a service if `page_questions` are invalid
 - :x: Cannot edit a digital-specialists draft with a bad price string
 - :x: Cannot edit a digital-specialists draft with a min_price greater than a max_price
 - :x: Cannot edit a digital-specialists draft with missing dependencies
 - :white_check_mark: Can edit a digital-specialists draft if `page_questions` are invalid or required in `anyOf`
 - :white_check_mark: Can mark as complete a valid digital-specialists draft
 - :x: Cannot mark as complete a digital-specialists draft without a specialist

:muscle: :muscle: :muscle: :muscle: :muscle: :muscle: :muscle: :muscle: :muscle: :muscle: :muscle: :muscle: :muscle: :muscle: 
![screen shot 2015-11-25 at 19 13 00](https://cloud.githubusercontent.com/assets/2454380/11407115/9d904a14-93a8-11e5-9c47-066174a14660.png)