### PR TITLE
[#111770956] Don't show suppliers as "failed" if no result yet

### DIFF
--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -263,7 +263,10 @@ def export_users_for_framework(framework_slug):
             submitted_draft_count = submitted_draft_counts_per_supplier[sf.supplier_id]
             application_status = \
                 'application' if submitted_draft_count and declaration_status == 'complete' else 'no_application'
-            application_result = 'pass' if sf.on_framework else 'fail'
+            if sf.on_framework is None:
+                application_result = 'no result'
+            else:
+                application_result = 'pass' if sf.on_framework else 'fail'
             framework_agreement = bool(sf.agreement_returned_at)
 
         user_rows.append({


### PR DESCRIPTION
Fixes this bug: https://www.pivotaltracker.com/story/show/111770956

Currently the export users endpoint shows applications as "fail" even if there is not yet any result recorded in the database.  This adds a "no result" value for applications that we do not yet have the result for.