### PR TITLE
Create route that returns information about users, suppliers, and their frameworks

### DIFF
--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -228,15 +228,9 @@ def export_users_for_framework(framework_slug):
     supplier_frameworks_and_suppliers_and_users = db.session.query(
         SupplierFramework, Supplier, User
     ).join(
-        Framework
+        Supplier, User, Framework
     ).filter(
         Framework.slug == framework_slug
-    ).filter(
-        SupplierFramework.framework_id == Framework.id
-    ).filter(
-        SupplierFramework.supplier_id == Supplier.supplier_id
-    ).filter(
-        User.supplier_id == Supplier.supplier_id
     ).all()
 
     submitted_draft_counts_per_supplier = {}
@@ -259,10 +253,8 @@ def export_users_for_framework(framework_slug):
                 submitted_draft_counts_per_supplier[sf.supplier_id] = db.session.query(
                     func.count()
                 ).filter(
-                    DraftService.supplier_id == sf.supplier_id
-                ).filter(
-                    DraftService.framework_id == sf.framework_id
-                ).filter(
+                    DraftService.supplier_id == sf.supplier_id,
+                    DraftService.framework_id == sf.framework_id,
                     DraftService.status == 'submitted'
                 ).scalar()
 

--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -214,8 +214,8 @@ def update_user(user_id):
         abort(400, "Could not update user with: {0}".format(user_update))
 
 
-@main.route('/users/csv/<framework_slug>', methods=['GET'])
-def list_all_supplier_users_who_have_applied_for_a_given_framework(framework_slug):
+@main.route('/users/export/<framework_slug>', methods=['GET'])
+def export_users_for_framework(framework_slug):
 
     # 400 if framework slug is invalid
     if not Framework.query.filter(Framework.slug == framework_slug).first():

--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -1,11 +1,12 @@
 from datetime import datetime
 from dmutils.audit import AuditTypes
+from sqlalchemy import func
 from sqlalchemy.exc import IntegrityError, DataError
 from flask import jsonify, abort, request, current_app
 
 from .. import main
 from ... import db, encryption
-from ...models import User, AuditEvent, Supplier
+from ...models import User, AuditEvent, Supplier, Framework, SupplierFramework, DraftService
 from ...utils import get_json_from_request, json_has_required_keys, \
     json_has_matching_id, pagination_links, get_valid_page_or_1
 from ...service_utils import validate_and_return_updater_request
@@ -211,6 +212,66 @@ def update_user(user_id):
     except (IntegrityError, DataError):
         db.session.rollback()
         abort(400, "Could not update user with: {0}".format(user_update))
+
+
+@main.route('/users/csv/<framework_slug>', methods=['GET'])
+def list_all_supplier_users_who_have_applied_for_a_given_framework(framework_slug):
+
+    # 400 if framework slug is invalid
+    if not Framework.query.filter(Framework.slug == framework_slug).first():
+        abort(400, 'invalid framework')
+
+    supplier_frameworks_and_suppliers_and_users = db.session.query(
+        SupplierFramework, Supplier, User
+    ).join(
+        Framework
+    ).filter(
+        Framework.slug == framework_slug
+    ).filter(
+        SupplierFramework.framework_id == Framework.id
+    ).filter(
+        SupplierFramework.supplier_id == Supplier.supplier_id
+    ).filter(
+        User.supplier_id == Supplier.supplier_id
+    ).all()
+
+    submitted_draft_counts_per_supplier = {}
+    user_rows = []
+
+    for sf, s, u in supplier_frameworks_and_suppliers_and_users:
+
+        # get number of completed draft services per supplier
+        # `application_status` is based on a complete declaration and at least one completed draft service
+        if sf.supplier_id not in submitted_draft_counts_per_supplier.keys():
+            submitted_draft_counts_per_supplier[sf.supplier_id] = db.session.query(
+                func.count()
+            ).filter(
+                DraftService.supplier_id == sf.supplier_id
+            ).filter(
+                DraftService.framework_id == sf.framework_id
+            ).filter(
+                DraftService.status == 'submitted'
+            ).scalar()
+
+        declaration_status = sf.declaration.get('status') if sf.declaration else 'unstarted'
+        submitted_draft_count = submitted_draft_counts_per_supplier[sf.supplier_id]
+        application_status = \
+            'application' if submitted_draft_count and declaration_status == 'complete' else 'no_application'
+
+        user_rows.append({
+            'user_id': u.id,
+            'user_email': u.email_address,
+            'supplier_id': s.supplier_id,
+            'supplier_name': s.name,
+            'framework_slug': sf.framework.slug,
+            'declaration_status': declaration_status,
+            'submitted_drafts': submitted_draft_count,
+            'application_status': application_status,
+            'framework_agreement': bool(sf.agreement_returned_at),
+            'application_result': 'pass' if sf.on_framework else 'fail'
+        })
+
+    return jsonify(users=[user for user in user_rows])
 
 
 def check_supplier_role(role, supplier_id):

