### PR TITLE
Remove mandatory evaluation types

### DIFF
--- a/json_schemas/briefs-digital-outcomes-and-specialists-digital-outcomes.json
+++ b/json_schemas/briefs-digital-outcomes-and-specialists-digital-outcomes.json
@@ -61,15 +61,14 @@
     "evaluationType": {
       "items": {
         "enum": [
-          "Written proposal",
           "Case study",
           "Work history",
           "Reference",
           "Presentation"
         ]
       },
-      "maxItems": 5,
-      "minItems": 1,
+      "maxItems": 4,
+      "minItems": 0,
       "type": "array",
       "uniqueItems": true
     },
@@ -207,7 +206,6 @@
     "culturalWeighting",
     "endUsers",
     "essentialRequirements",
-    "evaluationType",
     "existingTeam",
     "location",
     "numberOfSuppliers",

--- a/json_schemas/briefs-digital-outcomes-and-specialists-digital-specialists.json
+++ b/json_schemas/briefs-digital-outcomes-and-specialists-digital-specialists.json
@@ -51,15 +51,14 @@
     "evaluationType": {
       "items": {
         "enum": [
-          "Work history",
           "Reference",
           "Interview",
           "Scenario or test",
           "Presentation"
         ]
       },
-      "maxItems": 5,
-      "minItems": 1,
+      "maxItems": 4,
+      "minItems": 0,
       "type": "array",
       "uniqueItems": true
     },
@@ -184,7 +183,6 @@
     "culturalFitCriteria",
     "culturalWeighting",
     "essentialRequirements",
-    "evaluationType",
     "existingTeam",
     "location",
     "numberOfSuppliers",

--- a/json_schemas/briefs-digital-outcomes-and-specialists-user-research-participants.json
+++ b/json_schemas/briefs-digital-outcomes-and-specialists-user-research-participants.json
@@ -43,12 +43,11 @@
         "enum": [
           "Case study",
           "Reference",
-          "Written proposal",
           "Interview"
         ]
       },
-      "maxItems": 4,
-      "minItems": 1,
+      "maxItems": 3,
+      "minItems": 0,
       "type": "array",
       "uniqueItems": true
     },
@@ -183,7 +182,6 @@
   "required": [
     "culturalWeighting",
     "essentialRequirements",
-    "evaluationType",
     "location",
     "numberOfSuppliers",
     "organisation",

--- a/migrations/versions/630_remove_mandatory_assessment_methods_.py
+++ b/migrations/versions/630_remove_mandatory_assessment_methods_.py
@@ -1,0 +1,61 @@
+"""Remove mandatory assessment methods from briefs
+
+Revision ID: 630
+Revises: 620
+Create Date: 2016-06-03 15:26:53.890401
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '630'
+down_revision = '620'
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.sql import table, column
+from sqlalchemy.dialects import postgresql
+
+
+briefs = table(
+    'briefs',
+    column('id', sa.Integer),
+    column('lot_id', sa.Integer),
+    column('data', postgresql.JSON),
+)
+
+
+def upgrade():
+    conn = op.get_bind()
+    for brief in conn.execute(briefs.select()):
+        if brief.data.get('evaluationType') is None:
+            continue
+
+        optional_methods = list([
+            method for method in brief.data['evaluationType']
+            if method not in ['Work history', 'Written proposal']
+        ])
+
+        if brief.data['evaluationType'] != optional_methods:
+            if optional_methods:
+                brief.data['evaluationType'] = optional_methods
+            else:
+                brief.data.pop('evaluationType')
+
+            conn.execute(briefs.update().where(briefs.c.id == brief.id).values(
+                data=brief.data
+            ))
+
+
+def downgrade():
+    conn = op.get_bind()
+    for brief in conn.execute(briefs.select()):
+        # Add written proposal to all outcomes and research participants briefs
+        if brief.lot_id in [5, 8]:
+            brief.data['evaluationType'] = ['Written proposal'] + brief.data.get('evaluationType', [])
+        # Add work history to all specialists briefs
+        elif brief.lot_id == 6:
+            brief.data['evaluationType'] = ['Work history'] + brief.data.get('evaluationType', [])
+
+        conn.execute(briefs.update().where(briefs.c.id == brief.id).values(
+            data=brief.data
+        ))

--- a/scripts/list_migrations.py
+++ b/scripts/list_migrations.py
@@ -4,8 +4,11 @@
 from __future__ import print_function
 
 import sys
+import warnings
 
 from alembic.script import ScriptDirectory
+
+warnings.simplefilter('error')
 
 
 def detect_heads(migrations):

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -15,7 +15,7 @@ TEST_SUPPLIERS_COUNT = 3
 COMPLETE_DIGITAL_SPECIALISTS_BRIEF = {
     "essentialRequirements": ["MS Paint", "GIMP"],
     "startDate": "31/12/2016",
-    "evaluationType": ["Work history", "Reference", "Interview"],
+    "evaluationType": ["Reference", "Interview"],
     "niceToHaveRequirements":  ["LISP"],
     "existingTeam": "Nice people.",
     "specialistWork": "All the things",


### PR DESCRIPTION
### Update DOS evaluationType JSON schemas
Removes mandatory options and makes the question optional for all lots.

### Add a migration to drop mandatory assessment methods from brief data
Removes work history and written proposal from all briefs, since they're no longer a valid option for evaluationType and are added automatically to all briefs.

Downgrade will add the options to all briefs based on lot. Since we don't know if the brief had the option selected before the upgrade migration we add them to ALL briefs, including draft ones. This means we might end up adding it to briefs that didn't have it before, but that seems better than silently removing the option, as all briefs should have them selected in the end.