### PR TITLE
agreementDetails validation and set frameworkAgreementVersion automatically

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -422,9 +422,6 @@ def update_supplier_framework_details(supplier_id, framework_slug):
         interest_record_agreement_details_proposed = interest_record.agreement_details.copy() \
             if interest_record.agreement_details else {}
         interest_record_agreement_details_proposed.update(update_json.get('agreementDetails', {}))
-        interest_record_agreement_details_proposed = drop_foreign_fields(
-            interest_record_agreement_details_proposed, 'frameworkAgreementVersion'
-        )
 
         validate_agreement_details_data(
             interest_record_agreement_details_proposed,

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -408,6 +408,10 @@ def update_supplier_framework_details(supplier_id, framework_slug):
     if not interest_record:
         abort(404, "supplier_id '{}' has not registered interest in {}".format(supplier_id, framework_slug))
 
+    # `agreementDetails` shouldn't be passed in unless the framework has framework_agreement_details
+    if 'agreementDetails' in update_json and framework.framework_agreement_details is None:
+        abort(400, "Framework '{}' does not accept 'agreementDetails'".format(framework_slug))
+
     if (
             (framework.framework_agreement_details and framework.framework_agreement_details.get('frameworkAgreementVersion')) and  # noqa
             ('agreementDetails' in update_json or update_json.get('agreementReturned'))

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -5,7 +5,7 @@ from .. import main
 from ... import db
 from ...models import (
     Supplier, ContactInformation, AuditEvent,
-    Service, SupplierFramework, Framework
+    Service, SupplierFramework, Framework, User
 )
 from ...validation import (
     validate_supplier_json_or_400,
@@ -434,6 +434,11 @@ def update_supplier_framework_details(supplier_id, framework_slug):
             enforce_required=False,
             required_fields=required_fields
         )
+
+        if update_json.get('agreementDetails') and update_json['agreementDetails'].get('uploaderUserId'):
+            user = User.query.filter(User.id == update_json['agreementDetails']['uploaderUserId']).first()
+            if not user:
+                abort(400, "No user found with id '{}'".format(update_json['agreementDetails']['uploaderUserId']))
 
         interest_record.agreement_details = agreement_details or None
 

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -432,7 +432,6 @@ def update_supplier_framework_details(supplier_id, framework_slug):
     if 'agreementDetails' in update_json:
         agreement_details.update(update_json['agreementDetails'])
 
-    # thanks @ris!
     interest_record.agreement_details = agreement_details or None
 
     audit_event = AuditEvent(

--- a/app/models.py
+++ b/app/models.py
@@ -322,6 +322,9 @@ class SupplierFramework(db.Model):
 
     @validates('agreement_details')
     def validates_agreement_details(self, key, value):
+        if value is None:
+            return value
+
         value = strip_whitespace_from_data(value)
         value = purge_nulls_from_data(value)
 

--- a/app/models.py
+++ b/app/models.py
@@ -378,7 +378,7 @@ class SupplierFramework(db.Model):
         if countersigned_at:
             countersigned_at = countersigned_at.strftime(DATETIME_FORMAT)
 
-        return dict({
+        supplier_framework = dict({
             "supplierId": self.supplier_id,
             "supplierName": self.supplier.name,
             "frameworkSlug": self.framework.slug,
@@ -390,6 +390,17 @@ class SupplierFramework(db.Model):
             "countersigned": bool(countersigned_at),
             "countersignedAt": countersigned_at,
         }, **(data or {}))
+
+        if self.agreement_details and self.agreement_details.get('uploaderUserId'):
+            user = User.query.filter(
+                User.id == self.agreement_details.get('uploaderUserId')
+            ).first()
+
+            if user:
+                supplier_framework['agreementDetails']['uploaderUserName'] = user.name
+                supplier_framework['agreementDetails']['uploaderUserEmail'] = user.email_address
+
+        return supplier_framework
 
 
 class User(db.Model):

--- a/app/supplier_utils.py
+++ b/app/supplier_utils.py
@@ -1,4 +1,5 @@
-from .validation import validate_supplier_json_or_400, validate_new_supplier_json_or_400
+from flask import abort
+from .validation import validate_supplier_json_or_400, validate_new_supplier_json_or_400, get_validation_errors
 from .utils import get_json_from_request, json_has_matching_id, json_has_required_keys, drop_foreign_fields
 
 
@@ -21,3 +22,15 @@ def validate_and_return_supplier_request(supplier_id=None):
         validate_new_supplier_json_or_400(json_payload['suppliers'])
 
     return json_payload['suppliers']
+
+
+def validate_agreement_details_data(agreement_details, enforce_required=True, required_fields=None):
+    errs = get_validation_errors(
+        'agreement-details',
+        agreement_details,
+        enforce_required=enforce_required,
+        required_fields=required_fields
+    )
+
+    if errs:
+        abort(400, errs)

--- a/app/validation.py
+++ b/app/validation.py
@@ -15,6 +15,7 @@ MAXIMUM_SERVICE_ID_LENGTH = 20
 
 JSON_SCHEMAS_PATH = './json_schemas'
 SCHEMA_NAMES = [
+    'agreement-details',
     'brief-clarification-question',
     'briefs-digital-outcomes-and-specialists-digital-outcomes',
     'briefs-digital-outcomes-and-specialists-digital-specialists',
@@ -122,6 +123,13 @@ def validate_new_supplier_json_or_400(submitted_json):
 def validate_contact_information_json_or_400(submitted_json):
     try:
         get_validator('contact-information').validate(submitted_json)
+    except ValidationError as e:
+        abort(400, "JSON was not a valid format. {}".format(e.message))
+
+
+def validate_agreement_details_json_or_400(submitted_json):
+    try:
+        get_validator('agreement-details').validate(submitted_json)
     except ValidationError as e:
         abort(400, "JSON was not a valid format. {}".format(e.message))
 

--- a/app/validation.py
+++ b/app/validation.py
@@ -127,13 +127,6 @@ def validate_contact_information_json_or_400(submitted_json):
         abort(400, "JSON was not a valid format. {}".format(e.message))
 
 
-def validate_agreement_details_json_or_400(submitted_json):
-    try:
-        get_validator('agreement-details').validate(submitted_json)
-    except ValidationError as e:
-        abort(400, "JSON was not a valid format. {}".format(e.message))
-
-
 def validates_against_schema(validator_name, submitted_json):
     try:
         get_validator(validator_name).validate(submitted_json)

--- a/json_schemas/agreement-details.json
+++ b/json_schemas/agreement-details.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "additionalProperties": false,
+  "minProperties": 1,
+  "properties": {
+    "signerName": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "signerRole":  {
+      "minLength": 1,
+      "type": "string"
+    },
+    "uploaderUserId": {
+      "minimum": 1,
+      "type": "integer"
+    }
+  },
+  "title": "Agreement Details Schema",
+  "type": "object"
+}

--- a/json_schemas/agreement-details.json
+++ b/json_schemas/agreement-details.json
@@ -16,6 +16,11 @@
       "type": "integer"
     }
   },
+  "required": [
+    "signerName",
+    "signerRole",
+    "uploaderUserId"
+  ],
   "title": "Agreement Details Schema",
   "type": "object"
 }

--- a/json_schemas/agreement-details.json
+++ b/json_schemas/agreement-details.json
@@ -3,6 +3,10 @@
   "additionalProperties": false,
   "minProperties": 1,
   "properties": {
+    "frameworkAgreementVersion": {
+      "minLength": 1,
+      "type": "string"
+    },
     "signerName": {
       "minLength": 1,
       "type": "string"
@@ -17,6 +21,7 @@
     }
   },
   "required": [
+    "frameworkAgreementVersion",
     "signerName",
     "signerRole",
     "uploaderUserId"

--- a/tests/app/views/test_services.py
+++ b/tests/app/views/test_services.py
@@ -1881,7 +1881,6 @@ class TestGetService(BaseApplicationTest):
             db.session.commit()
         response = self.client.get('/services/123-disabled-456')
         data = json.loads(response.get_data())
-        print(response.get_data())
         assert_equal(data['serviceMadeUnavailableAuditEvent']['type'], 'framework_update')
         assert_equal(data['serviceMadeUnavailableAuditEvent']['user'], 'joeblogs')
         assert_in('createdAt', data['serviceMadeUnavailableAuditEvent'])

--- a/tests/app/views/test_suppliers.py
+++ b/tests/app/views/test_suppliers.py
@@ -1571,10 +1571,12 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest, JSONUpdateTestMixin):
             0, 'digital-outcomes-and-specialists',
             update={'agreementDetails': agreement_details_payload})
 
-        # weird because it still returns a 200-level response even though it doesn't update anything
-        assert response.status_code == 200
+        assert response.status_code == 400
         data = json.loads(response.get_data())
-        assert data['frameworkInterest']['agreementDetails'] is None
+        strings_we_expect_in_the_error_message = [
+            'Framework', 'digital-outcomes-and-specialists', 'does not accept',  'agreementDetails']
+        for error_string in strings_we_expect_in_the_error_message:
+            assert error_string in data['error']
 
     def test_setting_agreement_details_with_nonexistent_user_id_doesnt_return_user_details(self):
         agreement_details_payload = {

--- a/tests/app/views/test_suppliers.py
+++ b/tests/app/views/test_suppliers.py
@@ -1671,6 +1671,31 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest, JSONUpdateTestMixin):
         expected_error_dict = {'signerName': 'answer_required', 'signerRole': 'answer_required'}
         assert expected_error_dict == data['error']
 
+    def test_can_manually_override_framework_agreement_version_for_returned_framework_agreement(self):
+        response = self.supplier_framework_update(
+            0,
+            'g-cloud-8',
+            update={
+                'agreementReturned': True,
+                'agreementDetails': {
+                    'signerName': 'name',
+                    'signerRole': 'role',
+                    'uploaderUserId': 1
+                }
+            }
+        )
+        assert response.status_code == 200
+        data = json.loads(response.get_data())
+        assert data['frameworkInterest']['agreementDetails']['frameworkAgreementVersion'] == 'v1.0'
+
+        response2 = self.supplier_framework_update(
+            0, 'g-cloud-8',
+            update={'agreementDetails': {'frameworkAgreementVersion': 'v2.0'}}
+        )
+        assert response2.status_code == 200
+        data2 = json.loads(response2.get_data())
+        assert data2['frameworkInterest']['agreementDetails']['frameworkAgreementVersion'] == 'v2.0'
+
     def test_changing_on_framework_from_failed_to_passed(self):
         response = self.supplier_framework_update(
             0,

--- a/tests/app/views/test_suppliers.py
+++ b/tests/app/views/test_suppliers.py
@@ -1578,7 +1578,7 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest, JSONUpdateTestMixin):
         for error_string in strings_we_expect_in_the_error_message:
             assert error_string in data['error']
 
-    def test_setting_agreement_details_with_nonexistent_user_id_doesnt_return_user_details(self):
+    def test_can_not_set_agreement_details_with_nonexistent_user_id(self):
         agreement_details_payload = {
             "signerName": "name",
             "signerRole": "role",
@@ -1589,12 +1589,11 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest, JSONUpdateTestMixin):
             update={'agreementDetails': agreement_details_payload})
 
         data = json.loads(response.get_data())
