### PR TITLE
[PROPOSAL] mutable json validation fix through SanitizedJSON TypeDecorator

### DIFF
--- a/app/fields.py
+++ b/app/fields.py
@@ -1,0 +1,23 @@
+from sqlalchemy.dialects.postgresql import JSON
+from sqlalchemy.types import TypeDecorator
+
+from .utils import strip_whitespace_from_data, purge_nulls_from_data
+
+
+class SanitizedJSON(TypeDecorator):
+    impl = JSON
+
+    def process_bind_param(self, value, dialect):
+        if value is None:
+            # it's not our job to prevent nulls (not here, anyway)
+            return value
+
+        value = strip_whitespace_from_data(value)
+        value = purge_nulls_from_data(value)
+
+        return value
+
+    def coerce_compared_value(self, op, value):
+        # required to prevent `process_bind_param` from being used to transform comparison values (which for JSON
+        # includes key-lookup strings destined for the sql)
+        return self.impl.coerce_compared_value(op, value)


### PR DESCRIPTION
Tests don't pass - I know - this is just a demo.

This is one possible way we could deal with the json-objects-being-mutated-skipping-model-validation problem. It works by delaying this sanitization until the value is being adapted for a database `INSERT` or `UPDATE`. However this changes things slightly because json values no longer get cleaned _as they are assigned_. Only happens when they get saved back to db.

Pros of this approach:

- Implementation is simple.

Cons of this approach:

- Would require code changes of places where the cleaned value is expected to be retrieved back _before_ the object has been saved back to db. One common source of this (corresponding to the majority of test failures) is places where the json schema validation is run _just after_ json data assignment, not giving this sanitizer a chance to run. I suppose in theory the json schema validation could be triggered through a similar mechanism, working implicitly instead of explicitly, but that would cause the schema validator to be run on every single `INSERT` or `UPDATE` involving a json field. Another potential place for unvalidated json to slip through back to the user is where an update-y view did a `.serialize()` to get the json blob for returning in the request _before_ the object is actually saved (at least in this case wrong data wouldn't reach the database)

Note I've only switched fields to `SanitizedJSON` where they were previously doing the exact same validation steps through `@validates`. Some fields remain as vanilla `JSON`.

Another way this could be done is through building a MutableDict-style object (a la http://docs.sqlalchemy.org/en/rel_1_0/orm/extensions/mutable.html) but the implementation of that would be a little more involved (but should require no code changes outside the field as behaviour would be the same as through using `@validates`).