### PR TITLE
Add detail to service status updates

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -3,9 +3,9 @@ from dmutils.audit import AuditTypes
 from flask import jsonify, abort, request, current_app
 
 from .. import main
-from ...models import ArchivedService, Service, Supplier
+from ...models import ArchivedService, Service, Supplier, AuditEvent
 
-from sqlalchemy import asc
+from sqlalchemy import asc, desc
 from ...validation import is_valid_service_id_or_400
 from ...utils import url_for, pagination_links, display_list, get_valid_page_or_1
 
@@ -189,7 +189,18 @@ def get_service(service_id):
         Service.service_id == service_id
     ).first_or_404()
 
-    return jsonify(services=service.serialize())
+    status_update_audit_event = AuditEvent.query.filter(
+        AuditEvent.object == service,
+        AuditEvent.type == AuditTypes.update_service_status.value,
+    ).order_by(desc(AuditEvent.created_at)).first()
+
+    if status_update_audit_event is not None:
+        status_update_audit_event = status_update_audit_event.serialize()
+
+    return jsonify(
+        services=service.serialize(),
+        statusUpdateAuditEvent=status_update_audit_event
+    )
 
 
 @main.route('/archived-services/<int:archived_service_id>', methods=['GET'])

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -189,13 +189,15 @@ def get_service(service_id):
         Service.service_id == service_id
     ).first_or_404()
 
-    status_update_audit_event = AuditEvent.query.filter(
-        AuditEvent.object == service,
-        AuditEvent.type == AuditTypes.update_service_status.value,
-    ).order_by(desc(AuditEvent.created_at)).first()
+    status_update_audit_event = None
+    if service.status is not 'published':
+        status_update_audit_event = AuditEvent.query.filter(
+            AuditEvent.object == service,
+            AuditEvent.type == AuditTypes.update_service_status.value,
+        ).order_by(desc(AuditEvent.created_at)).first()
 
