### PR TITLE
Add phone number to user

### DIFF
--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -113,7 +113,7 @@ def create_user():
     now = datetime.utcnow()
     user = User(
         email_address=json_payload['emailAddress'].lower(),
-        phone_number=json_payload.get('phoneNumber'),
+        phone_number=json_payload.get('phoneNumber') or None,
         name=json_payload['name'],
         role=json_payload['role'],
         password=password,

--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -113,6 +113,7 @@ def create_user():
     now = datetime.utcnow()
     user = User(
         email_address=json_payload['emailAddress'].lower(),
+        phone_number=json_payload.get('phoneNumber'),
         name=json_payload['name'],
         role=json_payload['role'],
         password=password,

--- a/app/models.py
+++ b/app/models.py
@@ -438,6 +438,7 @@ class User(db.Model):
         user = {
             'id': self.id,
             'emailAddress': self.email_address,
+            'phoneNumber': self.phone_number,
             'name': self.name,
             'role': self.role,
             'active': self.active,

--- a/app/models.py
+++ b/app/models.py
@@ -385,6 +385,8 @@ class User(db.Model):
                      nullable=False)
     email_address = db.Column(db.String, index=True, unique=True,
                               nullable=False)
+    phone_number = db.Column(db.String, index=False, unique=False,
+                             nullable=True)
     password = db.Column(db.String, index=False, unique=False,
                          nullable=False)
     active = db.Column(db.Boolean, index=False, unique=False,

--- a/json_schemas/users.json
+++ b/json_schemas/users.json
@@ -21,7 +21,7 @@
       "type": "string"
     },
     "phoneNumber": {
-      "pattern": "^$|^\\+?([\\d\\s()-]){6,20}$",
+      "pattern": "^$|^\\+?([\\d\\s()-]){9,20}$",
       "type": "string"
     },
     "role": {

--- a/json_schemas/users.json
+++ b/json_schemas/users.json
@@ -20,6 +20,10 @@
       "minLength": 10,
       "type": "string"
     },
+    "phoneNumber": {
+      "pattern": "^$|^([\\d\\s()+-]){6,20}$",
+      "type": "string"
+    },
     "role": {
       "enum": [
         "buyer",

--- a/json_schemas/users.json
+++ b/json_schemas/users.json
@@ -21,7 +21,7 @@
       "type": "string"
     },
     "phoneNumber": {
-      "pattern": "^$|^([\\d\\s()+-]){6,20}$",
+      "pattern": "^$|^\\+?([\\d\\s()-]){6,20}$",
       "type": "string"
     },
     "role": {

--- a/migrations/versions/620_add_phone_number.py
+++ b/migrations/versions/620_add_phone_number.py
@@ -1,0 +1,22 @@
+"""Add phone number to users table
+
+Revision ID: 620
+Revises: 610
+Create Date: 2016-05-25 10:45:58.171835
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '620'
+down_revision = '610'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('users', sa.Column('phone_number', sa.String(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('users', 'phone_number')

--- a/tests/app/views/test_briefs.py
+++ b/tests/app/views/test_briefs.py
@@ -425,6 +425,7 @@ class TestBriefs(BaseApplicationTest):
                     {
                         'id': 1,
                         'emailAddress': 'test+1@digital.gov.uk',
+                        'phoneNumber': None,
                         'name': 'my name',
                         'role': 'buyer',
                         'active': True,

--- a/tests/app/views/test_users.py
+++ b/tests/app/views/test_users.py
@@ -249,6 +249,20 @@ class TestUsersPost(BaseApplicationTest, JSONTestMixin):
         data = json.loads(response.get_data())['users']
         assert data['active']
 
+    def test_creating_buyer_user_with_bad_phone_number_fails(self):
+        response = self.client.post(
+            '/users',
+            data=json.dumps({
+                'users': {
+                    'emailAddress': 'joeblogs@digital.cabinet-office.gov.uk',
+                    'phoneNumber': '123456',
+                    'password': '1234567890',
+                    'role': 'buyer',
+                    'name': 'joe bloggs'}}),
+            content_type='application/json')
+
+        assert response.status_code == 400
+
     def test_creating_buyer_user_with_no_phone_stores_none(self):
         response = self.client.post(
             '/users',

--- a/tests/app/views/test_users.py
+++ b/tests/app/views/test_users.py
@@ -192,16 +192,16 @@ class TestUsersPost(BaseApplicationTest, JSONTestMixin):
             '/users',
             data=json.dumps({
                 'users': {
-                    'emailAddress': 'joeblogs@email.com',
+                    'emailAddress': 'joeblogs@email.gov.uk',
                     'phoneNumber': '01234 567890',
                     'password': '1234567890',
-                    'role': 'admin',
+                    'role': 'buyer',
                     'name': 'joe bloggs'}}),
             content_type='application/json')
 
         assert_equal(response.status_code, 201)
         data = json.loads(response.get_data())["users"]
-        assert_equal(data["emailAddress"], "joeblogs@email.com")
+        assert_equal(data["emailAddress"], "joeblogs@email.gov.uk")
 
     def test_creating_buyer_user_with_bad_email_domain_fails(self):
         response = self.client.post(

--- a/tests/app/views/test_users.py
+++ b/tests/app/views/test_users.py
@@ -193,6 +193,7 @@ class TestUsersPost(BaseApplicationTest, JSONTestMixin):
             data=json.dumps({
                 'users': {
                     'emailAddress': 'joeblogs@email.com',
+                    'phoneNumber': '01234 567890',
                     'password': '1234567890',
                     'role': 'admin',
                     'name': 'joe bloggs'}}),
@@ -222,6 +223,22 @@ class TestUsersPost(BaseApplicationTest, JSONTestMixin):
             data=json.dumps({
                 'users': {
                     'emailAddress': 'joeblogs@digital.cabinet-office.gov.uk',
+                    'password': '1234567890',
+                    'role': 'buyer',
+                    'name': 'joe bloggs'}}),
+            content_type='application/json')
+
+        assert response.status_code == 201
+        data = json.loads(response.get_data())['users']
+        assert data['active']
+
+    def test_creating_buyer_user_with_no_phone_number_succeeds(self):
+        response = self.client.post(
+            '/users',
+            data=json.dumps({
+                'users': {
+                    'emailAddress': 'joeblogs@digital.cabinet-office.gov.uk',
+                    'phoneNumber': '',
                     'password': '1234567890',
                     'role': 'buyer',
                     'name': 'joe bloggs'}}),

--- a/tests/app/views/test_users.py
+++ b/tests/app/views/test_users.py
@@ -248,6 +248,22 @@ class TestUsersPost(BaseApplicationTest, JSONTestMixin):
         data = json.loads(response.get_data())['users']
         assert data['active']
 
+    def test_creating_buyer_user_with_no_phone_stores_none(self):
+        response = self.client.post(
+            '/users',
+            data=json.dumps({
+                'users': {
+                    'emailAddress': 'joeblogs@digital.cabinet-office.gov.uk',
+                    'phoneNumber': '',
+                    'password': '1234567890',
+                    'role': 'buyer',
+                    'name': 'joe bloggs'}}),
+            content_type='application/json')
+
+        assert response.status_code == 201
+        data = json.loads(response.get_data())['users']
+        assert_equal(data['phoneNumber'], None)
+
     def test_can_post_an_admin_user(self):
         response = self.client.post(
             '/users',

--- a/tests/app/views/test_users.py
+++ b/tests/app/views/test_users.py
@@ -202,6 +202,7 @@ class TestUsersPost(BaseApplicationTest, JSONTestMixin):
         assert_equal(response.status_code, 201)
         data = json.loads(response.get_data())["users"]
         assert_equal(data["emailAddress"], "joeblogs@email.gov.uk")
+        assert_equal(data["phoneNumber"], "01234 567890")
 
     def test_creating_buyer_user_with_bad_email_domain_fails(self):
         response = self.client.post(


### PR DESCRIPTION
For [this](https://www.pivotaltracker.com/story/show/119726147) story on Pivotal.

More work to come on the buyer front end to capture phone numbers on sign up.

This PR:

0. Updates the user model and adds a migration to add a phone_number column.
0. Adds phoneNumber to the serialize method on the User model.
0. Adds phoneNumber to the user json schema with a pattern to validate it. The patter check if the number is empty, or if it's a combination of digits, +'s, -'s, parenthesis or spaces. It also makes sure it's character length is in the range 6-20.
0. Updates the post /users view to create users with the phone number.
0. Updates one test and adds another to ensure users can be created with and without a phone number.
0. Updates an old test which was testing the wrong thing (creating an admin user when it should have been creating a buyer user)
