### PR TITLE
Remove `update_details` from everywhere

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -345,7 +345,7 @@ def register_framework_interest(supplier_id, framework_slug):
 
     json_payload = get_json_from_request()
     updater_json = validate_and_return_updater_request()
-    json_payload.pop('update_details')
+    json_payload.pop('updated_by')
     if json_payload:
         abort(400, "This PUT endpoint does not take a payload.")
 

--- a/tests/app/views/test_audits.py
+++ b/tests/app/views/test_audits.py
@@ -281,9 +281,7 @@ class TestAuditEvents(BaseApplicationTest):
             '/audit-events/{}/acknowledge'.format(
                 data['auditEvents'][0]['id']
             ),
-            data=json.dumps({
-                'update_details': {'updated_by': 'tests'}
-            }),
+            data=json.dumps({'updated_by': 'tests'}),
             content_type='application/json')
         # re-fetch to get updated data
         new_response = self.client.get('/audit-events')
@@ -301,9 +299,7 @@ class TestAuditEvents(BaseApplicationTest):
             '/audit-events/{}/acknowledge'.format(
                 data['auditEvents'][0]['id']
             ),
-            data=json.dumps({
-                'update_details': {'updated_by': 'tests'}
-            }),
+            data=json.dumps({'updated_by': 'tests'}),
             content_type='application/json')
         # re-fetch to get updated data
         new_response = self.client.get('/audit-events')
@@ -326,9 +322,7 @@ class TestAuditEvents(BaseApplicationTest):
             '/audit-events/{}/acknowledge'.format(
                 data['auditEvents'][0]['id']
             ),
-            data=json.dumps({
-                'update_details': {'updated_by': 'tests'}
-            }),
+            data=json.dumps({'updated_by': 'tests'}),
             content_type='application/json')
         # re-fetch to get updated data
         new_response = self.client.get(
@@ -350,9 +344,7 @@ class TestAuditEvents(BaseApplicationTest):
             '/audit-events/{}/acknowledge'.format(
                 data['auditEvents'][0]['id']
             ),
-            data=json.dumps({
-                'update_details': {'updated_by': 'tests'}
-            }),
+            data=json.dumps({'updated_by': 'tests'}),
             content_type='application/json')
         # re-fetch to get updated data
         new_response = self.client.get(

--- a/tests/app/views/test_briefs.py
+++ b/tests/app/views/test_briefs.py
@@ -47,9 +47,7 @@ class TestBriefs(BaseApplicationTest):
                     'lot': 'digital-specialists',
                     'title': 'the title',
                 },
-                'update_details': {
-                    'updated_by': 'example'
-                }
+                'updated_by': 'example'
             }),
             content_type='application/json')
         data = json.loads(res.get_data(as_text=True))
@@ -87,9 +85,7 @@ class TestBriefs(BaseApplicationTest):
                     'frameworkSlug': 'digital-outcomes-and-specialists',
                     'lot': 'digital-specialists',
                 },
-                'update_details': {
-                    'updated_by': 'example'
-                },
+                'updated_by': 'example',
                 'page_questions': ['title'],
             }),
             content_type='application/json')
@@ -136,7 +132,7 @@ class TestBriefs(BaseApplicationTest):
                     'lot': 'digital-specialists',
                     'title': 'my title',
                 },
-                'update_details': {'updated_by': 'example'}
+                'updated_by': 'example'
             }),
             content_type='application/json')
 
@@ -182,7 +178,7 @@ class TestBriefs(BaseApplicationTest):
                     'frameworkSlug': 'digital-outcomes-and-specialists',
                     'lot': 'digital-specialists',
                 },
-                'update_details': {'updated_by': 'example'}
+                'updated_by': 'example'
             }),
             content_type='application/json')
 
@@ -214,7 +210,7 @@ class TestBriefs(BaseApplicationTest):
                     'frameworkSlug': 'digital-outcomes-and-specialists',
                     'lot': 'not-exists',
                 },
-                'update_details': {'updated_by': 'example'}
+                'updated_by': 'example'
             }),
             content_type='application/json')
 
@@ -244,7 +240,7 @@ class TestBriefs(BaseApplicationTest):
             '/briefs/1',
             data=json.dumps({
                 'briefs': {},
-                'update_details': {'updated_by': 'example'},
+                'updated_by': 'example',
                 'page_questions': ['title'],
             }),
             content_type='application/json')
@@ -275,7 +271,7 @@ class TestBriefs(BaseApplicationTest):
             '/briefs/1',
             data=json.dumps({
                 'briefs': {'title': 'my title'},
-                'update_details': {'updated_by': 'example'}
+                'updated_by': 'example'
             }),
             content_type='application/json')
 
@@ -309,7 +305,7 @@ class TestBriefs(BaseApplicationTest):
             '/briefs/1',
             data=json.dumps({
                 'briefs': {},
-                'update_details': {'updated_by': 'example'},
+                'updated_by': 'example',
             }),
             content_type='application/json')
 
@@ -438,7 +434,7 @@ class TestBriefs(BaseApplicationTest):
             '/briefs/1/status',
             data=json.dumps({
                 'briefs': {'status': 'live'},
-                'update_details': {'updated_by': 'example'}
+                'updated_by': 'example'
             }),
             content_type='application/json')
         data = json.loads(res.get_data(as_text=True))
@@ -480,7 +476,7 @@ class TestBriefs(BaseApplicationTest):
             '/briefs/1/status',
             data=json.dumps({
                 'briefs': {'status': 'live'},
-                'update_details': {'updated_by': 'example'}
+                'updated_by': 'example'
             }),
             content_type='application/json')
         data = json.loads(res.get_data(as_text=True))
@@ -510,7 +506,7 @@ class TestBriefs(BaseApplicationTest):
             '/briefs/1/status',
             data=json.dumps({
                 'briefs': {'status': 'invalid'},
-                'update_details': {'updated_by': 'example'}
+                'updated_by': 'example'
             }),
             content_type='application/json')
         data = json.loads(res.get_data(as_text=True))
@@ -551,9 +547,7 @@ class TestBriefs(BaseApplicationTest):
                     'lot': 'digital-specialists',
                     'title': 'the title',
                 },
-                'update_details': {
-                    'updated_by': 'example'
-                }
+                'updated_by': 'example'
             }),
             content_type='application/json')
         data = json.loads(res.get_data(as_text=True))
@@ -593,9 +587,7 @@ class TestBriefs(BaseApplicationTest):
                     'title': 'the title',
                     'status': 'live'
                 },
