### PR TITLE
Allow updating brief status from 'live' to 'draft'

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -923,8 +923,8 @@ class Brief(db.Model):
             return
         elif value == 'live':
             self.published_at = datetime.utcnow()
-        elif value == 'draft' and self.published_at is not None:
-            raise ValidationError("Cannot change brief status from 'live' to 'draft'")
+        elif value == 'draft':
+            self.published_at = None
         elif value == 'closed':
             raise ValidationError("Cannot change brief status to 'closed'")
         else:

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -223,11 +223,11 @@ class TestBriefs(BaseApplicationTest):
         with pytest.raises(ValidationError):
             brief.status = 'invalid'
 
-    def test_cannot_set_live_brief_to_draft(self):
+    def test_can_set_live_brief_to_draft(self):
         brief = Brief(data={}, framework=self.framework, lot=self.lot, published_at=datetime.utcnow())
+        brief.status = 'draft'
 
-        with pytest.raises(ValidationError):
-            brief.status = 'draft'
+        assert brief.published_at is None
 
     def test_cannot_set_brief_to_closed(self):
         brief = Brief(data={}, framework=self.framework, lot=self.lot)

--- a/tests/app/views/test_briefs.py
+++ b/tests/app/views/test_briefs.py
@@ -668,8 +668,8 @@ class TestBriefs(BaseApplicationTest):
         assert res.status_code == 400
         assert data['error'] == "Framework is not live"
 
-    def test_cannot_return_a_live_brief_to_pending(self):
-        self.setup_dummy_briefs(1, status='live')
+    def test_can_unpublish_a_live_brief(self):
+        self.setup_dummy_briefs(1, title="Published brief", status='live')
 
         res = self.client.put(
             '/briefs/1/status',
@@ -680,8 +680,9 @@ class TestBriefs(BaseApplicationTest):
             content_type='application/json')
         data = json.loads(res.get_data(as_text=True))
 
-        assert res.status_code == 400
-        assert data['error'] == "Cannot change brief status from 'live' to 'draft'"
+        assert res.status_code == 200
+        assert data['briefs']['status'] == 'draft'
+        assert 'publishedAt' not in data['briefs']
 
     def test_cannot_set_status_to_invalid_value(self):
         self.setup_dummy_briefs(1, status='draft')


### PR DESCRIPTION
We need to unpublish requirements if there's a problem with one of the questions (like point scores not being set on all requirements) so allowing to do this through the API.

The frontend apps set the status explicitly to 'live' when the use the status update apiclient method, but in the future we could add a separate '.publish_brief' method to make sure we don't allow users to accidentally unpublish briefs on their own.