### PR TITLE
Add endpoint to add a framework

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1,5 +1,6 @@
 import random
 from datetime import datetime, timedelta
+import re
 
 from flask import current_app
 from flask_sqlalchemy import BaseQuery
@@ -115,8 +116,16 @@ class Framework(db.Model):
             raise ValidationError("Invalid framework value '{}'".format(framework))
         return framework
 
+    slug_pattern = re.compile("^[\w-]+$")
+
+    @validates("slug")
+    def validates_slug(self, key, slug):
+        if not self.slug_pattern.match(slug):
+            raise ValidationError("Invalid slug value '{}'".format(slug))
+        return slug
+
     def __repr__(self):
-        return '<{}: {}>'.format(self.__class__.__name__, self.name)
+        return '<{}: {} slug={}>'.format(self.__class__.__name__, self.name, self.slug)
 
 
 class ContactInformation(db.Model):

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ SQLAlchemy==1.0.5
 SQLAlchemy-Utils==0.30.5
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@16.0.0#egg=digitalmarketplace-utils==16.0.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@3.1.0#egg=digitalmarketplace-apiclient==3.1.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@3.7.0#egg=digitalmarketplace-apiclient==3.7.0
 
 # For schema validation
 jsonschema==2.5.1


### PR DESCRIPTION
The error message for invalid clarification questions flag is less than ideal. This is because if handled with a validtor method we would raise an error with a field name that does not match that given in the request and when handled with a DataError we can't easily be sure that the error is caused by invalid clarification questions flag.