-                'update_details': {
-                    'updated_by': 'example'
-                }
+                'updated_by': 'example'
             }),
             content_type='application/json')
         data = json.loads(res.get_data(as_text=True))
@@ -617,7 +609,7 @@ class TestBriefs(BaseApplicationTest):
         fetch_again = self.client.get('/briefs/{}'.format(brief_id))
         assert fetch_again.status_code == 200
 
-    def test_reject_delete_with_no_update_details(self):
+    def test_reject_delete_with_no_updated_by(self):
         res = self.client.delete('/briefs/0000000000',
                                  data=json.dumps({}),
                                  content_type='application/json')
@@ -628,7 +620,7 @@ class TestBriefs(BaseApplicationTest):
     def test_should_404_on_delete_a_brief_that_doesnt_exist(self):
         res = self.client.delete(
             '/briefs/0000000000',
-            data=json.dumps({'update_details': {'updated_by': 'example'}}),
+            data=json.dumps({'updated_by': 'example'}),
             content_type='application/json'
         )
         assert res.status_code == 404
@@ -664,7 +656,7 @@ class TestBriefs(BaseApplicationTest):
                 "clarificationQuestion": {
                     "answer": "That",
                 },
-                "update_details": {"updated_by": "example"},
+                "updated_by": "example",
             }),
             content_type="application/json")
 
@@ -702,7 +694,7 @@ class TestBriefs(BaseApplicationTest):
                     "question": "What?",
                     "answer": "That",
                 },
-                "update_details": {"updated_by": "example"},
+                "updated_by": "example",
             }),
             content_type="application/json")
 

