### PR TITLE
Add and expose framework_agreement_version field to framework model

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -80,6 +80,7 @@ class Framework(db.Model):
     slug = db.Column(db.String, nullable=False, unique=True, index=True)
     name = db.Column(db.String(255), nullable=False)
     framework = db.Column(db.String(), index=True, nullable=False)
+    framework_agreement_version = db.Column(db.String(), nullable=True)
     status = db.Column(db.String(),
                        index=True, nullable=False,
                        default='pending')

--- a/app/models.py
+++ b/app/models.py
@@ -104,6 +104,7 @@ class Framework(db.Model):
             'name': self.name,
             'slug': self.slug,
             'framework': self.framework,
+            'frameworkAgreementVersion': self.framework_agreement_version,
             'status': self.status,
             'clarificationQuestionsOpen': self.clarification_questions_open,
             'lots': [lot.serialize() for lot in self.lots],

--- a/migrations/versions/640_add_framework_agreement_version_to_.py
+++ b/migrations/versions/640_add_framework_agreement_version_to_.py
@@ -1,0 +1,25 @@
+"""add framework_agreement_version to Framework
+
+Revision ID: 640
+Revises: 630
+Create Date: 2016-06-16 11:37:21.802880
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '640'
+down_revision = '630'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('frameworks', sa.Column('framework_agreement_version', sa.String(), nullable=True))
+    op.execute("""
+        UPDATE frameworks SET framework_agreement_version = 'v1.0' WHERE slug = 'g-cloud-8'
+    """)
+
+
+def downgrade():
+    op.drop_column('frameworks', 'framework_agreement_version')

--- a/tests/app/views/test_frameworks.py
+++ b/tests/app/views/test_frameworks.py
@@ -19,8 +19,18 @@ class TestListFrameworks(BaseApplicationTest):
             assert_equal(response.status_code, 200)
             assert_equal(len(data['frameworks']),
                          len(Framework.query.all()))
-            assert_equal(sorted(data['frameworks'][0].keys()),
-                         ['clarificationQuestionsOpen', 'framework', 'id', 'lots', 'name', 'slug', 'status'])
+            assert_equal(
+                set(data['frameworks'][0].keys()),
+                set([
+                    'clarificationQuestionsOpen',
+                    'framework',
+                    'frameworkAgreementVersion',
+                    'id',
+                    'lots',
+                    'name',
+                    'slug',
+                    'status',
+                ]))
 
 
 class TestCreateFramework(BaseApplicationTest):


### PR DESCRIPTION
Added framework_agreement_version field to framework model
Migration also sets special value of 'v1.0' for g-cloud-8 framework_agreement_version
Updated relevant test_all_frameworks_are_returned test