### PR TITLE
[#121573503] API changes (2) - countersigned and signer_details fields

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -413,11 +413,8 @@ def update_supplier_framework_details(supplier_id, framework_slug):
 
     if 'onFramework' in update_json:
         interest_record.on_framework = update_json['onFramework']
-    if 'agreementReturned' in update_json:
-        if update_json['agreementReturned']:
-            interest_record.agreement_returned_at = uniform_now
-        else:
-            interest_record.agreement_returned_at = None
+    if update_json.get('agreementReturned'):
+        interest_record.agreement_returned_at = uniform_now
     if update_json.get('countersigned'):
         interest_record.countersigned_at = uniform_now
     if 'signerDetails' in update_json:

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -418,7 +418,13 @@ def update_supplier_framework_details(supplier_id, framework_slug):
     if update_json.get('countersigned'):
         interest_record.countersigned_at = uniform_now
     if 'signerDetails' in update_json:
-        interest_record.signer_details = update_json["signerDetails"]
+        if update_json["signerDetails"] is None:
+            interest_record.signer_details = None
+        else:
+            interest_record.signer_details = interest_record.signer_details or {}
+            interest_record.signer_details.update(update_json["signerDetails"])
+            # a dummy assignment to force the validator to run. FIXME sort this out project-wide
+            interest_record.signer_details = interest_record.signer_details
 
     audit_event = AuditEvent(
         audit_type=AuditTypes.supplier_update,

--- a/app/models.py
+++ b/app/models.py
@@ -307,6 +307,8 @@ class SupplierFramework(db.Model):
     declaration = db.Column(JSON)
     on_framework = db.Column(db.Boolean, nullable=True)
     agreement_returned_at = db.Column(db.DateTime, index=False, unique=False, nullable=True)
+    countersigned_at = db.Column(db.DateTime, index=False, unique=False, nullable=True)
+    signer_details = db.Column(JSON)
 
     supplier = db.relationship(Supplier, lazy='joined', innerjoin=True)
     framework = db.relationship(Framework, lazy='joined', innerjoin=True)

--- a/app/models.py
+++ b/app/models.py
@@ -320,6 +320,13 @@ class SupplierFramework(db.Model):
 
         return value
 
+    @validates('signer_details')
+    def validates_signer_details(self, key, value):
+        value = strip_whitespace_from_data(value)
+        value = purge_nulls_from_data(value)
+
+        return value
+
     @staticmethod
     def find_by_framework(framework_slug):
         return SupplierFramework.query.filter(

--- a/app/models.py
+++ b/app/models.py
@@ -363,6 +363,11 @@ class SupplierFramework(db.Model):
         agreement_returned_at = self.agreement_returned_at
         if agreement_returned_at:
             agreement_returned_at = agreement_returned_at.strftime(DATETIME_FORMAT)
+
+        countersigned_at = self.countersigned_at
+        if countersigned_at:
+            countersigned_at = countersigned_at.strftime(DATETIME_FORMAT)
+
         return dict({
             "supplierId": self.supplier_id,
             "supplierName": self.supplier.name,
@@ -371,6 +376,9 @@ class SupplierFramework(db.Model):
             "onFramework": self.on_framework,
             "agreementReturned": bool(agreement_returned_at),
             "agreementReturnedAt": agreement_returned_at,
+            "signerDetails": self.signer_details,
+            "countersigned": bool(countersigned_at),
+            "countersignedAt": countersigned_at,
         }, **(data or {}))
 
 

--- a/migrations/versions/650_add_countersign_and_signer_details.py
+++ b/migrations/versions/650_add_countersign_and_signer_details.py
@@ -1,0 +1,24 @@
+"""add countersign and signer details
+
+Revision ID: 650
+Revises: 640
+Create Date: 2016-06-16 13:18:43.766961
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '650'
+down_revision = '640'
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+def upgrade():
+    op.add_column('supplier_frameworks', sa.Column('countersigned_at', sa.DateTime(), nullable=True))
+    op.add_column('supplier_frameworks', sa.Column('signer_details', postgresql.JSON(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('supplier_frameworks', 'signer_details')
+    op.drop_column('supplier_frameworks', 'countersigned_at')

--- a/tests/app/views/test_suppliers.py
+++ b/tests/app/views/test_suppliers.py
@@ -1418,26 +1418,6 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest, JSONUpdateTestMixin):
             data = json.loads(response.get_data())
             assert_equal(data['frameworkInterest']['countersignedAt'], '2012-12-12T00:00:00.000000Z')
 
-    def test_agreement_returned_at_is_unset_when_agreement_returned_flag_is_false(self):
-        with freeze_time('2012-12-12'):
-            response = self.supplier_framework_update(
-                0, 'digital-outcomes-and-specialists',
-                update={'agreementReturned': True})
-
-            assert_equal(response.status_code, 200)
-            data = json.loads(response.get_data())
-            assert_equal(data['frameworkInterest']['agreementReturned'], True)
-            assert_equal(data['frameworkInterest']['agreementReturnedAt'], '2012-12-12T00:00:00.000000Z')
-
-            response2 = self.supplier_framework_update(
-                0, 'digital-outcomes-and-specialists',
-                update={'agreementReturned': False})
-
-            assert_equal(response2.status_code, 200)
-            data2 = json.loads(response2.get_data())
-            assert_equal(data2['frameworkInterest']['agreementReturned'], False)
-            assert_equal(data2['frameworkInterest']['agreementReturnedAt'], None)
-
     def test_setting_signer_details(self):
         supplier_details_payload = {
             "some": [

--- a/tests/app/views/test_suppliers.py
+++ b/tests/app/views/test_suppliers.py
@@ -1284,7 +1284,10 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest, JSONUpdateTestMixin):
                 supplier_id=0, framework_id=2,
                 declaration={'an_answer': 'Yes it is'},
                 on_framework=True,
-                agreement_returned_at=datetime(2015, 10, 10, 10, 10, 10))
+                agreement_returned_at=datetime(2015, 10, 10, 10, 10, 10),
+                countersigned_at=datetime(2015, 11, 12, 13, 14, 15),
+                signer_details={u'some': u'thing'},
+            )
             db.session.add(answers)
             db.session.commit()
 
@@ -1310,6 +1313,9 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest, JSONUpdateTestMixin):
         assert_equal(data['frameworkInterest']['onFramework'], True)
         assert_equal(data['frameworkInterest']['agreementReturned'], True)
         assert_equal(data['frameworkInterest']['agreementReturnedAt'], '2015-10-10T10:10:10.000000Z')
+        assert_equal(data['frameworkInterest']['countersigned'], True)
+        assert_equal(data['frameworkInterest']['countersignedAt'], '2015-11-12T13:14:15.000000Z')
+        assert_equal(data['frameworkInterest']['signerDetails'], {'some': 'thing'})
 
     def test_get_supplier_framework_info_non_existent_by_framework(self):
         response = self.client.get(
@@ -1336,6 +1342,9 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest, JSONUpdateTestMixin):
         assert_equal(data['frameworkInterest']['onFramework'], True)
         assert_equal(data['frameworkInterest']['agreementReturned'], False)
         assert_is(data['frameworkInterest']['agreementReturnedAt'], None)
+        assert_equal(data['frameworkInterest']['countersigned'], False)
+        assert_is(data['frameworkInterest']['countersignedAt'], None)
+        assert_is(data['frameworkInterest']['signerDetails'], None)
 
     def test_adding_supplier_has_not_passed(self):
         response = self.supplier_framework_update(
@@ -1362,6 +1371,26 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest, JSONUpdateTestMixin):
             assert_equal(data['frameworkInterest']['frameworkSlug'], 'digital-outcomes-and-specialists')
             assert_equal(data['frameworkInterest']['agreementReturned'], True)
             assert_equal(data['frameworkInterest']['agreementReturnedAt'], "2012-12-12T00:00:00.000000Z")
+            assert_equal(data['frameworkInterest']['countersigned'], False)
+            assert_is(data['frameworkInterest']['countersignedAt'], None)
+            assert_is(data['frameworkInterest']['signerDetails'], None)
+
+    def test_adding_that_agreement_has_been_countersigned(self):
+        with freeze_time('2012-12-12'):
+            response = self.supplier_framework_update(
+                0,
+                'digital-outcomes-and-specialists',
+                update={'countersigned': True}
+            )
+            assert_equal(response.status_code, 200)
+            data = json.loads(response.get_data())
+            assert_equal(data['frameworkInterest']['supplierId'], 0)
+            assert_equal(data['frameworkInterest']['frameworkSlug'], 'digital-outcomes-and-specialists')
+            assert_equal(data['frameworkInterest']['agreementReturned'], False)
+            assert_is(data['frameworkInterest']['agreementReturnedAt'], None)
+            assert_equal(data['frameworkInterest']['countersigned'], True)
+            assert_equal(data['frameworkInterest']['countersignedAt'], "2012-12-12T00:00:00.000000Z")
+            assert_is(data['frameworkInterest']['signerDetails'], None)
 
     def test_agreement_returned_at_timestamp_cannot_be_set(self):
         with freeze_time('2012-12-12'):
@@ -1374,18 +1403,56 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest, JSONUpdateTestMixin):
             data = json.loads(response.get_data())
             assert_equal(data['frameworkInterest']['agreementReturnedAt'], '2012-12-12T00:00:00.000000Z')
 
-    def test_agreement_returned_at_is_unset_when_agreement_reutrned_flag_is_false(self):
-        self.supplier_framework_update(
-            0, 'digital-outcomes-and-specialists',
-            update={'agreementReturned': True})
+    def test_countersigned_at_timestamp_cannot_be_set(self):
+        with freeze_time('2012-12-12'):
+            response = self.supplier_framework_update(
+                0,
+                'digital-outcomes-and-specialists',
+                update={
+                    'agreementReturned': True,
+                    'countersigned': True,
+                    'countersignedAt': '2013-13-13T00:00:00.000000Z',
+                }
+            )
+            assert_equal(response.status_code, 200)
+            data = json.loads(response.get_data())
+            assert_equal(data['frameworkInterest']['countersignedAt'], '2012-12-12T00:00:00.000000Z')
+
+    def test_agreement_returned_at_is_unset_when_agreement_returned_flag_is_false(self):
+        with freeze_time('2012-12-12'):
+            response = self.supplier_framework_update(
+                0, 'digital-outcomes-and-specialists',
+                update={'agreementReturned': True})
+
+            assert_equal(response.status_code, 200)
+            data = json.loads(response.get_data())
+            assert_equal(data['frameworkInterest']['agreementReturned'], True)
+            assert_equal(data['frameworkInterest']['agreementReturnedAt'], '2012-12-12T00:00:00.000000Z')
+
+            response2 = self.supplier_framework_update(
+                0, 'digital-outcomes-and-specialists',
+                update={'agreementReturned': False})
+
+            assert_equal(response2.status_code, 200)
+            data2 = json.loads(response2.get_data())
+            assert_equal(data2['frameworkInterest']['agreementReturned'], False)
+            assert_equal(data2['frameworkInterest']['agreementReturnedAt'], None)
+
+    def test_setting_signer_details(self):
+        supplier_details_payload = {
+            "some": [
+                "arbitrary",
+                123,
+                ["json"]
+            ],
+        }
         response = self.supplier_framework_update(
             0, 'digital-outcomes-and-specialists',
-            update={'agreementReturned': False})
+            update={'signerDetails': supplier_details_payload})
 
         assert_equal(response.status_code, 200)
         data = json.loads(response.get_data())
-        assert_equal(data['frameworkInterest']['agreementReturned'], False)
-        assert_equal(data['frameworkInterest']['agreementReturnedAt'], None)
+        assert_equal(data['frameworkInterest']['signerDetails'], supplier_details_payload)
 
     def test_changing_from_failed_to_passed(self):
         response = self.supplier_framework_update(

--- a/tests/app/views/test_suppliers.py
+++ b/tests/app/views/test_suppliers.py
@@ -1419,20 +1419,40 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest, JSONUpdateTestMixin):
             assert_equal(data['frameworkInterest']['countersignedAt'], '2012-12-12T00:00:00.000000Z')
 
     def test_setting_signer_details(self):
-        supplier_details_payload = {
+        signer_details_payload = {
             "some": [
                 "arbitrary",
                 123,
                 ["json"]
             ],
+            "here": "there",
         }
         response = self.supplier_framework_update(
             0, 'digital-outcomes-and-specialists',
-            update={'signerDetails': supplier_details_payload})
+            update={'signerDetails': signer_details_payload})
 
         assert_equal(response.status_code, 200)
         data = json.loads(response.get_data())
-        assert_equal(data['frameworkInterest']['signerDetails'], supplier_details_payload)
+        assert_equal(data['frameworkInterest']['signerDetails'], signer_details_payload)
+
+        # while we're at it let's test the signerDetails partial updating behaviour
+        signer_details_update_payload = {
+            "other": {
+                "json": 456,
+            },
+            "here": None,
+        }
+        response2 = self.supplier_framework_update(
+            0, 'digital-outcomes-and-specialists',
+            update={'signerDetails': signer_details_update_payload})
+
+        signer_details_payload.update(signer_details_update_payload)
+        # json validator should strip this key
+        del signer_details_payload["here"]
+
+        assert_equal(response2.status_code, 200)
+        data2 = json.loads(response2.get_data())
+        assert_equal(data2['frameworkInterest']['signerDetails'], signer_details_payload)
 
     def test_changing_from_failed_to_passed(self):
         response = self.supplier_framework_update(

--- a/tests/app/views/test_suppliers.py
+++ b/tests/app/views/test_suppliers.py
@@ -1104,6 +1104,9 @@ class TestGetSupplierFrameworks(BaseApplicationTest):
                         'complete_drafts_count': 1,
                         'services_count': 0,
                         'supplierName': 'Supplier 1',
+                        'signerDetails': None,
+                        'countersigned': False,
+                        'countersignedAt': None,
                     }
                 ]
             }
@@ -1128,6 +1131,9 @@ class TestGetSupplierFrameworks(BaseApplicationTest):
                         'complete_drafts_count': 0,
                         'services_count': 1,
                         'supplierName': 'Supplier 2',
+                        'signerDetails': None,
+                        'countersigned': False,
+                        'countersignedAt': None,
                     }
                 ]
             }


### PR DESCRIPTION
Added migration for Supplier_frameworks countersigning and signer_details fields

Added signerDetails and countersigned fields to SupplierFramework.serialize

Updated API endpoint to set/update the above fields and added cross validation between agreement_signed_at and countersigned_at fields

We decided that the signer_details field was best left as a mostly 'dumb' field which can accept any json input and won't presume anything about how it is going to be used i.e. won't do any automatic resetting of itself