--- a/tests/app/views/test_drafts.py
+++ b/tests/app/views/test_drafts.py
@@ -21,8 +21,7 @@ class TestDraftServices(BaseApplicationTest):
 
         self.service_id = str(payload['id'])
         self.updater_json = {
-            'update_details': {
-                'updated_by': 'joeblogs'}
+            'updated_by': 'joeblogs'
         }
         self.create_draft_json = self.updater_json.copy()
         self.create_draft_json['services'] = {
@@ -52,8 +51,7 @@ class TestDraftServices(BaseApplicationTest):
         self.client.put(
             '/services/%s' % self.service_id,
             data=json.dumps(
-                {'update_details': {
-                    'updated_by': 'joeblogs'},
+                {'updated_by': 'joeblogs',
                  'services': payload}),
             content_type='application/json')
 
@@ -173,12 +171,12 @@ class TestDraftServices(BaseApplicationTest):
 
         assert_equal(res.status_code, 400)
 
-    def test_reject_copy_with_no_update_details(self):
+    def test_reject_copy_with_no_updated_by(self):
         res = self.client.put('/draft-services/copy-from/0000000000')
 
         assert_equal(res.status_code, 400)
 
-    def test_reject_create_with_no_update_details(self):
+    def test_reject_create_with_no_updated_by(self):
         res = self.client.post('/draft-services')
 
         assert_equal(res.status_code, 400)
@@ -204,14 +202,14 @@ class TestDraftServices(BaseApplicationTest):
 
         assert_equal(res.status_code, 400)
 
-    def test_reject_delete_with_no_update_details(self):
+    def test_reject_delete_with_no_updated_by(self):
         res = self.client.delete('/draft-services/0000000000',
                                  data=json.dumps({}),
                                  content_type='application/json')
 
         assert_equal(res.status_code, 400)
 
-    def test_reject_publish_with_no_update_details(self):
+    def test_reject_publish_with_no_updated_by(self):
         res = self.client.post('/draft-services/0000000000/publish',
                                data=json.dumps({}),
                                content_type='application/json')
@@ -485,8 +483,7 @@ class TestDraftServices(BaseApplicationTest):
         res = self.client.post(
             '/draft-services/{}'.format(draft_id),
             data=json.dumps({
-                'update_details': {
-                    'updated_by': 'joeblogs'},
+                'updated_by': 'joeblogs',
                 'services': {
                     'badField': 'new service name',
                     'priceUnit': 'chickens'
@@ -643,8 +640,7 @@ class TestDraftServices(BaseApplicationTest):
         update = self.client.post(
             '/draft-services/{}'.format(draft_id),
             data=json.dumps({
-                'update_details': {
-                    'updated_by': 'joeblogs'},
+                'updated_by': 'joeblogs',
                 'services': {
                     'serviceName': 'new service name'
                 }
@@ -669,8 +665,7 @@ class TestDraftServices(BaseApplicationTest):
         update = self.client.post(
             '/draft-services/{}'.format(draft_id),
             data=json.dumps({
-                'update_details': {
-                    'updated_by': 'joeblogs'},
+                'updated_by': 'joeblogs',
                 'services': {
                     'serviceName': '      a new  service name      ',
                     'serviceFeatures': [
@@ -704,8 +699,7 @@ class TestDraftServices(BaseApplicationTest):
         update = self.client.post(
             '/draft-services/{}'.format(draft_id),
             data=json.dumps({
-                'update_details': {
-                    'updated_by': 'joeblogs'},
+                'updated_by': 'joeblogs',
                 'services': {
                     'serviceName': 'new service name'
                 }
@@ -738,8 +732,7 @@ class TestDraftServices(BaseApplicationTest):
         update = self.client.post(
             '/draft-services/{}'.format(self.service_id),
             data=json.dumps({
-                'update_details': {
-                    'updated_by': 'joeblogs'}
+                'updated_by': 'joeblogs'
             }),
             content_type='application/json')
 
@@ -748,11 +741,7 @@ class TestDraftServices(BaseApplicationTest):
     def test_should_not_be_able_to_publish_if_no_draft_exists(self):
         res = self.client.post(
             '/draft-services/98765/publish',
-            data=json.dumps({
-                'update_details': {
-                    'updated_by': 'joeblogs',
-                }
-            }),
+            data=json.dumps({'updated_by': 'joeblogs'}),
             content_type='application/json')
         assert_equal(res.status_code, 404)
 
@@ -779,8 +768,7 @@ class TestDraftServices(BaseApplicationTest):
         self.client.post(
             '/draft-services/{}'.format(draft_id),
             data=json.dumps({
-                'update_details': {
-                    'updated_by': 'joeblogs'},
+                'updated_by': 'joeblogs',
                 'services': {
                     'serviceName': 'chickens'
                 }
@@ -796,11 +784,7 @@ class TestDraftServices(BaseApplicationTest):
 
         res = self.client.post(
             '/draft-services/{}/publish'.format(draft_id),
-            data=json.dumps({
-                'update_details': {
-                    'updated_by': 'joeblogs',
-                }
-            }),
+            data=json.dumps({'updated_by': 'joeblogs'}),
             content_type='application/json')
         assert_equal(res.status_code, 200)
 
@@ -919,7 +903,7 @@ class TestDraftServices(BaseApplicationTest):
         g7_complete = self.load_example_listing("G7-SCS").copy()
         g7_complete.pop('id')
         draft_update_json = {'services': g7_complete,
-                             'update_details': {'updated_by': 'joeblogs'}}
+                             'updated_by': 'joeblogs'}
         res2 = self.client.post(
             '/draft-services/{}'.format(draft['id']),
             data=json.dumps(draft_update_json),
@@ -932,20 +916,14 @@ class TestDraftServices(BaseApplicationTest):
     def complete_draft_service(self, draft_id):
         return self.client.post(
             '/draft-services/{}/complete'.format(draft_id),
-            data=json.dumps({
-                'update_details': {
-                    'updated_by': 'joeblogs',
-                }
-            }),
+            data=json.dumps({'updated_by': 'joeblogs'}),
             content_type='application/json')
 
     def publish_draft_service(self, draft_id):
         return self.client.post(
             '/draft-services/{}/publish'.format(draft_id),
             data=json.dumps({
-                'update_details': {
-                    'updated_by': 'joeblogs',
-                }
+                'updated_by': 'joeblogs'
             }),
             content_type='application/json')
 
@@ -1052,9 +1030,7 @@ class TestCopyDraft(BaseApplicationTest, JSONUpdateTestMixin):
             db.session.commit()
 
         create_draft_json = {
-            'update_details': {
-                'updated_by': 'joeblogs'
-            },
+            'updated_by': 'joeblogs',
             'services': {
                 'frameworkSlug': 'g-cloud-7',
                 'lot': 'scs',
@@ -1080,7 +1056,7 @@ class TestCopyDraft(BaseApplicationTest, JSONUpdateTestMixin):
     def test_copy_draft(self):
         res = self.client.post(
             '/draft-services/%s/copy' % self.draft_id,
-            data=json.dumps({'update_details': {'updated_by': 'joeblogs'}}),
+            data=json.dumps({'updated_by': 'joeblogs'}),
             content_type='application/json')
 
         data = json.loads(res.get_data())
@@ -1095,7 +1071,7 @@ class TestCopyDraft(BaseApplicationTest, JSONUpdateTestMixin):
     def test_copy_draft_should_create_audit_event(self):
         res = self.client.post(
             '/draft-services/%s/copy' % self.draft_id,
-            data=json.dumps({'update_details': {'updated_by': 'joeblogs'}}),
+            data=json.dumps({'updated_by': 'joeblogs'}),
             content_type='application/json')
 
         assert_equal(res.status_code, 201)
@@ -1116,7 +1092,7 @@ class TestCopyDraft(BaseApplicationTest, JSONUpdateTestMixin):
     def test_should_not_create_draft_with_invalid_data(self):
         res = self.client.post(
             '/draft-services/1000/copy',
-            data=json.dumps({'update_details': {'updated_by': 'joeblogs'}}),
+            data=json.dumps({'updated_by': 'joeblogs'}),
             content_type='application/json')
 
         assert_equal(res.status_code, 404)
@@ -1124,7 +1100,7 @@ class TestCopyDraft(BaseApplicationTest, JSONUpdateTestMixin):
     def test_should_not_copy_draft_service_description(self):
         res = self.client.post(
             '/draft-services/{}/copy'.format(self.draft_id),
-            data=json.dumps({"update_details": {"updated_by": "me"}}),
+            data=json.dumps({"updated_by": "me"}),
             content_type="application/json")
         data = json.loads(res.get_data())
 
@@ -1134,7 +1110,7 @@ class TestCopyDraft(BaseApplicationTest, JSONUpdateTestMixin):
     def test_should_not_copy_draft_documents(self):
         res = self.client.post(
             '/draft-services/{}/copy'.format(self.draft_id),
-            data=json.dumps({"update_details": {"updated_by": "me"}}),
+            data=json.dumps({"updated_by": "me"}),
             content_type="application/json")
         data = json.loads(res.get_data())
 
@@ -1167,9 +1143,7 @@ class TestCompleteDraft(BaseApplicationTest, JSONUpdateTestMixin):
         draft_json = self.load_example_listing("G7-SCS")
         draft_json['frameworkSlug'] = 'g-cloud-7'
         create_draft_json = {
-            'update_details': {
-                'updated_by': 'joeblogs'
-            },
+            'updated_by': 'joeblogs',
             'services': draft_json
         }
 
@@ -1184,7 +1158,7 @@ class TestCompleteDraft(BaseApplicationTest, JSONUpdateTestMixin):
     def test_complete_draft(self):
         res = self.client.post(
             '/draft-services/%s/complete' % self.draft_id,
-            data=json.dumps({'update_details': {'updated_by': 'joeblogs'}}),
+            data=json.dumps({'updated_by': 'joeblogs'}),
             content_type='application/json')
 
         data = json.loads(res.get_data())
@@ -1194,7 +1168,7 @@ class TestCompleteDraft(BaseApplicationTest, JSONUpdateTestMixin):
     def test_complete_draft_should_create_audit_event(self):
         res = self.client.post(
             '/draft-services/%s/complete' % self.draft_id,
-            data=json.dumps({'update_details': {'updated_by': 'joeblogs'}}),
+            data=json.dumps({'updated_by': 'joeblogs'}),
             content_type='application/json')
 
         assert_equal(res.status_code, 200)
@@ -1209,7 +1183,7 @@ class TestCompleteDraft(BaseApplicationTest, JSONUpdateTestMixin):
             'draftId': self.draft_id,
         })
 
-    def test_should_not_complete_draft_without_update_details(self):
+    def test_should_not_complete_draft_without_updated_by(self):
         res = self.client.post(
             '/draft-services/%s/complete' % self.draft_id,
             data=json.dumps({}),
@@ -1219,9 +1193,7 @@ class TestCompleteDraft(BaseApplicationTest, JSONUpdateTestMixin):
 
     def test_should_not_complete_invalid_draft(self):
         create_draft_json = {
-            'update_details': {
-                'updated_by': 'joeblogs'
-            },
+            'updated_by': 'joeblogs',
             'services': {
                 'frameworkSlug': 'g-cloud-7',
                 'lot': 'scs',
@@ -1240,7 +1212,7 @@ class TestCompleteDraft(BaseApplicationTest, JSONUpdateTestMixin):
 
         res = self.client.post(
             '/draft-services/%s/complete' % draft['id'],
-            data=json.dumps({'update_details': {'updated_by': 'joeblogs'}}),
+            data=json.dumps({'updated_by': 'joeblogs'}),
             content_type='application/json')
 
         assert_equal(res.status_code, 400)
@@ -1257,8 +1229,7 @@ class TestDOSServices(BaseApplicationTest):
 
         payload = self.load_example_listing("DOS-digital-specialist")
         self.updater_json = {
-            'update_details': {
-                'updated_by': 'joeblogs'}
+            'updated_by': 'joeblogs'
         }
         self.create_draft_json = self.updater_json.copy()
         self.create_draft_json['services'] = payload
@@ -1292,9 +1263,7 @@ class TestDOSServices(BaseApplicationTest):
         res = self.client.post(
             '/draft-services/{}'.format(draft_id),
             data=json.dumps({
-                'update_details': {
-                    'updated_by': 'joeblogs'
-                },
+                'updated_by': 'joeblogs',
                 'services': services,
                 'page_questions': page_questions if page_questions is not None else []
             }),
@@ -1460,7 +1429,7 @@ class TestDOSServices(BaseApplicationTest):
 
         res = self.client.post(
             '/draft-services/{}/copy'.format(draft['services']['id']),
-            data=json.dumps({"update_details": {"updated_by": "me"}}),
+            data=json.dumps({"updated_by": "me"}),
             content_type="application/json")
         data = json.loads(res.get_data())
 
@@ -1516,9 +1485,7 @@ class TestUpdateDraftStatus(BaseApplicationTest, JSONUpdateTestMixin):
         draft_json = self.load_example_listing("G7-SCS")
         draft_json['frameworkSlug'] = 'g-cloud-7'
         create_draft_json = {
-            'update_details': {
-                'updated_by': 'joeblogs'
-            },
+            'updated_by': 'joeblogs',
             'services': draft_json
         }
 
@@ -1533,7 +1500,7 @@ class TestUpdateDraftStatus(BaseApplicationTest, JSONUpdateTestMixin):
     def test_update_draft_status(self):
         res = self.client.post(
             '/draft-services/%s/update-status' % self.draft_id,
-            data=json.dumps({'services': {'status': 'failed'}, 'update_details': {'updated_by': 'joeblogs'}}),
+            data=json.dumps({'services': {'status': 'failed'}, 'updated_by': 'joeblogs'}),
             content_type='application/json')
 
         data = json.loads(res.get_data())
@@ -1543,7 +1510,7 @@ class TestUpdateDraftStatus(BaseApplicationTest, JSONUpdateTestMixin):
     def test_update_draft_status_should_create_audit_event(self):
         res = self.client.post(
             '/draft-services/%s/update-status' % self.draft_id,
-            data=json.dumps({'services': {'status': 'failed'}, 'update_details': {'updated_by': 'joeblogs'}}),
+            data=json.dumps({'services': {'status': 'failed'}, 'updated_by': 'joeblogs'}),
             content_type='application/json')
 
         assert_equal(res.status_code, 200)
@@ -1561,7 +1528,7 @@ class TestUpdateDraftStatus(BaseApplicationTest, JSONUpdateTestMixin):
     def test_should_not_update_draft_status_to_invalid_status(self):
         res = self.client.post(
             '/draft-services/%s/update-status' % self.draft_id,
-            data=json.dumps({'services': {'status': 'INVALID-STATUS'}, 'update_details': {'updated_by': 'joeblogs'}}),
+            data=json.dumps({'services': {'status': 'INVALID-STATUS'}, 'updated_by': 'joeblogs'}),
             content_type='application/json')
 
         assert_equal(res.status_code, 400)

--- a/tests/app/views/test_frameworks.py
+++ b/tests/app/views/test_frameworks.py
@@ -328,7 +328,7 @@ class TestGetFrameworkSuppliers(BaseApplicationTest):
                 response = self.client.put(
                     '/suppliers/{}/frameworks/g-cloud-7'.format(supplier_id),
                     data=json.dumps({
-                        'update_details': {'updated_by': 'example'}
+                        'updated_by': 'example'
                     }),
                     content_type='application/json')
                 assert response.status_code == 201, response.get_data(as_text=True)
@@ -336,7 +336,7 @@ class TestGetFrameworkSuppliers(BaseApplicationTest):
                 response = self.client.post(
                     '/suppliers/{}/frameworks/g-cloud-7'.format(supplier_id),
                     data=json.dumps({
-                        'update_details': {'updated_by': 'example'},
+                        'updated_by': 'example',
                         'frameworkInterest': {'agreementReturned': True},
                     }),
                     content_type='application/json')

--- a/tests/app/views/test_services.py
+++ b/tests/app/views/test_services.py
@@ -390,8 +390,7 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin):
         self.client.put(
             '/services/%s' % self.service_id,
             data=json.dumps(
-                {'update_details': {
-                    'updated_by': 'joeblogs'},
+                {'updated_by': 'joeblogs',
                  'services': payload}),
             content_type='application/json')
 
@@ -399,8 +398,7 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin):
         response = self.client.post(
             "/services",
             data=json.dumps(
-                {'update_details': {
-                    'updated_by': 'joeblogs'},
+                {'updated_by': 'joeblogs',
                  'services': {
                      'serviceName': 'new service name'}}),
             content_type='application/json')
@@ -411,8 +409,7 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin):
         response = self.client.post(
             "/services/9999999999",
             data=json.dumps(
-                {'update_details': {
-                    'updated_by': 'joeblogs'},
+                {'updated_by': 'joeblogs',
                  'services': {
                      'serviceName': 'new service name'}}),
             content_type='application/json')
@@ -424,8 +421,7 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin):
             response = self.client.post(
                 '/services/%s' % self.service_id,
                 data=json.dumps(
-                    {'update_details': {
-                        'updated_by': 'joeblogs'},
+                    {'updated_by': 'joeblogs',
                      'services': {
                          'serviceName': 'new service name'}}))
 
@@ -437,8 +433,7 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin):
             response = self.client.post(
                 '/services/%s' % self.service_id,
                 data=json.dumps(
-                    {'update_details': {
-                        'updated_by': 'joeblogs'},
+                    {'updated_by': 'joeblogs',
                      'services': {
                          'serviceName': 'new service name'}}),
                 content_type='application/octet-stream')
@@ -461,8 +456,7 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin):
             response = self.client.post(
                 '/services/%s' % self.service_id,
                 data=json.dumps(
-                    {'update_details': {
-                        'updated_by': 'joeblogs'},
+                    {'updated_by': 'joeblogs',
                      'services': {
                          'serviceName': 'new service name'}}),
                 content_type='application/json')
@@ -480,8 +474,7 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin):
             response = self.client.post(
                 '/services/%s' % self.service_id,
                 data=json.dumps(
-                    {'update_details': {
-                        'updated_by': 'joeblogs'},
+                    {'updated_by': 'joeblogs',
                      'services': {
                          'serviceName': 'new service name'}}),
                 content_type='application/json')
@@ -505,14 +498,14 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin):
             self.client.post(
                 '/services/%s' % self.service_id,
                 data=json.dumps(
-                    {'update_details': {'updated_by': 'joeblogs'},
+                    {'updated_by': 'joeblogs',
                      'services': {'serviceName': 'new service name'}}),
                 content_type='application/json')
 
             self.client.post(
                 '/services/%s' % self.service_id,
                 data=json.dumps(
-                    {'update_details': {'updated_by': 'joeblogs'},
+                    {'updated_by': 'joeblogs',
                      'services': {'serviceName': 'new new service name'}}),
                 content_type='application/json')
 
@@ -546,8 +539,7 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin):
             response = self.client.post(
                 '/services/%s' % self.service_id,
                 data=json.dumps(
-                    {'update_details': {
-                        'updated_by': 'joeblogs'},
+                    {'updated_by': 'joeblogs',
                      'services': {
                          'serviceName': 'new service name',
                          'incidentEscalation': False,
@@ -571,8 +563,7 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin):
             response = self.client.post(
                 '/services/%s' % self.service_id,
                 data=json.dumps(
-                    {'update_details': {
-                        'updated_by': 'joeblogs'},
+                    {'updated_by': 'joeblogs',
                      'services': {
                          'supportTypes': support_types}}),
                 content_type='application/json')
@@ -598,8 +589,7 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin):
             response = self.client.post(
                 '/services/%s' % self.service_id,
                 data=json.dumps(
-                    {'update_details': {
-                        'updated_by': 'joeblogs'},
+                    {'updated_by': 'joeblogs',
                      'services': {
                          'identityAuthenticationControls':
                              identity_authentication_controls}}),
@@ -624,8 +614,7 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin):
             response = self.client.post(
                 "/services/" + self.service_id,
                 data=json.dumps(
-                    {'update_details': {
-                        'updated_by': 'joeblogs'},
+                    {'updated_by': 'joeblogs',
                      'services': {
                          'thisIsInvalid': 'so I should never see this'}}),
                 content_type='application/json')
@@ -640,10 +629,9 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin):
             response = self.client.post(
                 "/services/" + self.service_id,
                 data=json.dumps(
-                    {'update_details': {
-                        'updated_by': 'joeblogs'},
+                    {'updated_by': 'joeblogs',
                      'services': {
-                        'priceUnit': 'per Truth'}}),
+                         'priceUnit': 'per Truth'}}),
                 content_type='application/json')
 
             assert_equal(response.status_code, 400)
@@ -655,8 +643,7 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin):
             response = self.client.post(
                 '/services/%s' % self.service_id,
                 data=json.dumps(
-                    {'update_details': {
-                        'updated_by': 'joeblogs'},
+                    {'updated_by': 'joeblogs',
                      'services': {
                          'serviceName': 'new service name'}}),
                 content_type='application/json')
@@ -676,8 +663,7 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin):
             response = self.client.post(
                 '/services/%s' % self.service_id,
                 data=json.dumps(
-                    {'update_details': {
-                        'updated_by': 'joeblogs'},
+                    {'updated_by': 'joeblogs',
                      'services': {
                          'serviceName': 'new service name'}}),
                 content_type='application/json')
@@ -699,8 +685,7 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin):
                 response = self.client.post(
                     '/services/%s' % self.service_id,
                     data=json.dumps(
-                        {'update_details': {
-                            'updated_by': 'joeblogs'},
+                        {'updated_by': 'joeblogs',
                          'services': {
                              'serviceName': 'new service name' + str(i)}}),
                     content_type='application/json')
@@ -721,8 +706,7 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin):
                 '/services/%s' % self.service_id,
                 data=json.dumps(
                     {
-                        'update_details': {
-                            'updated_by': 'joeblogs'},
+                        'updated_by': 'joeblogs',
                         'services': data['services']
                     }
                 ),
@@ -758,8 +742,7 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin):
         response = self.client.post(
             '/services/%s' % self.service_id,
             data=json.dumps(
-                {'update_details': {
-                    'updated_by': 'joeblogs'},
+                {'updated_by': 'joeblogs',
                  'services': {
                      'serviceName': 'new service name', 'id': 'differentId'}}),
             content_type='application/json')
@@ -772,8 +755,7 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin):
         response = self.client.post(
             '/services/%s' % self.service_id,
             data=json.dumps(
-                {'update_details': {
-                    'updated_by': 'joeblogs'},
+                {'updated_by': 'joeblogs',
                  'services': {
                      'status': 'enabled'}}),
             content_type='application/json')
@@ -800,9 +782,7 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin):
                     status
                 ),
                 data=json.dumps(
-                    {'update_details': {
-                        'updated_by': 'joeblogs'}
-                     }),
+                    {'updated_by': 'joeblogs'}),
                 content_type='application/json'
             )
 
@@ -817,9 +797,7 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin):
                 "disabled"
             ),
             data=json.dumps(
-                {'update_details': {
-                    'updated_by': 'joeblogs'}
-                 }),
+                {'updated_by': 'joeblogs'}),
             content_type='application/json'
         )
 
@@ -862,9 +840,7 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin):
                     status
                 ),
                 data=json.dumps(
-                    {'update_details': {
-                        'updated_by': 'joeblogs'}
-                     }),
+                    {'updated_by': 'joeblogs'}),
                 content_type='application/json'
             )
 
@@ -882,9 +858,7 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin):
                 self.service_id,
             ),
             data=json.dumps(
-                {'update_details': {
-                    'updated_by': 'joeblogs'}
-                 }),
+                {'updated_by': 'joeblogs'}),
             content_type='application/json'
         )
 
@@ -900,9 +874,7 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin):
             response = self.client.post(
                 '/services/{}'.format(self.service_id),
                 data=json.dumps({
-                    'update_details': {
-                        'updated_by': 'joeblogs',
-                    },
+                    'updated_by': 'joeblogs',
                     'services': data['services'],
                 }),
                 content_type='application/json')
@@ -923,9 +895,7 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin):
             response = self.client.put('/services/{}'.format(payload['id']),
                                        data=json.dumps({
                                            'services': payload,
-                                           "update_details": {
-                                               "updated_by": "joeblogs",
-                                           },
+                                           "updated_by": "joeblogs",
                                        }),
                                        content_type='application/json')
             assert_equal(response.status_code, 201)
@@ -935,9 +905,7 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin):
                                             "services": {
                                                 "serviceName": "fooo",
                                             },
-                                            "update_details": {
-                                                "updated_by": "joeblogs",
-                                            },
+                                            "updated_by": "joeblogs"
                                         }),
                                         content_type='application/json')
             assert_equal(response.status_code, 200)
@@ -964,8 +932,7 @@ class TestShouldCallSearchApiOnPutToCreateService(BaseApplicationTest):
                 '/services/1234567890123456',
                 data=json.dumps(
                     {
-                        'update_details': {
-                            'updated_by': 'joeblogs'},
+                        'updated_by': 'joeblogs',
                         'services': payload}
                 ),
                 content_type='application/json')
@@ -986,8 +953,7 @@ class TestShouldCallSearchApiOnPutToCreateService(BaseApplicationTest):
                 '/services/' + payload["id"],
                 data=json.dumps(
                     {
-                        'update_details': {
-                            'updated_by': 'joeblogs'},
+                        'updated_by': 'joeblogs',
                         'services': payload}
                 ),
                 content_type='application/json')
@@ -1007,8 +973,7 @@ class TestShouldCallSearchApiOnPutToCreateService(BaseApplicationTest):
                 '/services/1234567890123456',
                 data=json.dumps(
                     {
-                        'update_details': {
-                            'updated_by': 'joeblogs'},
+                        'updated_by': 'joeblogs',
                         'services': payload}
                 ),
                 content_type='application/json')
@@ -1055,8 +1020,7 @@ class TestShouldCallSearchApiOnPost(BaseApplicationTest):
                 '/services/1234567890123456',
                 data=json.dumps(
                     {
-                        'update_details': {
-                            'updated_by': 'joeblogs'},
+                        'updated_by': 'joeblogs',
                         'services': payload}
                 ),
                 content_type='application/json')
