### PR TITLE
[#119645373] Briefs: Don't use location when deciding whether suppliers can apply

### DIFF
--- a/app/brief_utils.py
+++ b/app/brief_utils.py
@@ -30,7 +30,6 @@ def get_supplier_service_eligible_for_brief(supplier, brief):
         framework_slugs=[brief.framework.slug],
         statuses=["published"],
         lot_slug=brief.lot.slug,
-        location=brief.data["location"],
         role=brief.data["specialistRole"] if brief.lot.slug == "digital-specialists" else None
     )
 

--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -277,7 +277,6 @@ def list_brief_services(brief_id):
         framework_slugs=[brief.framework.slug],
         statuses=["published"],
         lot_slug=brief.lot.slug,
-        location=brief.data["location"],
         role=brief.data["specialistRole"] if brief.lot.slug == "digital-specialists" else None
     )
 

--- a/tests/app/views/test_briefs.py
+++ b/tests/app/views/test_briefs.py
@@ -992,7 +992,7 @@ class TestSupplierIsEligibleForBrief(BaseApplicationTest):
 
         assert response.status_code == 404
 
-    def test_supplier_is_ineligible_if_not_in_specialist_location(self):
+    def test_supplier_is_eligible_even_if_not_in_specialist_location(self):
         self.setup_services()
         with self.app.app_context():
             self.setup_dummy_user(id=1)
@@ -1008,7 +1008,7 @@ class TestSupplierIsEligibleForBrief(BaseApplicationTest):
         data = json.loads(response.get_data(as_text=True))
 
         assert response.status_code == 200
-        assert not data["services"]
+        assert data["services"]
 
     def test_supplier_is_ineligible_if_does_not_supply_the_role(self):
         self.setup_services()
@@ -1028,7 +1028,7 @@ class TestSupplierIsEligibleForBrief(BaseApplicationTest):
         assert response.status_code == 200
         assert not data["services"]
 
-    def test_supplier_is_ineligible_if_does_not_supply_in_outcome_location(self):
+    def test_supplier_is_eligible_even_if_does_not_supply_in_outcome_location(self):
         self.setup_services()
         with self.app.app_context():
             self.setup_dummy_user(id=1)
@@ -1044,4 +1044,4 @@ class TestSupplierIsEligibleForBrief(BaseApplicationTest):
         data = json.loads(response.get_data(as_text=True))
 
         assert response.status_code == 200
-        assert not data["services"]
+        assert data["services"]


### PR DESCRIPTION
This comes as two commits. The first simply removes the checks which prevent the brief being listed by the API and therefore applied for. The second removed the ability to filter briefs by location at all. This may or may not be desired, so submitted as two commits, the second can be discarded if needs be.

All tests pass locally at both revisions.