### PR TITLE
Add support for PaaS trial deployments

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,6 +2,7 @@ from functools import wraps
 from flask import Flask
 from flask.ext.bootstrap import Bootstrap
 from flask.ext.sqlalchemy import SQLAlchemy
+import json
 
 import dmapiclient
 from dmutils import init_app, flask_featureflags
@@ -29,6 +30,10 @@ def create_app(config_name):
 
     if not application.config['DM_API_AUTH_TOKENS']:
         raise Exception("No DM_API_AUTH_TOKENS provided")
+
+    if application.config['VCAP_SERVICES']:
+        cf_services = json.loads(application.config['VCAP_SERVICES'])
+        application.config['SQLALCHEMY_DATABASE_URI'] = cf_services['PostgreSQL'][0]['credentials']['uri']
 
     from .main import main as main_blueprint
     application.register_blueprint(main_blueprint)

--- a/config.py
+++ b/config.py
@@ -36,6 +36,8 @@ class Config:
 
     DM_FAILED_LOGIN_LIMIT = 5
 
+    VCAP_SERVICES = None
+
 
 class Test(Config):
     DM_SEARCH_API_AUTH_TOKEN = 'test'

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,7 @@ strict-rfc3339==0.5
 requests==2.9.1
 docopt==0.6.2
 six==1.9.0
+
+# For Cloud Foundry
+cffi==1.5.2
+gunicorn==19.4.5


### PR DESCRIPTION
This is mostly changes from @robyoung's PaaS spike branch.

### Add gunicorn to requirements.txt for PaaS deploys  …
Add gunicorn to requirements.txt for running the app on Cloud Foundry
(possibly not ideal see [1]).

Explicitly add cffi to requirements so that Cloud Foundry spots it and
adds libffi.

There doesnt' seem to be an easy way to use a different requirements
file for Cloud Foundry, so we'll have to add the dependencies
everywhere.

[1] etianen/django-herokuapp#9

### Pull SQLAlchemy URI from VCAP_SERVICES  …
Cloud Foundry stores the connected services configuration in the
VCAP_SERVICES environment variable, so in order to connect to the
database instance we need to parse the URL value from the variable.

http://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#VCAP-SERVICES