### PR TITLE
Introduce Makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,11 @@ addons:
 env:
   - SQLALCHEMY_DATABASE_URI=postgresql://postgres:@localhost:5432/digitalmarketplace_test
 install:
-  - pip install -r requirements_for_test.txt
+  - make requirements_for_test
 before_script:
   - psql -c 'create database digitalmarketplace_test;' -U postgres
 script:
-  - ./scripts/run_tests.sh --cov=app --cov-report=term-missing
+  - PYTEST_ARGS='--cov=app --cov-report=term-missing' make test
 after_success:
   - coveralls
 notifications:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,36 @@
+SHELL := /bin/bash
+
+run_all: requirements run_migrations run_app
+
+run_app: virtualenv
+	./scripts/run_app.sh
+
+run_migrations: virtualenv
+	python application.py db upgrade
+
+virtualenv:
+	[ -z $$VIRTUAL_ENV ] && virtualenv venv || true
+
+bootstrap: virtualenv
+	./scripts/bootstrap.sh
+
+requirements: virtualenv requirements.txt
+	pip install -r requirements.txt
+
+requirements_for_test: virtualenv requirements_for_test.txt
+	pip install -r requirements_for_test.txt
+
+test: test_pep8 test_migrations test_unit
+
+test_pep8: virtualenv
+	pep8 .
+
+test_migrations: virtualenv
+	./scripts/list_migrations.py 1>/dev/null
+
+test_unit: virtualenv
+	export DM_API_AUTH_TOKENS=$${DM_API_AUTH_TOKENS:=myToken}
+
+	py.test
+
+.PHONY: virtualenv requirements requirements_for_test test_pep8 test_migrations test_unit test test_all run_migrations run_app run_all

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,6 @@ test_migrations: virtualenv
 test_unit: virtualenv
 	export DM_API_AUTH_TOKENS=$${DM_API_AUTH_TOKENS:=myToken}
 
-	py.test
+	py.test ${PYTEST_ARGS}
 
 .PHONY: virtualenv requirements requirements_for_test test_pep8 test_migrations test_unit test test_all run_migrations run_app run_all

--- a/README.md
+++ b/README.md
@@ -8,7 +8,24 @@ API tier for Digital Marketplace.
 
 - Python app, based on the [Flask framework](http://flask.pocoo.org/)
 
-## Setup
+## Quickstart
+
+Install [Virtualenv](https://virtualenv.pypa.io/en/latest/)
+```
+sudo easy_install virtualenv
+```
+
+Bootstrap the database
+```
+make bootstrap
+```
+
+Install dependencies, run migrations and run the app
+```
+make run_all
+```
+
+## Full setup
 
 Install [Virtualenv](https://virtualenv.pypa.io/en/latest/)
 
@@ -20,7 +37,7 @@ Ensure you have Postgres running locally, and then bootstrap your development
 environment
 
 ```
-./scripts/bootstrap.sh
+make bootstrap
 ```
 
 ### Activate the virtual environment
@@ -34,34 +51,31 @@ source ./venv/bin/activate
 When new database migrations are added you can bring your local database schema
 up to date by running upgrade.
 
-```python application.py db upgrade```
+```make run_migrations```
 
 ### Upgrade dependencies
 
 Install new Python dependencies with pip
 
-```pip install -r requirements_for_test.txt```
+```make requirements_for_test```
 
 ### Run the tests
 
-```
-./scripts/run_tests.sh
-```
+This will run the linter, validate the migrations and run the unit tests.
+
+```make test```
+
+To test individual parts of the test stack use the `test_pep8`, `test_migrations`
+or `test_unit` targets.
 
 ### Run the development server
 
-To run the API for local development you can use the convenient run script, 
-which sets the environment variables required for local development: 
+Run the API with environment variables required for local development set.
+This will install requirements, run database migrations and run the app.
 
-```
-./scripts/run_app.sh
-```
+```make run_all```
 
-More generally, the command to start the server is:
-
-```
-python application.py runserver
-```
+To just run the application use the `run_app` target.
 
 ## Using the API locally
 


### PR DESCRIPTION
Originally this PR was about running database migrations from the `run_app.sh` script to help prevent people forgetting to run migrations. This solution was not popular.

A Makefile was discussed as a solution that allows us to have a single command that runs migrations and runs the app while still allowing people to run just the application.