### PR TITLE
Only show active users in export

### DIFF
--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -231,6 +231,8 @@ def export_users_for_framework(framework_slug):
         Supplier, User, Framework
     ).filter(
         Framework.slug == framework_slug
+    ).filter(
+        User.active.is_(True)
     ).all()
 
     submitted_draft_counts_per_supplier = {}

--- a/tests/app/test_users.py
+++ b/tests/app/test_users.py
@@ -1105,7 +1105,6 @@ class TestUsersExport(BaseUserTest):
     def test_response_unstarted_declaration_no_drafts(self):
         self._setup()
         data = json.loads(self._return_users_export_after_setting_framework_status().get_data())["users"]
-        print(data)
         assert len(data) == len(self.users)
         for datum in data:
             self._assert_things_about_export_response(datum)
@@ -1180,6 +1179,27 @@ class TestUsersExport(BaseUserTest):
                 'application_status': 'application',
                 'framework_agreement': True
             })
+
+    def test_response_does_not_include_disabled_users(self):
+        self._setup()
+        self._post_user({
+            "emailAddress": "disabled-user@example.com",
+            "name": "Disabled User",
+            "password": "minimum10characterpassword",
+            "role": "supplier",
+            "supplierId": self.supplier_id
+        })
+        response = self.client.post(
+            '/users/{}'.format(self.users[-1]['id']),
+            data=json.dumps({
+                "users": {"active": False},
+                "update_details": {"updated_by": "test"}
+            }),
+            content_type='application/json')
+        assert response.status_code == 200
+
+        data = json.loads(self._return_users_export_after_setting_framework_status().get_data())["users"]
+        assert len(data) == len(self.users) - 1
 
     # Test 400 if bad framework name
     def test_400_response_if_bad_framework_name(self):

--- a/tests/app/views/test_users.py
+++ b/tests/app/views/test_users.py
@@ -4,7 +4,7 @@ from nose.tools import assert_equal, assert_not_equal, assert_in, assert_is_none
 from app import db, encryption
 from app.models import User, Supplier
 from datetime import datetime
-from .helpers import BaseApplicationTest, JSONUpdateTestMixin
+from ..helpers import BaseApplicationTest, JSONUpdateTestMixin
 from dmutils.formats import DATETIME_FORMAT
 
 


### PR DESCRIPTION
When generating an email list we noticed that it was bigger than the list generated by the original script. This is due to user's active flag not being checked and therefore disabled users being included in the list.

This change also moves the `test_users` module under the same package that all the other views tests live. It's probably easier to review the two commits separately.