### PR TITLE
None requirements answers

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -111,7 +111,7 @@ def strip_whitespace_from_data(data):
         if isinstance(value, list):
             # Strip whitespace and remove empty items from lists
             data[key] = list(
-                filter(lambda x: x not in ['', None],
+                filter(lambda x: x != '',
                        map(lambda x: x.strip() if isinstance(x, string_types) else x, value))
             )
         elif isinstance(value, string_types):

--- a/app/validation.py
+++ b/app/validation.py
@@ -263,6 +263,9 @@ def _translate_json_schema_error(key, validator, validator_value, message):
     elif validator == 'type' and validator_value == 'number':
         return 'not_a_number'
 
+    elif validator == 'type' and validator_value == 'boolean':
+        return 'answer_required'
+
     return message
 
 

--- a/tests/app/views/test_brief_response.py
+++ b/tests/app/views/test_brief_response.py
@@ -218,7 +218,8 @@ class TestCreateBriefResponse(BaseBriefResponseTest, JSONUpdateTestMixin):
         assert res.status_code == 400, res.get_data(as_text=True)
         assert 'Brief response already exists' in res.get_data(as_text=True)
 
-    @given(example_listings.brief_response_data(None, 5).filter(lambda x: len(x['essentialRequirements']) != 5))
+    @given(example_listings.brief_response_data(None, 5).filter(
+        lambda x: len(x['essentialRequirements']) != 5 and all(i is not None for i in x['essentialRequirements'])))
     def test_cannot_respond_to_a_brief_with_wrong_number_of_essential_reqs(self, live_framework, brief_response_data):
         res = self.create_brief_response(dict(brief_response_data, **{
             'briefId': self.brief_id,
@@ -230,8 +231,22 @@ class TestCreateBriefResponse(BaseBriefResponseTest, JSONUpdateTestMixin):
         assert res.status_code == 400, res.get_data(as_text=True)
         assert data['error']['essentialRequirements'] == 'answer_required'
 
-    @given(example_listings.brief_response_data(5, None).filter(lambda x: len(x['niceToHaveRequirements']) != 5))
+    @given(example_listings.brief_response_data(5, None).filter(
+        lambda x: len(x['niceToHaveRequirements']) != 5 and all(i is not None for i in x['niceToHaveRequirements'])))
     def test_cannot_respond_to_a_brief_with_wrong_number_of_nicetohave_reqs(self, live_framework, brief_response_data):
+        res = self.create_brief_response(dict(brief_response_data, **{
+            'briefId': self.brief_id,
+            'supplierId': 0,
+        }))
+
+        data = json.loads(res.get_data(as_text=True))
+
+        assert res.status_code == 400, res.get_data(as_text=True)
+        assert data['error']['niceToHaveRequirements'] == 'answer_required'
+
+    @given(example_listings.brief_response_data(5, None).filter(
+        lambda x: any(i is None for i in x['niceToHaveRequirements'])))
+    def test_cannot_respond_to_a_brief_with_none_reqs_values(self, live_framework, brief_response_data):
         res = self.create_brief_response(dict(brief_response_data, **{
             'briefId': self.brief_id,
             'supplierId': 0,

--- a/tests/example_listings.py
+++ b/tests/example_listings.py
@@ -1,4 +1,9 @@
-from hypothesis import strategies, settings
+from hypothesis import settings
+from hypothesis.strategies import (
+    fixed_dictionaries, lists,
+    booleans, integers, text, none,
+    composite, sampled_from, one_of,
+)
 
 settings.register_profile("unit", settings(
     database=None,
@@ -7,31 +12,28 @@ settings.register_profile("unit", settings(
 settings.load_profile("unit")
 
 
+@composite
+def requirements_list(draw, length, answers=False):
+    if answers:
+        elements = booleans() if length is not None else one_of(booleans(), none())
+    else:
+        elements = text(min_size=1, alphabet='abcdefgh', average_size=10)
+    return draw(lists(
+        elements=elements,
+        min_size=length,
+        max_size=length if length is not None else 10
+    ))
+
+
 def brief_response_data(essential_count=5, nice_to_have_count=5):
-    return strategies.fixed_dictionaries({
-        "essentialRequirements": strategies.lists(
-            elements=strategies.booleans(),
-            min_size=essential_count,
-            max_size=essential_count if essential_count is not None else 10,
-        ),
-        "niceToHaveRequirements": strategies.lists(
-            elements=strategies.booleans(),
-            min_size=nice_to_have_count,
-            max_size=nice_to_have_count if nice_to_have_count is not None else 10,
-        ),
+    return fixed_dictionaries({
+        "essentialRequirements": requirements_list(essential_count, answers=True),
+        "niceToHaveRequirements": requirements_list(nice_to_have_count, answers=True),
     })
 
 
 def brief_data(essential_count=5, nice_to_have_count=5):
-    return strategies.fixed_dictionaries({
-        'essentialRequirements': strategies.lists(
-            elements=strategies.text(min_size=1, alphabet='abcdefgh', average_size=10),
-            min_size=essential_count,
-            max_size=essential_count if essential_count is not None else 10,
-        ),
-        'niceToHaveRequirements': strategies.lists(
-            elements=strategies.text(min_size=1, alphabet='abcdefgh', average_size=10),
-            min_size=nice_to_have_count,
-            max_size=nice_to_have_count if nice_to_have_count is not None else 10,
-        ),
+    return fixed_dictionaries({
+        'essentialRequirements': requirements_list(essential_count),
+        'niceToHaveRequirements': requirements_list(nice_to_have_count),
     })


### PR DESCRIPTION
### Don't drop None values when stripping whitespace
Changes utils function to only remove empty strings from lists (no longer removes `None` values :exclamation:). None can be either a valid or invalid value depending on the field, so the validation logic should be encoded in the field schema. If None is valid, the schema should define it as one of the possible item values, otherwise a validation error should be returned.

### Add None values to brief response requirements tests
Makes type validator return `answer_required` error message code for boolean types. :exclamation:
For requirements questions `None` value means that the quesiton wasn't answered, which should trigger a validation error similar to wrong number of answers.

This will replace a generic "there was a problem with the answer" message with "question requires an answer" for other boolean fields if a value triggers a type validator error, but I don't think this happens on requests made by frontend apps right now.

Checks that None values cause an error response when creating brief responses.