--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -222,6 +222,9 @@ def export_users_for_framework(framework_slug):
     if not framework:
         abort(400, 'invalid framework')
 
+    if framework.status == 'coming':
+        abort(400, 'framework not yet open')
+
     supplier_frameworks_and_suppliers_and_users = db.session.query(
         SupplierFramework, Supplier, User
     ).join(

--- a/tests/app/test_users.py
+++ b/tests/app/test_users.py
@@ -1089,19 +1089,19 @@ class TestUsersExport(BaseUserTest):
         data = json.loads(self._return_users_export_after_setting_framework_status().get_data())["users"]
         assert data == []
 
-    # Test 1 supplier no users
+    # Test one supplier with no users
     def test_get_response_when_no_users(self):
         self._setup(post_users=False, register_supplier_with_framework=False)
         data = json.loads(self._return_users_export_after_setting_framework_status().get_data())["users"]
         assert data == []
 
-    # Test supplier not registered on the framework
+    # Test one supplier not registered on the framework
     def test_get_response_when_not_registered_with_framework(self):
         self._setup(register_supplier_with_framework=False)
         data = json.loads(self._return_users_export_after_setting_framework_status().get_data())["users"]
         assert data == []
 
-    # Test get back users for supplier who has unstarted declaration no drafts
+    # Test users for supplier with unstarted declaration no drafts
     def test_response_unstarted_declaration_no_drafts(self):
         self._setup()
         data = json.loads(self._return_users_export_after_setting_framework_status().get_data())["users"]
@@ -1110,7 +1110,7 @@ class TestUsersExport(BaseUserTest):
         for datum in data:
             self._assert_things_about_export_response(datum)
 
-    # Test get back users for supplier who has unstarted declaration 1 draft
+    # Test users for supplier with unstarted declaration one draft
     def test_response_unstarted_declaration_one_draft(self):
         self._setup()
         self._post_complete_draft_service()
@@ -1119,7 +1119,7 @@ class TestUsersExport(BaseUserTest):
         for datum in data:
             self._assert_things_about_export_response(datum)
 
-    # Test get back users for supplier who has started declaration 1 draft
+    # Test users for supplier with started declaration one draft
     def test_response_started_declaration_one_draft(self):
         self._setup()
         self._put_incomplete_declaration()
@@ -1129,7 +1129,7 @@ class TestUsersExport(BaseUserTest):
         for datum in data:
             self._assert_things_about_export_response(datum, parameters={'declaration_status': 'started'})
 
-    # Test get back users for supplier who has completed declaration no drafts
+    # Test users for supplier with completed declaration no drafts
     def test_response_complete_declaration_no_drafts(self):
         self._setup()
         self._put_complete_declaration()
@@ -1138,7 +1138,7 @@ class TestUsersExport(BaseUserTest):
         for datum in data:
             self._assert_things_about_export_response(datum, parameters={'declaration_status': 'complete'})
 
-    # Test get back users for supplier who has completed declaration 1 draft
+    # Test users for supplier with completed declaration one draft
     def test_response_complete_declaration_one_draft(self):
         self._setup()
         self._put_complete_declaration()
@@ -1151,7 +1151,7 @@ class TestUsersExport(BaseUserTest):
                 'application_status': 'application'
             })
 
-    # Test get back users for supplier who has completed declaration 1 draft but framework is still 'open'
+    # Test users for supplier with completed declaration one draft but framework still open
     def test_response_complete_declaration_one_draft_while_framework_still_open(self):
         self._setup()
         self._put_complete_declaration()
@@ -1166,7 +1166,7 @@ class TestUsersExport(BaseUserTest):
                 'framework_agreement': ''
             })
 
