### PR TITLE
Rename framework gcloud to g-cloud

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -30,6 +30,10 @@ def list_suppliers():
     if framework:
         is_valid_string_or_400(framework)
 
+        # TODO: remove backwards compatibility
+        if framework == 'gcloud':
+            framework = 'g-cloud'
+
         suppliers = Supplier.query.join(
             Service.supplier, Service.framework
         ).filter(

--- a/app/models.py
+++ b/app/models.py
@@ -54,15 +54,18 @@ class Lot(db.Model):
 class Framework(db.Model):
     __tablename__ = 'frameworks'
 
-    STATUSES = [
+    STATUSES = (
         'coming', 'open', 'pending', 'standstill', 'live', 'expired'
-    ]
+    )
+    FRAMEWORKS = (
+        'g-cloud',
+        'dos',
+    )
 
     id = db.Column(db.Integer, primary_key=True)
     slug = db.Column(db.String, nullable=False, unique=True, index=True)
     name = db.Column(db.String(255), nullable=False)
-    framework = db.Column(db.Enum('gcloud', name='frameworks_enum'),
-                          index=True, nullable=False)
+    framework = db.Column(db.String(), index=True, nullable=False)
     status = db.Column(db.String(),
                        index=True, nullable=False,
                        default='pending')
@@ -97,6 +100,12 @@ class Framework(db.Model):
             raise ValidationError("Invalid status value '{}'".format(value))
 
         return value
+
+    @validates('framework')
+    def validates_framework(self, key, framework):
+        if framework not in self.FRAMEWORKS:
+            raise ValidationError("Invalid framework value '{}'".format(framework))
+        return framework
 
     def __repr__(self):
         return '<{}: {}>'.format(self.__class__.__name__, self.name)

--- a/migrations/versions/480_use_sqlalchemy_validator_instead_of_.py
+++ b/migrations/versions/480_use_sqlalchemy_validator_instead_of_.py
@@ -1,0 +1,38 @@
+"""Use SQLAlchemy validator instead of enum for framework
+
+Revision ID: 480
+Revises: 470
+Create Date: 2016-01-29 15:47:25.481313
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '480'
+down_revision = '470'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.execute("""
+        ALTER TABLE frameworks ALTER COLUMN framework
+        TYPE character varying USING framework::character varying
+    """)
+
+    op.execute("""
+        DROP TYPE framework_enum
+    """)
+
+
+def downgrade():
+    op.execute("""
+        CREATE TYPE framework_enum AS ENUM (
+            'gcloud', 'dos'
+        )
+    """)
+
+    op.execute("""
+        ALTER TABLE frameworks ALTER COLUMN framework TYPE framework_enum
+        USING framework::framework_enum
+    """)

--- a/migrations/versions/490_rename_framework_gcloud_to_g_cloud.py
+++ b/migrations/versions/490_rename_framework_gcloud_to_g_cloud.py
@@ -1,0 +1,26 @@
+"""Rename framework gcloud to g-cloud
+
+Revision ID: 490
+Revises: 480
+Create Date: 2016-01-29 16:08:51.484729
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '490'
+down_revision = '480'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.execute("""
+        UPDATE frameworks SET framework='g-cloud' WHERE framework='gcloud'
+    """)
+
+
+def downgrade():
+    op.execute("""
+        UPDATE frameworks SET framework='gcloud' WHERE framework='g-cloud'
+    """)

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -35,7 +35,7 @@ def test_framework_should_not_accept_invalid_status():
         f = Framework(
             name='foo',
             slug='foo',
-            framework='gcloud',
+            framework='g-cloud',
             status='invalid',
         )
         db.session.add(f)
@@ -49,7 +49,7 @@ def test_framework_should_accept_valid_statuses():
             f = Framework(
                 name='foo',
                 slug='foo-{}'.format(i),
-                framework='gcloud',
+                framework='g-cloud',
                 status=status,
             )
             db.session.add(f)

--- a/tests/app/views/test_frameworks.py
+++ b/tests/app/views/test_frameworks.py
@@ -61,7 +61,7 @@ class TestUpdateFramework(BaseApplicationTest):
         super(TestUpdateFramework, self).setup()
         framework = Framework()
         framework.name = 'Example G-Cloud framework'
-        framework.framework = 'gcloud'
+        framework.framework = 'g-cloud'
         framework.slug = 'example'
         framework.status = 'open'
 

--- a/tests/app/views/test_services.py
+++ b/tests/app/views/test_services.py
@@ -1667,7 +1667,7 @@ class TestGetService(BaseApplicationTest):
                 id=123,
                 name="expired",
                 slug="expired",
-                framework="gcloud",
+                framework="g-cloud",
                 status="expired",
             ))
             db.session.add(

--- a/tests/app/views/test_suppliers.py
+++ b/tests/app/views/test_suppliers.py
@@ -211,8 +211,16 @@ class TestListSuppliersOnFramework(BaseApplicationTest):
         response = self.client.get('/suppliers?framework=invalid!')
         assert_equal(400, response.status_code)
 
-    def test_should_return_suppliers_on_framework(self):
+    def test_should_return_suppliers_on_framework_backwards_compatibility(self):
+        # TODO: REMOVE WHEN BUYER APP IS UPDATED
         response = self.client.get('/suppliers?framework=gcloud')
+        assert_equal(200, response.status_code)
+        data = json.loads(response.get_data())
+        assert_equal(1, len(data['suppliers']))
+        assert_equal('Active', data['suppliers'][0]['name'])
+
+    def test_should_return_suppliers_on_framework(self):
+        response = self.client.get('/suppliers?framework=g-cloud')
         assert_equal(200, response.status_code)
         data = json.loads(response.get_data())
         assert_equal(1, len(data['suppliers']))
@@ -220,7 +228,10 @@ class TestListSuppliersOnFramework(BaseApplicationTest):
 
     def test_should_return_no_suppliers_no_framework(self):
         response = self.client.get('/suppliers?framework=bad')
-        assert_equal(400, response.status_code)
+        data = json.loads(response.get_data())
+
+        assert response.status_code == 200
+        assert len(data['suppliers']) == 0
 
     def test_should_return_all_suppliers_if_no_framework(self):
         response = self.client.get('/suppliers')
@@ -809,7 +820,7 @@ class TestSetSupplierDeclarations(BaseApplicationTest):
             framework = Framework(
                 slug='test-open',
                 name='Test open',
-                framework='gcloud',
+                framework='g-cloud',
                 status='open')
             db.session.add(framework)
             db.session.commit()


### PR DESCRIPTION
In the frameworks table change gcloud to g-cloud so that it can be used as the slug for buyer frontend URLs.

This is required for https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/210