### PR TITLE
Create migration for specialist requirementLengths

### DIFF
--- a/migrations/versions/690_add_brief_length_to_published_briefs.py
+++ b/migrations/versions/690_add_brief_length_to_published_briefs.py
@@ -1,0 +1,45 @@
+"""Give published specialist briefs a requirementsLength of '2 weeks'
+
+Revision ID: 690
+Revises: 680
+Create Date: 2016-07-28 12:30:11.406853
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '690'
+down_revision = '680'
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.sql import table, column
+from sqlalchemy.dialects import postgresql
+
+briefs = table(
+    'briefs',
+    column('id', sa.Integer),
+    column('published_at', sa.DateTime),
+    column('data', postgresql.JSON),
+    column('lot_id', sa.Integer)
+)
+
+
+def upgrade():
+    conn = op.get_bind()
+    for brief in conn.execute(briefs.select()):
+        # skip briefs that are unpublished (&) not a specialist brief (&) have requirements length set
+        if not brief.publishedAt or brief.lot_id != 6 or brief.data.get('requirementsLength') != None:
+            continue
+
+        brief.data['requirementsLength'] = '2 weeks'
+        conn.execute(
+            briefs.update().where(
+                briefs.c.id == brief.id
+            ).values(
+                data=brief.data
+            )
+        )
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
This PR is part of [this](https://www.pivotaltracker.com/story/show/123706751) story on Pivotal and has come about due to [this](https://github.com/alphagov/digitalmarketplace-api/pull/422) PR.

The migration is to add a `requirementsLength` value to published specialists briefs.

Currently the downgrade is blank as without adding a new flag somewhere, I'm not sure how the migrated briefs could be differentiated from actual briefs. Any advice more than welcome!