### PR TITLE
[#126295215] Only index `g-cloud` services

### DIFF
--- a/app/service_utils.py
+++ b/app/service_utils.py
@@ -129,7 +129,11 @@ def commit_and_archive_service(updated_service, update_details,
 
 
 def index_service(service):
-    if service.framework.status == 'live' and service.status == 'published':
+    if (
+        service.framework.status == 'live' and
+        service.framework.framework == 'g-cloud' and
+        service.status == 'published'
+    ):
         try:
             search_api_client.index(service.service_id, service.serialize())
         except dmapiclient.HTTPError as e:


### PR DESCRIPTION
We've been indexing all edited services as long as:
(a) they are live (published)
(b) the framework they belong to is live

Unfortunately, this meant that DOS services were getting into
our g-cloud index.

New logic also checks:
(c) the framework they belong to is a `g-cloud` framework

We talked about several other solutions, including one where we only
index services if their `Framework.framework` value matches an
alias in our elasticsearch indices.  This *would* work and it
would save us from hardcoding `g-cloud` in our application code,
but we don't think the scale of the problem really calls for
this level of abstraction.

Currently, we're only using elasticsearch for one set of services
and all of those services are `g-cloud` services.  Done. Easy.

[Bug in Pivotal](https://www.pivotaltracker.com/story/show/126295215)