### PR TITLE
Add framework framework

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -509,7 +509,7 @@ class ServiceTableMixin(object):
             'id', 'status',
             'supplierId', 'supplierName',
             'frameworkSlug', 'frameworkFramework', 'frameworkName', 'frameworkStatus',
-            'lot', 'lotName',
+            'lot', 'lotSlug', 'lotName',
             'updatedAt', 'createdAt', 'links'
         ])
 
@@ -534,6 +534,7 @@ class ServiceTableMixin(object):
             'frameworkName': self.framework.name,
             'frameworkStatus': self.framework.status,
             'lot': self.lot.slug,
+            'lotSlug': self.lot.slug,
             'lotName': self.lot.name,
             'updatedAt': self.updated_at.strftime(DATETIME_FORMAT),
             'createdAt': self.created_at.strftime(DATETIME_FORMAT),
@@ -823,7 +824,7 @@ class Brief(db.Model):
         data = drop_foreign_fields(data, [
             'id',
             'frameworkSlug', 'frameworkFramework', 'frameworkName', 'frameworkStatus',
-            'lot', 'lotName',
+            'lot', 'lotSlug', 'lotName',
             'updatedAt', 'createdAt', 'links'
         ])
 
@@ -859,6 +860,7 @@ class Brief(db.Model):
             'frameworkName': self.framework.name,
             'frameworkStatus': self.framework.status,
             'lot': self.lot.slug,
+            'lotSlug': self.lot.slug,
             'lotName': self.lot.name,
             'createdAt': self.created_at.strftime(DATETIME_FORMAT),
             'updatedAt': self.updated_at.strftime(DATETIME_FORMAT),

--- a/app/models.py
+++ b/app/models.py
@@ -508,7 +508,7 @@ class ServiceTableMixin(object):
         data = drop_foreign_fields(value, [
             'id', 'status',
             'supplierId', 'supplierName',
-            'frameworkSlug', 'frameworkName', 'frameworkStatus',
+            'frameworkSlug', 'frameworkFramework', 'frameworkName', 'frameworkStatus',
             'lot', 'lotName',
             'updatedAt', 'createdAt', 'links'
         ])
@@ -530,6 +530,7 @@ class ServiceTableMixin(object):
             'supplierId': self.supplier.supplier_id,
             'supplierName': self.supplier.name,
             'frameworkSlug': self.framework.slug,
+            'frameworkFramework': self.framework.framework,
             'frameworkName': self.framework.name,
             'frameworkStatus': self.framework.status,
             'lot': self.lot.slug,
@@ -821,7 +822,7 @@ class Brief(db.Model):
     def validates_data(self, key, data):
         data = drop_foreign_fields(data, [
             'id',
-            'frameworkSlug', 'frameworkName', 'frameworkStatus',
+            'frameworkSlug', 'frameworkFramework', 'frameworkName', 'frameworkStatus',
             'lot', 'lotName',
             'updatedAt', 'createdAt', 'links'
         ])
@@ -854,6 +855,7 @@ class Brief(db.Model):
             'id': self.id,
             'status': self.status,
             'frameworkSlug': self.framework.slug,
+            'frameworkFramework': self.framework.framework,
             'frameworkName': self.framework.name,
             'frameworkStatus': self.framework.status,
             'lot': self.lot.slug,

--- a/tests/app/views/test_briefs.py
+++ b/tests/app/views/test_briefs.py
@@ -329,6 +329,7 @@ class TestBriefs(BaseApplicationTest):
                 'frameworkName': 'Digital Outcomes and Specialists',
                 'frameworkStatus': 'live',
                 'lot': 'digital-specialists',
+                'lotSlug': 'digital-specialists',
                 'lotName': 'Digital specialists',
                 'createdAt': mock.ANY,
                 'updatedAt': mock.ANY,

--- a/tests/app/views/test_briefs.py
+++ b/tests/app/views/test_briefs.py
@@ -325,6 +325,7 @@ class TestBriefs(BaseApplicationTest):
                 'id': 1,
                 'status': 'draft',
                 'frameworkSlug': 'digital-outcomes-and-specialists',
