### PR TITLE
Do not paginate briefs fetch if user_id is supplied

### DIFF
--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -128,18 +128,24 @@ def list_briefs():
             status.strip() for status in request.args['status'].split(',')
             ])
 
-    briefs = briefs.paginate(
-        page=page,
-        per_page=current_app.config['DM_API_BRIEFS_PAGE_SIZE'])
-
-    return jsonify(
-        briefs=[brief.serialize() for brief in briefs.items],
-        links=pagination_links(
-            briefs,
-            '.list_briefs',
-            request.args
+    if user_id:
+        return jsonify(
+            briefs=[brief.serialize() for brief in briefs.all()],
+            links=dict()
         )
-    )
+    else:
+        briefs = briefs.paginate(
+            page=page,
+            per_page=current_app.config['DM_API_BRIEFS_PAGE_SIZE'])
+
+        return jsonify(
+            briefs=[brief.serialize() for brief in briefs.items],
+            links=pagination_links(
+                briefs,
+                '.list_briefs',
+                request.args
+            )
+        )
 
 
 @main.route('/briefs/<int:brief_id>/status', methods=['PUT'])

--- a/tests/app/views/test_briefs.py
+++ b/tests/app/views/test_briefs.py
@@ -512,6 +512,17 @@ class TestBriefs(BaseApplicationTest):
         assert len(data['briefs']) == 2
         assert data['links']['prev'] == 'http://localhost/briefs?page=1'
 
+    def test_list_briefs_no_pagination_if_user_id_supplied(self):
+        self.setup_dummy_briefs(7)
+
+        res = self.client.get('/briefs?user_id=1')
+        data = json.loads(res.get_data(as_text=True))
+
+        assert res.status_code == 200
+
+        assert len(data['briefs']) == 7
+        assert data['links'] == {}
+
     def test_make_a_brief_live(self):
         self.setup_dummy_briefs(1, title='The Title')
 


### PR DESCRIPTION
For a single user we should return all briefs - this is useful, e.g. for the buyer dashboard in the frontend.