-    # Test get back users for supplier who has completed declaration + framework agreement
+    # Test users for supplier with completed declaration one draft and framework agreement
     def test_response_submitted_framework_agreement_on_framework(self):
         self._setup()
         self._put_complete_declaration()
@@ -1181,8 +1181,15 @@ class TestUsersExport(BaseUserTest):
                 'framework_agreement': True
             })
 
-    # Test get back users bad framework name
+    # Test 400 if bad framework name
     def test_400_response_if_bad_framework_name(self):
         self._setup()
         response = self.client.get('/users/export/{}'.format('cyber-outcomes-and-cyber-specialists'))
+        assert response.status_code == 400
+
+    # Test 400 if bad framework status
+    def test_400_response_if_framework_is_coming(self):
+        self._setup()
+        self._set_framework_status('coming')
+        response = self.client.get('/users/export/{}'.format(self.framework_slug))
         assert response.status_code == 400

--- a/tests/app/test_users.py
+++ b/tests/app/test_users.py
@@ -950,12 +950,12 @@ class TestUsersGet(BaseUserTest):
             response.get_data(as_text=True))
 
 
-class TestUsersCSV(BaseUserTest):
+class TestUsersExport(BaseUserTest):
     framework_slug = None
     updater_json = None
 
     def setup(self):
-        super(TestUsersCSV, self).setup()
+        super(TestUsersExport, self).setup()
         with self.app.app_context():
             self.framework_slug = 'digital-outcomes-and-specialists'
             self.set_framework_status(self.framework_slug, 'open')
@@ -1042,8 +1042,8 @@ class TestUsersCSV(BaseUserTest):
     def _post_framework_agreement(self):
         self._post_framework_interest({'frameworkInterest': {'agreementReturned': True}})
 
-    def _return_users_csv_response(self):
-        response = self.client.get('/users/csv/{}'.format(self.framework_slug))
+    def _return_users_export(self):
+        response = self.client.get('/users/export/{}'.format(self.framework_slug))
         assert response.status_code == 200
         return response
 
@@ -1055,7 +1055,7 @@ class TestUsersCSV(BaseUserTest):
         if register_supplier_with_framework:
             self._register_supplier_with_framework()
 
