### PR TITLE
Add additional indexes for audit_events table

### DIFF
--- a/app/main/views/drafts.py
+++ b/app/main/views/drafts.py
@@ -2,7 +2,7 @@ from dmapiclient.audit import AuditTypes
 from flask import jsonify, abort, request, current_app
 
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy import asc, desc
+from sqlalchemy import asc
 
 from .. import main
 from ... import db, isolation_level
@@ -160,14 +160,11 @@ def fetch_draft_service(draft_id):
         DraftService.id == draft_id
     ).first_or_404()
 
-    last_audit_event = AuditEvent.query.filter(
-        AuditEvent.object == draft,
-        AuditEvent.type.in_([
-            AuditTypes.create_draft_service.value,
-            AuditTypes.update_draft_service.value,
-            AuditTypes.complete_draft_service.value,
-        ]),
-    ).order_by(desc(AuditEvent.created_at)).first()
+    last_audit_event = AuditEvent.query.last_for_object(draft, [
+        AuditTypes.create_draft_service.value,
+        AuditTypes.update_draft_service.value,
+        AuditTypes.complete_draft_service.value,
+    ])
 
     return jsonify(
         services=draft.serialize(),

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -5,7 +5,7 @@ from flask import jsonify, abort, request, current_app
 from .. import main
 from ...models import ArchivedService, Service, Supplier, AuditEvent
 
-from sqlalchemy import asc, desc
+from sqlalchemy import asc
 from ...validation import is_valid_service_id_or_400
 from ...utils import url_for, pagination_links, display_list, get_valid_page_or_1
 
@@ -191,10 +191,9 @@ def get_service(service_id):
 
     status_update_audit_event = None
     if service.status is not 'published':
-        status_update_audit_event = AuditEvent.query.filter(
-            AuditEvent.object == service,
-            AuditEvent.type == AuditTypes.update_service_status.value,
-        ).order_by(desc(AuditEvent.created_at)).first()
+        status_update_audit_event = AuditEvent.query.last_for_object(service, [
+            AuditTypes.update_service_status.value,
+        ])
 
         if status_update_audit_event is not None:
             status_update_audit_event = status_update_audit_event.serialize()

--- a/app/models.py
+++ b/app/models.py
@@ -3,7 +3,7 @@ from datetime import datetime
 
 from flask import current_app
 from flask_sqlalchemy import BaseQuery
-from sqlalchemy import asc
+from sqlalchemy import asc, desc
 from sqlalchemy import func
 from sqlalchemy.dialects.postgresql import JSON
 from sqlalchemy.ext.declarative import declared_attr
@@ -681,6 +681,14 @@ class AuditEvent(db.Model):
         self.object = db_object
         self.user = user
         self.acknowledged = False
+
+    class query_class(BaseQuery):
+        def last_for_object(self, object, types=None):
+            events = self.filter(AuditEvent.object == object)
+            if types is not None:
+                events = events.filter(AuditEvent.type.in_(types))
+
+            return events.order_by(desc(AuditEvent.created_at)).first()
 
     def serialize(self, include_user=False):
         """

--- a/migrations/versions/450_add_additional_indexes_for_audit_events.py
+++ b/migrations/versions/450_add_additional_indexes_for_audit_events.py
@@ -1,0 +1,27 @@
+"""Add additional indexes for audit_events
+
+Revision ID: 450
+Revises: 440
+Create Date: 2016-01-08 15:14:18.621169
+
+"""
+
+revision = '450'
+down_revision = '440'
+
+from alembic import op
+
+
+def upgrade():
+    op.create_index('idx_audit_events_object_and_type', 'audit_events',
+                    ['object_type', 'object_id', 'type', 'created_at'], unique=False)
+    op.create_index('idx_audit_events_type_acknowledged', 'audit_events',
+                    ['type', 'acknowledged'], unique=False)
+    op.drop_index('idx_audit_events_object', table_name='audit_events')
+
+
+def downgrade():
+    op.create_index('idx_audit_events_object', 'audit_events',
+                    ['object_type', 'object_id'], unique=False)
+    op.drop_index('idx_audit_events_type_acknowledged', table_name='audit_events')
+    op.drop_index('idx_audit_events_object_and_type', table_name='audit_events')


### PR DESCRIPTION
### Add additional indexes for audit_events table
We've seen some performance issues leading to request timeouts
on preview mostly related to the audit events table queries.

Slowest queries we've observed were:
* "Find last audit event for object" queries - were using the
  created_at index scan with filters that can take a long time
  for objects that were last updated a long time ago (query times
  up to 60s on preview).
* Count audit events with given type and acknowledged status query.
  Executed by flask-sqlalchemy `.paginate` method to get the total
  count. The query was using a Bitmap Heap Scan to check the
  acknowledged status after a type index scan, which slows down as
  table size increases.

Other common queries triggered by `/audit-events` endpoint are mostly
using the `created_at` index due to pagination limit.

### Move draft and services 'last event' query to model query class
Since we've noticed some performance issues with the 'last event'
queries, moving them to a single location to make sure they're
using the same order and filter conditions that can be covered
by a single database index.