### PR TITLE
Add option to have audit events return newest-first

### DIFF
--- a/app/main/views/audits.py
+++ b/app/main/views/audits.py
@@ -1,7 +1,7 @@
 from flask import jsonify, abort, request, current_app
 from datetime import datetime
 from ...models import AuditEvent
-from sqlalchemy import asc, Date, cast
+from sqlalchemy import asc, desc, Date, cast
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.sql.expression import true, false
 from ...utils import pagination_links, get_valid_page_or_1
@@ -38,7 +38,9 @@ def list_audits():
         abort(400, 'invalid page size supplied')
 
     audits = AuditEvent.query.order_by(
-        asc(AuditEvent.created_at)
+        desc(AuditEvent.created_at)
+        if convert_to_boolean(request.args.get('latest_first'))
+        else asc(AuditEvent.created_at)
     )
 
     audit_date = request.args.get('audit-date', None)

--- a/tests/app/views/test_audits.py
+++ b/tests/app/views/test_audits.py
@@ -46,6 +46,22 @@ class TestAuditEvents(BaseApplicationTest):
         assert_equal(data['auditEvents'][0]['user'], '0')
         assert_equal(data['auditEvents'][0]['data']['request'], 'data')
 
+    def test_should_get_audit_events_sorted(self):
+        self.add_audit_events(5)
+        response = self.client.get('/audit-events')
+        data = json.loads(response.get_data())
+
+        assert_equal(response.status_code, 200)
+        assert_equal(data['auditEvents'][0]['user'], '0')
+        assert_equal(data['auditEvents'][4]['user'], '4')
+
+        response = self.client.get('/audit-events?latest_first=true')
+        data = json.loads(response.get_data())
+
+        assert_equal(response.status_code, 200)
+        assert_equal(data['auditEvents'][0]['user'], '4')
+        assert_equal(data['auditEvents'][4]['user'], '0')
+
     def test_should_get_audit_event_using_audit_date(self):
         today = datetime.utcnow().strftime("%Y-%m-%d")
 


### PR DESCRIPTION
This makes more sense for the front end. By default it is most useful to see the latest events, and then paginating to get to older ones.

Otherwise you could reload the page for today and might not even notice that new events had been added to end since you last looked (especially if they got paginated onto the next page).