### PR TITLE
Add libffi-devel

### DIFF
--- a/.ebextensions/packages.config
+++ b/.ebextensions/packages.config
@@ -2,3 +2,4 @@ packages:
   yum:
     postgresql93-devel: []
     git: []
+    libffi-devel: []


### PR DESCRIPTION
This is required by the newer version of bcrypt we're using.