### PR TITLE
[#125881031]list_briefs view: add support for filtering by multiple (comma separated) lots & frameworks

### DIFF
--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -118,15 +118,19 @@ def list_briefs():
         briefs = briefs.filter(Brief.users.any(id=user_id))
 
     if request.args.get('framework'):
-        briefs = briefs.filter(Brief.framework.has(Framework.slug == request.args.get('framework')))
+        briefs = briefs.filter(Brief.framework.has(
+            Framework.slug.in_(framework_slug.strip() for framework_slug in request.args["framework"].split(","))
+        ))
 
     if request.args.get('lot'):
-        briefs = briefs.filter(Brief.lot.has(Lot.slug == request.args.get('lot')))
+        briefs = briefs.filter(Brief.lot.has(
+            Lot.slug.in_(lot_slug.strip() for lot_slug in request.args["lot"].split(","))
+        ))
 
     if request.args.get('status'):
-        briefs = briefs.has_statuses(*[
+        briefs = briefs.has_statuses(*(
             status.strip() for status in request.args['status'].split(',')
-            ])
+            ))
 
     if user_id:
         return jsonify(


### PR DESCRIPTION
Though we don't have multiple brief-capable frameworks yet, code added to support multiple
framework filtering for reasons of symmetry, reducing the number of different implementations
of parameter handling we're using in this view.

This is for story https://www.pivotaltracker.com/story/show/125881031 "Filter catalogue of opportunities"
