### PR TITLE
Specialist briefs can be open for 1 or 2 weeks.

### DIFF
--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -109,7 +109,11 @@ def get_brief(brief_id):
 
 @main.route('/briefs', methods=['GET'])
 def list_briefs():
-    briefs = Brief.query.order_by(Brief.published_at.desc(), Brief.id)
+    if request.args.get('human'):
+        briefs = Brief.query.order_by(Brief.status.desc(), Brief.published_at.desc(), Brief.id)
+    else:
+        briefs = Brief.query.order_by(Brief.published_at.desc(), Brief.id)
+
     page = get_valid_page_or_1()
 
     user_id = get_int_or_400(request.args, 'user_id')

--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -112,7 +112,7 @@ def list_briefs():
     if request.args.get('human'):
         briefs = Brief.query.order_by(Brief.status.desc(), Brief.published_at.desc(), Brief.id)
     else:
-        briefs = Brief.query.order_by(Brief.published_at.desc(), Brief.id)
+        briefs = Brief.query.order_by(Brief.id)
 
     page = get_valid_page_or_1()
 

--- a/app/models.py
+++ b/app/models.py
@@ -931,16 +931,9 @@ class Brief(db.Model):
     def applications_closed_at(self):
         if self.published_at is None:
             return None
+        brief_publishing_date_and_length = self._build_date_and_length_data()
 
-        published_day = self.published_at.replace(hour=23, minute=59, second=59, microsecond=0)
-        requirements_length = self.data.get('requirementsLength')
-        data = {
-            'publishedAt': published_day,
-            'requirementsLength': requirements_length
-        }
-        closing_date = get_publishing_dates(data)['closing_date']
-
-        return closing_date
+        return get_publishing_dates(brief_publishing_date_and_length)['closing_date']
 
     @applications_closed_at.expression
     def applications_closed_at(cls):
@@ -954,31 +947,17 @@ class Brief(db.Model):
     def clarification_questions_closed_at(self):
         if self.published_at is None:
             return None
+        brief_publishing_date_and_length = self._build_date_and_length_data()
 
-        published_day = self.published_at.replace(hour=23, minute=59, second=59, microsecond=0)
-        requirements_length = self.data.get('requirementsLength')
-        data = {
-            'publishedAt': published_day,
-            'requirementsLength': requirements_length
-        }
-        closing_date = get_publishing_dates(data)['questions_close']
-
-        return closing_date
+        return get_publishing_dates(brief_publishing_date_and_length)['questions_close']
 
     @hybrid_property
     def clarification_questions_published_by(self):
         if self.published_at is None:
             return None
+        brief_publishing_date_and_length = self._build_date_and_length_data()
 
-        published_day = self.published_at.replace(hour=23, minute=59, second=59, microsecond=0)
-        requirements_length = self.data.get('requirementsLength')
-        data = {
-            'publishedAt': published_day,
-            'requirementsLength': requirements_length
-        }
-        closing_date = get_publishing_dates(data)['answers_close']
-
-        return closing_date
+        return get_publishing_dates(brief_publishing_date_and_length)['answers_close']
 
     @hybrid_property
     def clarification_questions_are_closed(self):
@@ -1034,6 +1013,15 @@ class Brief(db.Model):
         current_data.update(data)
 
         self.data = current_data
+
+    def _build_date_and_length_data(self):
+        published_day = self.published_at.replace(hour=23, minute=59, second=59, microsecond=0)
+        requirements_length = self.data.get('requirementsLength')
+
+        return {
+            'publishedAt': published_day,
+            'requirementsLength': requirements_length
+        }
 
     def serialize(self, with_users=False):
         data = dict(self.data.items())

--- a/app/models.py
+++ b/app/models.py
@@ -939,9 +939,9 @@ class Brief(db.Model):
     def applications_closed_at(cls):
         return sql_case([
             (cls.data['requirementsLength'].astext == '1 week', func.date_trunc('day', cls.published_at) + sql_cast(
-                '7 days 23:59:59', INTERVAL)),
+                '1 week 23:59:59', INTERVAL)),
             ], else_=func.date_trunc('day', cls.published_at) + sql_cast(
-                '14 days 23:59:59', INTERVAL))
+                '2 weeks 23:59:59', INTERVAL))
 
     @hybrid_property
     def clarification_questions_closed_at(self):

--- a/app/models.py
+++ b/app/models.py
@@ -19,6 +19,7 @@ from sqlalchemy.types import String
 from sqlalchemy import Sequence
 from sqlalchemy_utils import generic_relationship
 from dmutils.formats import DATETIME_FORMAT