@@ -1081,8 +1045,7 @@ class TestShouldCallSearchApiOnPost(BaseApplicationTest):
                 '/services/1234567890123456',
                 data=json.dumps(
                     {
-                        'update_details': {
-                            'updated_by': 'joeblogs'},
+                        'updated_by': 'joeblogs',
                         'services': payload}
                 ),
                 content_type='application/json')
@@ -1099,8 +1062,7 @@ class TestShouldCallSearchApiOnPost(BaseApplicationTest):
                 '/services/4-G2-0123-456',
                 data=json.dumps(
                     {
-                        'update_details': {
-                            'updated_by': 'joeblogs'},
+                        'updated_by': 'joeblogs',
                         'services': payload}
                 ),
                 content_type='application/json')
@@ -1118,8 +1080,7 @@ class TestShouldCallSearchApiOnPost(BaseApplicationTest):
                 '/services/1234567890123456',
                 data=json.dumps(
                     {
-                        'update_details': {
-                            'updated_by': 'joeblogs'},
+                        'updated_by': 'joeblogs',
                         'services': payload}
                 ),
                 content_type='application/json')
@@ -1186,9 +1147,7 @@ class TestShouldCallSearchApiOnPostStatusUpdate(BaseApplicationTest):
                     new_status
                 ),
                 data=json.dumps(
-                    {'update_details': {
-                        'updated_by': 'joeblogs'}
-                     }),
+                    {'updated_by': 'joeblogs'}),
                 content_type='application/json'
             )
 
