### PR TITLE
Add data to lots table

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -44,6 +44,7 @@ class Lot(db.Model):
     slug = db.Column(db.String, nullable=False, index=True)
     name = db.Column(db.String, nullable=False)
     one_service_limit = db.Column(db.Boolean, nullable=False, default=False)
+    data = db.Column(JSON)
 
     @property
     def allows_brief(self):
@@ -53,13 +54,15 @@ class Lot(db.Model):
         return '<{}: {}>'.format(self.__class__.__name__, self.name)
 
     def serialize(self):
-        return {
+        lot = {
             'id': self.id,
             'slug': self.slug,
             'name': self.name,
             'oneServiceLimit': self.one_service_limit,
             'allowsBrief': self.allows_brief,
         }
+        lot.update(dict(self.data.items()))
+        return lot
 
 
 class Framework(db.Model):

--- a/app/models.py
+++ b/app/models.py
@@ -54,15 +54,15 @@ class Lot(db.Model):
         return '<{}: {}>'.format(self.__class__.__name__, self.name)
 
     def serialize(self):
-        lot = {
+        data = dict(self.data.items())
+        data.update({
             'id': self.id,
             'slug': self.slug,
             'name': self.name,
             'oneServiceLimit': self.one_service_limit,
             'allowsBrief': self.allows_brief,
-        }
-        lot.update(dict(self.data.items()))
-        return lot
+        })
+        return data
 
 
 class Framework(db.Model):

--- a/migrations/versions/600_add_units_to_lots.py
+++ b/migrations/versions/600_add_units_to_lots.py
@@ -20,12 +20,7 @@ def upgrade():
     op.execute("""
         UPDATE lots
           SET data = '{"unitSingular": "service", "unitPlural": "services"}'
-          WHERE  slug in ('saas', 'paas', 'iaas', 'scs', 'digital-outcomes', 'user-research-participants');
-    """)
-    op.execute("""
-        UPDATE lots
-          SET data = '{"unitSingular": "specialist", "unitPlural": "specialists"}'
-          WHERE  slug = 'digital-specialists';
+          WHERE  slug in ('saas', 'paas', 'iaas', 'scs', 'digital-outcomes', 'digital-specialists', 'user-research-participants');
     """)
     op.execute("""
         UPDATE lots

--- a/migrations/versions/600_add_units_to_lots.py
+++ b/migrations/versions/600_add_units_to_lots.py
@@ -1,0 +1,38 @@
+"""Add units to lots, for display by the frontend aps
+
+Revision ID: 600
+Revises: 590
+Create Date: 2016-05-05 10:49:45.258601
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '600'
+down_revision = '590'
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+def upgrade():
+    op.add_column('lots', sa.Column('data', postgresql.JSON(), nullable=True))
+    op.execute("""
+        UPDATE lots
+          SET data = '{"unitSingular": "service", "unitPlural": "services"}'
+          WHERE  slug in ('saas', 'paas', 'iaas', 'scs', 'digital-outcomes', 'user-research-participants');
+    """)
+    op.execute("""
+        UPDATE lots
+          SET data = '{"unitSingular": "specialist", "unitPlural": "specialists"}'
+          WHERE  slug = 'digital-specialists';
+    """)
+    op.execute("""
+        UPDATE lots
+          SET data = '{"unitSingular": "lab", "unitPlural": "labs"}'
+          WHERE  slug = 'user-research-studios';
+    """)
+
+
+def downgrade():
+    op.drop_column('lots', 'data')

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -667,3 +667,20 @@ class TestSupplierFrameworks(BaseApplicationTest):
         supplier_framework.declaration = {'foo': ' bar ', 'bar': '', 'other': ' '}
 
         assert supplier_framework.declaration == {'foo': 'bar', 'bar': '', 'other': ''}
+
+
+class TestLot(BaseApplicationTest):
+    def test_lot_data_is_serialized(self):
+        with self.app.app_context():
+            self.framework = Framework.query.filter(Framework.slug == 'digital-outcomes-and-specialists').first()
+            self.lot = self.framework.get_lot('digital-specialists')
+
+            assert self.lot.serialize() == {
+                u'id': 6,
+                u'name': u'Digital specialists',
+                u'slug': u'digital-specialists',
+                u'allowsBrief': True,
+                u'oneServiceLimit': True,
+                u'unitSingular': u'specialist',
+                u'unitPlural': u'specialists',
+            }

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -673,14 +673,14 @@ class TestLot(BaseApplicationTest):
     def test_lot_data_is_serialized(self):
         with self.app.app_context():
             self.framework = Framework.query.filter(Framework.slug == 'digital-outcomes-and-specialists').first()
-            self.lot = self.framework.get_lot('digital-specialists')
+            self.lot = self.framework.get_lot('user-research-studios')
 
             assert self.lot.serialize() == {
-                u'id': 6,
-                u'name': u'Digital specialists',
-                u'slug': u'digital-specialists',
-                u'allowsBrief': True,
-                u'oneServiceLimit': True,
-                u'unitSingular': u'specialist',
-                u'unitPlural': u'specialists',
+                u'id': 7,
+                u'name': u'User research studios',
+                u'slug': u'user-research-studios',
+                u'allowsBrief': False,
+                u'oneServiceLimit': False,
+                u'unitSingular': u'lab',
+                u'unitPlural': u'labs',
             }

--- a/tests/app/views/test_frameworks.py
+++ b/tests/app/views/test_frameworks.py
@@ -140,18 +140,42 @@ class TestGetFramework(BaseApplicationTest):
 
         data = json.loads(response.get_data())
         assert data['frameworks']['lots'] == [
-            {u'id': 1, u'name': u'Software as a Service',
-             u'oneServiceLimit': False, u'slug': u'saas',
-             u'allowsBrief': False},
-            {u'id': 2, u'name': u'Platform as a Service',
-             u'oneServiceLimit': False, u'slug': u'paas',
-             u'allowsBrief': False},
-            {u'id': 3, u'name': u'Infrastructure as a Service',
-             u'oneServiceLimit': False, u'slug': u'iaas',
-             u'allowsBrief': False},
-            {u'id': 4, u'name': u'Specialist Cloud Services',
-             u'oneServiceLimit': False, u'slug': u'scs',
-             u'allowsBrief': False},
+            {
+                u'id': 1,
+                u'name': u'Software as a Service',
+                u'slug': u'saas',
+                u'allowsBrief': False,
+                u'unitSingular': u'service',
+                u'oneServiceLimit': False,
+                u'unitPlural': u'services',
+            },
+            {
+                u'id': 2,
+                u'name': u'Platform as a Service',
+                u'slug': u'paas',
+                u'allowsBrief': False,
+                u'oneServiceLimit': False,
+                u'unitSingular': u'service',
+                u'unitPlural': u'services',
+            },
+            {
+                u'id': 3,
+                u'name': u'Infrastructure as a Service',
+                u'slug': u'iaas',
+                u'allowsBrief': False,
+                u'oneServiceLimit': False,
+                u'unitSingular': u'service',
+                u'unitPlural': u'services',
+            },
+            {
+                u'id': 4,
+                u'name': u'Specialist Cloud Services',
+                u'slug': u'scs',
+                u'allowsBrief': False,
+                u'oneServiceLimit': False,
+                u'unitSingular': u'service',
+                u'unitPlural': u'services',
+            }
         ]
 
     def test_a_404_is_raised_if_it_does_not_exist(self):


### PR DESCRIPTION
This is required to do a "proper" fix for the following bug:
https://www.pivotaltracker.com/story/show/118986461

By keeping relevant data in the lots table about the type of thing that gets submitted for that lot we can avoid having logic in the frontend that needs to know the specifics of different lots.  Instead the frontend can get everything it needs to know from the API.