### PR TITLE
Make update details payload consistent

### DIFF
--- a/app/main/views/audits.py
+++ b/app/main/views/audits.py
@@ -10,8 +10,7 @@ from ... import db, models
 from dmapiclient.audit import AuditTypes
 from dmutils.config import convert_to_boolean
 from ...validation import is_valid_date, is_valid_acknowledged_state
-from ...service_utils import validate_and_return_updater_request
-from ...utils import get_json_from_request, json_has_required_keys
+from ...utils import get_json_from_request, json_has_required_keys, validate_and_return_updater_request
 
 
 AUDIT_OBJECT_TYPES = {

--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -6,9 +6,9 @@ from ... import db
 from ...models import User, Brief, AuditEvent
 from ...utils import (
     get_json_from_request, json_has_required_keys, pagination_links,
-    get_valid_page_or_1, get_request_page_questions
+    get_valid_page_or_1, get_request_page_questions, validate_and_return_updater_request
 )
-from ...service_utils import validate_and_return_lot, validate_and_return_updater_request
+from ...service_utils import validate_and_return_lot
 from ...brief_utils import validate_brief_data
 
 

--- a/app/main/views/drafts.py
+++ b/app/main/views/drafts.py
@@ -10,10 +10,10 @@ from ...utils import json_only_has_required_keys
 from ...validation import is_valid_service_id_or_400
 from ...models import Service, DraftService, Supplier, AuditEvent, Framework
 from ...utils import (
+    validate_and_return_updater_request,
     get_request_page_questions
 )
 from ...service_utils import (
-    validate_and_return_updater_request,
     update_and_validate_service, index_service,
     commit_and_archive_service, create_service_from_draft,
     validate_and_return_related_objects, validate_service_data,

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -7,14 +7,16 @@ from ...models import ArchivedService, Service, Supplier, AuditEvent, Framework
 
 from sqlalchemy import asc
 from ...validation import is_valid_service_id_or_400
-from ...utils import url_for, pagination_links, display_list, get_valid_page_or_1
+from ...utils import (
+    url_for, pagination_links, display_list, get_valid_page_or_1,
+    validate_and_return_updater_request,
+)
 
 from ...service_utils import (
     validate_and_return_service_request,
     update_and_validate_service,
     index_service,
     delete_service_from_index,
-    validate_and_return_updater_request,
     commit_and_archive_service,
     validate_service_data,
     validate_and_return_related_objects,

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -164,10 +164,8 @@ def update_supplier(supplier_id):
         Supplier.supplier_id == supplier_id
     ).first_or_404()
 
-    json_has_required_keys(
-        request_data,
-        ['suppliers', 'updated_by']
-    )
+    updater_json = validate_and_return_updater_request()
+    json_has_required_keys(request_data, ['suppliers'])
 
     supplier_data = supplier.serialize()
     supplier_data.update(request_data['suppliers'])
@@ -186,7 +184,7 @@ def update_supplier(supplier_id):
         AuditEvent(
             audit_type=AuditTypes.supplier_update,
             db_object=supplier,
-            user=request_data['updated_by'],
+            user=updater_json['updated_by'],
             data={'update': request_data['suppliers']})
     )
 
@@ -208,10 +206,8 @@ def update_contact_information(supplier_id, contact_id):
         ContactInformation.supplier_id == supplier_id,
     ).first_or_404()
 
-    json_has_required_keys(request_data, [
-        'contactInformation', 'updated_by'
-    ])
-
+    updater_json = validate_and_return_updater_request()
+    json_has_required_keys(request_data, ['contactInformation'])
     contact_data = contact.serialize()
     contact_data.update(request_data['contactInformation'])
     contact_data = drop_foreign_fields(
@@ -229,7 +225,7 @@ def update_contact_information(supplier_id, contact_id):
         AuditEvent(
             audit_type=AuditTypes.contact_update,
             db_object=contact.supplier,
-            user=request_data['updated_by'],
+            user=updater_json['updated_by'],
             data={'update': request_data['contactInformation']})
     )
 
@@ -266,7 +262,8 @@ def set_a_declaration(supplier_id, framework_slug):
         status_code = 201
 
     request_data = get_json_from_request()
-    json_has_required_keys(request_data, ['declaration', 'updated_by'])
+    updater_json = validate_and_return_updater_request()
+    json_has_required_keys(request_data, ['declaration'])
 
     supplier_framework.declaration = request_data['declaration'] or {}
     db.session.add(supplier_framework)