-        assert response.status_code == 200
-        assert data['frameworkInterest']['agreementDetails'] == {
-            "signerName": "name",
-            "signerRole": "role",
-            "uploaderUserId": 999
-        }
+        assert response.status_code == 400
+        strings_we_expect_in_the_error_message = [
+            'No user found with id', '999']
+        for error_string in strings_we_expect_in_the_error_message:
+            assert error_string in data['error']
 
     def test_schema_validation_fails_if_unknown_fields_present_in_agreement_details(self):
         agreement_details_payload = {

--- a/tests/app/views/test_suppliers.py
+++ b/tests/app/views/test_suppliers.py
@@ -1272,6 +1272,7 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest, JSONUpdateTestMixin):
         super(TestSupplierFrameworkUpdates, self).setup()
 
         self.setup_dummy_suppliers(1)
+        self.setup_dummy_user(1, role='supplier')
 
         with self.app.app_context():
             self.set_framework_status('digital-outcomes-and-specialists', 'open')
@@ -1482,7 +1483,27 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest, JSONUpdateTestMixin):
         assert data2['frameworkInterest']['agreementDetails'] == {
             "signerName": "name",
             "signerRole": "role",
-            "uploaderUserId": 1
+            "uploaderUserId": 1,
+            "uploaderUserName": "my name",
+            "uploaderUserEmail": "test+1@digital.gov.uk",
+        }
+
+    def test_setting_agreement_details_with_nonexistent_user_id_doesnt_return_user_details(self):
+        agreement_details_payload = {
+            "signerName": "name",
+            "signerRole": "role",
+            "uploaderUserId": 999
+        }
+        response = self.supplier_framework_update(
+            0, 'digital-outcomes-and-specialists',
+            update={'agreementDetails': agreement_details_payload})
+
+        data = json.loads(response.get_data())
+        assert response.status_code == 200
+        assert data['frameworkInterest']['agreementDetails'] == {
+            "signerName": "name",
+            "signerRole": "role",
+            "uploaderUserId": 999
         }
 
     def test_schema_validation_fails_if_unknown_fields_present_in_agreement_details(self):

