### PR TITLE
Upgrade Flask-Bcrypt

### DIFF
--- a/app/encryption.py
+++ b/app/encryption.py
@@ -7,7 +7,7 @@ def authenticate_user(password, user):
 
 
 def hashpw(password):
-    return generate_password_hash(password, 10)
+    return generate_password_hash(password, 10).decode('utf-8')
 
 
 def checkpw(password, hashed_password):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Flask==0.10.1
-Flask-Bcrypt==0.6.2
+Flask-Bcrypt==0.7.1
 Flask-Bootstrap==3.3.0.1
 Flask-Migrate==1.3.1
 Flask-Script==2.0.5


### PR DESCRIPTION
Internally this upgrades from python-bcrypt 0.3.1 to bcrypt 2.0.0

Hashed passwords are now returned as bytes so we need to decode to get
strings.