### PR TITLE
Change brief application and questions closing times to 23:59

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -867,16 +867,16 @@ class Brief(db.Model):
         if self.published_at is None:
             return None
 
-        # Set time to midnight next day and add full number of days before application closes
-        published_day = self.published_at.replace(hour=0, minute=0, second=0, microsecond=0)
-        closing_time = published_day + timedelta(days=self.APPLICATIONS_OPEN_DAYS + 1)
+        # Set time to 23:59:59 same day and add full number of days before application closes
+        published_day = self.published_at.replace(hour=23, minute=59, second=59, microsecond=0)
+        closing_time = published_day + timedelta(days=self.APPLICATIONS_OPEN_DAYS)
 
         return closing_time
 
     @applications_closed_at.expression
     def applications_closed_at(cls):
         return func.date_trunc('day', cls.published_at) + sql_cast(
-            '%d days' % (cls.APPLICATIONS_OPEN_DAYS + 1), INTERVAL
+            '%d days 23:59:59' % cls.APPLICATIONS_OPEN_DAYS, INTERVAL
         )
 
     @hybrid_property
@@ -884,9 +884,9 @@ class Brief(db.Model):
         if self.published_at is None:
             return None
 
-        # Set time to midnight next day and add full number of days before questions close
-        published_day = self.published_at.replace(hour=0, minute=0, second=0, microsecond=0)
-        closing_time = published_day + timedelta(days=self.CLARIFICATION_QUESTIONS_OPEN_DAYS + 1)
+        # Set time to 23:59:59 same day and add full number of days before questions close
+        published_day = self.published_at.replace(hour=23, minute=59, second=59, microsecond=0)
+        closing_time = published_day + timedelta(days=self.CLARIFICATION_QUESTIONS_OPEN_DAYS)
 
         return closing_time
 

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -185,8 +185,8 @@ class TestBriefs(BaseApplicationTest):
         brief = Brief(data={}, framework=self.framework, lot=self.lot,
                       published_at=datetime(2016, 3, 3, 12, 30, 1, 2))
 
-        assert brief.applications_closed_at == datetime(2016, 3, 18)
-        assert brief.clarification_questions_closed_at == datetime(2016, 3, 11)
+        assert brief.applications_closed_at == datetime(2016, 3, 17, 23, 59, 59)
+        assert brief.clarification_questions_closed_at == datetime(2016, 3, 10, 23, 59, 59)
 
     def test_query_brief_applications_closed_at_date(self):
         with self.app.app_context():
@@ -194,7 +194,7 @@ class TestBriefs(BaseApplicationTest):
                                  published_at=datetime(2016, 3, 3, 12, 30, 1, 2)))
             db.session.commit()
 
-            assert Brief.query.filter(Brief.applications_closed_at == datetime(2016, 3, 18)).count() == 1
+            assert Brief.query.filter(Brief.applications_closed_at == datetime(2016, 3, 17, 23, 59, 59)).count() == 1
 
     def test_expired_status_for_a_brief_with_passed_close_date(self):
         brief = Brief(data={}, framework=self.framework, lot=self.lot,


### PR DESCRIPTION
Setting the closing date and time to 23:59 + 14 days means that we can show the date part of the timestamp separately since it's the last day applications/questions are open as opposed to the first day they're closed for 00:00 dates. Making the change in the API allows frontend apps to display the date without any modifications.