@@ -274,7 +271,7 @@ def set_a_declaration(supplier_id, framework_slug):
         AuditEvent(
             audit_type=AuditTypes.answer_selection_questions,
             db_object=supplier_framework,
-            user=request_data['updated_by'],
+            user=updater_json['updated_by'],
             data={'update': request_data['declaration']})
     )
 
@@ -337,7 +334,6 @@ def get_supplier_framework_info(supplier_id, framework_slug):
 
 @main.route('/suppliers/<supplier_id>/frameworks/<framework_slug>', methods=['PUT'])
 def register_framework_interest(supplier_id, framework_slug):
-    updater_json = validate_and_return_updater_request()
 
     framework = Framework.query.filter(
         Framework.slug == framework_slug
@@ -348,6 +344,7 @@ def register_framework_interest(supplier_id, framework_slug):
     ).first_or_404()
 
     json_payload = get_json_from_request()
+    updater_json = validate_and_return_updater_request()
     json_payload.pop('update_details')
     if json_payload:
         abort(400, "This PUT endpoint does not take a payload.")
@@ -369,7 +366,7 @@ def register_framework_interest(supplier_id, framework_slug):
     )
     audit_event = AuditEvent(
         audit_type=AuditTypes.register_framework_interest,
-        user=updater_json.get('updated_by'),
+        user=updater_json['updated_by'],
         data={'supplierId': supplier.supplier_id, 'frameworkSlug': framework_slug},
         db_object=supplier
     )
@@ -387,7 +384,6 @@ def register_framework_interest(supplier_id, framework_slug):
 
 @main.route('/suppliers/<supplier_id>/frameworks/<framework_slug>', methods=['POST'])
 def update_supplier_framework_details(supplier_id, framework_slug):
-    updater_json = validate_and_return_updater_request()
 
     framework = Framework.query.filter(
         Framework.slug == framework_slug
@@ -398,6 +394,7 @@ def update_supplier_framework_details(supplier_id, framework_slug):
     ).first_or_404()
 
     json_payload = get_json_from_request()
+    updater_json = validate_and_return_updater_request()
     json_has_required_keys(json_payload, ["frameworkInterest"])
     update_json = json_payload["frameworkInterest"]
 
@@ -419,7 +416,7 @@ def update_supplier_framework_details(supplier_id, framework_slug):
 
     audit_event = AuditEvent(
         audit_type=AuditTypes.supplier_update,
-        user=updater_json.get('updated_by'),
+        user=updater_json['updated_by'],
         data={'supplierId': supplier.supplier_id, 'frameworkSlug': framework_slug, 'update': update_json},
         db_object=supplier
     )

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -11,8 +11,7 @@ from ...validation import (
     is_valid_string_or_400
 )
 from ...utils import pagination_links, drop_foreign_fields, get_json_from_request, \
-    json_has_required_keys, json_has_matching_id, get_valid_page_or_1
-from ...service_utils import validate_and_return_updater_request
+    json_has_required_keys, json_has_matching_id, get_valid_page_or_1, validate_and_return_updater_request
 from ...supplier_utils import validate_and_return_supplier_request
 from dmapiclient.audit import AuditTypes
 

--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -8,9 +8,8 @@ from .. import main
 from ... import db, encryption
 from ...models import User, AuditEvent, Supplier, Framework, SupplierFramework, DraftService
 from ...utils import get_json_from_request, json_has_required_keys, \
-    json_has_matching_id, pagination_links, get_valid_page_or_1
-from ...service_utils import validate_and_return_updater_request
-from ...validation import validate_user_json_or_400, validate_user_auth_json_or_400, is_valid_buyer_email
+    json_has_matching_id, pagination_links, get_valid_page_or_1, validate_and_return_updater_request
+from ...validation import validate_user_json_or_400, validate_user_auth_json_or_400
 
 
 @main.route('/users/auth', methods=['POST'])

--- a/app/service_utils.py
+++ b/app/service_utils.py
@@ -3,17 +3,10 @@ from sqlalchemy.exc import IntegrityError, DataError
 
 from .utils import get_json_from_request, \
     json_has_matching_id, json_has_required_keys