--- a/tests/app/views/test_suppliers.py
+++ b/tests/app/views/test_suppliers.py
@@ -1316,32 +1316,32 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest, JSONUpdateTestMixin):
             '/suppliers/0/frameworks/g-cloud-4')
 
         data = json.loads(response.get_data())
-        assert_equal(response.status_code, 200)
-        assert_equal(data['frameworkInterest']['supplierId'], 0)
-        assert_equal(data['frameworkInterest']['frameworkSlug'], 'g-cloud-4')
-        assert_equal(data['frameworkInterest']['declaration'], {'an_answer': 'Yes it is'})
-        assert_equal(data['frameworkInterest']['onFramework'], True)
-        assert_equal(data['frameworkInterest']['agreementReturned'], True)
-        assert_equal(data['frameworkInterest']['agreementReturnedAt'], '2015-10-10T10:10:10.000000Z')
-        assert_equal(data['frameworkInterest']['countersigned'], True)
-        assert_equal(data['frameworkInterest']['countersignedAt'], '2015-11-12T13:14:15.000000Z')
-        assert_equal(data['frameworkInterest']['agreementDetails'], {
+        assert response.status_code, 200
+        assert data['frameworkInterest']['supplierId'] == 0
+        assert data['frameworkInterest']['frameworkSlug'] == 'g-cloud-4'
+        assert data['frameworkInterest']['declaration'] == {'an_answer': 'Yes it is'}
+        assert data['frameworkInterest']['onFramework'] is True
+        assert data['frameworkInterest']['agreementReturned'] is True
+        assert data['frameworkInterest']['agreementReturnedAt'] == '2015-10-10T10:10:10.000000Z'
+        assert data['frameworkInterest']['countersigned'] is True
+        assert data['frameworkInterest']['countersignedAt'] == '2015-11-12T13:14:15.000000Z'
+        assert data['frameworkInterest']['agreementDetails'] == {
             'signerName': 'thing',
             'signerRole': 'thing',
             'uploaderUserId': 20
-        })
+        }
 
     def test_get_supplier_framework_info_non_existent_by_framework(self):
         response = self.client.get(
             '/suppliers/0/frameworks/g-cloud-5')
 
