### PR TITLE
Turn Off Apache KeepAlive

### DIFF
--- a/.ebextensions/apache_keepalive.config
+++ b/.ebextensions/apache_keepalive.config
@@ -4,5 +4,4 @@ files:
     owner: root
     group: root
     content: |
-      KeepAlive On
-      KeepAliveTimeout 61
+      KeepAlive Off


### PR DESCRIPTION
Setting a high KeepAliveTimeout value seems to interfere with ELB
health checks and either prevents the deployment with the default
ELB health check intervals or causes ELB_5xx errors during the
deployment.

I'm not sure if this is caused by ELB/Apache interaction or if it's
Apache/mod_wsgi.

Instead, let's try disabling keep-alive altogether. This might force
ELB to close the backend connection after each request instead of
trying to reuse it, but I couldn't find an explanation of ELB
behaviour, so I'm not sure if this will improve the ELB_5xx rate.