### PR TITLE
Changes to signer_details

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -417,14 +417,14 @@ def update_supplier_framework_details(supplier_id, framework_slug):
         interest_record.agreement_returned_at = uniform_now
     if update_json.get('countersigned'):
         interest_record.countersigned_at = uniform_now
-    if 'signerDetails' in update_json:
-        if update_json["signerDetails"] is None:
-            interest_record.signer_details = None
+    if 'agreementDetails' in update_json:
+        if update_json["agreementDetails"] is None:
+            interest_record.agreement_details = None
         else:
-            interest_record.signer_details = interest_record.signer_details or {}
-            interest_record.signer_details.update(update_json["signerDetails"])
+            interest_record.agreement_details = interest_record.agreement_details or {}
+            interest_record.agreement_details.update(update_json["agreementDetails"])
             # a dummy assignment to force the validator to run. FIXME sort this out project-wide
-            interest_record.signer_details = interest_record.signer_details
+            interest_record.agreement_details = interest_record.agreement_details
 
     audit_event = AuditEvent(
         audit_type=AuditTypes.supplier_update,

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -413,8 +413,11 @@ def update_supplier_framework_details(supplier_id, framework_slug):
 
     if 'onFramework' in update_json:
         interest_record.on_framework = update_json['onFramework']
-    if update_json.get('agreementReturned'):
-        interest_record.agreement_returned_at = uniform_now
+    if 'agreementReturned' in update_json:
+        if update_json["agreementReturned"] is False:
+            interest_record.agreement_returned_at = None
+        else:
+            interest_record.agreement_returned_at = uniform_now
     if update_json.get('countersigned'):
         interest_record.countersigned_at = uniform_now
     if 'agreementDetails' in update_json:

--- a/app/models.py
+++ b/app/models.py
@@ -308,7 +308,7 @@ class SupplierFramework(db.Model):
     on_framework = db.Column(db.Boolean, nullable=True)
     agreement_returned_at = db.Column(db.DateTime, index=False, unique=False, nullable=True)
     countersigned_at = db.Column(db.DateTime, index=False, unique=False, nullable=True)
-    signer_details = db.Column(JSON)
+    agreement_details = db.Column(JSON)
 
     supplier = db.relationship(Supplier, lazy='joined', innerjoin=True)
     framework = db.relationship(Framework, lazy='joined', innerjoin=True)
@@ -320,8 +320,8 @@ class SupplierFramework(db.Model):
 
         return value
 
-    @validates('signer_details')
-    def validates_signer_details(self, key, value):
+    @validates('agreement_details')
+    def validates_agreement_details(self, key, value):
         value = strip_whitespace_from_data(value)
         value = purge_nulls_from_data(value)
 
@@ -383,7 +383,7 @@ class SupplierFramework(db.Model):
             "onFramework": self.on_framework,
             "agreementReturned": bool(agreement_returned_at),
             "agreementReturnedAt": agreement_returned_at,
-            "signerDetails": self.signer_details,
+            "agreementDetails": self.agreement_details,
             "countersigned": bool(countersigned_at),
             "countersignedAt": countersigned_at,
         }, **(data or {}))

