### PR TITLE
Update JSON schemas from latest content

### DIFF
--- a/json_schemas/brief-responses-digital-outcomes-and-specialists-digital-outcomes.json
+++ b/json_schemas/brief-responses-digital-outcomes-and-specialists-digital-outcomes.json
@@ -19,7 +19,7 @@
       "type": "array"
     },
     "respondToEmailAddress": {
-      "minLength": 1,
+      "format": "email",
       "type": "string"
     }
   },

--- a/json_schemas/brief-responses-digital-outcomes-and-specialists-digital-outcomes.json
+++ b/json_schemas/brief-responses-digital-outcomes-and-specialists-digital-outcomes.json
@@ -17,10 +17,15 @@
       "maxItems": 10,
       "minItems": 0,
       "type": "array"
+    },
+    "respondToEmailAddress": {
+      "minLength": 1,
+      "type": "string"
     }
   },
   "required": [
-    "essentialRequirements"
+    "essentialRequirements",
+    "respondToEmailAddress"
   ],
   "title": "Digital Outcomes and Specialists Digital outcomes Brief Response Schema",
   "type": "object"

--- a/json_schemas/brief-responses-digital-outcomes-and-specialists-digital-specialists.json
+++ b/json_schemas/brief-responses-digital-outcomes-and-specialists-digital-specialists.json
@@ -29,7 +29,7 @@
       "type": "array"
     },
     "respondToEmailAddress": {
-      "minLength": 1,
+      "format": "email",
       "type": "string"
     },
     "specialistName": {

--- a/json_schemas/brief-responses-digital-outcomes-and-specialists-digital-specialists.json
+++ b/json_schemas/brief-responses-digital-outcomes-and-specialists-digital-specialists.json
@@ -28,6 +28,10 @@
       "minItems": 0,
       "type": "array"
     },
+    "respondToEmailAddress": {
+      "minLength": 1,
+      "type": "string"
+    },
     "specialistName": {
       "maxLength": 100,
       "minLength": 1,
@@ -38,6 +42,7 @@
     "availability",
     "dayRate",
     "essentialRequirements",
+    "respondToEmailAddress",
     "specialistName"
   ],
   "title": "Digital Outcomes and Specialists Digital specialists Brief Response Schema",

--- a/json_schemas/brief-responses-digital-outcomes-and-specialists-user-research-participants.json
+++ b/json_schemas/brief-responses-digital-outcomes-and-specialists-user-research-participants.json
@@ -19,7 +19,7 @@
       "type": "array"
     },
     "respondToEmailAddress": {
-      "minLength": 1,
+      "format": "email",
       "type": "string"
     },
     "userParticipantResponse": {

--- a/json_schemas/brief-responses-digital-outcomes-and-specialists-user-research-participants.json
+++ b/json_schemas/brief-responses-digital-outcomes-and-specialists-user-research-participants.json
@@ -2,12 +2,34 @@
   "$schema": "http://json-schema.org/schema#",
   "additionalProperties": false,
   "properties": {
+    "essentialRequirements": {
+      "items": {
+        "type": "boolean"
+      },
+      "maxItems": 10,
+      "minItems": 1,
+      "type": "array"
+    },
+    "niceToHaveRequirements": {
+      "items": {
+        "type": "boolean"
+      },
+      "maxItems": 10,
+      "minItems": 0,
+      "type": "array"
+    },
+    "respondToEmailAddress": {
+      "minLength": 1,
+      "type": "string"
+    },
     "userParticipantResponse": {
       "minLength": 1,
       "type": "string"
     }
   },
   "required": [
+    "essentialRequirements",
+    "respondToEmailAddress",
     "userParticipantResponse"
   ],
   "title": "Digital Outcomes and Specialists User research participants Brief Response Schema",

--- a/json_schemas/briefs-digital-outcomes-and-specialists-user-research-participants.json
+++ b/json_schemas/briefs-digital-outcomes-and-specialists-user-research-participants.json
@@ -7,6 +7,16 @@
       "pattern": "^(?:\\S+\\s+){0,99}\\S+$",
       "type": "string"
     },
+    "essentialRequirements": {
+      "items": {
+        "maxLength": 100,
+        "pattern": "^(?:\\S+\\s+){0,9}\\S+$",
+        "type": "string"
+      },
+      "maxItems": 10,
+      "minItems": 1,
+      "type": "array"
+    },
     "location": {
       "enum": [
         "Scotland",
@@ -24,6 +34,16 @@
         "International (outside the UK)"
       ]
     },
+    "niceToHaveRequirements": {
+      "items": {
+        "maxLength": 100,
+        "pattern": "^(?:\\S+\\s+){0,9}\\S+$",
+        "type": "string"
+      },
+      "maxItems": 10,
+      "minItems": 0,
+      "type": "array"
+    },
     "organisation": {
       "maxLength": 100,
       "minLength": 1,
@@ -37,6 +57,7 @@
   },
   "required": [
     "backgroundInformation",
+    "essentialRequirements",
     "location",
     "organisation",
     "title"

--- a/tests/example_listings.py
+++ b/tests/example_listings.py
@@ -3,7 +3,7 @@ from hypothesis.strategies import (
     fixed_dictionaries, lists,
     booleans, integers, text, none,
     composite, sampled_from, one_of,
-)
+    just)
 
 settings.register_profile("unit", settings(
     database=None,
@@ -29,6 +29,7 @@ def brief_response_data(essential_count=5, nice_to_have_count=5):
     return fixed_dictionaries({
         "essentialRequirements": requirements_list(essential_count, answers=True),
         "niceToHaveRequirements": requirements_list(nice_to_have_count, answers=True),
+        "respondToEmailAddress": just("supplier@email.com"),
     })
 
 


### PR DESCRIPTION
I still think we also need to make `niceToHaveRequirements` required, but that can be part of the wider overhaul of content that will have to come at some point soon.

This adds the email address required for brief responses, so we know who to tell buyers to contact.

**UPDATE** - the email format validation in the second commit is auto-generated from the content in this pull-request: https://github.com/alphagov/digitalmarketplace-frameworks/pull/215