### PR TITLE
Fix framework stats service counting drafts twice for old declarations

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -101,6 +101,7 @@ def get_framework_stats(framework_slug):
             ).group_by(
                 DraftService.status, Lot.slug, is_declaration_complete
             ).filter(
+                SupplierFramework.framework_id == framework.id,
                 DraftService.framework_id == framework.id,
                 cast(SupplierFramework.declaration, String) != 'null'
             ).all()


### PR DESCRIPTION
Framework drafts query uses an outerjoin between Drafts and framework
declarations on supplier_id field, which creates duplicate Draft rows
for suppliers who have completed declarations for other frameworks.

Filtering out rows with incorrect SupplierFrameworks.framework_id fixes
the problem.

Modified stats test to create a single set of suppliers and two sets
of framework applications for two different frameworks to check that
data from other frameworks doesn't affect the stats.