### PR TITLE
Limit brief response specialist day rate

### DIFF
--- a/app/brief_utils.py
+++ b/app/brief_utils.py
@@ -25,7 +25,7 @@ def validate_brief_data(brief, enforce_required=True, required_fields=None):
         abort(400, errs)
 
 
-def is_supplier_eligible_for_brief(supplier, brief):
+def get_supplier_service_eligible_for_brief(supplier, brief):
     services = filter_services(
         framework_slugs=[brief.framework.slug],
         statuses=["published"],
@@ -36,4 +36,4 @@ def is_supplier_eligible_for_brief(supplier, brief):
 
     services = services.filter(Service.supplier_id == supplier.supplier_id)
 
-    return services.count() > 0
+    return services.first()

--- a/app/main/views/brief_responses.py
+++ b/app/main/views/brief_responses.py
@@ -54,7 +54,10 @@ def create_brief_response():
         brief=brief,
     )
 
-    brief_response.validate()
+    brief_role = brief.data["specialistRole"] if brief.lot.slug == "digital-specialists" else None
+    service_max_day_rate = brief_service.data[brief_role + "PriceMax"] if brief_role else None
+
+    brief_response.validate(max_day_rate=service_max_day_rate)
 
     db.session.add(brief_response)
     try:

--- a/app/main/views/brief_responses.py
+++ b/app/main/views/brief_responses.py
@@ -11,7 +11,7 @@ from ...utils import (
     validate_and_return_updater_request,
 )
 
-from ...brief_utils import is_supplier_eligible_for_brief
+from ...brief_utils import get_supplier_service_eligible_for_brief
 from ...service_utils import validate_and_return_supplier
 
 
@@ -40,7 +40,8 @@ def create_brief_response():
 
     supplier = validate_and_return_supplier(brief_response_json)
 
-    if not is_supplier_eligible_for_brief(supplier, brief):
+    brief_service = get_supplier_service_eligible_for_brief(supplier, brief)
+    if not brief_service:
         abort(400, "Supplier not eligible")
 
     # Check if brief response already exists from this supplier

--- a/app/models.py
+++ b/app/models.py
@@ -930,8 +930,8 @@ class Brief(db.Model):
     def add_clarification_question(self, question, answer):
         clarification_question = BriefClarificationQuestion(
             brief=self,
-            question=question,
-            answer=answer)
+            question=question.strip(),
+            answer=answer.strip())
         clarification_question.validate()
 
         Session.object_session(self).add(clarification_question)

--- a/app/models.py
+++ b/app/models.py
@@ -1019,7 +1019,7 @@ class BriefResponse(db.Model):
 
         return data
 
-    def validate(self, enforce_required=True, required_fields=None):
+    def validate(self, enforce_required=True, required_fields=None, max_day_rate=None):
         errs = get_validation_errors(
             'brief-responses-{}-{}'.format(self.brief.framework.slug, self.brief.lot.slug),
             self.data,
@@ -1038,6 +1038,10 @@ class BriefResponse(db.Model):
             len(self.data.get('niceToHaveRequirements', [])) != len(self.brief.data.get('niceToHaveRequirements', []))
         ):
             errs['niceToHaveRequirements'] = 'answer_required'
+
+        if max_day_rate and 'dayRate' not in errs:
+            if float(self.data['dayRate']) > float(max_day_rate):
+                errs['dayRate'] = 'max_less_than_min'
 
         if errs:
             raise ValidationError(errs)

--- a/app/validation.py
+++ b/app/validation.py
@@ -253,7 +253,7 @@ def _translate_json_schema_error(key, validator, validator_value, message):
     elif validator == 'pattern':
         # Since error messages are now specified in the manifests, we can (in the future) generalise the returned
         # string and just show the correct message
-        if key.endswith(('priceMin', 'priceMax', 'PriceMin', 'PriceMax')):
+        if key.endswith(('dayRate', 'priceMin', 'priceMax', 'PriceMin', 'PriceMax')):
             return 'not_money_format'
 
         return 'under_{}_words'.format(_get_word_count(validator_value))

--- a/app/validation.py
+++ b/app/validation.py
@@ -239,6 +239,7 @@ def _translate_json_schema_error(key, validator, validator_value, message):
         'maximum': 'not_a_number',
         'maxItems': 'under_10_items',
         'maxLength': 'under_character_limit',
+        'format': 'invalid_format',
     }
 
     if validator in validator_type_to_error:

--- a/json_schemas/brief-responses-digital-outcomes-and-specialists-digital-outcomes.json
+++ b/json_schemas/brief-responses-digital-outcomes-and-specialists-digital-outcomes.json
@@ -20,6 +20,7 @@
     },
     "respondToEmailAddress": {
       "format": "email",
+      "minLength": 1,
       "type": "string"
     }
   },

