### PR TITLE
Brief applications closed at

### DIFF
--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -113,8 +113,13 @@ def list_briefs():
     page = get_valid_page_or_1()
 
     user_id = get_int_or_400(request.args, 'user_id')
+    status = request.args.get('status')
+
     if user_id:
         briefs = briefs.filter(Brief.users.any(id=user_id))
+
+    if status:
+        briefs = briefs.filter(Brief.status == status)
 
     briefs = briefs.paginate(
         page=page,

--- a/app/models.py
+++ b/app/models.py
@@ -778,7 +778,7 @@ class AuditEvent(db.Model):
 class Brief(db.Model):
     __tablename__ = 'briefs'
 
-    QUESTIONS_OPEN_DAYS = 7
+    CLARIFICATION_QUESTIONS_OPEN_DAYS = 7
     APPLICATIONS_OPEN_DAYS = 14
 
     id = db.Column(db.Integer, primary_key=True)
@@ -854,6 +854,17 @@ class Brief(db.Model):
         return func.date_trunc('day', cls.published_at) + sql_cast(
             '%d days' % (cls.APPLICATIONS_OPEN_DAYS + 1), INTERVAL
         )
+
+    @hybrid_property
+    def clarification_questions_closed_at(self):
+        if self.published_at is None:
+            return None
+
+        # Set time to midnight next day and add full number of days before questions close
+        published_day = self.published_at.replace(hour=0, minute=0, second=0, microsecond=0)
+        closing_time = published_day + timedelta(days=self.CLARIFICATION_QUESTIONS_OPEN_DAYS + 1)
+
+        return closing_time
 
     @hybrid_property
     def status(self):

--- a/app/models.py
+++ b/app/models.py
@@ -932,8 +932,12 @@ class Brief(db.Model):
             ],
         })
 