--- a/migrations/versions/660_change_signer_details_to_agreement_.py
+++ b/migrations/versions/660_change_signer_details_to_agreement_.py
@@ -1,0 +1,22 @@
+"""change signer_details to agreement_details
+
+Revision ID: 660
+Revises: 650
+Create Date: 2016-07-01 15:10:17.026710
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '660'
+down_revision = '650'
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+def upgrade():
+    op.execute('alter table supplier_frameworks rename signer_details to agreement_details')
+
+
+def downgrade():
+    op.execute('alter table supplier_frameworks rename agreement_details to signer_details')

--- a/tests/app/views/test_suppliers.py
+++ b/tests/app/views/test_suppliers.py
@@ -1104,7 +1104,7 @@ class TestGetSupplierFrameworks(BaseApplicationTest):
                         'complete_drafts_count': 1,
                         'services_count': 0,
                         'supplierName': 'Supplier 1',
-                        'signerDetails': None,
+                        'agreementDetails': None,
                         'countersigned': False,
                         'countersignedAt': None,
                     }
@@ -1131,7 +1131,7 @@ class TestGetSupplierFrameworks(BaseApplicationTest):
                         'complete_drafts_count': 0,
                         'services_count': 1,
                         'supplierName': 'Supplier 2',
-                        'signerDetails': None,
+                        'agreementDetails': None,
                         'countersigned': False,
                         'countersignedAt': None,
                     }
@@ -1286,7 +1286,7 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest, JSONUpdateTestMixin):
                 on_framework=True,
                 agreement_returned_at=datetime(2015, 10, 10, 10, 10, 10),
                 countersigned_at=datetime(2015, 11, 12, 13, 14, 15),
-                signer_details={u'some': u'thing'},
+                agreement_details={u'some': u'thing'},
             )
             db.session.add(answers)
             db.session.commit()
@@ -1315,7 +1315,7 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest, JSONUpdateTestMixin):
         assert_equal(data['frameworkInterest']['agreementReturnedAt'], '2015-10-10T10:10:10.000000Z')
         assert_equal(data['frameworkInterest']['countersigned'], True)
         assert_equal(data['frameworkInterest']['countersignedAt'], '2015-11-12T13:14:15.000000Z')
-        assert_equal(data['frameworkInterest']['signerDetails'], {'some': 'thing'})
+        assert_equal(data['frameworkInterest']['agreementDetails'], {'some': 'thing'})
 
     def test_get_supplier_framework_info_non_existent_by_framework(self):
         response = self.client.get(
@@ -1344,7 +1344,7 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest, JSONUpdateTestMixin):
         assert_is(data['frameworkInterest']['agreementReturnedAt'], None)
         assert_equal(data['frameworkInterest']['countersigned'], False)
         assert_is(data['frameworkInterest']['countersignedAt'], None)
-        assert_is(data['frameworkInterest']['signerDetails'], None)
+        assert_is(data['frameworkInterest']['agreementDetails'], None)
 
     def test_adding_supplier_has_not_passed(self):
         response = self.supplier_framework_update(
@@ -1373,7 +1373,7 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest, JSONUpdateTestMixin):
             assert_equal(data['frameworkInterest']['agreementReturnedAt'], "2012-12-12T00:00:00.000000Z")
             assert_equal(data['frameworkInterest']['countersigned'], False)
             assert_is(data['frameworkInterest']['countersignedAt'], None)
-            assert_is(data['frameworkInterest']['signerDetails'], None)
+            assert_is(data['frameworkInterest']['agreementDetails'], None)
 
     def test_adding_that_agreement_has_been_countersigned(self):
         with freeze_time('2012-12-12'):
@@ -1390,7 +1390,7 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest, JSONUpdateTestMixin):
             assert_is(data['frameworkInterest']['agreementReturnedAt'], None)
             assert_equal(data['frameworkInterest']['countersigned'], True)
             assert_equal(data['frameworkInterest']['countersignedAt'], "2012-12-12T00:00:00.000000Z")
-            assert_is(data['frameworkInterest']['signerDetails'], None)
+            assert_is(data['frameworkInterest']['agreementDetails'], None)
 
     def test_agreement_returned_at_timestamp_cannot_be_set(self):
         with freeze_time('2012-12-12'):
@@ -1418,8 +1418,8 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest, JSONUpdateTestMixin):
             data = json.loads(response.get_data())
             assert_equal(data['frameworkInterest']['countersignedAt'], '2012-12-12T00:00:00.000000Z')
 
-    def test_setting_signer_details(self):
-        signer_details_payload = {
+    def test_setting_agreement_details(self):
+        agreement_details_payload = {
             "some": [
                 "arbitrary",
                 123,
@@ -1429,14 +1429,14 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest, JSONUpdateTestMixin):
         }
         response = self.supplier_framework_update(
             0, 'digital-outcomes-and-specialists',
-            update={'signerDetails': signer_details_payload})
+            update={'agreementDetails': agreement_details_payload})
 
         assert_equal(response.status_code, 200)
         data = json.loads(response.get_data())
-        assert_equal(data['frameworkInterest']['signerDetails'], signer_details_payload)
+        assert_equal(data['frameworkInterest']['agreementDetails'], agreement_details_payload)
 
-        # while we're at it let's test the signerDetails partial updating behaviour
-        signer_details_update_payload = {
+        # while we're at it let's test the agreementDetails partial updating behaviour
+        agreement_details_update_payload = {
             "other": {
                 "json": 456,
             },
@@ -1444,15 +1444,15 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest, JSONUpdateTestMixin):
         }
         response2 = self.supplier_framework_update(
             0, 'digital-outcomes-and-specialists',
-            update={'signerDetails': signer_details_update_payload})
+            update={'agreementDetails': agreement_details_update_payload})
 
-        signer_details_payload.update(signer_details_update_payload)
+        agreement_details_payload.update(agreement_details_update_payload)
         # json validator should strip this key
-        del signer_details_payload["here"]
+        del agreement_details_payload["here"]
 
         assert_equal(response2.status_code, 200)
         data2 = json.loads(response2.get_data())
-        assert_equal(data2['frameworkInterest']['signerDetails'], signer_details_payload)
+        assert_equal(data2['frameworkInterest']['agreementDetails'], agreement_details_payload)
 
     def test_changing_from_failed_to_passed(self):
         response = self.supplier_framework_update(

--- a/tests/app/views/test_suppliers.py
+++ b/tests/app/views/test_suppliers.py
@@ -1403,6 +1403,19 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest, JSONUpdateTestMixin):
             data = json.loads(response.get_data())
             assert_equal(data['frameworkInterest']['agreementReturnedAt'], '2012-12-12T00:00:00.000000Z')
 
+    def test_agreement_returned_at_is_unset_when_agreement_returned_flag_is_false(self):
+        self.supplier_framework_update(
+            0, 'digital-outcomes-and-specialists',
+            update={'agreementReturned': True})
+        response = self.supplier_framework_update(
+            0, 'digital-outcomes-and-specialists',
+            update={'agreementReturned': False})
+
+        assert_equal(response.status_code, 200)
+        data = json.loads(response.get_data())
+        assert_equal(data['frameworkInterest']['agreementReturned'], False)
+        assert_equal(data['frameworkInterest']['agreementReturnedAt'], None)
+
     def test_countersigned_at_timestamp_cannot_be_set(self):
         with freeze_time('2012-12-12'):
             response = self.supplier_framework_update(


### PR DESCRIPTION
Renamed `signer_details` to `agreement_details` after discussion that this field should take more information about the general agreement rather than just being restricted to details about signing. This includes a database migration to do so and changes to the API and tests.

Also added back in functionality to unset agreement_returned which had previously been removed in [this pull request](https://github.com/alphagov/digitalmarketplace-api/pull/408). Functionality is now a little stricter and expects 'False' rather than something that is not true.