### PR TITLE
[#119728323] Add migration to add `withdrawn_at` field to Brief model

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -879,6 +879,7 @@ class Brief(db.Model):
     updated_at = db.Column(db.DateTime, index=True, nullable=False,
                            default=datetime.utcnow, onupdate=datetime.utcnow)
     published_at = db.Column(db.DateTime, index=True, nullable=True)
+    withdrawn_at = db.Column(db.DateTime, index=True, nullable=True)
 
     __table_args__ = (db.ForeignKeyConstraint([framework_id, _lot_id],
                                               ['framework_lots.framework_id', 'framework_lots.lot_id']),

--- a/migrations/versions/680_brief_withdrawn_at.py
+++ b/migrations/versions/680_brief_withdrawn_at.py
@@ -1,0 +1,24 @@
+"""brief withdrawn at
+
+Revision ID: 680
+Revises: 670
+Create Date: 2016-07-25 10:22:21.258292
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '680'
+down_revision = '670'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('briefs', sa.Column('withdrawn_at', sa.DateTime(), nullable=True))
+    op.create_index(op.f('ix_briefs_withdrawn_at'), 'briefs', ['withdrawn_at'], unique=False)
+
+
+def downgrade():
+    op.drop_index(op.f('ix_briefs_withdrawn_at'), table_name='briefs')
+    op.drop_column('briefs', 'withdrawn_at')


### PR DESCRIPTION
Migration for [this story](https://www.pivotaltracker.com/story/show/119728323) to withdraw a publish brief.

This is a separate PR just for the migration, the rest of the story will follow as discussed last week.