+from dmutils.dates import get_publishing_dates
 
 from . import db
 from .utils import link, url_for, strip_whitespace_from_data, drop_foreign_fields, purge_nulls_from_data
@@ -931,36 +932,53 @@ class Brief(db.Model):
         if self.published_at is None:
             return None
 
-        # Set time to 23:59:59 same day and add full number of days before application closes
         published_day = self.published_at.replace(hour=23, minute=59, second=59, microsecond=0)
-        closing_time = published_day + timedelta(days=self.APPLICATIONS_OPEN_DAYS)
+        requirements_length = self.data.get('requirementsLength')
+        data = {
+            'publishedAt': published_day,
+            'requirementsLength': requirements_length
+        }
+        closing_date = get_publishing_dates(data)['closing_date']
 
-        return closing_time
+        return closing_date
 
     @applications_closed_at.expression
     def applications_closed_at(cls):
-        return func.date_trunc('day', cls.published_at) + sql_cast(
-            '%d days 23:59:59' % cls.APPLICATIONS_OPEN_DAYS, INTERVAL
-        )
+        return sql_case([
+            (cls.data['requirementsLength'].astext == '1 week', func.date_trunc('day', cls.published_at) + sql_cast(
+                '7 days 23:59:59', INTERVAL)),
+            ], else_=func.date_trunc('day', cls.published_at) + sql_cast(
+                '14 days 23:59:59', INTERVAL))
 
     @hybrid_property
     def clarification_questions_closed_at(self):
         if self.published_at is None:
             return None
 
-        # Set time to 23:59:59 same day and add full number of days before questions close
         published_day = self.published_at.replace(hour=23, minute=59, second=59, microsecond=0)
-        closing_time = published_day + timedelta(days=self.CLARIFICATION_QUESTIONS_OPEN_DAYS)
+        requirements_length = self.data.get('requirementsLength')
+        data = {
+            'publishedAt': published_day,
+            'requirementsLength': requirements_length
+        }
+        closing_date = get_publishing_dates(data)['questions_close']
 
-        return closing_time
+        return closing_date
 
     @hybrid_property
     def clarification_questions_published_by(self):
         if self.published_at is None:
             return None
 
-        # All clarification questions should be published N days before brief closes
-        return self.applications_closed_at - timedelta(days=self.CLARIFICATION_QUESTIONS_PUBLISHED_DAYS)
+        published_day = self.published_at.replace(hour=23, minute=59, second=59, microsecond=0)
+        requirements_length = self.data.get('requirementsLength')
+        data = {
+            'publishedAt': published_day,
+            'requirementsLength': requirements_length
+        }
+        closing_date = get_publishing_dates(data)['answers_close']
+
+        return closing_date
 
     @hybrid_property
     def clarification_questions_are_closed(self):

--- a/json_schemas/briefs-digital-outcomes-and-specialists-digital-specialists.json
+++ b/json_schemas/briefs-digital-outcomes-and-specialists-digital-specialists.json
@@ -116,6 +116,12 @@
       "pattern": "^$|(^(?:\\S+\\s+){0,99}\\S+$)",
       "type": "string"
     },
