### PR TITLE
Fix bug if multiple @'s in buyer email address

### DIFF
--- a/app/validation.py
+++ b/app/validation.py
@@ -290,5 +290,5 @@ _BUYER_EMAIL_DOMAINS = load_buyer_email_domains('./data/buyer-email-domains.txt'
 
 
 def is_valid_buyer_email(email):
-    _, domain = email.split('@')
+    domain = email.split('@')[-1]
     return any(domain == d or domain.endswith('.' + d) for d in _BUYER_EMAIL_DOMAINS)

--- a/tests/app/test_validation.py
+++ b/tests/app/test_validation.py
@@ -533,6 +533,7 @@ def check_schema(schema):
     ('test@something.gov.uk', True),
     ('test@somegov.uk', False),
     ('test@gov.ok', False),
+    ('test@test@gov.uk', True)
 ])
 def test_is_valid_buyer_email(email, expected):
     assert is_valid_buyer_email(email) == expected


### PR DESCRIPTION
For [this](https://www.pivotaltracker.com/story/show/121730503) bug on Pivotal.
See [other related work](https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/350) on the buyer front end.

If a buyer supplies an email address with two or more `@` symbols in, the current method for checking the domain of the address will fail with a ValueError. This modifies the method to deal with multiple @'s.

This allows a bad email address to pass through the domain check (if it has a valid domain; if not it will fail as usual), and fail gracefully when checked against the pattern defined in the json schema.

Hopefully this should never actually happen as the email address is validated in the buyer front end before this (see PR linked above).



