### PR TITLE
Add new endpoint to update the status of a draft

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ SQLAlchemy==1.0.5
 SQLAlchemy-Utils==0.30.5
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@16.0.0#egg=digitalmarketplace-utils==16.0.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@1.2.0#egg=digitalmarketplace-apiclient==1.2.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@1.3.0#egg=digitalmarketplace-apiclient==1.3.0
 
 # For schema validation
 jsonschema==2.5.1

--- a/tests/app/views/test_drafts.py
+++ b/tests/app/views/test_drafts.py
@@ -1493,3 +1493,82 @@ class TestDOSServices(BaseApplicationTest):
         data = json.loads(complete.get_data())
         assert_in("specialist_required", "{}".format(data['error']['_form']))
         assert_equal(complete.status_code, 400)
+
+
+class TestUpdateDraftStatus(BaseApplicationTest):
+    def setup(self):
+        super(TestUpdateDraftStatus, self).setup()
+
+        with self.app.app_context():
+            db.session.add(Supplier(supplier_id=1, name=u"Supplier 1"))
+            db.session.add(
+                ContactInformation(
+                    supplier_id=1,
+                    contact_name=u"Test",
+                    email=u"supplier@user.dmdev",
+                    postcode=u"SW1A 1AA"
+                )
+            )
+            Framework.query.filter_by(slug='g-cloud-7').update(dict(status='open'))
+            db.session.commit()
+        draft_json = self.load_example_listing("G7-SCS")
+        draft_json['frameworkSlug'] = 'g-cloud-7'
+        create_draft_json = {
+            'update_details': {
+                'updated_by': 'joeblogs'
+            },
+            'services': draft_json
+        }
+
+        draft = self.client.post(
+            '/draft-services',
+            data=json.dumps(create_draft_json),
+            content_type='application/json')
+
+        self.draft = json.loads(draft.get_data())['services']
+        self.draft_id = self.draft['id']
+
+    def test_update_draft_status(self):
+        res = self.client.post(
+            '/draft-services/%s/update-status' % self.draft_id,
+            data=json.dumps({'services': {'status': 'failed'}, 'update_details': {'updated_by': 'joeblogs'}}),
+            content_type='application/json')
+
+        data = json.loads(res.get_data())
+        assert_equal(res.status_code, 200, res.get_data())
+        assert_equal(data['services']['status'], 'failed')
+
+    def test_update_draft_status_should_create_audit_event(self):
+        res = self.client.post(
+            '/draft-services/%s/update-status' % self.draft_id,
+            data=json.dumps({'services': {'status': 'failed'}, 'update_details': {'updated_by': 'joeblogs'}}),
+            content_type='application/json')
+
+        assert_equal(res.status_code, 200)
+
+        audit_response = self.client.get('/audit-events')
+        assert_equal(audit_response.status_code, 200)
+        data = json.loads(audit_response.get_data())
+        assert_equal(len(data['auditEvents']), 2)
+        assert_equal(data['auditEvents'][1]['user'], 'joeblogs')
+        assert_equal(data['auditEvents'][1]['type'], 'update_draft_service_status')
+        assert_equal(data['auditEvents'][1]['data'], {
+            'draftId': self.draft_id, 'status': 'failed'
+        })
+
+    def test_should_not_update_draft_status_without_update_details(self):
+        res = self.client.post(
+            '/draft-services/%s/update-status' % self.draft_id,
+            data=json.dumps({'services': {'status': 'not-submitted'}}),
+            content_type='application/json')
+
+        assert_equal(res.status_code, 400)
+
+    def test_should_not_update_draft_status_to_invalid_status(self):
+        res = self.client.post(
+            '/draft-services/%s/update-status' % self.draft_id,
+            data=json.dumps({'services': {'status': 'INVALID-STATUS'}, 'update_details': {'updated_by': 'joeblogs'}}),
+            content_type='application/json')
+
+        assert_equal(res.status_code, 400)
+        assert_equal(json.loads(res.get_data()), {"error": "'INVALID-STATUS' is not a valid status"})


### PR DESCRIPTION
Currently we only have an endpoint to mark a service as complete, but that is the only change to `status` that can be made.

We now need to mark drafts as `failed`, so this commit adds a new endpoint hat can be used to update the status of a draft to any valid status (valid values are as listed in `DraftService.STATUSES`).

Depends on: 
 - [x] https://github.com/alphagov/digitalmarketplace-apiclient/pull/5