-        assert_equal(response.status_code, 404)
+        assert response.status_code == 404
 
     def test_get_supplier_framework_info_non_existent_by_supplier(self):
         response = self.client.get(
             '/suppliers/123/frameworks/g-cloud-4')
 
-        assert_equal(response.status_code, 404)
+        assert response.status_code == 404
 
     def test_adding_supplier_has_passed(self):
         response = self.supplier_framework_update(
@@ -1349,16 +1349,16 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest, JSONUpdateTestMixin):
             'digital-outcomes-and-specialists',
             update={'onFramework': True}
         )
-        assert_equal(response.status_code, 200)
+        assert response.status_code == 200
         data = json.loads(response.get_data())
-        assert_equal(data['frameworkInterest']['supplierId'], 0)
-        assert_equal(data['frameworkInterest']['frameworkSlug'], 'digital-outcomes-and-specialists')
-        assert_equal(data['frameworkInterest']['onFramework'], True)
-        assert_equal(data['frameworkInterest']['agreementReturned'], False)
-        assert_is(data['frameworkInterest']['agreementReturnedAt'], None)
-        assert_equal(data['frameworkInterest']['countersigned'], False)
-        assert_is(data['frameworkInterest']['countersignedAt'], None)
-        assert_is(data['frameworkInterest']['agreementDetails'], None)
+        assert data['frameworkInterest']['supplierId'] == 0
+        assert data['frameworkInterest']['frameworkSlug'], 'digital-outcomes-and-specialists'
+        assert data['frameworkInterest']['onFramework'] is True
+        assert data['frameworkInterest']['agreementReturned'] is False
+        assert data['frameworkInterest']['agreementReturnedAt'] is None
+        assert data['frameworkInterest']['countersigned'] is False
+        assert data['frameworkInterest']['countersignedAt'] is None
+        assert data['frameworkInterest']['agreementDetails'] is None
 
     def test_adding_supplier_has_not_passed(self):
         response = self.supplier_framework_update(
@@ -1366,11 +1366,11 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest, JSONUpdateTestMixin):
             'digital-outcomes-and-specialists',
             update={'onFramework': False}
         )
