### PR TITLE
Add framework expired to service status audit events

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -189,30 +189,30 @@ def get_service(service_id):
         Service.service_id == service_id
     ).first_or_404()
 
-    status_update_audit_event = None
+    service_made_unavailable_audit_event = None
     service_is_unavailable = False
     if service.status != 'published':
         service_is_unavailable = True
-        status_update_object = service
-        status_update_type = AuditTypes.update_service_status.value
+        audit_event_object_reference = service
+        audit_event_update_type = AuditTypes.update_service_status.value
     elif service.framework.status == 'expired':
         service_is_unavailable = True
-        status_update_object = Framework.query.filter(
+        audit_event_object_reference = Framework.query.filter(
             Framework.id == service.framework.id
         ).first_or_404()
-        status_update_type = AuditTypes.framework_update.value
+        audit_event_update_type = AuditTypes.framework_update.value
 
     if service_is_unavailable:
-        status_update_audit_event = AuditEvent.query.last_for_object(status_update_object, [
-            status_update_type
-        ])
+        service_made_unavailable_audit_event = AuditEvent.query.last_for_object(
+            audit_event_object_reference, [audit_event_update_type]
+        )
 
-    if status_update_audit_event is not None:
-        status_update_audit_event = status_update_audit_event.serialize()
+    if service_made_unavailable_audit_event is not None:
+        service_made_unavailable_audit_event = service_made_unavailable_audit_event.serialize()
 
     return jsonify(
         services=service.serialize(),
-        statusUpdateAuditEvent=status_update_audit_event
+        serviceMadeUnavailableAuditEvent=service_made_unavailable_audit_event
     )
 
 

--- a/tests/app/views/test_services.py
+++ b/tests/app/views/test_services.py
@@ -1780,11 +1780,6 @@ class TestGetService(BaseApplicationTest):
         data = json.loads(response.get_data())
         assert_equal(data['statusUpdateAuditEvent'], None)
 
-        # clean up audit events
-        with self.app.app_context():
-            db.session.delete(audit_event)
-            db.session.commit()
-
     def test_get_service_returns_last_status_update_audit_if_disabled(self):
         # create an audit event for the disabled service
         with self.app.app_context():
@@ -1815,11 +1810,6 @@ class TestGetService(BaseApplicationTest):
         assert_equal(data['statusUpdateAuditEvent']['data']['serviceId'], '123-disabled-456')
         assert_equal(data['statusUpdateAuditEvent']['data']['old_status'], 'published')
         assert_equal(data['statusUpdateAuditEvent']['data']['new_status'], 'disabled')
-
-        # clean up audit events
-        with self.app.app_context():
-            db.session.delete(audit_event)
-            db.session.commit()
 
     def test_get_service_returns_last_status_update_audit_if_published_but_framework_is_expired(self):
         # create an audit event for the disabled service

--- a/tests/app/views/test_services.py
+++ b/tests/app/views/test_services.py
@@ -1778,7 +1778,7 @@ class TestGetService(BaseApplicationTest):
             db.session.commit()
         response = self.client.get('/services/123-disabled-456')
         data = json.loads(response.get_data())
-        assert_equal(data['statusUpdateAuditEvent'], None)
+        assert_equal(data['serviceMadeUnavailableAuditEvent'], None)
 
     def test_get_service_returns_last_status_update_audit_if_disabled(self):
         # create an audit event for the disabled service
@@ -1804,12 +1804,12 @@ class TestGetService(BaseApplicationTest):
             db.session.commit()
         response = self.client.get('/services/123-disabled-456')
         data = json.loads(response.get_data())
-        assert_equal(data['statusUpdateAuditEvent']['type'], 'update_service_status')
-        assert_equal(data['statusUpdateAuditEvent']['user'], 'joeblogs')
-        assert_in('createdAt', data['statusUpdateAuditEvent'])
-        assert_equal(data['statusUpdateAuditEvent']['data']['serviceId'], '123-disabled-456')
-        assert_equal(data['statusUpdateAuditEvent']['data']['old_status'], 'published')
-        assert_equal(data['statusUpdateAuditEvent']['data']['new_status'], 'disabled')
+        assert_equal(data['serviceMadeUnavailableAuditEvent']['type'], 'update_service_status')
+        assert_equal(data['serviceMadeUnavailableAuditEvent']['user'], 'joeblogs')
+        assert_in('createdAt', data['serviceMadeUnavailableAuditEvent'])
+        assert_equal(data['serviceMadeUnavailableAuditEvent']['data']['serviceId'], '123-disabled-456')
+        assert_equal(data['serviceMadeUnavailableAuditEvent']['data']['old_status'], 'published')
+        assert_equal(data['serviceMadeUnavailableAuditEvent']['data']['new_status'], 'disabled')
 
     def test_get_service_returns_last_status_update_audit_if_published_but_framework_is_expired(self):
         # create an audit event for the disabled service
@@ -1840,7 +1840,7 @@ class TestGetService(BaseApplicationTest):
             db.session.commit()
         response = self.client.get('/services/123-published-456')
         data = json.loads(response.get_data())
-        assert_equal(data['statusUpdateAuditEvent']['type'], 'framework_update')
-        assert_equal(data['statusUpdateAuditEvent']['user'], 'joeblogs')
-        assert_in('createdAt', data['statusUpdateAuditEvent'])
-        assert_equal(data['statusUpdateAuditEvent']['data']['update']['status'], 'expired')
+        assert_equal(data['serviceMadeUnavailableAuditEvent']['type'], 'framework_update')
+        assert_equal(data['serviceMadeUnavailableAuditEvent']['user'], 'joeblogs')
+        assert_in('createdAt', data['serviceMadeUnavailableAuditEvent'])
+        assert_equal(data['serviceMadeUnavailableAuditEvent']['data']['update']['status'], 'expired')


### PR DESCRIPTION
An extension to the functionality added in https://github.com/alphagov/digitalmarketplace-api/pull/314.

Services on expired frameworks should also return an audit event for the status change, just one triggered by the framework status change instead of that for the service.