### PR TITLE
Update brief-response schemas

### DIFF
--- a/json_schemas/brief-responses-digital-outcomes-and-specialists-digital-specialists.json
+++ b/json_schemas/brief-responses-digital-outcomes-and-specialists-digital-specialists.json
@@ -2,6 +2,16 @@
   "$schema": "http://json-schema.org/schema#",
   "additionalProperties": false,
   "properties": {
+    "availability": {
+      "maxLength": 100,
+      "minLength": 1,
+      "type": "string"
+    },
+    "dayRate": {
+      "maxLength": 100,
+      "minLength": 1,
+      "type": "string"
+    },
     "essentialRequirements": {
       "items": {
         "type": "boolean"
@@ -17,11 +27,19 @@
       "maxItems": 10,
       "minItems": 0,
       "type": "array"
+    },
+    "specialistName": {
+      "maxLength": 100,
+      "minLength": 1,
+      "type": "string"
     }
   },
   "required": [
-    "essentialRequirements"
+    "availability",
+    "dayRate",
+    "essentialRequirements",
+    "specialistName"
   ],
-  "title": "Digital Outcomes and Specialists Digital outcomes Brief Response Schema",
+  "title": "Digital Outcomes and Specialists Digital specialists Brief Response Schema",
   "type": "object"
 }

--- a/json_schemas/brief-responses-digital-outcomes-and-specialists-user-research-participants.json
+++ b/json_schemas/brief-responses-digital-outcomes-and-specialists-user-research-participants.json
@@ -17,11 +17,16 @@
       "maxItems": 10,
       "minItems": 0,
       "type": "array"
+    },
+    "userParticipantResponse": {
+      "minLength": 1,
+      "type": "string"
     }
   },
   "required": [
-    "essentialRequirements"
+    "essentialRequirements",
+    "userParticipantResponse"
   ],
-  "title": "Digital Outcomes and Specialists Digital outcomes Brief Response Schema",
+  "title": "Digital Outcomes and Specialists User research participants Brief Response Schema",
   "type": "object"
 }


### PR DESCRIPTION
All of the brief-response schemas bar `digital-outcomes` have had more questions
added to them, so this commit brings them up-to-date with the content repository.