-        assert_equal(response.status_code, 200)
+        assert response.status_code == 200
         data = json.loads(response.get_data())
-        assert_equal(data['frameworkInterest']['supplierId'], 0)
-        assert_equal(data['frameworkInterest']['frameworkSlug'], 'digital-outcomes-and-specialists')
-        assert_equal(data['frameworkInterest']['onFramework'], False)
+        assert data['frameworkInterest']['supplierId'] == 0
+        assert data['frameworkInterest']['frameworkSlug'], 'digital-outcomes-and-specialists'
+        assert data['frameworkInterest']['onFramework'] is False
 
     def test_adding_that_agreement_has_been_returned(self):
         with freeze_time('2012-12-12'):
@@ -1379,15 +1379,15 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest, JSONUpdateTestMixin):
                 'digital-outcomes-and-specialists',
                 update={'agreementReturned': True}
             )
-            assert_equal(response.status_code, 200)
+            assert response.status_code == 200
             data = json.loads(response.get_data())
-            assert_equal(data['frameworkInterest']['supplierId'], 0)
-            assert_equal(data['frameworkInterest']['frameworkSlug'], 'digital-outcomes-and-specialists')
-            assert_equal(data['frameworkInterest']['agreementReturned'], True)
-            assert_equal(data['frameworkInterest']['agreementReturnedAt'], "2012-12-12T00:00:00.000000Z")
-            assert_equal(data['frameworkInterest']['countersigned'], False)
-            assert_is(data['frameworkInterest']['countersignedAt'], None)
-            assert_equal(data['frameworkInterest']['agreementDetails'], {u'frameworkAgreementVersion': u'v1.0'})
+            assert data['frameworkInterest']['supplierId'] == 0
+            assert data['frameworkInterest']['frameworkSlug'] == 'digital-outcomes-and-specialists'
+            assert data['frameworkInterest']['agreementReturned'] is True
+            assert data['frameworkInterest']['agreementReturnedAt'] == "2012-12-12T00:00:00.000000Z"
+            assert data['frameworkInterest']['countersigned'] is False
+            assert data['frameworkInterest']['countersignedAt'] is None
+            assert data['frameworkInterest']['agreementDetails'] == {u'frameworkAgreementVersion': u'v1.0'}
 
     def test_adding_that_agreement_has_been_countersigned(self):
         with freeze_time('2012-12-12'):
@@ -1396,15 +1396,15 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest, JSONUpdateTestMixin):
                 'digital-outcomes-and-specialists',
                 update={'countersigned': True}
             )
-            assert_equal(response.status_code, 200)
+            assert response.status_code == 200
             data = json.loads(response.get_data())
-            assert_equal(data['frameworkInterest']['supplierId'], 0)
-            assert_equal(data['frameworkInterest']['frameworkSlug'], 'digital-outcomes-and-specialists')
-            assert_equal(data['frameworkInterest']['agreementReturned'], False)
-            assert_is(data['frameworkInterest']['agreementReturnedAt'], None)
-            assert_equal(data['frameworkInterest']['countersigned'], True)
-            assert_equal(data['frameworkInterest']['countersignedAt'], "2012-12-12T00:00:00.000000Z")
-            assert_is(data['frameworkInterest']['agreementDetails'], None)
+            assert data['frameworkInterest']['supplierId'] == 0
+            assert data['frameworkInterest']['frameworkSlug'] == 'digital-outcomes-and-specialists'
+            assert data['frameworkInterest']['agreementReturned'] is False
+            assert data['frameworkInterest']['agreementReturnedAt'] is None
+            assert data['frameworkInterest']['countersigned'] is True
+            assert data['frameworkInterest']['countersignedAt'] == "2012-12-12T00:00:00.000000Z"
+            assert data['frameworkInterest']['agreementDetails'] is None
 
     def test_agreement_returned_at_timestamp_cannot_be_set(self):
         with freeze_time('2012-12-12'):
@@ -1413,9 +1413,9 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest, JSONUpdateTestMixin):
                 'digital-outcomes-and-specialists',
                 update={'agreementReturned': True, 'agreementReturnedAt': '2013-13-13T00:00:00.000000Z'}
             )
