### PR TITLE
Latest schemas with additional early market engagement

### DIFF
--- a/json_schemas/briefs-digital-outcomes-and-specialists-digital-specialists.json
+++ b/json_schemas/briefs-digital-outcomes-and-specialists-digital-specialists.json
@@ -33,6 +33,11 @@
       "minimum": 5,
       "type": "integer"
     },
+    "earlyMarketEngagement": {
+      "minLength": 0,
+      "pattern": "^$|(^(?:\\S+\\s+){0,199}\\S+$)",
+      "type": "string"
+    },
     "essentialRequirements": {
       "items": {
         "maxLength": 300,

--- a/json_schemas/briefs-digital-outcomes-and-specialists-user-research-participants.json
+++ b/json_schemas/briefs-digital-outcomes-and-specialists-user-research-participants.json
@@ -23,6 +23,11 @@
       "minimum": 10,
       "type": "integer"
     },
+    "earlyMarketEngagement": {
+      "minLength": 0,
+      "pattern": "^$|(^(?:\\S+\\s+){0,199}\\S+$)",
+      "type": "string"
+    },
     "essentialRequirements": {
       "items": {
         "maxLength": 300,


### PR DESCRIPTION
Part of this bugfix: Fixes this bug: https://www.pivotaltracker.com/story/show/118274239

New schemas to match content version 0.30.5 (pull-requested here: https://github.com/alphagov/digitalmarketplace-frameworks/pull/250)