### PR TITLE
Allow service IDs to be generated for DOS

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1052,7 +1052,4 @@ def filter_null_value_fields(obj):
 
 
 def generate_new_service_id(framework_slug):
-    if framework_slug == 'g-cloud-7':
-        return str(random.randint(7e15, 8e15-1))
-    else:
-        raise NotImplemented("Can only generate service_id for G-Cloud 7")
+    return str(random.randint(10 ** 14, 10 ** 15 - 1))


### PR DESCRIPTION
Remove the restriction on serivce IDs that only allows them to be
generated for g-cloud-7.

This generates a string of integers between 16 characters long.
I've changed from exponential notation to raising to the power because
the exponential notation creates floats and the larger float overflows.