-from .validation import validate_updater_json_or_400, get_validation_errors
+from .validation import get_validation_errors
 from . import search_api_client, dmapiclient
 from . import db
 from .models import ArchivedService, AuditEvent, Framework, Service, Supplier
-
-
-def validate_and_return_updater_request():
-    json_payload = get_json_from_request()
-    json_has_required_keys(json_payload, ['update_details'])
-    validate_updater_json_or_400(json_payload['update_details'])
-    return json_payload['update_details']
 
 
 def validate_and_return_service_request(service_id):

--- a/app/utils.py
+++ b/app/utils.py
@@ -3,6 +3,15 @@ from flask import abort, request
 from six import iteritems, string_types
 from werkzeug.exceptions import BadRequest
 
+from .validation import validate_updater_json_or_400
+
+
+def validate_and_return_updater_request():
+    json_payload = get_json_from_request()
+    json_has_required_keys(json_payload, ['update_details'])
+    validate_updater_json_or_400(json_payload['update_details'])
+    return json_payload['update_details']
+
 
 def link(rel, href):
     """Generate a link dict from a rel, href pair."""

--- a/app/utils.py
+++ b/app/utils.py
@@ -8,9 +8,13 @@ from .validation import validate_updater_json_or_400
 
 def validate_and_return_updater_request():
     json_payload = get_json_from_request()
-    json_has_required_keys(json_payload, ['update_details'])
-    validate_updater_json_or_400(json_payload['update_details'])
-    return json_payload['update_details']
+
+    if 'update_details' in json_payload:
+        json_payload = json_payload['update_details']
+
+    validate_updater_json_or_400(json_payload)
+
+    return {'updated_by': json_payload['updated_by']}
 
 
 def link(rel, href):

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -239,16 +239,6 @@ class JSONUpdateTestMixin(object):
         assert_in(b'Invalid JSON',
                   response.get_data())
 
-    def test_invalid_json_causes_failure(self):
-        response = self.client.open(
-            self.endpoint,
-            method=self.method,
-            data='{"not": "valid"}',
-            content_type='application/json')
-
-        assert_equal(response.status_code, 400)
-        assert_in(b'Invalid JSON', response.get_data())
-
     def test_invalid_content_type_causes_failure(self):
         response = self.client.open(
             self.endpoint,

--- a/tests/app/views/test_drafts.py
+++ b/tests/app/views/test_drafts.py
@@ -1,4 +1,4 @@
-from tests.app.helpers import BaseApplicationTest
+from tests.app.helpers import BaseApplicationTest, JSONUpdateTestMixin
 from datetime import datetime
 from flask import json
 import mock
@@ -1025,7 +1025,10 @@ class TestDraftServices(BaseApplicationTest):
         assert_equal(audit_event['type'], 'create_draft_service')
 
 
-class TestCopyDraft(BaseApplicationTest):
+class TestCopyDraft(BaseApplicationTest, JSONUpdateTestMixin):
+    endpoint = '/draft-services/{self.draft_id}/copy'
+    method = 'post'
+
     def setup(self):
         super(TestCopyDraft, self).setup()
 
@@ -1109,14 +1112,6 @@ class TestCopyDraft(BaseApplicationTest):
             'originalDraftId': self.draft_id
         })
 
