### PR TITLE
[#122321641] move Framework.framework_agreement_version into new framework_agreement_details json field

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -80,7 +80,7 @@ class Framework(db.Model):
     slug = db.Column(db.String, nullable=False, unique=True, index=True)
     name = db.Column(db.String(255), nullable=False)
     framework = db.Column(db.String(), index=True, nullable=False)
-    framework_agreement_version = db.Column(db.String(), nullable=True)
+    framework_agreement_details = db.Column(JSON, nullable=True)
     status = db.Column(db.String(),
                        index=True, nullable=False,
                        default='pending')
@@ -104,7 +104,7 @@ class Framework(db.Model):
             'name': self.name,
             'slug': self.slug,
             'framework': self.framework,
-            'frameworkAgreementVersion': self.framework_agreement_version,
+            'frameworkAgreementVersion': (self.framework_agreement_details or {}).get("frameworkAgreementVersion"),
             'status': self.status,
             'clarificationQuestionsOpen': self.clarification_questions_open,
             'lots': [lot.serialize() for lot in self.lots],

--- a/migrations/versions/670_move_framework_framework_agreement_version.py
+++ b/migrations/versions/670_move_framework_framework_agreement_version.py
@@ -1,0 +1,37 @@
+"""Move Framework.framework_agreement_version into new framework_agreement_details json field
+
+Revision ID: 670
+Revises: 660
+Create Date: 2016-06-29 11:54:27.719038
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '670'
+down_revision = '660'
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+def upgrade():
+    op.add_column('frameworks', sa.Column('framework_agreement_details', postgresql.JSON(), nullable=True))
+    op.execute("""
+        UPDATE frameworks SET
+            -- using to_json to ensure framework_agreement_version gets properly escaped for json
+            framework_agreement_details = (
+                '{"frameworkAgreementVersion":' || to_json(framework_agreement_version) || '}'
+            )::json
+        WHERE
+            framework_agreement_version IS NOT NULL and framework_agreement_version != ''
+    """)
+    op.drop_column('frameworks', 'framework_agreement_version')
+
+
+def downgrade():
+    op.add_column('frameworks', sa.Column('framework_agreement_version', sa.VARCHAR(), autoincrement=False, nullable=True))
+    op.execute("""
+        UPDATE frameworks SET
+            framework_agreement_version = framework_agreement_details->>'frameworkAgreementVersion'
+    """)
+    op.drop_column('frameworks', 'framework_agreement_details')


### PR DESCRIPTION
migrating old framework_agreement_version values into "frameworkAgreementVersion" json attributes and emulating old serialization behaviour of framework_agreement_version.

Story https://www.pivotaltracker.com/story/show/122321641

This is going to need to be migration-rebased once #408 is merged.

Interested in feedback @allait, @pcraig3 on what the `serialize()` output should be for this. Currently I've emulated the previous api output, but was wondering if I should really just be dumping the json itself out as-is as `frameworkAgreementVersion`.

@TheDoubleK 's opinions on the matter:
```
<kevkeenoy> With other objects where we have a JSON blob of data we tend to unpack it I think.
<kevkeenoy> But this feels a bit different for some reason.
<kevkeenoy> That I can't really put my finger on.
<kevkeenoy> I guess because with eg services the data blob is the main thing.
<kevkeenoy> And other fields are essentially metadata
<kevkeenoy> But with this one the new thing isn't the whole thing - and feels like it might be better
    to leave it encapsulated as "all the countersigning info"
```