### PR TITLE
Set apache KeepAliveTimeout to greater than ELB idle timeout

### DIFF
--- a/.ebextensions/apache-keepalive.config
+++ b/.ebextensions/apache-keepalive.config
@@ -1,0 +1,8 @@
+files:
+  "/etc/httpd/conf.d/keepalive.conf":
+    mode: "000644"
+    owner: root
+    group: root
+    content: |
+      KeepAlive On
+      KeepAliveTimeout 61


### PR DESCRIPTION
One of the possible explanations for the 504 responses we're seeing
is that ELBs keep sending requests to connections closed by the app
webserver.

Recommendation we've received from AWS support is to set keep-alive
timeout to a value greater than ELB idle connection timeout (which
is 60s by default).

Looking at apache config on Elastic Beanstalk instances it doesn't
look like an explicit value is set anywhere, so Apache is probably
using the default KeepAliveTimeout of 5s.

Setting a value above 60s to see if it fixes the issue. There's a
risk that a high keep-alive value will tie up Apache workers with
idle connections if ELBs are opening more backend connections than
the number of Apache threads.

(http://docs.aws.amazon.com/ElasticLoadBalancing/latest/DeveloperGuide/ts-elb-error-message.html#ts-elb-errorcodes-http504)