### PR TITLE
List audit events for a user

### DIFF
--- a/app/main/views/audits.py
+++ b/app/main/views/audits.py
@@ -18,12 +18,14 @@ AUDIT_OBJECT_TYPES = {
     "suppliers": models.Supplier,
     "services": models.Service,
     "frameworks": models.Framework,
+    "users": models.User,
 }
 
 AUDIT_OBJECT_ID_FIELDS = {
     "suppliers": models.Supplier.supplier_id,
     "services": models.Service.service_id,
     "frameworks": models.Framework.slug,
+    "users": models.User.id,
 }
 
 


### PR DESCRIPTION
Allow audit events for a given user to be listed through the API.
Currently the only way to view these through the API is to list all
audit events and filter them client side.