### PR TITLE
Update essential and nice-to-have maxItems for brief responses

### DIFF
--- a/json_schemas/brief-responses-digital-outcomes-and-specialists-digital-outcomes.json
+++ b/json_schemas/brief-responses-digital-outcomes-and-specialists-digital-outcomes.json
@@ -11,7 +11,7 @@
       "items": {
         "type": "boolean"
       },
-      "maxItems": 10,
+      "maxItems": 20,
       "minItems": 1,
       "type": "array"
     },
@@ -19,7 +19,7 @@
       "items": {
         "type": "boolean"
       },
-      "maxItems": 10,
+      "maxItems": 20,
       "minItems": 0,
       "type": "array"
     },

--- a/json_schemas/brief-responses-digital-outcomes-and-specialists-digital-specialists.json
+++ b/json_schemas/brief-responses-digital-outcomes-and-specialists-digital-specialists.json
@@ -15,7 +15,7 @@
       "items": {
         "type": "boolean"
       },
-      "maxItems": 10,
+      "maxItems": 20,
       "minItems": 1,
       "type": "array"
     },
@@ -23,7 +23,7 @@
       "items": {
         "type": "boolean"
       },
-      "maxItems": 10,
+      "maxItems": 20,
       "minItems": 0,
       "type": "array"
     },

--- a/json_schemas/brief-responses-digital-outcomes-and-specialists-user-research-participants.json
+++ b/json_schemas/brief-responses-digital-outcomes-and-specialists-user-research-participants.json
@@ -6,7 +6,7 @@
       "items": {
         "type": "boolean"
       },
-      "maxItems": 10,
+      "maxItems": 20,
       "minItems": 1,
       "type": "array"
     },
@@ -14,7 +14,7 @@
       "items": {
         "type": "boolean"
       },
-      "maxItems": 10,
+      "maxItems": 20,
       "minItems": 0,
       "type": "array"
     },


### PR DESCRIPTION
The limit of nice-to-have and essential requirements for briefs has been raised to 20, but the same changes hasn't been applied to the brief response boolean lists. So trying to respond to a brief with more than 10 requirements of any type always resulted in an error.