### PR TITLE
Criteria weighting validation

### DIFF
--- a/app/brief_utils.py
+++ b/app/brief_utils.py
@@ -13,6 +13,14 @@ def validate_brief_data(brief, enforce_required=True, required_fields=None):
         required_fields=required_fields
     )
 
+    criteria_weighting_keys = ['technicalWeighting', 'culturalWeighting', 'priceWeighting']
+    # Only check total if all weightings are set
+    if all(key in brief.data for key in criteria_weighting_keys):
+        criteria_weightings = sum(brief.data[key] for key in criteria_weighting_keys)
+        if criteria_weightings != 100:
+            for key in set(criteria_weighting_keys) - set(errs):
+                errs[key] = 'total_should_be_100'
+
     if errs:
         abort(400, errs)
 

--- a/json_schemas/briefs-digital-outcomes-and-specialists-digital-outcomes.json
+++ b/json_schemas/briefs-digital-outcomes-and-specialists-digital-outcomes.json
@@ -17,6 +17,12 @@
       "minLength": 1,
       "type": "string"
     },
+    "culturalWeighting": {
+      "exclusiveMaximum": true,
+      "maximum": 20,
+      "minimum": 5,
+      "type": "integer"
+    },
     "currentTechnologies": {
       "minLength": 0,
       "pattern": "^$|(^(?:\\S+\\s+){0,99}\\S+$)",
@@ -107,6 +113,12 @@
         "live"
       ]
     },
+    "priceWeighting": {
+      "exclusiveMaximum": true,
+      "maximum": 85,
+      "minimum": 20,
+      "type": "integer"
+    },
     "startDate": {
       "maxLength": 100,
       "minLength": 1,
@@ -116,6 +128,12 @@
       "minLength": 1,
       "pattern": "^(?:\\S+\\s+){0,99}\\S+$",
       "type": "string"
+    },
+    "technicalWeighting": {
+      "exclusiveMaximum": true,
+      "maximum": 75,
+      "minimum": 10,
+      "type": "integer"
     },
     "title": {
       "maxLength": 100,
@@ -136,6 +154,7 @@
   "required": [
     "backgroundInformation",
     "contractLength",
+    "culturalWeighting",
     "endUsers",
     "essentialRequirements",
     "evaluationType",
@@ -143,8 +162,10 @@
     "location",
     "organisation",
     "outcome",
+    "priceWeighting",
     "startDate",
     "successCriteria",
+    "technicalWeighting",
     "title",
     "userNeeds"
   ],

--- a/json_schemas/briefs-digital-outcomes-and-specialists-digital-outcomes.json
+++ b/json_schemas/briefs-digital-outcomes-and-specialists-digital-outcomes.json
@@ -18,7 +18,7 @@
       "type": "string"
     },
     "culturalWeighting": {
-      "exclusiveMaximum": true,
+      "exclusiveMaximum": false,
       "maximum": 20,
       "minimum": 5,
       "type": "integer"
@@ -114,7 +114,7 @@
       ]
     },
     "priceWeighting": {
-      "exclusiveMaximum": true,
+      "exclusiveMaximum": false,
       "maximum": 85,
       "minimum": 20,
       "type": "integer"
@@ -130,7 +130,7 @@
       "type": "string"
     },
     "technicalWeighting": {
-      "exclusiveMaximum": true,
+      "exclusiveMaximum": false,
       "maximum": 75,
       "minimum": 10,
       "type": "integer"

--- a/json_schemas/briefs-digital-outcomes-and-specialists-digital-specialists.json
+++ b/json_schemas/briefs-digital-outcomes-and-specialists-digital-specialists.json
@@ -17,6 +17,12 @@
       "minLength": 1,
       "type": "string"
     },
+    "culturalWeighting": {
+      "exclusiveMaximum": true,
+      "maximum": 20,
+      "minimum": 5,
+      "type": "integer"
+    },
     "currentTechnologies": {
       "minLength": 0,
       "pattern": "^$|(^(?:\\S+\\s+){0,99}\\S+$)",
@@ -83,6 +89,12 @@
       "minLength": 1,
       "type": "string"
     },