-    if status_update_audit_event is not None:
-        status_update_audit_event = status_update_audit_event.serialize()
+        if status_update_audit_event is not None:
+            status_update_audit_event = status_update_audit_event.serialize()
 
     return jsonify(
         services=service.serialize(),

--- a/tests/app/views/test_services.py
+++ b/tests/app/views/test_services.py
@@ -1754,33 +1754,58 @@ class TestGetService(BaseApplicationTest):
         assert_equal(data['services']['frameworkName'], u'G-Cloud 6')
         assert_equal(data['services']['frameworkStatus'], u'live')
 
-    def test_get_service_returns_last_status_update_audit_if_none(self):
-        response = self.client.get('/services/123-published-456')
+    def test_get_service_returns_empty_last_status_update_audit_if_published(self):
+        # create an audit event for the disabled service
+        with self.app.app_context():
+            service = Service.query.filter(
+                Service.service_id == '123-published-456'
+            ).first()
+            audit_event = AuditEvent(
+                audit_type=AuditTypes.update_service_status,
+                db_object=service,
+                user='joeblogs',
+                data={
+                    "supplierId": 1,
+                    "newArchivedServiceId": 2,
+                    "new_status": "published",
+                    "supplierName": "Supplier 1",
+                    "serviceId": "123-published-456",
+                    "old_status": "disabled",
+                    "oldArchivedServiceId": 1
+                }
+            )
+            db.session.add(audit_event)
+            db.session.commit()
+        response = self.client.get('/services/123-disabled-456')
         data = json.loads(response.get_data())
-        assert_in('statusUpdateAuditEvent', data)
+        assert_equal(data['statusUpdateAuditEvent'], None)
 
-    def test_get_service_returns_last_status_update_audit_if_present(self):
+        # clean up audit events
+        with self.app.app_context():
+            db.session.delete(audit_event)
+            db.session.commit()
+
+    def test_get_service_returns_last_status_update_audit_if_disabled(self):
         # create an audit event for the disabled service
         with self.app.app_context():
             service = Service.query.filter(
                 Service.service_id == '123-disabled-456'
             ).first()
-            db.session.add(
-                AuditEvent(
-                    audit_type=AuditTypes.update_service_status,
-                    db_object=service,
-                    user='joeblogs',
-                    data={
-                        "supplierId": 1,
-                        "newArchivedServiceId": 2,
-                        "new_status": "disabled",
-                        "supplierName": "Supplier 1",
-                        "serviceId": "123-disabled-456",
-                        "old_status": "published",
-                        "oldArchivedServiceId": 1
-                    }
-                )
+            audit_event = AuditEvent(
+                audit_type=AuditTypes.update_service_status,
+                db_object=service,
+                user='joeblogs',
+                data={
+                    "supplierId": 1,
+                    "newArchivedServiceId": 2,
+                    "new_status": "disabled",
+                    "supplierName": "Supplier 1",
+                    "serviceId": "123-disabled-456",
+                    "old_status": "published",
+                    "oldArchivedServiceId": 1
+                }
             )
+            db.session.add(audit_event)
             db.session.commit()
         response = self.client.get('/services/123-disabled-456')
         data = json.loads(response.get_data())
@@ -1790,3 +1815,8 @@ class TestGetService(BaseApplicationTest):
         assert_equal(data['statusUpdateAuditEvent']['data']['serviceId'], '123-disabled-456')
         assert_equal(data['statusUpdateAuditEvent']['data']['old_status'], 'published')
         assert_equal(data['statusUpdateAuditEvent']['data']['new_status'], 'disabled')
+
+        # clean up audit events
+        with self.app.app_context():
+            db.session.delete(audit_event)
+            db.session.commit()

--- a/tests/app/views/test_services.py
+++ b/tests/app/views/test_services.py
@@ -1757,7 +1757,7 @@ class TestGetService(BaseApplicationTest):
     def test_get_service_returns_last_status_update_audit_if_none(self):
         response = self.client.get('/services/123-published-456')
         data = json.loads(response.get_data())
-        assert_in('statusUpdateAuditEvents', data)
+        assert_in('statusUpdateAuditEvent', data)
 
     def test_get_service_returns_last_status_update_audit_if_present(self):
         # create an audit event for the disabled service
@@ -1784,9 +1784,9 @@ class TestGetService(BaseApplicationTest):
             db.session.commit()
         response = self.client.get('/services/123-disabled-456')
         data = json.loads(response.get_data())
-        assert_equal(data['statusUpdateAuditEvents']['type'], 'update_service_status')
-        assert_equal(data['statusUpdateAuditEvents']['user'], 'joeblogs')
-        assert_in('createdAt', data['statusUpdateAuditEvents'])
-        assert_equal(data['statusUpdateAuditEvents']['data']['serviceId'], '123-disabled-456')
-        assert_equal(data['statusUpdateAuditEvents']['data']['old_status'], 'published')
-        assert_equal(data['statusUpdateAuditEvents']['data']['new_status'], 'disabled')
+        assert_equal(data['statusUpdateAuditEvent']['type'], 'update_service_status')
+        assert_equal(data['statusUpdateAuditEvent']['user'], 'joeblogs')
+        assert_in('createdAt', data['statusUpdateAuditEvent'])
+        assert_equal(data['statusUpdateAuditEvent']['data']['serviceId'], '123-disabled-456')
+        assert_equal(data['statusUpdateAuditEvent']['data']['old_status'], 'published')
+        assert_equal(data['statusUpdateAuditEvent']['data']['new_status'], 'disabled')


### PR DESCRIPTION
We will need to show some information on service status changes for those that have been made unavailable.

Story: https://www.pivotaltracker.com/story/show/110695856

This should let us do page state like this:

![status_change_banner](https://cloud.githubusercontent.com/assets/87140/12064156/cc8f7e58-afb3-11e5-9807-6de3f1c54be7.png)


We already add some audit data to requests for drafts:

https://github.com/alphagov/digitalmarketplace-api/blob/master/app/main/views/drafts.py#L163

It was proposed we follow this pattern for services, restricting this only to where needed (services made unavailable).