-        if self.status == 'live':
-            data['publishedAt'] = self.published_at.strftime(DATETIME_FORMAT)
+        if self.published_at:
+            data.update({
+                'publishedAt': self.published_at.strftime(DATETIME_FORMAT),
+                'applicationsClosedAt': self.applications_closed_at.strftime(DATETIME_FORMAT),
+                'clarificationQuestionsClosedAt': self.clarification_questions_closed_at.strftime(DATETIME_FORMAT),
+            })
 
         data['links'] = {
             'self': url_for('.get_brief', brief_id=self.id),

--- a/app/models.py
+++ b/app/models.py
@@ -867,6 +867,10 @@ class Brief(db.Model):
         return closing_time
 
     @hybrid_property
+    def clarification_questions_are_closed(self):
+        return datetime.utcnow() > self.clarification_questions_closed_at
+
+    @hybrid_property
     def status(self):
         if self.published_at is None:
             return 'draft'
@@ -937,6 +941,7 @@ class Brief(db.Model):
                 'publishedAt': self.published_at.strftime(DATETIME_FORMAT),
                 'applicationsClosedAt': self.applications_closed_at.strftime(DATETIME_FORMAT),
                 'clarificationQuestionsClosedAt': self.clarification_questions_closed_at.strftime(DATETIME_FORMAT),
+                'clarificationQuestionsAreClosed': self.clarification_questions_are_closed,
             })
 
         data['links'] = {

--- a/migrations/versions/590_remove_brief_status_column.py
+++ b/migrations/versions/590_remove_brief_status_column.py
@@ -1,0 +1,26 @@
+"""Remove brief status column
+
+Revision ID: 590
+Revises: 580
+Create Date: 2016-03-03 14:56:59.218753
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '590'
+down_revision = '580'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.drop_column('briefs', 'status')
+
+
+def downgrade():
+    op.add_column('briefs', sa.Column('status', sa.VARCHAR(), autoincrement=False, nullable=True))
+    op.execute("""
+        UPDATE briefs SET status = (CASE WHEN published_at is not NULL THEN 'live' ELSE 'draft' END)
+    """)
+    op.alter_column('briefs', sa.Column('status', sa.VARCHAR(), nullable=False))

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -70,6 +70,8 @@ class BaseApplicationTest(object):
 
     def setup_dummy_user(self, id=123, role='buyer'):
         with self.app.app_context():
+            if User.query.get(id):
+                return id
             user = User(
                 id=id,
                 email_address="test+{}@digital.gov.uk".format(id),

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -201,6 +201,7 @@ class TestBriefs(BaseApplicationTest):
                       published_at=datetime.utcnow() - timedelta(days=1000))
 
         assert brief.status == 'closed'
+        assert brief.clarification_questions_are_closed
         assert brief.applications_closed_at < datetime.utcnow()
 
     def test_can_set_draft_brief_to_the_same_status(self):
@@ -212,6 +213,7 @@ class TestBriefs(BaseApplicationTest):
         assert brief.published_at is None
 
         brief.status = 'live'
+        assert not brief.clarification_questions_are_closed
         assert isinstance(brief.published_at, datetime)
 
     def test_status_must_be_valid(self):

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -186,6 +186,7 @@ class TestBriefs(BaseApplicationTest):
                       published_at=datetime(2016, 3, 3, 12, 30, 1, 2))
 
         assert brief.applications_closed_at == datetime(2016, 3, 18)
+        assert brief.clarification_questions_closed_at == datetime(2016, 3, 11)
 
     def test_query_brief_applications_closed_at_date(self):
         with self.app.app_context():

--- a/tests/app/views/test_briefs.py
+++ b/tests/app/views/test_briefs.py
@@ -355,6 +355,8 @@ class TestBriefs(BaseApplicationTest):
         data = json.loads(res.get_data(as_text=True))
 
         assert 'publishedAt' in data['briefs']
+        assert 'applicationsClosedAt' in data['briefs']
+        assert 'clarificationQuestionsClosedAt' in data['briefs']
 
     def test_get_brief_returns_404_if_not_found(self):
         res = self.client.get('/briefs/1')

--- a/tests/app/views/test_briefs.py
+++ b/tests/app/views/test_briefs.py
@@ -389,6 +389,26 @@ class TestBriefs(BaseApplicationTest):
         assert res.status_code == 200
         assert len(data['briefs']) == 3
 
+    def test_list_briefs_by_status(self):
+        self.setup_dummy_briefs(3, status='live')
+        self.setup_dummy_briefs(2, status='draft', brief_start=4)
+
+        res = self.client.get('/briefs?status=live')
+        data = json.loads(res.get_data(as_text=True))
+
+        assert res.status_code == 200
+        assert len(data['briefs']) == 3, data['briefs']
+
+    def test_cannot_list_briefs_by_invalid_status(self):
+        self.setup_dummy_briefs(1, status='live')
+        self.setup_dummy_briefs(1, status='draft', brief_start=2)
+
+        res = self.client.get('/briefs?status=invalid')
+        data = json.loads(res.get_data(as_text=True))
+
+        assert res.status_code == 200
+        assert len(data['briefs']) == 0
+
     def test_list_briefs_pagination_page_one(self):
         self.setup_dummy_briefs(7)
 

--- a/tests/app/views/test_briefs.py
+++ b/tests/app/views/test_briefs.py
@@ -357,6 +357,7 @@ class TestBriefs(BaseApplicationTest):
         assert 'publishedAt' in data['briefs']
         assert 'applicationsClosedAt' in data['briefs']
         assert 'clarificationQuestionsClosedAt' in data['briefs']
+        assert not data['briefs']['clarificationQuestionsAreClosed']
 
     def test_get_brief_returns_404_if_not_found(self):
         res = self.client.get('/briefs/1')


### PR DESCRIPTION
### Replace Brief.status column with a property
Replaces the column with a computed property. Setting the status now sets the related date fields instead so that the API clients can still reference `status` field both when reading and updating the brief.

### Add ability to filter briefs by status
Uses the sqlalchemy hybrid_property with a separate function to be used in query expressions.

This means we need to reimplement the logic twice (both for getting the status property for python and for filtering based on status in the database), but the `.status` property behaves like a regular column for the rest of the API code.

http://docs.sqlalchemy.org/en/latest/orm/extensions/hybrid.html#module-sqlalchemy.ext.hybrid

### Add Brief 'closed' status and applications_closed_at property
Adds a closed date calculated from the brief's published date for published briefs.

Similar to status, applications_closed_at is a hybrid property and has a separate implementation when used in SQLAlchemy expressions, which is covered by additional query tests.

Closed date is also checked to return 'closed' status if the brief application period has closed.

### Add Brief.clarification_questions_closed_at property
Sets the clarification questions close date, similar to the close date for brief responses.

### Add Brief.clarificaiton_quesitons_are_closed property
Checking whether the close date has passed seems like it will be the most common operation related to close dates. When checking whether applications are closed the app can check the brief status instead, but for clarification questions the frontend apps would need to parse the date first.

This adds a helper property to Brief objects and serialized data that returns true if clarification close date is in the future and false otherwise.