### PR TITLE
Fix stats

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -1,7 +1,7 @@
 from flask import jsonify, abort, request
 from sqlalchemy.types import String
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy import func, orm, case
+from sqlalchemy import func, orm, case, cast
 import datetime
 
 from dmutils.audit import AuditTypes
@@ -101,7 +101,8 @@ def get_framework_stats(framework_slug):
             ).group_by(
                 DraftService.status, Lot.slug, is_declaration_complete
             ).filter(
-                DraftService.framework_id == framework.id
+                DraftService.framework_id == framework.id,
+                cast(SupplierFramework.declaration, String) != 'null'
             ).all()
         ),
         'supplier_users': label_columns(
@@ -126,7 +127,8 @@ def get_framework_stats(framework_slug):
             ).outerjoin(
                 drafts_alias
             ).filter(
-                SupplierFramework.framework_id == framework.id
+                SupplierFramework.framework_id == framework.id,
+                cast(SupplierFramework.declaration, String) != 'null'
             ).group_by(
                 SupplierFramework.declaration['status'].cast(String), drafts_alias.supplier_id.isnot(None)
             ).all()

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -265,7 +265,7 @@ def set_a_declaration(supplier_id, framework_slug):
     request_data = get_json_from_request()
     json_has_required_keys(request_data, ['declaration', 'updated_by'])
 
-    supplier_framework.declaration = request_data['declaration']
+    supplier_framework.declaration = request_data['declaration'] or {}
     db.session.add(supplier_framework)
     db.session.add(
         AuditEvent(
@@ -361,7 +361,8 @@ def register_framework_interest(supplier_id, framework_slug):
 
     interest_record = SupplierFramework(
         supplier_id=supplier.supplier_id,
-        framework_id=framework.id
+        framework_id=framework.id,
+        declaration={}
     )
     audit_event = AuditEvent(
         audit_type=AuditTypes.register_framework_interest,

--- a/tests/app/views/test_frameworks.py
+++ b/tests/app/views/test_frameworks.py
@@ -279,6 +279,25 @@ class TestFrameworkStats(BaseApplicationTest):
             ]
         })
 
+    def test_stats_handles_null_declarations(self):
+        self.setup_data('g-cloud-7')
+        with self.app.app_context():
+            framework = Framework.query.filter(Framework.slug == 'g-cloud-7').first()
+            db.session.query(
+                SupplierFramework
+            ).filter(
+                SupplierFramework.framework_id == framework.id,
+                SupplierFramework.supplier_id.in_([0, 1])
+            ).update({
+                SupplierFramework.declaration: None
+            }, synchronize_session=False)
+
+            db.session.commit()
+
+        response = self.client.get('/frameworks/g-cloud-7/stats')
+
+        assert response.status_code == 200
+
 
 class TestGetFrameworkSuppliers(BaseApplicationTest):
     def setup(self):

--- a/tests/app/views/test_suppliers.py
+++ b/tests/app/views/test_suppliers.py
@@ -842,6 +842,22 @@ class TestSetSupplierDeclarations(BaseApplicationTest):
                 .find_by_supplier_and_framework(0, 'test-open')
             assert_equal(answers.declaration['question'], 'answer')
 
+    def test_add_null_declaration_should_result_in_dict(self):
+        with self.app.app_context():
+            response = self.client.put(
+                '/suppliers/0/frameworks/test-open/declaration',
+                data=json.dumps({
+                    'updated_by': 'testing',
+                    'declaration': None
+                }),
+                content_type='application/json')
+
+            assert response.status_code == 201
+            answers = SupplierFramework \
+                .find_by_supplier_and_framework(0, 'test-open')
+            assert isinstance(answers.declaration, dict)
+
+
     def test_update_existing_declaration(self):
         with self.app.app_context():
             framework_id = Framework.query.filter(
@@ -1178,6 +1194,7 @@ class TestRegisterFrameworkInterest(BaseApplicationTest):
             data = json.loads(response.get_data())
             assert_equal(data['frameworkInterest']['supplierId'], 1)
             assert_equal(data['frameworkInterest']['frameworkSlug'], 'digital-outcomes-and-specialists')
+            assert isinstance(data['frameworkInterest']['declaration'], dict)
 
     def test_can_not_register_interest_in_not_open_framework_(self):
         with self.app.app_context():

--- a/tests/app/views/test_suppliers.py
+++ b/tests/app/views/test_suppliers.py
@@ -857,7 +857,6 @@ class TestSetSupplierDeclarations(BaseApplicationTest):
                 .find_by_supplier_and_framework(0, 'test-open')
             assert isinstance(answers.declaration, dict)
 
-
     def test_update_existing_declaration(self):
         with self.app.app_context():
             framework_id = Framework.query.filter(


### PR DESCRIPTION
## Make declaration default to an empty dict
When we query declarations for stats we need to be able to look inside them. PostgreSQL complains if you try to query into a null value.

## Make stats handle null declarations
There was a bug fixed in the previous commit that would result in JSON 'null' values for the supplier declaration which would in turn cause the stats queries to fail. As this is a subtle bug and the stats are depended on they need to be pretty robust. This change excludes JSON 'null' values from the query.