@@ -1269,8 +1228,7 @@ class TestShouldCallSearchApiOnPostStatusUpdate(BaseApplicationTest):
                 'published'
             ),
             data=json.dumps(
-                {'update_details': {
-                    'updated_by': 'joeblogs'}}),
+                {'updated_by': 'joeblogs'}),
             content_type='application/json'
         )
 
@@ -1286,9 +1244,7 @@ class TestShouldCallSearchApiOnPostStatusUpdate(BaseApplicationTest):
                 'enabled'
             ),
             data=json.dumps(
-                {'update_details': {
-                    'updated_by': 'joeblogs'}
-                 }),
+                {'updated_by': 'joeblogs'}),
             content_type='application/json'
         )
 
@@ -1328,8 +1284,7 @@ class TestPutService(BaseApplicationTest, JSONUpdateTestMixin):
             response = self.client.put(
                 '/services/1234567890123456',
                 data=json.dumps({
-                    'update_details': {
-                        'updated_by': 'joeblogs'},
+                    'updated_by': 'joeblogs',
                     'services': payload,
                 }),
                 content_type='application/json')
@@ -1354,8 +1309,7 @@ class TestPutService(BaseApplicationTest, JSONUpdateTestMixin):
                 '/services/1234567890123456',
                 data=json.dumps(
                     {
-                        'update_details': {
-                            'updated_by': 'joeblogs'},
+                        'updated_by': 'joeblogs',
                         'services': payload}
                 ),
                 content_type='application/json')