-    def _assert_things_about_csv_response(self, row, parameters=None):
+    def _assert_things_about_export_response(self, row, parameters=None):
         _parameters = {
             'application_result': 'fail',
             'declaration_status': 'unstarted',
@@ -1080,56 +1080,56 @@ class TestUsersCSV(BaseUserTest):
 
     # Test no suppliers
     def test_get_response_when_no_suppliers(self):
-        data = json.loads(self._return_users_csv_response().get_data())["users"]
+        data = json.loads(self._return_users_export().get_data())["users"]
         assert data == []
 
     # Test 1 supplier no users
     def test_get_response_when_no_users(self):
         self._setup(post_users=False, register_supplier_with_framework=False)
-        data = json.loads(self._return_users_csv_response().get_data())["users"]
+        data = json.loads(self._return_users_export().get_data())["users"]
         assert data == []
 
     # Test supplier not registered on the framework
     def test_get_response_when_not_registered_with_framework(self):
         self._setup(register_supplier_with_framework=False)
-        data = json.loads(self._return_users_csv_response().get_data())["users"]
+        data = json.loads(self._return_users_export().get_data())["users"]
         assert data == []
 
     # Test get back users for supplier who has unstarted declaration no drafts
     def test_response_unstarted_declaration_no_drafts(self):
         self._setup()
-        data = json.loads(self._return_users_csv_response().get_data())["users"]
+        data = json.loads(self._return_users_export().get_data())["users"]
         assert len(data) == len(self.users)
         for datum in data:
-            self._assert_things_about_csv_response(datum)
+            self._assert_things_about_export_response(datum)
 
     # Test get back users for supplier who has unstarted declaration 1 draft
     def test_response_unstarted_declaration_one_draft(self):
         self._setup()
         self._post_complete_draft_service()
-        data = json.loads(self._return_users_csv_response().get_data())["users"]
+        data = json.loads(self._return_users_export().get_data())["users"]
         assert len(data) == len(self.users)
         for datum in data:
-            self._assert_things_about_csv_response(datum, parameters={'submitted_drafts': 1})
+            self._assert_things_about_export_response(datum, parameters={'submitted_drafts': 1})
 
     # Test get back users for supplier who has started declaration no drafts
     def test_response_started_declaration_no_drafts(self):
         self._setup()
         self._put_incomplete_declaration()
-        data = json.loads(self._return_users_csv_response().get_data())["users"]
+        data = json.loads(self._return_users_export().get_data())["users"]
         assert len(data) == len(self.users)
         for datum in data:
-            self._assert_things_about_csv_response(datum, parameters={'declaration_status': 'started'})
+            self._assert_things_about_export_response(datum, parameters={'declaration_status': 'started'})
 
     # Test get back users for supplier who has started declaration 1 draft
     def test_response_started_declaration_one_draft(self):
         self._setup()
         self._put_incomplete_declaration()
         self._post_complete_draft_service()
-        data = json.loads(self._return_users_csv_response().get_data())["users"]
+        data = json.loads(self._return_users_export().get_data())["users"]
         assert len(data) == len(self.users)
         for datum in data:
-            self._assert_things_about_csv_response(
+            self._assert_things_about_export_response(
                 datum,
                 parameters={
                     'declaration_status': 'started',
@@ -1140,20 +1140,20 @@ class TestUsersCSV(BaseUserTest):
     def test_response_complete_declaration_no_drafts(self):
         self._setup()
         self._put_complete_declaration()
-        data = json.loads(self._return_users_csv_response().get_data())["users"]
+        data = json.loads(self._return_users_export().get_data())["users"]
         assert len(data) == len(self.users)
         for datum in data:
-            self._assert_things_about_csv_response(datum, parameters={'declaration_status': 'complete'})
+            self._assert_things_about_export_response(datum, parameters={'declaration_status': 'complete'})
 
     # Test get back users for supplier who has completed declaration 1 draft
     def test_response_complete_declaration_one_draft(self):
         self._setup()
         self._put_complete_declaration()
         self._post_complete_draft_service()
-        data = json.loads(self._return_users_csv_response().get_data())["users"]
+        data = json.loads(self._return_users_export().get_data())["users"]
         assert len(data) == len(self.users)
         for datum in data:
-            self._assert_things_about_csv_response(
+            self._assert_things_about_export_response(
                 datum,
                 parameters={
                     'declaration_status': 'complete',
@@ -1166,10 +1166,10 @@ class TestUsersCSV(BaseUserTest):
         self._put_complete_declaration()
         self._post_complete_draft_service()
         self._post_framework_agreement()
-        data = json.loads(self._return_users_csv_response().get_data())["users"]
+        data = json.loads(self._return_users_export().get_data())["users"]
         assert len(data) == len(self.users)
         for datum in data:
-            self._assert_things_about_csv_response(
+            self._assert_things_about_export_response(
                 datum,
                 parameters={
                     'declaration_status': 'complete',
@@ -1178,7 +1178,7 @@ class TestUsersCSV(BaseUserTest):
             )
 
     # Test get back users bad framework name
-    def test_404_response_if_bad_framework_name(self):
+    def test_400_response_if_bad_framework_name(self):
         self._setup()
-        response = self.client.get('/users/csv/{}'.format('cyber-outcomes-and-cyber-specialists'))
+        response = self.client.get('/users/export/{}'.format('cyber-outcomes-and-cyber-specialists'))
         assert response.status_code == 400


### PR DESCRIPTION
Added a new route to export a list of users for suppliers who have (at least) shown interest in a framework.
User/Supplier data is returned, as well as information about whether a supplier has applied to the framework or returned their framework agreement.
This will be used by administrators who are currently relying on developers generating csv files by running various scripts.

Writing tests for the user exporting route was pretty involved because in order to test the various states, we have to insert quite a bit of information into the database, but they're done now, so that's nice.

[>> Story on Pivotal](https://www.pivotaltracker.com/story/show/107188322)

***

### Sample output

```json
{
  "users": [
  {
      "application_result": "pass",
      "application_status": "application",
      "declaration_status": "complete",
      "framework_agreement": true,
      "supplier_id": 10000,
      "user_email": "supplier-10000@user.com",
      "user_name": "DM Test Supplier"
    },
    {
      "application_result": "fail",
      "application_status": "no_application",
      "declaration_status": "complete",
      "framework_agreement": false,
      "supplier_id": 10101,
      "user_email": "supplier-10101@user.com",
      "user_name": "1Cyber Group Ltd"
    }
  ]
}
```