### PR TITLE
[#119728323] Withdraw a published brief

### DIFF
--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -160,14 +160,9 @@ def list_briefs():
         )
 
 
-@main.route('/briefs/<int:brief_id>/status', methods=['PUT'])
+@main.route('/briefs/<int:brief_id>/publish', methods=['PUT'])
 def update_brief_status(brief_id):
     updater_json = validate_and_return_updater_request()
-
-    json_payload = get_json_from_request()
-    json_has_required_keys(json_payload, ['briefs'])
-    brief_json = json_payload['briefs']
-    json_has_required_keys(brief_json, ['status'])
 
     brief = Brief.query.filter(
         Brief.id == brief_id
@@ -176,8 +171,8 @@ def update_brief_status(brief_id):
     if brief.framework.status != 'live':
         abort(400, "Framework is not live")
 
-    if brief_json['status'] != brief.status:
-        brief.status = brief_json['status']
+    if brief.status != 'live':
+        brief.status = 'live'
 
         validate_brief_data(brief, enforce_required=True)
 

--- a/app/models.py
+++ b/app/models.py
@@ -987,8 +987,8 @@ class Brief(db.Model):
                 self.withdrawn_at = datetime.utcnow()
             else:
                 raise ValidationError("Cannot withdraw a brief that has not been published")
-        elif value == 'draft':
-            self.published_at = None
+        elif value == 'draft' and self.published_at is not None:
+            raise ValidationError("Cannot change brief status to 'draft'")
         elif value == 'closed':
             raise ValidationError("Cannot change brief status to 'closed'")
         else:

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -114,13 +114,20 @@ class BaseApplicationTest(object):
                 )
             db.session.commit()
 
-    def setup_dummy_brief(self, id=None, user_id=1, status=None, data=None, published_at=None,
-                          framework_slug="digital-outcomes-and-specialists", lot_slug="digital-specialists"):
+    def setup_dummy_brief(
+        self, id=None, user_id=1, status=None, data=None, published_at=None, withdrawn_at=None,
+        framework_slug="digital-outcomes-and-specialists", lot_slug="digital-specialists"
+    ):
         if published_at is not None and status is not None:
             raise ValueError("Cannot provide both status and published_at")
+        if withdrawn_at is not None and publish_at is None:
+            raise ValueError("If setting withdrawn_at then published_at must also be set")
         if not published_at:
             if status == 'closed':
                 published_at = datetime.utcnow() - timedelta(days=1000)
+            elif status == 'withdrawn':
+                published_at = datetime.utcnow() - timedelta(days=1000)
+                withdrawn_at = datetime.utcnow()
             else:
                 published_at = None if status == 'draft' else datetime.utcnow()
         framework = Framework.query.filter(Framework.slug == framework_slug).first()
@@ -133,6 +140,7 @@ class BaseApplicationTest(object):
             lot=lot,
             users=[User.query.get(user_id)],
             published_at=published_at,
+            withdrawn_at=withdrawn_at,
         ))
 
     def setup_dummy_suppliers(self, n):

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -299,11 +299,11 @@ class TestBriefs(BaseApplicationTest):
         with pytest.raises(ValidationError):
             brief.status = 'invalid'
 
-    def test_can_set_live_brief_to_draft(self):
+    def test_cannot_set_live_brief_to_draft(self):
         brief = Brief(data={}, framework=self.framework, lot=self.lot, published_at=datetime.utcnow())
-        brief.status = 'draft'
 
-        assert brief.published_at is None
+        with pytest.raises(ValidationError):
+            brief.status = 'draft'
 
     def test_can_set_live_brief_to_withdrawn(self):
         brief = Brief(data={}, framework=self.framework, lot=self.lot, published_at=datetime.utcnow())

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -401,6 +401,36 @@ class TestBriefs(BaseApplicationTest):
             assert brief.clarification_questions[0].question == "How?"
             assert brief.clarification_questions[1].question == "When"
 
+    def test_copy_brief(self):
+        with self.app.app_context():
+            self.framework.status = 'live'
+            self.setup_dummy_user(role='buyer')
+
+            brief = Brief(
+                data={'title': 'my title'},
+                framework=self.framework,
+                lot=self.lot,
+                users=User.query.all()
+            )
+
+        copy = brief.copy()
+
+        assert brief.data == {'title': 'my title'}
+        assert brief.framework == copy.framework
+        assert brief.lot == copy.lot
+        assert brief.users == copy.users
+
+    def test_copy_brief_raises_error_if_framework_is_not_live(self):
+        brief = Brief(
+            data={},
+            framework=self.framework,
+            lot=self.lot
+        )
+        with pytest.raises(ValidationError) as e:
+            copy = brief.copy()
+
+        assert str(e.value.message) == "Framework is not live"
+
 
 class TestBriefResponses(BaseApplicationTest):
     def setup(self):

--- a/tests/app/views/test_briefs.py
+++ b/tests/app/views/test_briefs.py
@@ -767,22 +767,6 @@ class TestBriefs(BaseApplicationTest):
         assert res.status_code == 400
         assert data['error'] == "Framework is not live"
 
-    def test_can_unpublish_a_live_brief(self):
-        self.setup_dummy_briefs(1, title="Published brief", status='live')
-
-        res = self.client.put(
-            '/briefs/1/status',
-            data=json.dumps({
-                'briefs': {'status': 'draft'},
-                'update_details': {'updated_by': 'example'}
-            }),
-            content_type='application/json')
-        data = json.loads(res.get_data(as_text=True))
-
-        assert res.status_code == 200
-        assert data['briefs']['status'] == 'draft'
-        assert 'publishedAt' not in data['briefs']
-
     def test_publish_brief_makes_audit_event(self):
         self.setup_dummy_briefs(1, title='The Title')
 


### PR DESCRIPTION
Pivotal story: [https://www.pivotaltracker.com/story/show/119728323](https://www.pivotaltracker.com/story/show/119728323)

#### Adds functionality for a brief's status to be "withdrawn"
The required database migration to add a new `withdrawn_at` field was added separately in [this previous pull request](https://github.com/alphagov/digitalmarketplace-api/pull/421) and has already been merged. In this PR, we add logic to the model for when and how a brief's status should be set as "withdrawn". We also add logic so we can run SQL queries that filter for briefs that are withdrawn.

#### Deprecates `update_brief_status` route and introduce `update_brief_status_by_action` route to handle publishing and withdrawing of briefs
We previously allowed a flexible way of setting a brief's status, using the `update_brief_status` route, where a payload contained the value of the new status you want to set. This flexibility was used in cases such as withdrawing a brief the old way (status from 'live' to 'draft'). Now we introduce a more formal way to withdraw a brief (status from 'live' to 'withdrawn'), we no longer want to be able to go from 'live' to 'draft'. Instead of having layers of logic to decide if we are able to set the requested status, we will introduce explicit routes to publish and withdraw briefs as these are the only two expected actions.

We leave the `update_brief_status` route intact (with a deprecated comment) for backwards compatibility. Usage of this route should be replaced by the newer `update_brief_status_by_action` route. After all usage is transferred to the newer route then we can remove the deprecated route.

#### Introduce `copy` brief route
There is a user need to republish a brief that is very similar to it's withdrawn original. Previously this was sometimes facilitated as briefs with no responses would have their status set to "draft" when being withdrawn. Now this is no longer allowed, we add a route to make a draft copy of a brief. This route has been made as a general copy route that will make a draft copy of any brief (regardless of the original's status).