@@ -1402,8 +1356,7 @@ class TestPutService(BaseApplicationTest, JSONUpdateTestMixin):
                 '/services/1234567890123456',
                 data=json.dumps(
                     {
-                        'update_details': {
-                            'updated_by': 'joeblogs'},
+                        'updated_by': 'joeblogs',
                         'services': payload}
                 ),
                 content_type='application/json')
@@ -1438,8 +1391,7 @@ class TestPutService(BaseApplicationTest, JSONUpdateTestMixin):
                 '/services/1234567890123456',
                 data=json.dumps(
                     {
-                        'update_details': {
-                            'updated_by': 'joeblogs'},
+                        'updated_by': 'joeblogs',
                         'services': payload}
                 ),
                 content_type='application/json')
@@ -1481,8 +1433,7 @@ class TestPutService(BaseApplicationTest, JSONUpdateTestMixin):
                 '/services/4-disabled',
                 data=json.dumps(
                     {
-                        'update_details': {
-                            'updated_by': 'joeblogs'},
+                        'updated_by': 'joeblogs',
                         'services': payload}
                 ),
                 content_type='application/json')
@@ -1504,8 +1455,7 @@ class TestPutService(BaseApplicationTest, JSONUpdateTestMixin):
         response = self.client.put(
             '/services/1234567890123456',
             data=json.dumps({
-                'update_details': {
-                    'updated_by': 'joeblogs'},
+                'updated_by': 'joeblogs',
                 'services': {'id': "1234567890123457", 'foo': 'bar'}}),
             content_type='application/json')
 
