### PR TITLE
Fix how DM_API_AUTH_TOKENS are loaded

### DIFF
--- a/app/authentication.py
+++ b/app/authentication.py
@@ -14,24 +14,12 @@ def requires_authentication():
 
 
 def token_is_valid(incoming_token):
-    return incoming_token in get_allowed_tokens_from_environment()
+    return incoming_token in get_allowed_tokens_from_config(current_app.config)
 
 
-def get_allowed_tokens_from_environment():
-    """Return a list of allowed auth tokens from the DM_API_AUTH_TOKENS env
-       variable
-
-    >>> os.environ['DM_API_AUTH_TOKENS'] = ''
-    >>> list(get_allowed_tokens_from_environment())
-    []
-    >>> del os.environ['DM_API_AUTH_TOKENS']
-    >>> list(get_allowed_tokens_from_environment())
-    []
-    >>> os.environ['DM_API_AUTH_TOKENS'] = 'ab:cd'
-    >>> list(get_allowed_tokens_from_environment())
-    ['ab', 'cd']
-    """
-    return filter(None, os.environ.get('DM_API_AUTH_TOKENS', '').split(":"))
+def get_allowed_tokens_from_config(config):
+    """Return a list of allowed auth tokens from the application config"""
+    return [token for token in config.get('DM_API_AUTH_TOKENS', '').split(':') if token]
 
 
 def get_token_from_headers(headers):

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -44,8 +44,8 @@ class BaseApplicationTest(object):
         app.wsgi_app = WSGIApplicationWithEnvironment(
             app.wsgi_app,
             HTTP_AUTHORIZATION='Bearer {}'.format(valid_token))
-        self._auth_tokens = os.environ.get('DM_API_AUTH_TOKENS')
-        os.environ['DM_API_AUTH_TOKENS'] = valid_token
+        self._auth_tokens = app.config['DM_API_AUTH_TOKENS']
+        app.config['DM_API_AUTH_TOKENS'] = valid_token
 
     def do_not_provide_access_token(self):
         self.app.wsgi_app = self.app.wsgi_app.app
@@ -187,9 +187,9 @@ class BaseApplicationTest(object):
 
     def teardown_authorization(self):
         if self._auth_tokens is None:
-            del os.environ['DM_API_AUTH_TOKENS']
+            del self.app.config['DM_API_AUTH_TOKENS']
         else:
-            os.environ['DM_API_AUTH_TOKENS'] = self._auth_tokens
+            self.app.config['DM_API_AUTH_TOKENS'] = self._auth_tokens
 
     def teardown_database(self):
         with self.app.app_context():

--- a/tests/lib/test_authenticate.py
+++ b/tests/lib/test_authenticate.py
@@ -1,6 +1,6 @@
-from nose.tools import eq_
+import pytest
 
-from app.authentication import get_token_from_headers
+from app.authentication import get_token_from_headers, get_allowed_tokens_from_config
 
 
 def test_get_token_from_headers():
@@ -14,4 +14,13 @@ def test_get_token_from_headers():
 
 
 def check_token(headers, expected_token, message=None):
-    eq_(get_token_from_headers(headers), expected_token, message)
+    assert get_token_from_headers(headers) == expected_token, message
+
+
+@pytest.mark.parametrize('config,tokens', [
+    ({'DM_API_AUTH_TOKENS': 'foo:bar'}, ['foo', 'bar']),
+    ({'DM_API_AUTH_TOKENS': 'bar'}, ['bar']),
+    ({}, []),
+])
+def test_get_allowed_tokens_from_config(config, tokens):
+    assert get_allowed_tokens_from_config(config) == tokens


### PR DESCRIPTION
Default development and test values are not provided in config.py Therefore loading them directly from the environment will no longer work.