### PR TITLE
[#111613066] Fix audit events object-id and object-type filtering

### DIFF
--- a/app/main/views/audits.py
+++ b/app/main/views/audits.py
@@ -89,13 +89,10 @@ def list_audits():
             id_field == object_id
         ).first()
 
-        # FIXME this makes sure we return 0 audit events if the referenced
-        # object doesn't exist in case apps aren't handling a 404 response.
-        # Should be changed to a 404 once the apps are updated.
         if ref_object is None:
-            audits = audits.filter(false())
-        else:
-            audits = audits.filter(AuditEvent.object == ref_object)
+            abort(404, "Object with given object-type and object-id doesn't exist")
+
+        audits = audits.filter(AuditEvent.object == ref_object)
 
     elif object_id:
         abort(400, 'object-id cannot be provided without object-type')

--- a/tests/app/views/test_audits.py
+++ b/tests/app/views/test_audits.py
@@ -116,14 +116,13 @@ class TestAuditEvents(BaseApplicationTest):
         assert_equal(len(data['auditEvents']), 1)
         assert_equal(data['auditEvents'][0]['user'], 'rob')
 
-    def test_get_audit_event_for_missing_object_returns_no_events(self):
+    def test_get_audit_event_for_missing_object_returns_404(self):
         self.add_audit_events_with_db_object()
 
         response = self.client.get('/audit-events?object-type=suppliers&object-id=100000')
         data = json.loads(response.get_data())
 
-        assert_equal(response.status_code, 200)
-        assert_equal(len(data['auditEvents']), 0)
+        assert_equal(response.status_code, 404)
 
     def test_should_only_get_audit_event_with_correct_object_type(self):
         self.add_audit_events_with_db_object()

--- a/tests/app/views/test_audits.py
+++ b/tests/app/views/test_audits.py
@@ -116,6 +116,41 @@ class TestAuditEvents(BaseApplicationTest):
         assert_equal(len(data['auditEvents']), 1)
         assert_equal(data['auditEvents'][0]['user'], 'rob')
 
+    def test_get_audit_event_for_missing_object_returns_no_events(self):
+        self.add_audit_events_with_db_object()
+
+        response = self.client.get('/audit-events?object-type=suppliers&object-id=100000')
+        data = json.loads(response.get_data())
+
+        assert_equal(response.status_code, 200)
+        assert_equal(len(data['auditEvents']), 0)
+
+    def test_should_only_get_audit_event_with_correct_object_type(self):
+        self.add_audit_events_with_db_object()
+
+        with self.app.app_context():
+            # Create a second AuditEvent with the same object_id but with a
+            # different object_type to check that we're not filtering based
+            # on object_id only
+            supplier = Supplier.query.filter(Supplier.supplier_id == 1).first()
+            event = AuditEvent(
+                audit_type=AuditTypes.supplier_update,
+                db_object=supplier,
+                user='not rob',
+                data={'request': "data"}
+            )
+            event.object_type = 'Service'
+
+            db.session.add(event)
+            db.session.commit()
+
+        response = self.client.get('/audit-events?object-type=suppliers&object-id=1')
+        data = json.loads(response.get_data())
+
+        assert_equal(response.status_code, 200)
+        assert_equal(len(data['auditEvents']), 1)
+        assert_equal(data['auditEvents'][0]['user'], 'rob')
+
     def test_should_reject_invalid_object_type(self):
         self.add_audit_events_with_db_object()
 


### PR DESCRIPTION
List audit events endpoint used a join between the audit event
table and the `object-type` model, but didn't check the audit event
`object_type`. This means that eg an event with `object_id=1` could
be joined to Services, Suppliers or Frameworks record depending on
the `object-type` argument, which lead to incorrect audit events
being returned by the endpoint.

Instead of a join query we request the referenced object separately
and then filter the audit events based on that.