### PR TITLE
Publish clarification questions and answers on briefs

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -967,7 +967,8 @@ class BriefClarificationQuestion(db.Model):
     question = db.Column(db.String, nullable=False)
     answer = db.Column(db.String, nullable=False)
 
-    published_at = db.Column(db.DateTime, index=True, nullable=False)
+    published_at = db.Column(db.DateTime, index=True, nullable=False,
+                             default=datetime.utcnow)
 
     brief = db.relationship("Brief")
 

--- a/app/models.py
+++ b/app/models.py
@@ -879,6 +879,9 @@ class Brief(db.Model):
             'lotName': self.lot.name,
             'createdAt': self.created_at.strftime(DATETIME_FORMAT),
             'updatedAt': self.updated_at.strftime(DATETIME_FORMAT),
+            'clarificationQuestions': [
+                question.serialize() for question in self.clarification_questions
+            ],
         })
 
         if self.status == 'live':
@@ -1006,6 +1009,13 @@ class BriefClarificationQuestion(db.Model):
         if len(words) > 100:
             raise ValidationError("{} must not be more than 100 words".format(key.title()))
         return value
+
+    def serialize(self):
+        return {
+            "question": self.question,
+            "answer": self.answer,
+            "publishedAt": self.published_at.strftime(DATETIME_FORMAT),
+        }
 
 
 # Index for .last_for_object queries. Without a composite index the

--- a/app/models.py
+++ b/app/models.py
@@ -798,6 +798,7 @@ class Brief(db.Model):
     users = db.relationship('User', secondary='brief_users')
     framework = db.relationship('Framework', lazy='joined')
     lot = db.relationship('Lot', lazy='joined')
+    clarification_questions = db.relationship("BriefClarificationQuestion")
 
     @validates('users')
     def validates_users(self, key, user):
@@ -955,6 +956,20 @@ class BriefResponse(db.Model):
         })
 
         return data
+
+
+class BriefClarificationQuestion(db.Model):
+    __tablename__ = 'brief_clarification_questions'
+
+    id = db.Column(db.Integer, primary_key=True)
+    brief_id = db.Column(db.Integer, db.ForeignKey("briefs.id"), nullable=False)
+
+    question = db.Column(db.String, nullable=False)
+    answer = db.Column(db.String, nullable=False)
+
+    published_at = db.Column(db.DateTime, index=True, nullable=False)
+
+    brief = db.relationship("Brief")
 
 
 # Index for .last_for_object queries. Without a composite index the

--- a/app/models.py
+++ b/app/models.py
@@ -853,6 +853,7 @@ class Brief(db.Model):
             brief=self,
             question=question,
             answer=answer)
+        clarification_question.validate()
 
         Session.object_session(self).add(clarification_question)
 
@@ -1003,14 +1004,14 @@ class BriefClarificationQuestion(db.Model):
             raise ValidationError("Brief status must be 'live', not '{}'".format(brief.status))
         return brief
 
