### PR TITLE
Add briefs object type support to audit-events endpoints

### DIFF
--- a/app/main/views/audits.py
+++ b/app/main/views/audits.py
@@ -19,6 +19,7 @@ AUDIT_OBJECT_TYPES = {
     "services": models.Service,
     "frameworks": models.Framework,
     "users": models.User,
+    "briefs": models.Brief,
 }
 
 AUDIT_OBJECT_ID_FIELDS = {
@@ -26,6 +27,7 @@ AUDIT_OBJECT_ID_FIELDS = {
     "services": models.Service.service_id,
     "frameworks": models.Framework.slug,
     "users": models.User.id,
+    "briefs": models.Brief.id,
 }
 
 


### PR DESCRIPTION
Adds 'briefs' as possible value for audit event `object-type`, both for creating and filtering audit events.

This allows us to create audit events related to brief objects from other apps, eg creating events for brief clarification questions.