+    "requirementsLength": {
+      "enum": [
+        "1 week",
+        "2 weeks"
+      ]
+    },
     "securityClearance": {
       "minLength": 0,
       "pattern": "^$|(^(?:\\S+\\s+){0,49}\\S+$)",
@@ -188,6 +194,7 @@
     "numberOfSuppliers",
     "organisation",
     "priceWeighting",
+    "requirementsLength",
     "specialistRole",
     "specialistWork",
     "startDate",

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,8 +8,8 @@ psycopg2==2.5.4
 SQLAlchemy==1.0.5
 SQLAlchemy-Utils==0.30.5
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@21.0.0#egg=digitalmarketplace-utils==21.0.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@5.1.0#egg=digitalmarketplace-apiclient==5.1.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@21.4.0#egg=digitalmarketplace-utils==21.4.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@5.2.0#egg=digitalmarketplace-apiclient==5.2.0
 
 # For schema validation
 jsonschema==2.5.1

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -32,7 +32,8 @@ COMPLETE_DIGITAL_SPECIALISTS_BRIEF = {
     "culturalFitCriteria": ["CULTURAL", "FIT"],
     "numberOfSuppliers": 3,
     "summary": "Doing some stuff to help out.",
-    "workplaceAddress": "Aviation House"
+    "workplaceAddress": "Aviation House",
+    "requirementsLength": "2 weeks"
 }
 
 
@@ -92,22 +93,24 @@ class BaseApplicationTest(object):
 
             return user.id
 
-    def setup_dummy_briefs(self, n, title=None, status='draft', user_id=1, brief_start=1, lot="digital-specialists"):
+    def setup_dummy_briefs(self, n, title=None, status='draft', user_id=1, data=None,
+                           brief_start=1, lot="digital-specialists", published_at=None):
         user_id = self.setup_dummy_user(id=user_id)
 
         with self.app.app_context():
             framework = Framework.query.filter(Framework.slug == "digital-outcomes-and-specialists").first()
             lot = Lot.query.filter(Lot.slug == lot).first()
-            data = COMPLETE_DIGITAL_SPECIALISTS_BRIEF.copy()
+            data = data or COMPLETE_DIGITAL_SPECIALISTS_BRIEF.copy()
             data["title"] = title
             for i in range(brief_start, brief_start + n):
                 self.setup_dummy_brief(
                     id=i,
                     user_id=user_id,
-                    data=dict(COMPLETE_DIGITAL_SPECIALISTS_BRIEF, title=title),
+                    data=data,
                     framework_slug="digital-outcomes-and-specialists",
                     lot_slug=lot.slug,
                     status=status,
+                    published_at=published_at,
                 )
             db.session.commit()
 

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -181,7 +181,7 @@ class TestBriefs(BaseApplicationTest):
 
         assert brief.applications_closed_at is None
 
-    def test_closing_dates_are_set_with_published_at_when_no_requirementsLength(self):
+    def test_closing_dates_are_set_with_published_at_when_no_requirements_length(self):
         brief = Brief(data={}, framework=self.framework, lot=self.lot,
                       published_at=datetime(2016, 3, 3, 12, 30, 1, 2))
 
@@ -189,7 +189,7 @@ class TestBriefs(BaseApplicationTest):
         assert brief.clarification_questions_closed_at == datetime(2016, 3, 10, 23, 59, 59)
         assert brief.clarification_questions_published_by == datetime(2016, 3, 16, 23, 59, 59)
 
-    def test_closing_dates_are_set_with_published_at_when_requirementsLength_is_two_weeks(self):
+    def test_closing_dates_are_set_with_published_at_when_requirements_length_is_two_weeks(self):
         brief = Brief(data={'requirementsLength': '2 weeks'}, framework=self.framework, lot=self.lot,
                       published_at=datetime(2016, 3, 3, 12, 30, 1, 2))
 
@@ -197,7 +197,7 @@ class TestBriefs(BaseApplicationTest):
         assert brief.clarification_questions_closed_at == datetime(2016, 3, 10, 23, 59, 59)
         assert brief.clarification_questions_published_by == datetime(2016, 3, 16, 23, 59, 59)
 
-    def test_closing_dates_are_set_with_published_at_when_requirementsLength_is_one_week(self):
+    def test_closing_dates_are_set_with_published_at_when_requirements_length_is_one_week(self):
         brief = Brief(data={'requirementsLength': '1 week'}, framework=self.framework, lot=self.lot,
                       published_at=datetime(2016, 3, 3, 12, 30, 1, 2))
 

--- a/tests/app/views/test_briefs.py
+++ b/tests/app/views/test_briefs.py
@@ -611,7 +611,7 @@ class TestBriefs(BaseApplicationTest):
 
         res = self.client.get('/briefs?human=True')
         data = json.loads(res.get_data(as_text=True))
-        titles = map(lambda brief: brief['title'], data['briefs'])
+        titles = list(map(lambda brief: brief['title'], data['briefs']))
 
         assert res.status_code == 200
         assert titles == ['Fourth', 'Second', 'Third', 'First']


### PR DESCRIPTION
For [this](https://www.pivotaltracker.com/story/show/123706751) story on Pivotal.

Will require PR's on [utils](https://github.com/alphagov/digitalmarketplace-utils/pull/275) and [apiclient](https://github.com/alphagov/digitalmarketplace-apiclient/pull/30) to be accepted first.

This PR is to update the brief model to use the new dates package in dmutils.

It also updates the json schema to allow the new requirementsLength key for digital specialist briefs.

It also allows the api to return a list of briefs in a human readable order by passing in a new flag. This is for the buyer frontend catalogue of briefs, which is now ordered by live briefs and then closed briefs. Within those groups they're ordered by published date. This is done from the api so that pagination doesn't break.