### PR TITLE
Add 'clarificationQuestionsPublishedBy' to the brief API response

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -978,7 +978,8 @@ class Brief(db.Model):
                 'publishedAt': self.published_at.strftime(DATETIME_FORMAT),
                 'applicationsClosedAt': self.applications_closed_at.strftime(DATETIME_FORMAT),
                 'clarificationQuestionsClosedAt': self.clarification_questions_closed_at.strftime(DATETIME_FORMAT),
-                'clarificationQuestionsPublishedBy': self.clarification_questions_published_by.strftime(DATETIME_FORMAT),
+                'clarificationQuestionsPublishedBy': self.clarification_questions_published_by.strftime(
+                    DATETIME_FORMAT),
                 'clarificationQuestionsAreClosed': self.clarification_questions_are_closed,
             })
 

--- a/app/models.py
+++ b/app/models.py
@@ -803,6 +803,7 @@ class Brief(db.Model):
     __tablename__ = 'briefs'
 
     CLARIFICATION_QUESTIONS_OPEN_DAYS = 7
+    CLARIFICATION_QUESTIONS_PUBLISHED_DAYS = 1
     APPLICATIONS_OPEN_DAYS = 14
 
     id = db.Column(db.Integer, primary_key=True)
@@ -891,6 +892,14 @@ class Brief(db.Model):
         return closing_time
 
     @hybrid_property
+    def clarification_questions_published_by(self):
+        if self.published_at is None:
+            return None
+
+        # All clarification questions should be published N days before brief closes
+        return self.applications_closed_at - timedelta(days=self.CLARIFICATION_QUESTIONS_PUBLISHED_DAYS)
+
+    @hybrid_property
     def clarification_questions_are_closed(self):
         return datetime.utcnow() > self.clarification_questions_closed_at
 
@@ -969,6 +978,7 @@ class Brief(db.Model):
                 'publishedAt': self.published_at.strftime(DATETIME_FORMAT),
                 'applicationsClosedAt': self.applications_closed_at.strftime(DATETIME_FORMAT),
                 'clarificationQuestionsClosedAt': self.clarification_questions_closed_at.strftime(DATETIME_FORMAT),
+                'clarificationQuestionsPublishedBy': self.clarification_questions_published_by.strftime(DATETIME_FORMAT),
                 'clarificationQuestionsAreClosed': self.clarification_questions_are_closed,
             })
 

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -187,6 +187,7 @@ class TestBriefs(BaseApplicationTest):
 
         assert brief.applications_closed_at == datetime(2016, 3, 17, 23, 59, 59)
         assert brief.clarification_questions_closed_at == datetime(2016, 3, 10, 23, 59, 59)
+        assert brief.clarification_questions_published_by == datetime(2016, 3, 16, 23, 59, 59)
 
     def test_query_brief_applications_closed_at_date(self):
         with self.app.app_context():

--- a/tests/app/views/test_briefs.py
+++ b/tests/app/views/test_briefs.py
@@ -444,6 +444,7 @@ class TestBriefs(BaseApplicationTest):
         assert 'publishedAt' in data['briefs']
         assert 'applicationsClosedAt' in data['briefs']
         assert 'clarificationQuestionsClosedAt' in data['briefs']
+        assert 'clarificationQuestionsPublishedBy' in data['briefs']
         assert not data['briefs']['clarificationQuestionsAreClosed']
 
     def test_get_brief_returns_404_if_not_found(self):


### PR DESCRIPTION
Adds the deadline for publishing clarification questions and answers
to the serialized brief data.