### PR TITLE
Adjust /briefs and /users for admin app buyer download

### DIFF
--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -116,6 +116,8 @@ def list_briefs():
 
     page = get_valid_page_or_1()
 
+    with_users = request.args.get('with_users', 'false').lower() == 'true'
+
     user_id = get_int_or_400(request.args, 'user_id')
 
     if user_id:
@@ -138,7 +140,7 @@ def list_briefs():
 
     if user_id:
         return jsonify(
-            briefs=[brief.serialize() for brief in briefs.all()],
+            briefs=[brief.serialize(with_users) for brief in briefs.all()],
             links={},
         )
     else:
@@ -148,7 +150,7 @@ def list_briefs():
         )
 
         return jsonify(
-            briefs=[brief.serialize() for brief in briefs.items],
+            briefs=[brief.serialize(with_users) for brief in briefs.items],
             meta={
                 "total": briefs.total,
             },

--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -63,6 +63,15 @@ def list_users():
             links={}
         )
 
+    role = request.args.get('role')
+    if role:
+        if role in ['buyer']:
+            user_query = user_query.filter(
+                User.role == role
+            )
+        else:
+            abort(400, 'Invalid user role: {}'.format(role))
+
     supplier_id = request.args.get('supplier_id')
     if supplier_id is not None:
         try:

--- a/tests/app/views/test_briefs.py
+++ b/tests/app/views/test_briefs.py
@@ -2,6 +2,7 @@ import json
 from datetime import datetime
 from datetime import timedelta
 
+import pytest
 import mock
 from ..helpers import BaseApplicationTest, COMPLETE_DIGITAL_SPECIALISTS_BRIEF
 
@@ -615,6 +616,34 @@ class TestBriefs(BaseApplicationTest):
 
         assert res.status_code == 200
         assert titles == ['Fourth', 'Second', 'Third', 'First']
+
+    def test_list_briefs_with_user_data_set_true(self):
+        self.setup_dummy_briefs(1, title="Test Brief", user_id=123)
+
+        response = self.client.get('/briefs?with_users=true')
+        data = json.loads(response.get_data(as_text=True))
+
+        assert response.status_code == 200
+        assert data['briefs'][0]['users'][0]['name'] == 'my name'
+
+    def test_list_briefs_with_user_data_set_True(self):
+        self.setup_dummy_briefs(1, title="Test Brief", user_id=123)
+
+        response = self.client.get('/briefs?with_users=True')
+        data = json.loads(response.get_data(as_text=True))
+
+        assert response.status_code == 200
+        assert data['briefs'][0]['users'][0]['name'] == 'my name'
+
+    def test_list_briefs_with_user_data_set_false(self):
+        self.setup_dummy_briefs(1, title="Test Brief", user_id=123)
+
+        response = self.client.get('/briefs?with_users=false')
+        data = json.loads(response.get_data(as_text=True))
+
+        assert response.status_code == 200
+        with pytest.raises(KeyError):
+            data['briefs'][0]['users']
 
     def test_list_briefs_pagination_page_one(self):
         self.setup_dummy_briefs(7)

--- a/tests/app/views/test_users.py
+++ b/tests/app/views/test_users.py
@@ -1065,6 +1065,29 @@ class TestUsersGet(BaseUserTest):
             "supplier_id '{}' not found".format(non_existent_supplier),
             response.get_data(as_text=True))
 
+    def test_only_buyers_returned_with_role_param_set_to_buyer(self):
+        self._post_user({
+            "emailAddress": "Chris@gov.uk",
+            "name": "Chris",
+            "role": "buyer",
+            "password": "minimum10characterpassword"
+        })
+
+        response = self.client.get('/users?role=buyer')
+        data = json.loads(response.get_data())
+        buyer = data['users'][0]
+
+        assert response.status_code == 200
+        assert len(data['users']) == 1
+        assert buyer['name'] == 'Chris'
+
+    def test_400_returned_if_role_param_is_not_valid(self):
+        response = self.client.get('/users?role=incorrect')
+        data = response.get_data(as_text=True)
+
+        assert response.status_code == 400
+        assert_in("Invalid user role: incorrect", data)
+
 
 class TestUsersExport(BaseUserTest):
     framework_slug = None


### PR DESCRIPTION
This PR is part of [this](https://www.pivotaltracker.com/story/show/124104161) Pivotal story. 

This PR is alternative approach to the previos PR on the API for the same story, found [here](https://github.com/alphagov/digitalmarketplace-api/pull/430).

The specific endpoint set up in the previous PR was too specific and couldn't be reused for other means. This approach is hitting the api to get all briefs and all buyers and the combining them in the admin app.

To do this, the api needed to return a little more information. For briefs, it needed to return the user data along with the brief. For users, it needed a way of filtering just on buyers. This PR adds that functionality.

For both routes it also adds some metadata to the json being returned which gives the total number of paginated pages. The admin app will need to hit the api a certain number of times to make sure it's retrieved all briefs/buyers and this bit of meta allows that.