### PR TITLE
Return correct error message for non-integer values

### DIFF
--- a/app/brief_utils.py
+++ b/app/brief_utils.py
@@ -15,10 +15,10 @@ def validate_brief_data(brief, enforce_required=True, required_fields=None):
 
     criteria_weighting_keys = ['technicalWeighting', 'culturalWeighting', 'priceWeighting']
     # Only check total if all weightings are set
-    if all(key in brief.data for key in criteria_weighting_keys):
+    if not errs and all(key in brief.data for key in criteria_weighting_keys):
         criteria_weightings = sum(brief.data[key] for key in criteria_weighting_keys)
         if criteria_weightings != 100:
-            for key in set(criteria_weighting_keys) - set(errs):
+            for key in criteria_weighting_keys:
                 errs[key] = 'total_should_be_100'
 
     if errs:

--- a/app/validation.py
+++ b/app/validation.py
@@ -261,7 +261,7 @@ def _translate_json_schema_error(key, validator, validator_value, message):
     elif validator == 'enum' and key == 'priceUnit':
         return 'no_unit_specified'
 
-    elif validator == 'type' and validator_value == 'number':
+    elif validator == 'type' and validator_value in ['number', 'integer']:
         return 'not_a_number'
 
     elif validator == 'type' and validator_value == 'boolean':


### PR DESCRIPTION
Passing in non-integer values to fields that expected them (for example, [some of our 'weighting' keys](https://github.com/alphagov/digitalmarketplace-api/blob/master/json_schemas/briefs-digital-outcomes-and-specialists-digital-specialists.json#L20) used to return the wrong error message.

Also changed the logic around validating the sum of all of our weightings (they have to add up to 100) such that we won't try and sum the three values unless they've individually been validated successfully.