@@ -1517,8 +1467,7 @@ class TestPutService(BaseApplicationTest, JSONUpdateTestMixin):
         response = self.client.put(
             '/services/abc123456',
             data=json.dumps({
-                'update_details': {
-                    'updated_by': 'joeblogs'},
+                'updated_by': 'joeblogs',
                 'services': {'id': 'abc123456', 'foo': 'bar'}}),
             content_type='application/json')
 
@@ -1529,8 +1478,7 @@ class TestPutService(BaseApplicationTest, JSONUpdateTestMixin):
         response = self.client.put(
             '/services/abcdefghij12345678901',
             data=json.dumps({
-                'update_details': {
-                    'updated_by': 'joeblogs'},
+                'updated_by': 'joeblogs',
                 'services': {'id': 'abcdefghij12345678901', 'foo': 'bar'}}),
             content_type='application/json')
 
@@ -1544,8 +1492,7 @@ class TestPutService(BaseApplicationTest, JSONUpdateTestMixin):
         response = self.client.put(
             '/services/4-invalid-status',
             data=json.dumps({
-                'update_details': {
-                    'updated_by': 'joeblogs'},
+                'updated_by': 'joeblogs',
                 'services': payload}),
             content_type='application/json')
 
@@ -1559,8 +1506,7 @@ class TestPutService(BaseApplicationTest, JSONUpdateTestMixin):
         response = self.client.put(
             '/services/4-invalid-lot',
             data=json.dumps({
-                'update_details': {
-                    'updated_by': 'joeblogs'},
+                'updated_by': 'joeblogs',
                 'services': payload}),
             content_type='application/json')
 
@@ -1576,8 +1522,7 @@ class TestPutService(BaseApplicationTest, JSONUpdateTestMixin):
         response = self.client.put(
             '/services/1234567890123456',
             data=json.dumps({
-                'update_details': {
-                    'updated_by': 'joeblogs'},
+                'updated_by': 'joeblogs',
                 'services': payload
             }),
             content_type='application/json')
@@ -1594,8 +1539,7 @@ class TestPutService(BaseApplicationTest, JSONUpdateTestMixin):
                 '/services/6543210987654321',
                 data=json.dumps(
                     {
-                        'update_details': {
-                            'updated_by': 'joeblogs'},
+                        'updated_by': 'joeblogs',
                         'services': payload}
                 ),
                 content_type='application/json')
@@ -1614,8 +1558,7 @@ class TestPutService(BaseApplicationTest, JSONUpdateTestMixin):
                 '/services/1234567890123456',
                 data=json.dumps(
                     {
-                        'update_details': {
-                            'updated_by': 'joeblogs'},
+                        'updated_by': 'joeblogs',
                         'services': payload}
                 ),
                 content_type='application/json')

--- a/tests/app/views/test_suppliers.py
+++ b/tests/app/views/test_suppliers.py
@@ -1176,10 +1176,7 @@ class TestRegisterFrameworkInterest(BaseApplicationTest, JSONUpdateTestMixin):
     def register_interest(self, supplier_id, framework_slug, user='interested@example.com'):
         return self.client.put(
             '/suppliers/{}/frameworks/{}'.format(supplier_id, framework_slug),
-            data=json.dumps(
-                {
-                    'update_details': {'updated_by': user}
-                }),
+            data=json.dumps({'updated_by': user}),
             content_type='application/json')
 
     def test_can_register_interest_in_open_framework(self):
@@ -1220,7 +1217,7 @@ class TestRegisterFrameworkInterest(BaseApplicationTest, JSONUpdateTestMixin):
                 '/suppliers/1/frameworks/digital-outcomes-and-specialists',
                 data=json.dumps(
                     {
-                        'update_details': {'updated_by': 'interested@example.com'},
+                        'updated_by': 'interested@example.com',
                         'update': {'agreementReturned': True}
                     }),
                 content_type='application/json')
@@ -1274,10 +1271,7 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest, JSONUpdateTestMixin):
             self.set_framework_status('digital-outcomes-and-specialists', 'open')
             self.client.put(
                 '/suppliers/0/frameworks/digital-outcomes-and-specialists',
-                data=json.dumps(
-                    {
-                        'update_details': {'updated_by': 'interested@example.com'}
-                    }),
+                data=json.dumps({'updated_by': 'interested@example.com'}),
                 content_type='application/json')
 
             answers = SupplierFramework(
@@ -1293,7 +1287,7 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest, JSONUpdateTestMixin):
             '/suppliers/{}/frameworks/{}'.format(supplier_id, framework_slug),
             data=json.dumps(
                 {
-                    'update_details': {'updated_by': 'interested@example.com'},
+                    'updated_by': 'interested@example.com',
                     'frameworkInterest': update
                 }),
             content_type='application/json')

