### PR TITLE
Don't allow updating or deleting closed briefs

### DIFF
--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -74,8 +74,8 @@ def update_brief(brief_id):
         Brief.id == brief_id
     ).first_or_404()
 
-    if brief.status == 'live':
-        abort(400, "Cannot update a live brief")
+    if brief.status != 'draft':
+        abort(400, "Cannot update a {} brief".format(brief.status))
 
     brief.update_from_json(brief_json)
 
@@ -187,8 +187,8 @@ def delete_draft_brief(brief_id):
         Brief.id == brief_id
     ).first_or_404()
 
-    if brief.status == 'live':
-        abort(400, "Cannot delete a live brief")
+    if brief.status != 'draft':
+        abort(400, "Cannot delete a {} brief".format(brief.status))
 
     audit = AuditEvent(
         audit_type=AuditTypes.delete_brief,

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 import os
 import json
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from nose.tools import assert_equal, assert_in
 
@@ -87,6 +87,10 @@ class BaseApplicationTest(object):
             return user.id
 
     def setup_dummy_briefs(self, n, title=None, status='draft', user_id=1, brief_start=1):
+        if status == 'closed':
+            published_at = datetime.utcnow() - timedelta(days=1000)
+        else:
+            published_at = None if status == 'draft' else datetime.utcnow()
         user_id = self.setup_dummy_user(id=user_id)
 
         with self.app.app_context():
@@ -97,10 +101,10 @@ class BaseApplicationTest(object):
             for i in range(brief_start, brief_start + n):
                 db.session.add(Brief(
                     id=i,
-                    status=status,
                     data=data,
                     framework=framework,
                     lot=lot,
+                    published_at=published_at,
                     users=[User.query.get(user_id)]
                 ))
             db.session.commit()


### PR DESCRIPTION
### Change setup_dummy_briefs helper to support 'closed' status
Sets the published_at field directly instead of setting the status property.

### Don't allow updating or deleting closed briefs
Changes brief status checks to look for non-'draft' briefs instead of checking for 'live' status only. This way, 'live' and 'closed' briefs aren't allowed to be updated or removed and the check will cover any similar statuses added in the future.

Fixes the missing `test_` in test name for live brief delete.