-    def test_should_not_copy_draft_without_update_details(self):
-        res = self.client.post(
-            '/draft-services/%s/copy' % self.draft_id,
-            data=json.dumps({}),
-            content_type='application/json')
-
-        assert_equal(res.status_code, 400)
-
     def test_should_not_create_draft_with_invalid_data(self):
         res = self.client.post(
             '/draft-services/1000/copy',
@@ -1149,7 +1144,10 @@ class TestCopyDraft(BaseApplicationTest):
         assert_false("sfiaRateDocumentURL" in data['services'])
 
 
-class TestCompleteDraft(BaseApplicationTest):
+class TestCompleteDraft(BaseApplicationTest, JSONUpdateTestMixin):
+    endpoint = '/draft-services/{self.draft_id}/complete'
+    method = 'post'
+
     def setup(self):
         super(TestCompleteDraft, self).setup()
 
@@ -1495,7 +1493,10 @@ class TestDOSServices(BaseApplicationTest):
         assert_equal(complete.status_code, 400)
 
 
-class TestUpdateDraftStatus(BaseApplicationTest):
+class TestUpdateDraftStatus(BaseApplicationTest, JSONUpdateTestMixin):
+    endpoint = '/draft-services/{self.draft_id}/update-status'
+    method = 'post'
+
     def setup(self):
         super(TestUpdateDraftStatus, self).setup()
 
@@ -1555,14 +1556,6 @@ class TestUpdateDraftStatus(BaseApplicationTest):
         assert_equal(data['auditEvents'][1]['data'], {
             'draftId': self.draft_id, 'status': 'failed'
         })
-
-    def test_should_not_update_draft_status_without_update_details(self):
-        res = self.client.post(
-            '/draft-services/%s/update-status' % self.draft_id,
-            data=json.dumps({'services': {'status': 'not-submitted'}}),
-            content_type='application/json')
-
-        assert_equal(res.status_code, 400)
 
     def test_should_not_update_draft_status_to_invalid_status(self):
         res = self.client.post(

--- a/tests/app/views/test_frameworks.py
+++ b/tests/app/views/test_frameworks.py
@@ -6,7 +6,7 @@ from dateutil.parser import parse as parse_time
 
 from dmapiclient.audit import AuditTypes
 
-from ..helpers import BaseApplicationTest
+from ..helpers import BaseApplicationTest, JSONUpdateTestMixin
 from app.models import db, Framework, SupplierFramework, DraftService, AuditEvent, Supplier, User
 
 
@@ -60,7 +60,10 @@ class TestGetFramework(BaseApplicationTest):
             assert_equal(response.status_code, 404)
 
 
-class TestUpdateFramework(BaseApplicationTest):
+class TestUpdateFramework(BaseApplicationTest, JSONUpdateTestMixin):
+    endpoint = '/frameworks/example'
+    method = 'post'
+
     def setup(self):
         super(TestUpdateFramework, self).setup()
         framework = Framework()

--- a/tests/app/views/test_services.py
+++ b/tests/app/views/test_services.py
@@ -427,7 +427,7 @@ class TestPostService(BaseApplicationTest):
                 content_type='application/json')
 
             data = json.loads(response.get_data())
-            assert_in('Invalid JSON', data['error'])
+            assert_in('JSON validation error', data['error'])
             assert_equal(response.status_code, 400)
 
     def test_no_content_type_causes_failure(self):
@@ -465,8 +465,7 @@ class TestPostService(BaseApplicationTest):
                 content_type='application/json')
 
             assert_equal(response.status_code, 400)
-            assert_in(b'Invalid JSON',
-                      response.get_data())
+            assert_in(b'Invalid JSON', response.get_data())
 
     def test_can_post_a_valid_service_update(self):
         with self.app.app_context():
@@ -900,8 +899,7 @@ class TestPostService(BaseApplicationTest):
         )
 
         assert_equal(response.status_code, 400)
-        assert_in('update_details',
-                  json.loads(response.get_data())['error'])
+        assert_in('updated_by', json.loads(response.get_data())['error'])
 
     def test_should_404_without_status_parameter(self):
         response = self.client.post(
@@ -1547,11 +1545,8 @@ class TestPutService(BaseApplicationTest, JSONUpdateTestMixin):
                                           'foo': 'bar'}}),
             content_type='application/json')
 
-        assert_equal(json.loads(response.get_data())['error'],
-                     "Invalid JSON must have '["
-                     "'update_details']' keys")
         assert_equal(response.status_code, 400)
-        assert_in(b'Invalid JSON', response.get_data())
+        assert_in("'updated_by' is a required property", json.loads(response.get_data())['error'])
 
     def test_invalid_service_id_too_short(self):
         response = self.client.put(

--- a/tests/app/views/test_services.py
+++ b/tests/app/views/test_services.py
@@ -364,7 +364,9 @@ class TestListServices(BaseApplicationTest):
         assert_equal(response.status_code, 404)
 
 
-class TestPostService(BaseApplicationTest):
+class TestPostService(BaseApplicationTest, JSONUpdateTestMixin):
+    endpoint = '/services/{self.service_id}'
+    method = 'post'
     service_id = None
 
     def setup(self):
@@ -416,19 +418,6 @@ class TestPostService(BaseApplicationTest):
             content_type='application/json')
 
         assert_equal(response.status_code, 404)
