### PR TITLE
Remove unused parameter; fix typo

### DIFF
--- a/app/main/views/drafts.py
+++ b/app/main/views/drafts.py
@@ -261,7 +261,7 @@ def publish_draft_service(draft_id):
 
 
 @main.route('/draft-services', methods=['POST'])
-def create_new_draft_service(framework_slug=None):
+def create_new_draft_service():
     """
     Create a new draft service with lot, supplier_id, draft_id, framework_id
     :return: the new draft id and location e.g.

--- a/app/service_utils.py
+++ b/app/service_utils.py
@@ -31,7 +31,7 @@ def validate_and_return_related_objects(service_json):
     ).first()
 
     if not framework:
-        abort(400, "Framework '{}' does not exits".format(service_json['frameworkSlug']))
+        abort(400, "Framework '{}' does not exist".format(service_json['frameworkSlug']))
 
     lot = framework.get_lot(service_json['lot'])
 


### PR DESCRIPTION
Really minor change fixes a typo in an error message and removes an unused parameter.