### PR TITLE
Add a migration to remove old imported buyer accounts

### DIFF
--- a/migrations/versions/470_remove_old_imported_buyer_accounts.py
+++ b/migrations/versions/470_remove_old_imported_buyer_accounts.py
@@ -1,0 +1,24 @@
+"""Remove old imported buyer accounts
+
+Revision ID: 470
+Revises: 460
+Create Date: 2016-01-22 16:20:29.793439
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '470'
+down_revision = '460'
+
+from alembic import op
+
+
+def upgrade():
+    op.execute("""
+        DELETE FROM users
+        WHERE users.role = 'buyer';
+    """)
+
+
+def downgrade():
+    pass  # :(


### PR DESCRIPTION
Users with a "buyer" role were imported from the Grails app and are
a mix of buyer and supplier users. We used to convert them to supplier
accounts during registration, but now that we're planning to open buyer
registration for valid buyers we're going to delete all old accounts and
ask user to re-register if needed instead of trying to validate if the
existing buyer accounts are valid buyers.

**Since the migration completely removes user data, we need to create a manual production snapshot before releasing this**