-
-    def test_can_not_update_without_updater_details(self):
-        with self.app.app_context():
-            response = self.client.post(
-                '/services/%s' % self.service_id,
-                data=json.dumps(
-                    {'services': {
-                        'serviceName': 'new service name'}}),
-                content_type='application/json')
-
-            data = json.loads(response.get_data())
-            assert_in('JSON validation error', data['error'])
-            assert_equal(response.status_code, 400)
 
     def test_no_content_type_causes_failure(self):
         with self.app.app_context():
@@ -886,20 +875,6 @@ class TestPostService(BaseApplicationTest):
             for valid_status in valid_statuses:
                 assert_in(valid_status,
                           json.loads(response.get_data())['error'])
-
-    def test_should_400_without_update_details(self):
-        response = self.client.post(
-            '/services/{0}/status/{1}'.format(
-                self.service_id,
-                'enabled'
-            ),
-            data=json.dumps(
-                {}),
-            content_type='application/json'
-        )
-
-        assert_equal(response.status_code, 400)
-        assert_in('updated_by', json.loads(response.get_data())['error'])
 
     def test_should_404_without_status_parameter(self):
         response = self.client.post(
@@ -1537,16 +1512,6 @@ class TestPutService(BaseApplicationTest, JSONUpdateTestMixin):
         assert_equal(response.status_code, 400)
         assert_in(b'id parameter must match id in data',
                   response.get_data())
-
-    def test_when_no_update_details(self):
-        response = self.client.put(
-            '/services/1234567890123456',
-            data=json.dumps({'services': {'id': "1234567890123456",
-                                          'foo': 'bar'}}),
-            content_type='application/json')
-
-        assert_equal(response.status_code, 400)
-        assert_in("'updated_by' is a required property", json.loads(response.get_data())['error'])
 
     def test_invalid_service_id_too_short(self):
         response = self.client.put(

--- a/tests/app/views/test_suppliers.py
+++ b/tests/app/views/test_suppliers.py
@@ -7,7 +7,7 @@ from nose.tools import assert_equal, assert_in, assert_is_not_none, assert_true,
 from app import db
 from app.models import Supplier, ContactInformation, AuditEvent, \
     SupplierFramework, Framework, DraftService, Service
-from ..helpers import BaseApplicationTest, JSONUpdateTestMixin
+from ..helpers import BaseApplicationTest, JSONTestMixin, JSONUpdateTestMixin
 from random import randint
 
 
@@ -278,7 +278,7 @@ class TestListSuppliersByDunsNumber(BaseApplicationTest):
         assert_equal(2, len(data['suppliers']))
 
 
-class TestPutSupplier(BaseApplicationTest, JSONUpdateTestMixin):
+class TestPutSupplier(BaseApplicationTest, JSONTestMixin):
     method = "put"
     endpoint = "/suppliers/123456"
 
@@ -516,10 +516,6 @@ class TestUpdateSupplier(BaseApplicationTest, JSONUpdateTestMixin):
             content_type='application/json',
         )
 
-    def test_empty_update_request(self):
-        response = self.update_request(full_data={})
-        assert_equal(response.status_code, 400)
-
     def test_empty_update_supplier(self):
         response = self.update_request({})
         assert_equal(response.status_code, 200)
@@ -639,7 +635,10 @@ class TestUpdateSupplier(BaseApplicationTest, JSONUpdateTestMixin):
         assert_equal(response.status_code, 400)
 
 
-class TestUpdateContactInformation(BaseApplicationTest):
+class TestUpdateContactInformation(BaseApplicationTest, JSONUpdateTestMixin):
+    method = "post"
+    endpoint = "/suppliers/123456/contact-information/{self.contact_id}"
+
     def setup(self):
         super(TestUpdateContactInformation, self).setup()
 
@@ -664,10 +663,6 @@ class TestUpdateContactInformation(BaseApplicationTest):
             } if full_data is None else full_data),
             content_type='application/json',
         )
-
-    def test_empty_update_request(self):
-        response = self.update_request(full_data={})
-        assert_equal(response.status_code, 400)
 
     def test_empty_update(self):
         response = self.update_request({})
@@ -810,7 +805,7 @@ class TestUpdateContactInformation(BaseApplicationTest):
         assert_equal(response.status_code, 400)
 
 
-class TestSetSupplierDeclarations(BaseApplicationTest):
+class TestSetSupplierDeclarations(BaseApplicationTest, JSONUpdateTestMixin):
     method = 'put'
     endpoint = '/suppliers/0/frameworks/g-cloud-4/declaration'
 
