### PR TITLE
WIP add scripts/generate_model_diagram.py

### DIFF
--- a/scripts/generate_model_diagram.py
+++ b/scripts/generate_model_diagram.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+from sys import stdout
+
+import sadisplay
+from app import create_app
+from app import models
+
+
+def _build_desc():
+    return sadisplay.describe(
+        [getattr(models, attr) for attr in dir(models)],
+        show_methods=True,
+        show_properties=True,
+        show_indexes=True,
+    )
+
+if __name__ == "__main__":
+    app = create_app("development")
+    with app.app_context():
+        desc = _build_desc()
+        stdout.write(sadisplay.dot(desc).encode("utf8"))


### PR DESCRIPTION
I thought it would be nice to be able to generate a new diagram at any time as things change.

This works, but `sadisplay` is not added to `requirements.txt` - I'm not sure if it should be added to `requirements.txt` or `requirements_for_test.txt`, if either.

Thoughts?