--- a/tests/app/views/test_users.py
+++ b/tests/app/views/test_users.py
@@ -543,7 +543,7 @@ class TestUsersUpdate(BaseApplicationTest, JSONUpdateTestMixin):
             response = self.client.post(
                 '/users/123',
                 data=json.dumps({
-                    "update_details": {"updated_by": "a.user"},
+                    "updated_by": "a.user",
                     'users': {
                         'password': '1234567890'
                     }}),
@@ -568,7 +568,7 @@ class TestUsersUpdate(BaseApplicationTest, JSONUpdateTestMixin):
             response = self.client.post(
                 '/users/123',
                 data=json.dumps({
-                    "update_details": {"updated_by": "a.user"},
+                    "updated_by": "a.user",
                     'users': {
                         'password': 'not-in-my-audit-event'
                     }}),
@@ -605,7 +605,7 @@ class TestUsersUpdate(BaseApplicationTest, JSONUpdateTestMixin):
             response = self.client.post(
                 '/users/123',
                 data=json.dumps({
-                    "update_details": {"updated_by": "a.user"},
+                    "updated_by": "a.user",
                     'users': {
                         'active': False
                     }}),
@@ -654,7 +654,7 @@ class TestUsersUpdate(BaseApplicationTest, JSONUpdateTestMixin):
             response = self.client.post(
                 '/users/123',
                 data=json.dumps({
-                    "update_details": {"updated_by": "a.user"},
+                    "updated_by": "a.user",
                     'users': {
                         'locked': False
                     }}),
@@ -688,7 +688,7 @@ class TestUsersUpdate(BaseApplicationTest, JSONUpdateTestMixin):
             response = self.client.post(
                 '/users/123',
                 data=json.dumps({
-                    "update_details": {"updated_by": "a.user"},
+                    "updated_by": "a.user",
                     'users': {
                         'locked': True
                     }}),
@@ -712,7 +712,7 @@ class TestUsersUpdate(BaseApplicationTest, JSONUpdateTestMixin):
             response = self.client.post(
                 '/users/123',
                 data=json.dumps({
-                    "update_details": {"updated_by": "a.user"},
+                    "updated_by": "a.user",
                     'users': {
                         'name': 'I Just Got Married'
                     }}),
@@ -739,7 +739,7 @@ class TestUsersUpdate(BaseApplicationTest, JSONUpdateTestMixin):
             response = self.client.post(
                 '/users/123',
                 data=json.dumps({
-                    "update_details": {"updated_by": "a.user"},
+                    "updated_by": "a.user",
                     'users': {
                         'name': 'I Just Got Married'
                     }}),
@@ -763,7 +763,7 @@ class TestUsersUpdate(BaseApplicationTest, JSONUpdateTestMixin):
             response = self.client.post(
                 '/users/123',
                 data=json.dumps({
-                    "update_details": {"updated_by": "a.user"},
+                    "updated_by": "a.user",
                     'users': {
                         'role': 'supplier',
                         'supplierId': 456
@@ -791,7 +791,7 @@ class TestUsersUpdate(BaseApplicationTest, JSONUpdateTestMixin):
             response = self.client.post(
                 '/users/123',
                 data=json.dumps({
-                    "update_details": {"updated_by": "a.user"},
+                    "updated_by": "a.user",
                     'users': {
                         'role': 'buyer'
                     }}),
@@ -818,7 +818,7 @@ class TestUsersUpdate(BaseApplicationTest, JSONUpdateTestMixin):
         response = self.client.post(
             '/users/456',
             data=json.dumps({
-                'update_details': {'updated_by': 'a.user'},
+                'updated_by': 'a.user',
                 'users': {
                     'role': 'buyer',
                     'emailAddress': 'bad@example.com',
@@ -832,7 +832,7 @@ class TestUsersUpdate(BaseApplicationTest, JSONUpdateTestMixin):
         response = self.client.post(
             '/users/456',
             data=json.dumps({
-                'update_details': {'updated_by': 'a.user'},
+                'updated_by': 'a.user',
                 'users': {'emailAddress': 'bad@example.com'},
             }),
             content_type='application/json')
@@ -842,7 +842,7 @@ class TestUsersUpdate(BaseApplicationTest, JSONUpdateTestMixin):
         response = self.client.post(
             '/users/456',
             data=json.dumps({
-                'update_details': {'updated_by': 'a.user'},
+                'updated_by': 'a.user',
                 'users': {'role': 'buyer'},
             }),
             content_type='application/json')
@@ -855,7 +855,7 @@ class TestUsersUpdate(BaseApplicationTest, JSONUpdateTestMixin):
             response = self.client.post(
                 '/users/456',
                 data=json.dumps({
-                    "update_details": {"updated_by": "a.user"},
+                    "updated_by": "a.user",
                     'users': {
                         'role': 'buyer',
                         'supplierId': 456
@@ -872,7 +872,7 @@ class TestUsersUpdate(BaseApplicationTest, JSONUpdateTestMixin):
             response = self.client.post(
                 '/users/123',
                 data=json.dumps({
-                    "update_details": {"updated_by": "a.user"},
+                    "updated_by": "a.user",
                     'users': {
                         'role': 'shopkeeper'
                     }}),
@@ -886,7 +886,7 @@ class TestUsersUpdate(BaseApplicationTest, JSONUpdateTestMixin):
         response = self.client.post(
             '/users/123',
             data=json.dumps({
-                "update_details": {"updated_by": "a.user"},
+                "updated_by": "a.user",
                 'users': {
                     'role': 'supplier'
                 }}),
@@ -901,7 +901,7 @@ class TestUsersUpdate(BaseApplicationTest, JSONUpdateTestMixin):
             response = self.client.post(
                 '/users/123',
                 data=json.dumps({
-                    "update_details": {"updated_by": "a.user"},
+                    "updated_by": "a.user",
                     'users': {
                         'emailAddress': 'myshinynew@digital.gov.uk'
                     }}),
@@ -1027,7 +1027,7 @@ class TestUsersExport(BaseUserTest):
         with self.app.app_context():
             self.framework_slug = 'digital-outcomes-and-specialists'
             self.set_framework_status(self.framework_slug, 'open')
-            self.updater_json = {'update_details': {'updated_by': 'Paul'}}
+            self.updater_json = {'updated_by': 'Paul'}
 
     def _post_users(self):
         users = [
@@ -1060,7 +1060,7 @@ class TestUsersExport(BaseUserTest):
 
     def _put_declaration(self, status):
         data = {'declaration': {'status': status}}
-        data.update(self.updater_json['update_details'])
+        data.update(self.updater_json)
 
         response = self.client.put(
             '/suppliers/{}/frameworks/{}/declaration'.format(self.supplier_id, self.framework_slug),
@@ -1111,8 +1111,8 @@ class TestUsersExport(BaseUserTest):
         self._post_framework_interest({'frameworkInterest': {'agreementReturned': True}})
 
     def _post_result(self, result):
-        data = {'frameworkInterest': {'onFramework': result}, 'update_details': {'updated_by': 'Paul'}}
-        data.update(self.updater_json['update_details'])
+        data = {'frameworkInterest': {'onFramework': result}, 'updated_by': 'Paul'}
+        data.update(self.updater_json)
         response = self.client.post(
             '/suppliers/{}/frameworks/{}'.format(self.supplier_id, self.framework_slug),
             data=json.dumps(data),
@@ -1301,7 +1301,7 @@ class TestUsersExport(BaseUserTest):
             '/users/{}'.format(self.users[-1]['id']),
             data=json.dumps({
                 "users": {"active": False},
-                "update_details": {"updated_by": "test"}
+                "updated_by": "test"
             }),
             content_type='application/json')
         assert response.status_code == 200


### PR DESCRIPTION
The API client never sends `update_details` any more, so the API should just expect `updated_by`.

Thought this was a one-line change (in `suppliers.py`), but ended up sorting out the tests too. The only change everywhere here is to remove `update_details` in favour of plain old `updated_by`.