### PR TITLE
Pre-flight database version check

### DIFF
--- a/scripts/run_app.sh
+++ b/scripts/run_app.sh
@@ -14,6 +14,16 @@ export DM_SEARCH_API_URL=${DM_SEARCH_API_URL:=http://localhost:5001}
 echo "Environment variables in use:" 
 env | grep DM_
 
+# Database version pre-flight check
+CURRENT_DB_VERSION="$(python application.py db current 2>/dev/null | grep '(head)' | cut -f 1 -d ' ')"
+LATEST_DB_VERSION="$(python scripts/list_migrations.py | tail -n 1 | cut -f 1 -d ' ')"
+if [ -z "$SKIP_DB_CHECK" ] && [ "$CURRENT_DB_VERSION" -ne "$LATEST_DB_VERSION" ]; then
+  >&2 echo -e "\033[1;31mYour database version ($CURRENT_DB_VERSION) is not up to date ($LATEST_DB_VERSION).\033[0m" \
+              "\nUpdate it with 'python application.py db upgrade' or skip this check by setting the SKIP_DB_CHECK" \
+              "environment variable."
+  exit 1
+fi
+
 if [ "$1" = "gunicorn" ]; then
   "$VIRTUAL_ENV/bin/pip" install gunicorn
   "$VIRTUAL_ENV/bin/gunicorn" -w 4 -b 127.0.0.1:5000 application:application


### PR DESCRIPTION
Check that the database version is up to date before starting the app.
This originally ran the database migrations before running the app but there was a concern that this may not be expected and there there may be use cases where this was not desired. To address these concerns this change makes no changes but alerts the user to a problem and tells them how to fix it. It also provides a way to skip the check if it is not needed.