### PR TITLE
Wonderful new tests for the service indexing function.

### DIFF
--- a/tests/app/test_service_utils.py
+++ b/tests/app/test_service_utils.py
@@ -1,0 +1,58 @@
+import pytest
+import mock
+
+from tests.app.helpers import GCloud8ApplicationTest
+from app.service_utils import index_service
+from app.models import Service
+
+
+@mock.patch('app.models.url_for')
+@mock.patch('app.service_utils.search_api_client')
+class TestIndexServices(GCloud8ApplicationTest):
+
+    def test_updating_g_cloud_service_on_live_framework_does_index(self, search_api_client, url_for):
+        with self.app.app_context():
+            self.setup_dummy_suppliers(1)
+            self.setup_dummy_service(
+                service_id='10000000001',
+                supplier_id=0,
+                framework_id=4,  # G-Cloud 7
+                lot_id=4,  # scs,
+                status='published',
+                data={'serviceName': 'service Name'})
+
+            service = Service.query.first()
+
+            index_service(service)
+            assert search_api_client.index.called
+
+    def test_updating_g_cloud_service_on_non_live_framework_doesnt_index(self, search_api_client, url_for):
+        with self.app.app_context():
+            self.setup_dummy_suppliers(1)
+            self.setup_dummy_service(
+                service_id='10000000001',
+                supplier_id=0,
+                framework_id=1,  # G-Cloud 6
+                lot_id=4,  # scs,
+                status='published',
+                data={'serviceName': 'service Name'})
+
+            service = Service.query.first()
+
+            index_service(service)
+            assert not search_api_client.index.called
+
+    def test_updating_g_cloud_service_on_non_g_cloud_framework_doesnt_index(self, search_api_client, url_for):
+        with self.app.app_context():
+            self.setup_dummy_suppliers(1)
+            self.setup_dummy_service(
+                service_id='10000000001',
+                supplier_id=0,
+                framework_id=5,  # Digital Outcomes and Specialists
+                lot_id=6,  # digital-specialists
+                status='published',
+                data={'serviceName': 'service Name'})
+
+            service = Service.query.first()
+            index_service(service)
+            assert not search_api_client.index.called


### PR DESCRIPTION
Trying to write tests for the index method,
which previously had no tests.

First problem I ran into was that the tests are testing
an actual `Service` object, so they I couldn’t just use
the existing DOS/G-Cloud fixtures.

So I went for the method to create dummy services.

Then, I needed a G-Cloud 8 framework, so I created a class
that inherits from `BaseApplicationTest` but adds a G-Cloud 8
framework in the setup and removes it in the teardown.

Unfortunately, my tests were *still* failing because the
initial statuses of the frameworks were all wrong.
G5 and G6 are the only live frameworks; G7, DOS, and G8 are
in standstill, pending, and live, respectively.

So this is where I completely lost the plot.
I expanded the test class in this really clunky way to:
- override all of the initial framework statuses
- revert them all to their initial statuses in the teardown

If we start changing stuff about frameworks between
tests, then other tests start to fail.

Basically, this is the fundamental problem.
Our tests are all sharing the same set of `Framework` database
objects, which we used to set and update in migrations but we
don't any longer.  Now that we've stopped, the default state of
all of our frameworks no longer reflect the world as it
presently exists.

It’s also pretty inconvenient to create a totally new service
object.  Before we have a `Service`, we need:
- a `Supplier`
- a `Framework`
- a `Lot` that belongs to that `Framework`

And there’s no straightforward way to create new `Framework` 
or `Lot` objects and then get rid of them at the end of the test.

This pull request sucks and I don’t think we should merge it.
But we should figure out what to do about these tests.