--- a/json_schemas/brief-responses-digital-outcomes-and-specialists-digital-specialists.json
+++ b/json_schemas/brief-responses-digital-outcomes-and-specialists-digital-specialists.json
@@ -8,8 +8,7 @@
       "type": "string"
     },
     "dayRate": {
-      "maxLength": 100,
-      "minLength": 1,
+      "pattern": "^\\d{1,15}(?:\\.\\d{1,5})?$",
       "type": "string"
     },
     "essentialRequirements": {
@@ -30,6 +29,7 @@
     },
     "respondToEmailAddress": {
       "format": "email",
+      "minLength": 1,
       "type": "string"
     },
     "specialistName": {

--- a/json_schemas/brief-responses-digital-outcomes-and-specialists-user-research-participants.json
+++ b/json_schemas/brief-responses-digital-outcomes-and-specialists-user-research-participants.json
@@ -20,6 +20,7 @@
     },
     "respondToEmailAddress": {
       "format": "email",
+      "minLength": 1,
       "type": "string"
     },
     "userParticipantResponse": {

--- a/tests/app/test_validation.py
+++ b/tests/app/test_validation.py
@@ -323,7 +323,7 @@ def test_invalid_url_field_has_validation_error():
     data = load_example_listing("G7-SCS")
     data.update({'serviceDefinitionDocumentURL': 'not_a_url'})
     errs = get_validation_errors("services-g-cloud-7-scs", data)
-    assert "'not_a_url' is not" in errs['serviceDefinitionDocumentURL']
+    assert errs['serviceDefinitionDocumentURL'] == 'invalid_format'
 
 
 def test_too_many_words_causes_validation_error():

--- a/tests/app/views/test_briefs.py
+++ b/tests/app/views/test_briefs.py
@@ -827,6 +827,28 @@ class TestBriefs(BaseApplicationTest):
             "publishedAt": mock.ANY,
         }]
 
+    def test_clarification_question_strip_whitespace(self):
+        self.setup_dummy_briefs(1, title="The Title", status="live")
+
+        res = self.client.post(
+            "/briefs/1/clarification-questions",
+            data=json.dumps({
+                "clarificationQuestion": {
+                    "question": "What? ",
+                    "answer": "That ",
+                },
+                "update_details": {"updated_by": "example"},
+            }),
+            content_type="application/json")
+        data = json.loads(res.get_data(as_text=True))
+
+        assert res.status_code == 200
+        assert data["briefs"]["clarificationQuestions"] == [{
+            "question": "What?",
+            "answer": "That",
+            "publishedAt": mock.ANY,
+        }]
+
     def test_add_clarification_question_fails_if_no_question(self):
         self.setup_dummy_briefs(1, title="The Title", status="live")
 

--- a/tests/example_listings.py
+++ b/tests/example_listings.py
@@ -33,9 +33,21 @@ def brief_response_data(essential_count=5, nice_to_have_count=5):
     })
 
 
+def specialists_brief_response_data(min_day_rate=1, max_day_rate=1000):
+    return fixed_dictionaries({
+        "essentialRequirements": requirements_list(5, answers=True),
+        "niceToHaveRequirements": requirements_list(5, answers=True),
+        "respondToEmailAddress": just("supplier@email.com"),
+        "specialistName": text(min_size=1, average_size=10, alphabet='abcdefghijkl'),
+        "availability": text(min_size=1, average_size=10, alphabet='abcdefghijkl'),
+        "dayRate": integers(min_value=min_day_rate, max_value=max_day_rate).map(lambda x: str(x)),
+    })
+
+
 def brief_data(essential_count=5, nice_to_have_count=5):
     return fixed_dictionaries({
-        'location': text(alphabet='abcdefghijkl'),
+        'specialistRole': just('developer'),
+        'location': text(min_size=1, average_size=10, alphabet='abcdefghijkl'),
         'essentialRequirements': requirements_list(essential_count),
         'niceToHaveRequirements': requirements_list(nice_to_have_count),
     })


### PR DESCRIPTION
### Update brief responses JSON schemas
Sets dayRate pricing pattern and updates email field property after replacing 'email' type with string limit format in the content repo.

### Add 'dayRate' to the list of pricing field name suffixes
If dayRate is not recognised as a pricing field the validation will raise an exception when trying to get word count from the pricing pattern.

There's no other easy way to mark pricing fields right now and renaming dayRate to contain 'price*' doesn't seem appropriate.

Checking the question names in frameworks repo, dayRate doesn't appear anywhere else at the moment.

### Return 'invalid_format' error for JSON schema 'format' validator
Allows content questions that specify string format to set error message (eg setting a message for invalid email strings).

### Check that brief response day rate is less than the service maximum
For digital-speficalists responses dayRate should be less than or equal to the maximum price for the given specialist set in the supplier's DOS service.

### :bug: Strip trailing whitespace from brief clarification questions
Values with leading or trailing whitespace don't match the word-count regular expression resulting in a "Too many words" error message being displayed by the frontend apps.