+    "priceWeighting": {
+      "exclusiveMaximum": true,
+      "maximum": 85,
+      "minimum": 20,
+      "type": "integer"
+    },
     "specialistRole": {
       "enum": [
         "agileCoach",
@@ -107,6 +119,12 @@
       "minLength": 1,
       "type": "string"
     },
+    "technicalWeighting": {
+      "exclusiveMaximum": true,
+      "maximum": 75,
+      "minimum": 10,
+      "type": "integer"
+    },
     "title": {
       "maxLength": 100,
       "minLength": 1,
@@ -121,13 +139,16 @@
   "required": [
     "backgroundInformation",
     "contractLength",
+    "culturalWeighting",
     "essentialRequirements",
     "evaluationType",
     "importantDates",
     "location",
     "organisation",
+    "priceWeighting",
     "specialistRole",
     "startDate",
+    "technicalWeighting",
     "title"
   ],
   "title": "Digital Outcomes and Specialists Digital specialists Brief Schema",

--- a/json_schemas/briefs-digital-outcomes-and-specialists-digital-specialists.json
+++ b/json_schemas/briefs-digital-outcomes-and-specialists-digital-specialists.json
@@ -18,7 +18,7 @@
       "type": "string"
     },
     "culturalWeighting": {
-      "exclusiveMaximum": true,
+      "exclusiveMaximum": false,
       "maximum": 20,
       "minimum": 5,
       "type": "integer"
@@ -90,7 +90,7 @@
       "type": "string"
     },
     "priceWeighting": {
-      "exclusiveMaximum": true,
+      "exclusiveMaximum": false,
       "maximum": 85,
       "minimum": 20,
       "type": "integer"
@@ -120,7 +120,7 @@
       "type": "string"
     },
     "technicalWeighting": {
-      "exclusiveMaximum": true,
+      "exclusiveMaximum": false,
       "maximum": 75,
       "minimum": 10,
       "type": "integer"

--- a/json_schemas/briefs-digital-outcomes-and-specialists-user-research-participants.json
+++ b/json_schemas/briefs-digital-outcomes-and-specialists-user-research-participants.json
@@ -7,6 +7,12 @@
       "pattern": "^(?:\\S+\\s+){0,99}\\S+$",
       "type": "string"
     },
+    "culturalWeighting": {
+      "exclusiveMaximum": true,
+      "maximum": 70,
+      "minimum": 10,
+      "type": "integer"
+    },
     "essentialRequirements": {
       "items": {
         "maxLength": 100,
@@ -49,6 +55,18 @@
       "minLength": 1,
       "type": "string"
     },
+    "priceWeighting": {
+      "exclusiveMaximum": true,
+      "maximum": 80,
+      "minimum": 20,
+      "type": "integer"
+    },
+    "technicalWeighting": {
+      "exclusiveMaximum": true,
+      "maximum": 70,
+      "minimum": 10,
+      "type": "integer"
+    },
     "title": {
       "maxLength": 100,
       "minLength": 1,
@@ -57,9 +75,12 @@
   },
   "required": [
     "backgroundInformation",
+    "culturalWeighting",
     "essentialRequirements",
     "location",
     "organisation",
+    "priceWeighting",
+    "technicalWeighting",
     "title"
   ],
   "title": "Digital Outcomes and Specialists User research participants Brief Schema",

--- a/json_schemas/briefs-digital-outcomes-and-specialists-user-research-participants.json
+++ b/json_schemas/briefs-digital-outcomes-and-specialists-user-research-participants.json
@@ -8,7 +8,7 @@
       "type": "string"
     },
     "culturalWeighting": {
-      "exclusiveMaximum": true,
+      "exclusiveMaximum": false,
       "maximum": 70,
       "minimum": 10,
       "type": "integer"
@@ -56,13 +56,13 @@
       "type": "string"
     },
     "priceWeighting": {
-      "exclusiveMaximum": true,
+      "exclusiveMaximum": false,
       "maximum": 80,
       "minimum": 20,
       "type": "integer"
     },
     "technicalWeighting": {
-      "exclusiveMaximum": true,
+      "exclusiveMaximum": false,
       "maximum": 70,
       "minimum": 10,
       "type": "integer"

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -27,6 +27,9 @@ COMPLETE_DIGITAL_SPECIALISTS_BRIEF = {
     "startDate": "12th February 2016",
     "title": "I need a Developer",
     "workingArrangements": "",
+    "culturalWeighting": 10,
+    "priceWeighting": 20,
+    "technicalWeighting": 70,
 }
 
 

--- a/tests/app/views/test_briefs.py
+++ b/tests/app/views/test_briefs.py
@@ -315,6 +315,40 @@ class TestBriefs(BaseApplicationTest):
         assert res.status_code == 400
         assert data['error'] == {'title': 'under_character_limit'}
 
+    def test_update_brief_criteria_weightings(self):
+        self.setup_dummy_briefs(1)
+
+        res = self.client.post(
+            '/briefs/1',
+            data=json.dumps({
+                'briefs': {'technicalWeighting': 68, 'culturalWeighting': 7, 'priceWeighting': 25},
+                'update_details': {'updated_by': 'example'},
+            }),
+            content_type='application/json')
+        data = json.loads(res.get_data(as_text=True))
+
+        assert res.status_code == 200
+        assert data['briefs']['technicalWeighting'] == 68
+
+    def test_update_brief_criteria_validation(self):
+        self.setup_dummy_briefs(1)
+
+        res = self.client.post(
+            '/briefs/1',
+            data=json.dumps({
+                'briefs': {'technicalWeighting': 15, 'culturalWeighting': 80, 'priceWeighting': 30},
+                'update_details': {'updated_by': 'example'},
+            }),
+            content_type='application/json')
+        data = json.loads(res.get_data(as_text=True))
+
+        assert res.status_code == 400
+        assert data['error'] == {
+            "culturalWeighting": "not_a_number",
+            "priceWeighting": "total_should_be_100",
+            "technicalWeighting": "total_should_be_100"
+        }
+
     def test_update_brief_returns_404_if_not_found(self):
         res = self.client.post(
             '/briefs/1',


### PR DESCRIPTION
#### Add weighting fields to brief JSON schemas

### Add criteria weighting 100% total validation
Checks the criteria weighting sum if all criteria fields are set.
This relies on all three fields being required.

If the fields don't add up to a 100 an error is added for each field
that doesn't have any other validation errors.