### PR TITLE
Fix `min_price_less_than_max_price`

### DIFF
--- a/app/validation.py
+++ b/app/validation.py
@@ -159,9 +159,8 @@ def min_price_less_than_max_price(error_map, json_data):
     for key in json_data.keys():
         if key.lower().endswith('pricemin'):
             prefix = key[:-8]
-            max_price_key = prefix + ('PriceMax' if prefix else 'priceMax')
+            max_price_key = (prefix + 'PriceMax') if prefix else 'priceMax'
             if (
-                max_price_key in json_data and
                 json_data.get(max_price_key, None) and
                 key not in error_map and
                 max_price_key not in error_map

--- a/app/validation.py
+++ b/app/validation.py
@@ -155,27 +155,21 @@ def get_validation_errors(validator_name, json_data,
 
 
 def min_price_less_than_max_price(error_map, json_data):
+    price_errors = {}
+    for key in json_data.keys():
+        if key.lower().endswith('pricemin'):
+            prefix = key[:-8]
+            max_price_key = prefix + ('PriceMax' if prefix else 'priceMax')
+            if (
+                max_price_key in json_data and
+                json_data.get(max_price_key, None) and
+                key not in error_map and
+                max_price_key not in error_map
+            ):
+                if Decimal(json_data[key]) > Decimal(json_data[max_price_key]):
+                    price_errors[max_price_key] = 'max_less_than_min'
 
-    def return_min_and_max_price_keys(json_data):
-        if 'priceMin' in json_data:
-            return 'priceMin', 'priceMax'
-
-        specialist_price_keys = [k for k in json_data.keys() if k.endswith(('PriceMin', 'PriceMax'))]
-        if specialist_price_keys:
-            return \
-                next((key for key in specialist_price_keys if key.endswith('PriceMin')), None), \
-                next((key for key in specialist_price_keys if key.endswith('PriceMax')), None)
-
-        return None, None
-
-    min_price_key, max_price_key = return_min_and_max_price_keys(json_data)
-
-    if min_price_key:
-        if min_price_key in json_data and json_data.get(max_price_key):
-            if min_price_key not in error_map and max_price_key not in error_map:
-                if Decimal(json_data[min_price_key]) > Decimal(json_data[max_price_key]):
-                    return {max_price_key: 'max_less_than_min'}
-    return {}
+    return price_errors
 
 
 def is_valid_service_id(service_id):


### PR DESCRIPTION
This method wasn't working as expected.
It will now return all errors where max price is less than min price for price fields for the same thing.