@@ -894,20 +889,8 @@ class TestSetSupplierDeclarations(BaseApplicationTest):
                 .find_by_supplier_and_framework(0, 'test-open')
             assert_equal(supplier_framework.declaration['question'], 'answer2')
 
-    def test_invalid_payload_fails(self):
-        with self.app.app_context():
-            response = self.client.put(
-                '/suppliers/0/frameworks/test-open/declaration',
-                data=json.dumps({
-                    'invalid': {
-                    }
-                }),
-                content_type='application/json')
 
-            assert_equal(response.status_code, 400)
-
-
-class TestPostSupplier(BaseApplicationTest, JSONUpdateTestMixin):
+class TestPostSupplier(BaseApplicationTest, JSONTestMixin):
     method = "post"
     endpoint = "/suppliers"
 
@@ -1167,7 +1150,10 @@ class TestGetSupplierFrameworks(BaseApplicationTest):
         assert_equal(response.status_code, 404)
 
 
-class TestRegisterFrameworkInterest(BaseApplicationTest):
+class TestRegisterFrameworkInterest(BaseApplicationTest, JSONUpdateTestMixin):
+    method = "post"
+    endpoint = "/suppliers/1/frameworks/digital-outcomes-and-specialists"
+
     def setup(self):
         super(TestRegisterFrameworkInterest, self).setup()
 
@@ -1275,7 +1261,10 @@ class TestRegisterFrameworkInterest(BaseApplicationTest):
             assert_equal(data['frameworks'], ['digital-outcomes-and-specialists'])
 
 
-class TestSupplierFrameworkUpdates(BaseApplicationTest):
+class TestSupplierFrameworkUpdates(BaseApplicationTest, JSONUpdateTestMixin):
+    method = "post"
+    endpoint = "/suppliers/0/frameworks/digital-outcomes-and-specialists"
+
     def setup(self):
         super(TestSupplierFrameworkUpdates, self).setup()
 

--- a/tests/app/views/test_users.py
+++ b/tests/app/views/test_users.py
@@ -4,7 +4,7 @@ from nose.tools import assert_equal, assert_not_equal, assert_in, assert_is_none
 from app import db, encryption
 from app.models import User, Supplier
 from datetime import datetime
-from ..helpers import BaseApplicationTest, JSONUpdateTestMixin
+from ..helpers import BaseApplicationTest, JSONTestMixin, JSONUpdateTestMixin
 from dmutils.formats import DATETIME_FORMAT
 
 
@@ -183,7 +183,7 @@ class TestUsersAuth(BaseUserTest):
             self._return_post_login(status_code=403)
 
 
-class TestUsersPost(BaseApplicationTest, JSONUpdateTestMixin):
+class TestUsersPost(BaseApplicationTest, JSONTestMixin):
     method = "post"
     endpoint = "/users"
 
@@ -498,7 +498,10 @@ class TestUsersPost(BaseApplicationTest, JSONUpdateTestMixin):
         assert_in("JSON was not a valid format", data)
 
 
-class TestUsersUpdate(BaseApplicationTest):
+class TestUsersUpdate(BaseApplicationTest, JSONUpdateTestMixin):
+    method = "post"
+    endpoint = "/users/123"
+
     def setup(self):
         now = datetime.utcnow()
         super(TestUsersUpdate, self).setup()


### PR DESCRIPTION
### Move validate_and_return_updater_request to utils
This is a general function to check updated_by for all write requests.

### Add support for both update_details and updated_by JSON fields
Change `validate_and_return_updater_request` to accept either `update_details` or a top-level `updated_by` field.

This is an intermediate step to make all API endpoints use the helper function and make the update payload format consistent across all endpoints.

Once the apiclient and frontend apps have been updated to always use one of the formats we can drop support for the other one.

### Use updater validation helper in framework and supplier views
Makes sure all API endpoints are using the valudate updater details utils function.

### Use JSONUpdateTestMixin to test for missing update details
Remove ad-hoc endpoint tests in favour of JSONUpdateTestMixin test for missing update details.

Clean-up some duplicate tests and set endpoint and method on update view tests. Add support for using object attributes in endpoint, to make it possible to use the mixin with test classes that create the relevant object during test setup.

This updates most of the view tests with the exception of drafts and briefs. Briefs and drafts don't split tests between classes for each endpoint, so setting JSONUpdateTestMixin with one endpoint and method won't have the same benefit.