+                'frameworkFramework': 'dos',
                 'frameworkName': 'Digital Outcomes and Specialists',
                 'frameworkStatus': 'live',
                 'lot': 'digital-specialists',

--- a/tests/app/views/test_services.py
+++ b/tests/app/views/test_services.py
@@ -225,14 +225,24 @@ class TestListServices(BaseApplicationTest):
         assert_equal(data['services'][0]['id'], '2000000000')
         assert_equal(data['services'][1]['id'], '2000000003')
 
-    def test_list_services_returns_framework(self):
+    def test_list_services_returns_framework_and_lot_info(self):
         self.setup_dummy_services_including_unpublished(1)
         response = self.client.get('/services')
         data = json.loads(response.get_data())
         service = data['services'][0]
 
-        assert_equal(service['frameworkSlug'], u'g-cloud-6')
-        assert_equal(service['frameworkName'], u'G-Cloud 6')
+        framework_info = {
+            key: value for key, value in data['services'][0].items()
+            if key.startswith('framework') or key.startswith('lot')
+        }
+        assert framework_info == {
+            'frameworkSlug': 'g-cloud-6',
+            'frameworkName': 'G-Cloud 6',
+            'frameworkStatus': 'live',
+            'frameworkFramework': 'g-cloud',
+            'lot': 'saas',
+            'lotName': 'Software as a Service',
+        }
 
     def test_list_services_returns_supplier_info(self):
         self.setup_dummy_services_including_unpublished(1)
@@ -1752,12 +1762,22 @@ class TestGetService(BaseApplicationTest):
         assert_equal(data['services']['supplierId'], 1)
         assert_equal(data['services']['supplierName'], u'Supplier 1')
 
-    def test_get_service_returns_framework_info(self):
+    def test_get_service_returns_framework_and_lot_info(self):
         response = self.client.get('/services/123-published-456')
         data = json.loads(response.get_data())
-        assert_equal(data['services']['frameworkSlug'], 'g-cloud-6')
-        assert_equal(data['services']['frameworkName'], u'G-Cloud 6')
-        assert_equal(data['services']['frameworkStatus'], u'live')
+
+        framework_info = {
+            key: value for key, value in data['services'].items()
+            if key.startswith('framework') or key.startswith('lot')
+        }
+        assert framework_info == {
+            'frameworkSlug': 'g-cloud-6',
+            'frameworkName': 'G-Cloud 6',
+            'frameworkFramework': 'g-cloud',
+            'frameworkStatus': 'live',
+            'lot': 'saas',
+            'lotName': 'Software as a Service',
+        }
 
     def test_get_service_returns_empty_unavailability_audit_if_published(self):
         # create an audit event for the disabled service

--- a/tests/app/views/test_services.py
+++ b/tests/app/views/test_services.py
@@ -241,6 +241,7 @@ class TestListServices(BaseApplicationTest):
             'frameworkStatus': 'live',
             'frameworkFramework': 'g-cloud',
             'lot': 'saas',
+            'lotSlug': 'saas',
             'lotName': 'Software as a Service',
         }
 
@@ -1776,6 +1777,7 @@ class TestGetService(BaseApplicationTest):
             'frameworkFramework': 'g-cloud',
             'frameworkStatus': 'live',
             'lot': 'saas',
+            'lotSlug': 'saas',
             'lotName': 'Software as a Service',
         }
 


### PR DESCRIPTION
## Add framework.framework to serialized output
For briefs and services (ie. `services`, `draft_services` and `archived_services`) add the frameworkFramework field to the output. This is required for the admin app to be able to generate buyer app service URLs in a framework agnostic way.

The key `frameworkFramework` is not nice but it follows the existing pattern. This pattern should probably be changed to include sub-resources as sub-objects rather than having one big flat key space.

## Add `lotSlug` to serialized Brief and Service
This adds in `lotSlug` with the intention of replacing the `lot` key. This follows the pattern we're using elsewhere and also opens us up to adding sub-resources as objects rather than flattening them into the object.