### PR TITLE
Delete a brief

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ SQLAlchemy==1.0.5
 SQLAlchemy-Utils==0.30.5
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@16.0.0#egg=digitalmarketplace-utils==16.0.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@2.3.0#egg=digitalmarketplace-apiclient==2.3.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@2.3.2#egg=digitalmarketplace-apiclient==2.3.2
 
 # For schema validation
 jsonschema==2.5.1

--- a/tests/app/views/test_briefs.py
+++ b/tests/app/views/test_briefs.py
@@ -571,7 +571,7 @@ class TestBriefs(BaseApplicationTest):
 
         audit_response = self.client.get('/audit-events')
         assert audit_response.status_code == 200
-        audit_data = json.loads(audit_response.get_data())
+        audit_data = json.loads(audit_response.get_data(as_text=True))
         assert len(audit_data['auditEvents']) == 2
         assert audit_data['auditEvents'][0]['type'] == 'create_brief'
         assert audit_data['auditEvents'][1]['type'] == 'delete_brief'
@@ -622,7 +622,7 @@ class TestBriefs(BaseApplicationTest):
                                  content_type='application/json')
         assert res.status_code == 400
         error = json.loads(res.get_data(as_text=True))['error']
-        assert error == u"JSON validation error: u'updated_by' is a required property"
+        assert "'updated_by' is a required property" in error
 
     def test_should_404_on_delete_a_brief_that_doesnt_exist(self):
         res = self.client.delete(

--- a/tests/app/views/test_drafts.py
+++ b/tests/app/views/test_drafts.py
@@ -205,12 +205,16 @@ class TestDraftServices(BaseApplicationTest):
         assert_equal(res.status_code, 400)
 
     def test_reject_delete_with_no_update_details(self):
-        res = self.client.delete('/draft-services/0000000000')
+        res = self.client.delete('/draft-services/0000000000',
+                                 data=json.dumps({}),
+                                 content_type='application/json')
 
         assert_equal(res.status_code, 400)
 
     def test_reject_publish_with_no_update_details(self):
-        res = self.client.post('/draft-services/0000000000/publish')
+        res = self.client.post('/draft-services/0000000000/publish',
+                               data=json.dumps({}),
+                               content_type='application/json')
 
         assert_equal(res.status_code, 400)
 

--- a/tests/app/views/test_drafts.py
+++ b/tests/app/views/test_drafts.py
@@ -627,10 +627,7 @@ class TestDraftServices(BaseApplicationTest):
             data['auditEvents'][2]['data']['serviceId'], self.service_id
         )
 
-        fetch_again = self.client.get(
-            '/draft-services/{}'.format(self.service_id),
-            data=json.dumps(self.updater_json),
-            content_type='application/json')
+        fetch_again = self.client.get('/draft-services/{}'.format(draft_id))
         assert_equal(fetch_again.status_code, 404)
 
     def test_should_be_able_to_update_a_draft(self):


### PR DESCRIPTION
Adds an endpoint to delete a brief (draft briefs only can be deleted).
Tying up loose ends on "buyer writes a brief" story.

This depends on the APIclient PR being merged, to bring in the new audit type:
 - [x] https://github.com/alphagov/digitalmarketplace-apiclient/pull/13