### PR TITLE
Add South West England to JSON schemas

### DIFF
--- a/json_schemas/services-digital-outcomes-and-specialists-digital-outcomes.json
+++ b/json_schemas/services-digital-outcomes-and-specialists-digital-outcomes.json
@@ -96,6 +96,7 @@
           "Wales",
           "London",
           "South East England",
+          "South West England",
           "West England",
           "Northern Ireland"
         ]
@@ -130,9 +131,9 @@
           "Firewall audit",
           "Incident response and forensics",
           "Infrastructure review",
+          "IT health check",
           "Risk management",
           "Security policy",
-          "IT health check",
           "Threat modelling",
           "Vulnerability and penetration testing"
         ]
@@ -177,8 +178,8 @@
           "Incident management",
           "Monitoring",
           "Network administration",
-          "Systems administration",
           "Service desk",
+          "Systems administration",
           "Tooling"
         ]
       },

--- a/json_schemas/services-digital-outcomes-and-specialists-digital-specialists.json
+++ b/json_schemas/services-digital-outcomes-and-specialists-digital-specialists.json
@@ -360,6 +360,7 @@
           "Wales",
           "London",
           "South East England",
+          "South West England",
           "West England",
           "Northern Ireland"
         ]
@@ -394,6 +395,7 @@
           "Wales",
           "London",
           "South East England",
+          "South West England",
           "West England",
           "Northern Ireland"
         ]
@@ -425,6 +427,7 @@
           "Wales",
           "London",
           "South East England",
+          "South West England",
           "West England",
           "Northern Ireland"
         ]
@@ -456,6 +459,7 @@
           "Wales",
           "London",
           "South East England",
+          "South West England",
           "West England",
           "Northern Ireland"
         ]
@@ -490,6 +494,7 @@
           "Wales",
           "London",
           "South East England",
+          "South West England",
           "West England",
           "Northern Ireland"
         ]
@@ -521,6 +526,7 @@
           "Wales",
           "London",
           "South East England",
+          "South West England",
           "West England",
           "Northern Ireland"
         ]
@@ -552,6 +558,7 @@
           "Wales",
           "London",
           "South East England",
+          "South West England",
           "West England",
           "Northern Ireland"
         ]
@@ -589,6 +596,7 @@
           "Wales",
           "London",
           "South East England",
+          "South West England",
           "West England",
           "Northern Ireland"
         ]
@@ -620,6 +628,7 @@
           "Wales",
           "London",
           "South East England",
+          "South West England",
           "West England",
           "Northern Ireland"
         ]
@@ -651,6 +660,7 @@
           "Wales",
           "London",
           "South East England",
+          "South West England",
           "West England",
           "Northern Ireland"
         ]
@@ -682,6 +692,7 @@
           "Wales",
           "London",
           "South East England",
+          "South West England",
           "West England",
           "Northern Ireland"
         ]
@@ -713,6 +724,7 @@
           "Wales",
           "London",
           "South East England",
+          "South West England",
           "West England",
           "Northern Ireland"
         ]
@@ -744,6 +756,7 @@
           "Wales",
           "London",
           "South East England",
+          "South West England",
           "West England",
           "Northern Ireland"
         ]
@@ -775,6 +788,7 @@
           "Wales",
           "London",
           "South East England",
+          "South West England",
           "West England",
           "Northern Ireland"
         ]
@@ -806,6 +820,7 @@
           "Wales",
           "London",
           "South East England",
+          "South West England",
           "West England",
           "Northern Ireland"
         ]
@@ -837,6 +852,7 @@
           "Wales",
           "London",
           "South East England",
+          "South West England",
           "West England",
           "Northern Ireland"
         ]
@@ -868,6 +884,7 @@
           "Wales",
           "London",
           "South East England",
+          "South West England",
           "West England",
           "Northern Ireland"
         ]

--- a/json_schemas/services-digital-outcomes-and-specialists-user-research-participants.json
+++ b/json_schemas/services-digital-outcomes-and-specialists-user-research-participants.json
@@ -24,6 +24,7 @@
           "Wales",
           "London",
           "South East England",
+          "South West England",
           "West England",
           "Northern Ireland",
           "International (outside the UK)"


### PR DESCRIPTION
[#110243076](https://www.pivotaltracker.com/story/show/110243076)

This is the first part of the changing West England to South West England. Strangely some other values were reordered but no other functional have changed.