-    @validates("question", "answer")
-    def validates_question_and_answer(self, key, value):
-        if len(value) == 0:
-            raise ValidationError("{} must not be empty".format(key.title()))
-        words = re.split("\W+", value)
-        if len(words) > 100:
-            raise ValidationError("{} must not be more than 100 words".format(key.title()))
-        return value
+    def validate(self):
+        errs = get_validation_errors(
+            "brief-clarification-question",
+            {"question": self.question, "answer": self.answer}
+        )
+
+        if errs:
+            raise ValidationError(errs)
 
     def serialize(self):
         return {

--- a/app/models.py
+++ b/app/models.py
@@ -971,6 +971,12 @@ class BriefClarificationQuestion(db.Model):
 
     brief = db.relationship("Brief")
 
+    @validates('brief')
+    def validates_brief(self, key, brief):
+        if brief.status != "live":
+            raise ValidationError("Brief status must be 'live', not '{}'".format(brief.status))
+        return brief
+
 
 # Index for .last_for_object queries. Without a composite index the
 # query executes an index backward scan on created_at with filter,

--- a/app/models.py
+++ b/app/models.py
@@ -1,4 +1,5 @@
 import random
+import re
 from datetime import datetime
 
 from flask import current_app
@@ -985,6 +986,13 @@ class BriefClarificationQuestion(db.Model):
         if brief.status != "live":
             raise ValidationError("Brief status must be 'live', not '{}'".format(brief.status))
         return brief
+
+    @validates("question", "answer")
+    def validates_question_and_answer(self, key, value):
+        words = re.split("\W+", value)
+        if len(words) > 100:
+            raise ValidationError("{} must not be more than 100 words".format(key.title()))
+        return value
 
 
 # Index for .last_for_object queries. Without a composite index the

--- a/app/models.py
+++ b/app/models.py
@@ -962,7 +962,7 @@ class BriefClarificationQuestion(db.Model):
     __tablename__ = 'brief_clarification_questions'
 
     id = db.Column(db.Integer, primary_key=True)
-    brief_id = db.Column(db.Integer, db.ForeignKey("briefs.id"), nullable=False)
+    _brief_id = db.Column("brief_id", db.Integer, db.ForeignKey("briefs.id"), nullable=False)
 
     question = db.Column(db.String, nullable=False)
     answer = db.Column(db.String, nullable=False)
@@ -970,6 +970,14 @@ class BriefClarificationQuestion(db.Model):
     published_at = db.Column(db.DateTime, index=True, nullable=False)
 
     brief = db.relationship("Brief")
+
+    @property
+    def brief_id(self):
+        return self._brief_id
+
+    @brief_id.setter
+    def brief_id(self, brief_id):
+        raise ValidationError("Cannot update brief_id directly, use brief relationship")
 
     @validates('brief')
     def validates_brief(self, key, brief):

--- a/app/models.py
+++ b/app/models.py
@@ -1005,6 +1005,8 @@ class BriefClarificationQuestion(db.Model):
 
     @validates("question", "answer")
     def validates_question_and_answer(self, key, value):
+        if len(value) == 0:
+            raise ValidationError("{} must not be empty".format(key.title()))
         words = re.split("\W+", value)
         if len(words) > 100:
             raise ValidationError("{} must not be more than 100 words".format(key.title()))

--- a/app/validation.py
+++ b/app/validation.py
@@ -15,6 +15,7 @@ MAXIMUM_SERVICE_ID_LENGTH = 20
 
 JSON_SCHEMAS_PATH = './json_schemas'
 SCHEMA_NAMES = [
+    'brief-clarification-question',
     'briefs-digital-outcomes-and-specialists-digital-outcomes',
     'briefs-digital-outcomes-and-specialists-digital-specialists',
     'briefs-digital-outcomes-and-specialists-user-research-participants',

--- a/json_schemas/brief-clarification-question.json
+++ b/json_schemas/brief-clarification-question.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "title": "Brief clarification question schema",
+  "type": "object",
+  "properties": {
+    "question": {
+      "minLength": 1,
+      "pattern": "^$|(^(?:\\S+\\s+){0,99}\\S+$)",
+      "type": "string"
+    },
+    "answer": {
+      "minLength": 1,
+      "pattern": "^$|(^(?:\\S+\\s+){0,99}\\S+$)",
+      "type": "string"
+    }
+  },
+  "additionalProperties": false,
+  "required": ["question", "answer"]
+}

--- a/json_schemas/brief-clarification-question.json
+++ b/json_schemas/brief-clarification-question.json
@@ -5,11 +5,13 @@
   "properties": {
     "question": {
       "minLength": 1,
+      "maxLength": 5000,
       "pattern": "^$|(^(?:\\S+\\s+){0,99}\\S+$)",
       "type": "string"
     },
     "answer": {
       "minLength": 1,
+      "maxLength": 5000,
       "pattern": "^$|(^(?:\\S+\\s+){0,99}\\S+$)",
       "type": "string"
     }

--- a/migrations/versions/580_add_brief_clarification_questions.py
+++ b/migrations/versions/580_add_brief_clarification_questions.py
@@ -1,0 +1,32 @@
+"""Add brief clarification questions
+
+Revision ID: 580
+Revises: 570
+Create Date: 2016-02-23 16:53:28.171878
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '580'
+down_revision = '570'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.create_table('brief_clarification_questions',
+    sa.Column('id', sa.Integer(), nullable=False),
+    sa.Column('brief_id', sa.Integer(), nullable=False),
+    sa.Column('question', sa.String(), nullable=False),
+    sa.Column('answer', sa.String(), nullable=False),
+    sa.Column('published_at', sa.DateTime(), nullable=False),
+    sa.ForeignKeyConstraint(['brief_id'], ['briefs.id'], ),
+    sa.PrimaryKeyConstraint('id')
+    )
+    op.create_index(op.f('ix_brief_clarification_questions_published_at'), 'brief_clarification_questions', ['published_at'], unique=False)
+
+
+def downgrade():
+    op.drop_index(op.f('ix_brief_clarification_questions_published_at'), table_name='brief_clarification_questions')
+    op.drop_table('brief_clarification_questions')

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ SQLAlchemy==1.0.5
 SQLAlchemy-Utils==0.30.5
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@16.0.0#egg=digitalmarketplace-utils==16.0.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@2.3.2#egg=digitalmarketplace-apiclient==2.3.2
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@3.1.0#egg=digitalmarketplace-apiclient==3.1.0
 
 # For schema validation
 jsonschema==2.5.1

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -208,6 +208,33 @@ class TestBriefs(BaseApplicationTest):
                       framework=self.framework,
                       lot_id=self.framework.get_lot('user-research-studios').id)
 
+    def test_add_brief_clarification_question(self):
+        with self.app.app_context():
+            brief = Brief(data={}, framework=self.framework, lot=self.lot, status="live")
+            db.session.add(brief)
+            db.session.commit()
+
+            clarification = brief.add_clarification_question(
+                "How do expect to deliver this?",
+                "By the power of Grayskull")
+            db.session.commit()
+
+            assert len(brief.clarification_questions) == 1
+            assert len(BriefClarificationQuestion.query.filter(
+                BriefClarificationQuestion._brief_id == brief.id
+            ).all()) == 1
+
+    def test_new_clarification_questions_get_added_to_the_end(self):
+        with self.app.app_context():
+            brief = Brief(data={}, framework=self.framework, lot=self.lot, status="live")
+            db.session.add(brief)
+            brief.add_clarification_question("How?", "This")
+            brief.add_clarification_question("When", "Then")
+            db.session.commit()
+
+            assert brief.clarification_questions[0].question == "How?"
+            assert brief.clarification_questions[1].question == "When"
+
 
 class TestBriefResponses(BaseApplicationTest):
     def setup(self):

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -215,7 +215,7 @@ class TestBriefs(BaseApplicationTest):
             db.session.commit()
 
             clarification = brief.add_clarification_question(
-                "How do expect to deliver this?",
+                "How do you expect to deliver this?",
                 "By the power of Grayskull")
             db.session.commit()
 

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -306,13 +306,51 @@ class TestBriefClarificationQuestion(BaseApplicationTest):
 
     def test_published_at_is_set_on_creation(self):
         with self.app.app_context():
-            clarification_question = BriefClarificationQuestion(
+            question = BriefClarificationQuestion(
                 brief=self.brief, question="Why?", answer="Because")
 
-            db.session.add(clarification_question)
+            db.session.add(question)
             db.session.commit()
 
-            assert isinstance(clarification_question.published_at, datetime)
+            assert isinstance(question.published_at, datetime)
+
+    def test_question_must_not_be_null(self):
+        with self.app.app_context(), pytest.raises(IntegrityError):
+            question = BriefClarificationQuestion(brief=self.brief, answer="Because")
+
+            db.session.add(question)
+            db.session.commit()
+
+    def test_questions_must_not_be_more_than_100_words(self):
+        long_question = " ".join(["word"] * 101)
+        with self.app.app_context(), pytest.raises(ValidationError) as e:
+            BriefClarificationQuestion(brief=self.brief, question=long_question, answer="Because")
+
+        assert str(e.value) == "Question must not be more than 100 words"
+
+    def test_questions_can_be_100_words(self):
+        question = " ".join(["word"] * 100)
+        with self.app.app_context():
+            BriefClarificationQuestion(brief=self.brief, question=question, answer="Because")
+
+    def test_answer_must_not_be_null(self):
+        with self.app.app_context(), pytest.raises(IntegrityError):
+            question = BriefClarificationQuestion(brief=self.brief, question="Why?")
+
+            db.session.add(question)
+            db.session.commit()
+
+    def test_answers_must_not_be_more_than_100_words(self):
+        long_answer = " ".join(["word"] * 101)
+        with self.app.app_context(), pytest.raises(ValidationError) as e:
+            BriefClarificationQuestion(brief=self.brief, question="Why?", answer=long_answer)
+
+        assert str(e.value) == "Answer must not be more than 100 words"
+
+    def test_answers_can_be_100_words(self):
+        answer = " ".join(["word"] * 100)
+        with self.app.app_context():
+            BriefClarificationQuestion(brief=self.brief, question="Why?", answer=answer)
 
 
 class TestServices(BaseApplicationTest):

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -348,6 +348,12 @@ class TestBriefClarificationQuestion(BaseApplicationTest):
             db.session.add(question)
             db.session.commit()
 
+    def test_question_must_not_be_empty(self):
+        with self.app.app_context(), pytest.raises(ValidationError) as e:
+            BriefClarificationQuestion(brief=self.brief, question="", answer="Because")
+
+        assert str(e.value.message) == "Question must not be empty"
+
     def test_questions_must_not_be_more_than_100_words(self):
         long_question = " ".join(["word"] * 101)
         with self.app.app_context(), pytest.raises(ValidationError) as e:
@@ -366,6 +372,12 @@ class TestBriefClarificationQuestion(BaseApplicationTest):
 
             db.session.add(question)
             db.session.commit()
+
+    def test_answer_must_not_be_empty(self):
+        with self.app.app_context(), pytest.raises(ValidationError) as e:
+            BriefClarificationQuestion(brief=self.brief, question="Why?", answer="")
+
+        assert str(e.value.message) == "Answer must not be empty"
 
     def test_answers_must_not_be_more_than_100_words(self):
         long_answer = " ".join(["word"] * 101)

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -363,6 +363,14 @@ class TestBriefClarificationQuestion(BaseApplicationTest):
 
         assert e.value.message["question"] == "under_100_words"
 
+    def test_question_must_not_be_more_than_5000_characters(self):
+        long_question = "a" * 5001
+        with self.app.app_context(), pytest.raises(ValidationError) as e:
+            question = BriefClarificationQuestion(brief=self.brief, question=long_question, answer="Because")
+            question.validate()
+
+        assert e.value.message["question"] == "under_character_limit"
+
     def test_questions_can_be_100_words(self):
         question = " ".join(["word"] * 100)
         with self.app.app_context():
@@ -390,6 +398,14 @@ class TestBriefClarificationQuestion(BaseApplicationTest):
             question.validate()
 
         assert e.value.message["answer"] == "under_100_words"
+
+    def test_answer_must_not_be_more_than_5000_characters(self):
+        long_answer = "a" * 5001
+        with self.app.app_context(), pytest.raises(ValidationError) as e:
+            question = BriefClarificationQuestion(brief=self.brief, question="Why?", answer=long_answer)
+            question.validate()
+
+        assert e.value.message["answer"] == "under_character_limit"
 
     def test_answers_can_be_100_words(self):
         answer = " ".join(["word"] * 100)

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -350,21 +350,24 @@ class TestBriefClarificationQuestion(BaseApplicationTest):
 
     def test_question_must_not_be_empty(self):
         with self.app.app_context(), pytest.raises(ValidationError) as e:
-            BriefClarificationQuestion(brief=self.brief, question="", answer="Because")
+            question = BriefClarificationQuestion(brief=self.brief, question="", answer="Because")
+            question.validate()
 
-        assert str(e.value.message) == "Question must not be empty"
+        assert e.value.message["question"] == "answer_required"
 
     def test_questions_must_not_be_more_than_100_words(self):
         long_question = " ".join(["word"] * 101)
         with self.app.app_context(), pytest.raises(ValidationError) as e:
-            BriefClarificationQuestion(brief=self.brief, question=long_question, answer="Because")
+            question = BriefClarificationQuestion(brief=self.brief, question=long_question, answer="Because")
+            question.validate()
 
-        assert str(e.value.message) == "Question must not be more than 100 words"
+        assert e.value.message["question"] == "under_100_words"
 
     def test_questions_can_be_100_words(self):
         question = " ".join(["word"] * 100)
         with self.app.app_context():
-            BriefClarificationQuestion(brief=self.brief, question=question, answer="Because")
+            question = BriefClarificationQuestion(brief=self.brief, question=question, answer="Because")
+            question.validate()
 
     def test_answer_must_not_be_null(self):
         with self.app.app_context(), pytest.raises(IntegrityError):
@@ -375,21 +378,24 @@ class TestBriefClarificationQuestion(BaseApplicationTest):
 
     def test_answer_must_not_be_empty(self):
         with self.app.app_context(), pytest.raises(ValidationError) as e:
-            BriefClarificationQuestion(brief=self.brief, question="Why?", answer="")
+            question = BriefClarificationQuestion(brief=self.brief, question="Why?", answer="")
+            question.validate()
 
-        assert str(e.value.message) == "Answer must not be empty"
+        assert e.value.message["answer"] == "answer_required"
 
     def test_answers_must_not_be_more_than_100_words(self):
         long_answer = " ".join(["word"] * 101)
         with self.app.app_context(), pytest.raises(ValidationError) as e:
-            BriefClarificationQuestion(brief=self.brief, question="Why?", answer=long_answer)
+            question = BriefClarificationQuestion(brief=self.brief, question="Why?", answer=long_answer)
+            question.validate()
 
-        assert str(e.value.message) == "Answer must not be more than 100 words"
+        assert e.value.message["answer"] == "under_100_words"
 
     def test_answers_can_be_100_words(self):
         answer = " ".join(["word"] * 100)
         with self.app.app_context():
-            BriefClarificationQuestion(brief=self.brief, question="Why?", answer=answer)
+            question = BriefClarificationQuestion(brief=self.brief, question="Why?", answer=answer)
+            question.validate()
 
 
 class TestServices(BaseApplicationTest):

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -323,13 +323,13 @@ class TestBriefClarificationQuestion(BaseApplicationTest):
             with pytest.raises(ValidationError) as e:
                 BriefClarificationQuestion(brief=brief, question="Why?", answer="Because")
 
-            assert str(e.value) == "Brief status must be 'live', not 'draft'"
+            assert str(e.value.message) == "Brief status must be 'live', not 'draft'"
 
     def test_cannot_update_brief_by_id(self):
         with self.app.app_context(), pytest.raises(ValidationError) as e:
             BriefClarificationQuestion(brief_id=self.brief.id, question="Why?", answer="Because")
 
-        assert str(e.value) == "Cannot update brief_id directly, use brief relationship"
+        assert str(e.value.message) == "Cannot update brief_id directly, use brief relationship"
 
     def test_published_at_is_set_on_creation(self):
         with self.app.app_context():
@@ -353,7 +353,7 @@ class TestBriefClarificationQuestion(BaseApplicationTest):
         with self.app.app_context(), pytest.raises(ValidationError) as e:
             BriefClarificationQuestion(brief=self.brief, question=long_question, answer="Because")
 
-        assert str(e.value) == "Question must not be more than 100 words"
+        assert str(e.value.message) == "Question must not be more than 100 words"
 
     def test_questions_can_be_100_words(self):
         question = " ".join(["word"] * 100)
@@ -372,7 +372,7 @@ class TestBriefClarificationQuestion(BaseApplicationTest):
         with self.app.app_context(), pytest.raises(ValidationError) as e:
             BriefClarificationQuestion(brief=self.brief, question="Why?", answer=long_answer)
 
-        assert str(e.value) == "Answer must not be more than 100 words"
+        assert str(e.value.message) == "Answer must not be more than 100 words"
 
     def test_answers_can_be_100_words(self):
         answer = " ".join(["word"] * 100)

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -304,6 +304,16 @@ class TestBriefClarificationQuestion(BaseApplicationTest):
 
         assert str(e.value) == "Cannot update brief_id directly, use brief relationship"
 
+    def test_published_at_is_set_on_creation(self):
+        with self.app.app_context():
+            clarification_question = BriefClarificationQuestion(
+                brief=self.brief, question="Why?", answer="Because")
+
+            db.session.add(clarification_question)
+            db.session.commit()
+
+            assert isinstance(clarification_question.published_at, datetime)
+
 
 class TestServices(BaseApplicationTest):
     def test_framework_is_live_only_returns_live_frameworks(self):

--- a/tests/app/views/test_briefs.py
+++ b/tests/app/views/test_briefs.py
@@ -346,7 +346,8 @@ class TestBriefs(BaseApplicationTest):
                         'role': 'buyer',
                         'active': True,
                     }
-                ]
+                ],
+                "clarificationQuestions": [],
             }
         )
 
@@ -628,5 +629,93 @@ class TestBriefs(BaseApplicationTest):
         res = self.client.delete(
             '/briefs/0000000000',
             data=json.dumps({'update_details': {'updated_by': 'example'}}),
-            content_type='application/json')
+            content_type='application/json'
+        )
         assert res.status_code == 404
+
+    def test_add_clarification_question(self):
+        self.setup_dummy_briefs(1, title="The Title", status="live")
+
+        res = self.client.post(
+            "/briefs/1/clarification-questions",
+            data=json.dumps({
+                "clarificationQuestion": {
+                    "question": "What?",
+                    "answer": "That",
+                },
+                "update_details": {"updated_by": "example"},
+            }),
+            content_type="application/json")
+        data = json.loads(res.get_data(as_text=True))
+
+        assert res.status_code == 200
+        assert data["briefs"]["clarificationQuestions"] == [{
+            "question": "What?",
+            "answer": "That",
+            "publishedAt": mock.ANY,
+        }]
+
+    def test_add_clarification_question_fails_if_no_question(self):
+        self.setup_dummy_briefs(1, title="The Title", status="live")
+
+        res = self.client.post(
+            "/briefs/1/clarification-questions",
+            data=json.dumps({
+                "clarificationQuestion": {
+                    "answer": "That",
+                },
+                "update_details": {"updated_by": "example"},
+            }),
+            content_type="application/json")
+
+        assert res.status_code == 400
+
+    def test_add_clarification_question_fails_if_no_answer(self):
+        self.setup_dummy_briefs(1, title="The Title", status="live")
+
+        res = self.client.post(
+            "/briefs/1/clarification-questions",
+            data=json.dumps({
+                "clarificationQuestion": {
+                    "question": "What?",
+                },
+                "update_details": {"updated_by": "example"},
+            }),
+            content_type="application/json")
+
+        assert res.status_code == 400
+
+    def test_cannot_get_clarification_questions_directly(self):
+        self.setup_dummy_briefs(1, title="The Title", status="live")
+
+        res = self.client.get("/briefs/1/clarification-questions")
+
+        assert res.status_code == 405
+
+    def test_adding_a_clarification_question_makes_an_audit_event(self):
+        self.setup_dummy_briefs(1, title="The Title", status="live")
+
+        self.client.post(
+            "/briefs/1/clarification-questions",
+            data=json.dumps({
+                "clarificationQuestion": {
+                    "question": "What?",
+                    "answer": "That",
+                },
+                "update_details": {"updated_by": "example"},
+            }),
+            content_type="application/json")
+
+        audit_response = self.client.get("/audit-events")
+        assert audit_response.status_code == 200
+        data = json.loads(audit_response.get_data(as_text=True))
+
+        audits = [
+            event for event in data["auditEvents"]
+            if event["type"] == AuditTypes.add_brief_clarification_question.value
+        ]
+        assert len(audits) == 1
+        assert audits[0]['data'] == {
+            "question": "What?",
+            "answer": "That",
+        }


### PR DESCRIPTION
[#112340959](https://www.pivotaltracker.com/story/show/112340959)

Depends on https://github.com/alphagov/digitalmarketplace-apiclient/pull/15

This allows clarification questions and answers to be published on a live brief.

I've done validation on the model rather than with a JSON schema as we are not using a JSON data column.