-            assert_equal(response.status_code, 200)
+            assert response.status_code == 200
             data = json.loads(response.get_data())
-            assert_equal(data['frameworkInterest']['agreementReturnedAt'], '2012-12-12T00:00:00.000000Z')
+            assert data['frameworkInterest']['agreementReturnedAt'] == '2012-12-12T00:00:00.000000Z'
 
     def test_agreement_returned_at_and_agreement_details_are_unset_when_agreement_returned_is_false(self):
         response = self.supplier_framework_update(
@@ -1451,9 +1451,9 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest, JSONUpdateTestMixin):
                     'countersignedAt': '2013-13-13T00:00:00.000000Z',
                 }
             )
-            assert_equal(response.status_code, 200)
+            assert response.status_code == 200
             data = json.loads(response.get_data())
-            assert_equal(data['frameworkInterest']['countersignedAt'], '2012-12-12T00:00:00.000000Z')
+            assert data['frameworkInterest']['countersignedAt'] == '2012-12-12T00:00:00.000000Z'
 
     def test_setting_agreement_details(self):
         agreement_details_payload = {
@@ -1488,7 +1488,7 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest, JSONUpdateTestMixin):
     def test_schema_validation_fails_if_unknown_fields_present_in_agreement_details(self):
         agreement_details_payload = {
             "signerName": "Normal Person",
-            "signerMobilePhoneOperatingSystem": "Windows Phone",
+            "disallowedKey": "value",
         }
         response = self.supplier_framework_update(
             0, 'digital-outcomes-and-specialists',
@@ -1497,9 +1497,11 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest, JSONUpdateTestMixin):
 
         assert response.status_code == 400
         data = json.loads(response.get_data())
-        error_message = u'JSON was not a valid format. ' \
-                        u'Additional properties are not allowed (\'signerMobilePhoneOperatingSystem\' was unexpected)'
-        assert error_message in data['error']
+        # split assertions into keyphrases due to nested unicode string in python 2
+        strings_we_expect_in_the_error_message = [
+            'JSON was not a valid format.', 'disallowedKey', 'was unexpected']
+        for error_string in strings_we_expect_in_the_error_message:
+            assert error_string in data['error']
 
     def test_schema_validation_fails_if_empty_object_sent_as_agreement_details(self):
         response = self.supplier_framework_update(
@@ -1509,7 +1511,7 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest, JSONUpdateTestMixin):
 
         assert response.status_code == 400
         data = json.loads(response.get_data())
-        error_message = u'JSON was not a valid format. {} does not have enough properties'
+        error_message = 'JSON was not a valid format. {} does not have enough properties'
         assert error_message in data['error']
 
     def test_schema_validation_fails_if_empty_strings_sent_as_agreement_details(self):
@@ -1524,8 +1526,11 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest, JSONUpdateTestMixin):
 
         assert response.status_code == 400
         data = json.loads(response.get_data())
-        error_message = u'JSON was not a valid format. \'\' is too short'
-        assert error_message in data['error']
+        # split assertions into keyphrases due to nested unicode string in python 2
+        strings_we_expect_in_the_error_message = [
+            'JSON was not a valid format.',  'is too short']
+        for error_string in strings_we_expect_in_the_error_message:
+            assert error_string in data['error']
 
     def test_changing_from_failed_to_passed(self):
         response = self.supplier_framework_update(
@@ -1533,20 +1538,20 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest, JSONUpdateTestMixin):
             'digital-outcomes-and-specialists',
             update={'onFramework': False}
         )
-        assert_equal(response.status_code, 200)
+        assert response.status_code == 200
         data = json.loads(response.get_data())
-        assert_equal(data['frameworkInterest']['onFramework'], False)
-        assert_equal(data['frameworkInterest']['agreementReturned'], False)
+        assert data['frameworkInterest']['onFramework'] is False
+        assert data['frameworkInterest']['agreementReturned'] is False
 
         response2 = self.supplier_framework_update(
             0,
             'digital-outcomes-and-specialists',
             update={'onFramework': True}
         )
-        assert_equal(response2.status_code, 200)
+        assert response2.status_code, 200
         data = json.loads(response2.get_data())
-        assert_equal(data['frameworkInterest']['onFramework'], True)
-        assert_equal(data['frameworkInterest']['agreementReturned'], False)
+        assert data['frameworkInterest']['onFramework'] is True
+        assert data['frameworkInterest']['agreementReturned'] is False
 
     def test_changing_from_passed_to_failed(self):
         response = self.supplier_framework_update(
@@ -1554,20 +1559,20 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest, JSONUpdateTestMixin):
             'digital-outcomes-and-specialists',
             update={'onFramework': True}
         )
