### PR TITLE
Bugfix: delete keys with None values when saving declaration changes

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -277,6 +277,13 @@ class SupplierFramework(db.Model):
     supplier = db.relationship(Supplier, lazy='joined', innerjoin=True)
     framework = db.relationship(Framework, lazy='joined', innerjoin=True)
 
+    @validates('declaration')
+    def validates_declaration(self, key, value):
+        value = strip_whitespace_from_data(value)
+        value = purge_nulls_from_data(value)
+
+        return value
+
     @staticmethod
     def find_by_framework(framework_slug):
         return SupplierFramework.query.filter(

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from nose.tools import assert_equal, assert_raises
 
 from app import db, create_app
-from app.models import User, Framework, Service, ValidationError
+from app.models import User, Framework, Service, ValidationError, SupplierFramework
 from .helpers import BaseApplicationTest
 
 
@@ -119,3 +119,17 @@ class TestServices(BaseApplicationTest):
             services = Service.query.has_statuses('published', 'disabled')
 
             assert_equal(services.count(), 2)
+
+
+class TestSupplierFrameworks(BaseApplicationTest):
+    def test_nulls_are_stripped_from_declaration(self):
+        supplier_framework = SupplierFramework()
+        supplier_framework.declaration = {'foo': 'bar', 'bar': None}
+
+        assert supplier_framework.declaration == {'foo': 'bar'}
+
+    def test_whitespace_values_are_stripped_from_declaration(self):
+        supplier_framework = SupplierFramework()
+        supplier_framework.declaration = {'foo': ' bar ', 'bar': '', 'other': ' '}
+
+        assert supplier_framework.declaration == {'foo': 'bar', 'bar': '', 'other': ''}


### PR DESCRIPTION
Updating a declaration with the admin app on a page with optional questions that have not been answered creates keys with `None` values in the saved declaration.

 This causes the template that displays the declarations to break.

 This change purges keys with `None` values before saving.