### PR TITLE
[#114207705] Allow filtering briefs by multiple statuses, lot and framework

### DIFF
--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -4,7 +4,7 @@ from sqlalchemy.exc import IntegrityError
 from dmapiclient.audit import AuditTypes
 from .. import main
 from ... import db
-from ...models import User, Brief, AuditEvent
+from ...models import User, Brief, AuditEvent, Framework, Lot
 from ...utils import (
     get_json_from_request, get_int_or_400, json_has_required_keys, pagination_links,
     get_valid_page_or_1, get_request_page_questions, validate_and_return_updater_request
@@ -116,6 +116,12 @@ def list_briefs():
 
     if user_id:
         briefs = briefs.filter(Brief.users.any(id=user_id))
+
+    if request.args.get('framework'):
+        briefs = briefs.filter(Brief.framework.has(Framework.slug == request.args.get('framework')))
+
+    if request.args.get('lot'):
+        briefs = briefs.filter(Brief.lot.has(Lot.slug == request.args.get('lot')))
 
     if request.args.get('status'):
         briefs = briefs.has_statuses(*[

--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -109,17 +109,18 @@ def get_brief(brief_id):
 
 @main.route('/briefs', methods=['GET'])
 def list_briefs():
-    briefs = Brief.query.order_by(Brief.id)
+    briefs = Brief.query.order_by(Brief.published_at.desc(), Brief.id)
     page = get_valid_page_or_1()
 
     user_id = get_int_or_400(request.args, 'user_id')
-    status = request.args.get('status')
 
     if user_id:
         briefs = briefs.filter(Brief.users.any(id=user_id))
 
-    if status:
-        briefs = briefs.filter(Brief.status == status)
+    if request.args.get('status'):
+        briefs = briefs.has_statuses(*[
+            status.strip() for status in request.args['status'].split(',')
+            ])
 
     briefs = briefs.paginate(
         page=page,

--- a/app/models.py
+++ b/app/models.py
@@ -899,6 +899,10 @@ class Brief(db.Model):
             (cls.applications_closed_at > datetime.utcnow(), 'live')
         ], else_='closed')
 
+    class query_class(BaseQuery):
+        def has_statuses(self, *statuses):
+            return self.filter(Brief.status.in_(statuses))
+
     def add_clarification_question(self, question, answer):
         clarification_question = BriefClarificationQuestion(
             brief=self,

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -86,7 +86,7 @@ class BaseApplicationTest(object):
 
             return user.id
 
-    def setup_dummy_briefs(self, n, title=None, status='draft', user_id=1, brief_start=1):
+    def setup_dummy_briefs(self, n, title=None, status='draft', user_id=1, brief_start=1, lot="digital-specialists"):
         if status == 'closed':
             published_at = datetime.utcnow() - timedelta(days=1000)
         else:
@@ -95,7 +95,7 @@ class BaseApplicationTest(object):
 
         with self.app.app_context():
             framework = Framework.query.filter(Framework.slug == "digital-outcomes-and-specialists").first()
-            lot = Lot.query.filter(Lot.slug == "digital-specialists").first()
+            lot = Lot.query.filter(Lot.slug == lot).first()
             data = COMPLETE_DIGITAL_SPECIALISTS_BRIEF.copy()
             data["title"] = title
             for i in range(brief_start, brief_start + n):

--- a/tests/app/views/test_briefs.py
+++ b/tests/app/views/test_briefs.py
@@ -437,6 +437,58 @@ class TestBriefs(BaseApplicationTest):
         assert res.status_code == 200
         assert len(data['briefs']) == 5, data['briefs']
 
+    def test_list_briefs_by_framework(self):
+        self.setup_dummy_briefs(3, status='live')
+        self.setup_dummy_briefs(2, status='draft', brief_start=4)
+
+        res = self.client.get('/briefs?framework=digital-outcomes-and-specialists')
+        data = json.loads(res.get_data(as_text=True))
+
+        assert res.status_code == 200
+        assert len(data['briefs']) == 5, data['briefs']
+
+    def test_cannot_list_briefs_by_invalid_framework(self):
+        self.setup_dummy_briefs(1, status='live')
+        self.setup_dummy_briefs(1, status='draft', brief_start=2)
+
+        res = self.client.get('/briefs?framework=digital-biscuits-and-cakes')
+        data = json.loads(res.get_data(as_text=True))
+
+        assert res.status_code == 200
+        assert len(data['briefs']) == 0
+
+    def test_list_briefs_by_framework_and_status(self):
+        self.setup_dummy_briefs(3, status='live')
+        self.setup_dummy_briefs(2, status='draft', brief_start=4)
+
+        res = self.client.get('/briefs?framework=digital-outcomes-and-specialists&status=draft')
+        data = json.loads(res.get_data(as_text=True))
+
+        assert res.status_code == 200
+        assert len(data['briefs']) == 2, data['briefs']
+
+    def test_list_briefs_by_lot(self):
+        self.setup_dummy_briefs(3, status='live', lot='digital-outcomes')
+        self.setup_dummy_briefs(1, status='draft', lot='digital-outcomes', brief_start=4)
+        self.setup_dummy_briefs(2, status='live', lot='digital-specialists', brief_start=5)
+
+        res = self.client.get('/briefs?lot=digital-outcomes')
+        data = json.loads(res.get_data(as_text=True))
+
+        assert res.status_code == 200
+        assert len(data['briefs']) == 4, data['briefs']
+
+    def test_list_briefs_by_lot_and_status(self):
+        self.setup_dummy_briefs(3, status='live', lot='digital-outcomes')
+        self.setup_dummy_briefs(1, status='draft', lot='digital-outcomes', brief_start=4)
+        self.setup_dummy_briefs(2, status='live', lot='digital-specialists', brief_start=5)
+
+        res = self.client.get('/briefs?lot=digital-outcomes&status=live')
+        data = json.loads(res.get_data(as_text=True))
+
+        assert res.status_code == 200
+        assert len(data['briefs']) == 3, data['briefs']
+
     def test_list_briefs_pagination_page_one(self):
         self.setup_dummy_briefs(7)
 

--- a/tests/app/views/test_briefs.py
+++ b/tests/app/views/test_briefs.py
@@ -427,6 +427,16 @@ class TestBriefs(BaseApplicationTest):
         assert res.status_code == 200
         assert len(data['briefs']) == 0
 
+    def test_list_briefs_by_multiple_statuses(self):
+        self.setup_dummy_briefs(3, status='live')
+        self.setup_dummy_briefs(2, status='draft', brief_start=4)
+
+        res = self.client.get('/briefs?status=draft,live')
+        data = json.loads(res.get_data(as_text=True))
+
+        assert res.status_code == 200
+        assert len(data['briefs']) == 5, data['briefs']
+
     def test_list_briefs_pagination_page_one(self):
         self.setup_dummy_briefs(7)
 


### PR DESCRIPTION
Required for: https://www.pivotaltracker.com/story/show/114207705

We need both `live` and `closed` briefs in a single list for the catalogue of briefs in the frontend.

This mimics the `has_statuses` query that we already have for selecting services with multiple different statuses.

Also now allows filtering briefs by framework and lot slugs.