-        assert_equal(response.status_code, 200)
+        assert response.status_code == 200
         data = json.loads(response.get_data())
-        assert_equal(data['frameworkInterest']['onFramework'], True)
-        assert_equal(data['frameworkInterest']['agreementReturned'], False)
+        assert data['frameworkInterest']['onFramework'] is True
+        assert data['frameworkInterest']['agreementReturned'] is False
 
         response2 = self.supplier_framework_update(
             0,
             'digital-outcomes-and-specialists',
             update={'onFramework': False}
         )
-        assert_equal(response2.status_code, 200)
+        assert response2.status_code == 200
         data = json.loads(response2.get_data())
-        assert_equal(data['frameworkInterest']['onFramework'], False)
-        assert_equal(data['frameworkInterest']['agreementReturned'], False)
+        assert data['frameworkInterest']['onFramework'] is False
+        assert data['frameworkInterest']['agreementReturned'] is False
 
     def test_pass_fail_update_creates_audit_event(self):
         self.supplier_framework_update(
@@ -1584,10 +1589,9 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest, JSONUpdateTestMixin):
                 AuditEvent.object == supplier,
                 AuditEvent.type == "supplier_update"
             ).first()
-
-            assert_equal(audit.type, "supplier_update")
-            assert_equal(audit.user, "interested@example.com")
-            assert_equal(audit.data['supplierId'], 0)
-            assert_equal(audit.data['frameworkSlug'], 'digital-outcomes-and-specialists')
-            assert_equal(audit.data['update']['onFramework'], True)
-            assert_equal(audit.data['update']['agreementReturned'], True)
+            assert audit.type == "supplier_update"
+            assert audit.user == "interested@example.com"
+            assert audit.data['supplierId'] == 0
+            assert audit.data['frameworkSlug'] == 'digital-outcomes-and-specialists'
+            assert audit.data['update']['onFramework'] is True
+            assert audit.data['update']['agreementReturned'] is True


### PR DESCRIPTION
- Added JSON schema validation for `agreementDetails` which only allows 
`signerName`, `signerRole`, `signerUserId`, `frameworkAgreementVersion` fields, along with the required validation for each of those fields. In time `agreementDetails` will soon be used for storing countersigning fields as well but that is not in our story scope at the moment and so those fields have not yet been added to the schema. This schema validation is then used in our API endpoint.

- `agreementDetails` will only be set if the relevant framework has a `frameworkAgreementVersion`. This will allow the previous signing process to run as normal.

- The user process for adding fields to `agreementDetails` will not see all required fields set at the same time due to a multipage form / multistep process. Therefore we introduce `validate_agreement_details_data` function which allows us to override which fields are required (if not all as set in the JSON schema). This is a similar pattern that has been used in other apps. Example usage will allow us to set `signerName` and `signerRole` without having to set `uploaderUserID` until the next step.

- If `agreementReturned` is set for a supplier framework then we will set `agreementDetails.frameworkAgreementVersion` to that of the relevant framework's agreement version. 

- If `agreementReturned` is unset then we will also unset `agreementDetails`. 

- The endpoint will allow `agreementDetails.frameworkAgreementVersion` to be updated but only in the case when the agreement is already marked as returned. It is anticipated that this behaviour will not actually be needed but does allow us the ability just in case.

- Note, we used a slightly roundabout way of assigning `interest_record.agreement_details` due to SQLAlchemy not picking up internal changes to `agreementDetails`. (It may be possible to rewrite this in a more straightforward way if one of @risicle's two propsed pull requests are accepted.)

- We store the `uploaderUserId`. Later on in our apps we will use this data to show information related to the uploaderUser, such as their name and email address. So this can happen easily we have added to `SupplierFramework.serialize()` to include `uploaderUserName` and `uploaderUserEmail` in `agreementDetails` if there is a `uploaderUserId`.

- Tidying up of test code to move from using `assert_*` functions to use the `assert` keyword plainly i.e. using `assert a == b` rather than `assert_equal(a,b)`.

- Some older tests have had their method names updated so they reflect clearly what they are doing e.g. `test_pass_fail_update_creates_audit_event` to `test_changing_on_framework_to_passed_creates_audit_event`
