### PR TITLE
Add tests for `index_service` function; improve framework-setting fixtures

### DIFF
--- a/tests/app/test_service_utils.py
+++ b/tests/app/test_service_utils.py
@@ -9,9 +9,8 @@ from app.models import Service, Framework
 @mock.patch('app.service_utils.search_api_client')
 class TestIndexServices(BaseApplicationTest):
 
-    @pytest.mark.parametrize('update_framework_status', [('live', 'g-cloud-8')], indirect=True)
     def test_live_g_cloud_8_published_service_is_indexed(
-            self, search_api_client, add_g_cloud_8, update_framework_status
+            self, search_api_client, live_g8_framework
     ):
         with self.app.app_context():
             g8 = Framework.query.filter(Framework.slug == 'g-cloud-8').first()
@@ -22,9 +21,8 @@ class TestIndexServices(BaseApplicationTest):
 
             assert search_api_client.index.called
 
-    @pytest.mark.parametrize('update_framework_status', [('live', 'g-cloud-8')], indirect=True)
     def test_live_g_cloud_8_enabled_service_is_not_indexed(
-            self, search_api_client, add_g_cloud_8, update_framework_status
+            self, search_api_client, live_g8_framework
     ):
         with self.app.app_context():
             g8 = Framework.query.filter(Framework.slug == 'g-cloud-8').first()
@@ -35,8 +33,7 @@ class TestIndexServices(BaseApplicationTest):
 
             assert not search_api_client.index.called
 
-    @pytest.mark.parametrize('update_framework_status', [('live', 'digital-outcomes-and-specialists')], indirect=True)
-    def test_live_dos_published_service_is_not_indexed(self, search_api_client, update_framework_status):
+    def test_live_dos_published_service_is_not_indexed(self, search_api_client, live_dos_framework):
         with self.app.app_context():
             dos = Framework.query.filter(Framework.slug == 'digital-outcomes-and-specialists').first()
 
@@ -46,8 +43,7 @@ class TestIndexServices(BaseApplicationTest):
 
             assert not search_api_client.index.called
 
-    @pytest.mark.parametrize('update_framework_status', [('expired', 'g-cloud-6')], indirect=True)
-    def test_expired_g_cloud_6_published_service_is_not_indexed(self, search_api_client, update_framework_status):
+    def test_expired_g_cloud_6_published_service_is_not_indexed(self, search_api_client, expired_g6_framework):
         with self.app.app_context():
             g6 = Framework.query.filter(Framework.slug == 'g-cloud-6').first()
 

--- a/tests/app/test_service_utils.py
+++ b/tests/app/test_service_utils.py
@@ -1,0 +1,58 @@
+import pytest
+import mock
+
+from tests.app.helpers import BaseApplicationTest
+from app.service_utils import index_service
+from app.models import Service, Framework
+
+
+@mock.patch('app.service_utils.search_api_client')
+class TestIndexServices(BaseApplicationTest):
+
+    @pytest.mark.parametrize('update_framework_status', [('live', 'g-cloud-8')], indirect=True)
+    def test_live_g_cloud_8_published_service_is_indexed(
+            self, search_api_client, add_g_cloud_8, update_framework_status
+    ):
+        with self.app.app_context():
+            g8 = Framework.query.filter(Framework.slug == 'g-cloud-8').first()
+
+            with mock.patch.object(Service, "serialize") as serialize_mock:
+                service = Service(status='published', framework=g8)
+                index_service(service)
+
+            assert search_api_client.index.called
+
+    @pytest.mark.parametrize('update_framework_status', [('live', 'g-cloud-8')], indirect=True)
+    def test_live_g_cloud_8_enabled_service_is_not_indexed(
+            self, search_api_client, add_g_cloud_8, update_framework_status
+    ):
+        with self.app.app_context():
+            g8 = Framework.query.filter(Framework.slug == 'g-cloud-8').first()
+
+            with mock.patch.object(Service, "serialize") as serialize_mock:
+                service = Service(status='enabled', framework=g8)
+                index_service(service)
+
+            assert not search_api_client.index.called
+
+    @pytest.mark.parametrize('update_framework_status', [('live', 'digital-outcomes-and-specialists')], indirect=True)
+    def test_live_dos_published_service_is_not_indexed(self, search_api_client, update_framework_status):
+        with self.app.app_context():
+            dos = Framework.query.filter(Framework.slug == 'digital-outcomes-and-specialists').first()
+
+            with mock.patch.object(Service, "serialize") as serialize_mock:
+                service = Service(status='published', framework=dos)
+                index_service(service)
+
+            assert not search_api_client.index.called
+
+    @pytest.mark.parametrize('update_framework_status', [('expired', 'g-cloud-6')], indirect=True)
+    def test_expired_g_cloud_6_published_service_is_not_indexed(self, search_api_client, update_framework_status):
+        with self.app.app_context():
+            g6 = Framework.query.filter(Framework.slug == 'g-cloud-6').first()
+
+            with mock.patch.object(Service, "serialize") as serialize_mock:
+                service = Service(status='published', framework=g6)
+                index_service(service)
+
+            assert not search_api_client.index.called

--- a/tests/app/views/test_brief_response.py
+++ b/tests/app/views/test_brief_response.py
@@ -1,4 +1,5 @@
 import json
+import pytest
 
 from hypothesis import given
 
@@ -85,7 +86,7 @@ class TestCreateBriefResponse(BaseBriefResponseTest, JSONUpdateTestMixin):
     method = 'post'
 
     @given(example_listings.brief_response_data())
-    def test_create_new_brief_response(self, live_framework, brief_response_data):
+    def test_create_new_brief_response(self, update_framework, brief_response_data):
         res = self.create_brief_response(dict(brief_response_data, **{
             'briefId': self.brief_id,
             'supplierId': 0,
@@ -98,7 +99,7 @@ class TestCreateBriefResponse(BaseBriefResponseTest, JSONUpdateTestMixin):
         assert data['briefResponses']['briefId'] == self.brief_id
 
     @given(example_listings.brief_response_data())
-    def test_create_brief_response_creates_an_audit_event(self, live_framework, brief_response_data):
+    def test_create_brief_response_creates_an_audit_event(self, update_framework, brief_response_data):
         res = self.create_brief_response(dict(brief_response_data, **{
             'briefId': self.brief_id,
             'supplierId': 0,
@@ -120,7 +121,7 @@ class TestCreateBriefResponse(BaseBriefResponseTest, JSONUpdateTestMixin):
             })
         }
 
-    def test_cannot_create_brief_response_with_empty_json(self, live_framework):
+    def test_cannot_create_brief_response_with_empty_json(self, update_framework):
         res = self.client.post(
             '/brief-responses',
             data=json.dumps({
@@ -131,7 +132,7 @@ class TestCreateBriefResponse(BaseBriefResponseTest, JSONUpdateTestMixin):
 
         assert res.status_code == 400
 
-    def test_cannot_create_brief_response_with_invalid_json(self, live_framework):
+    def test_cannot_create_brief_response_with_invalid_json(self, update_framework):
         res = self.client.post(
             '/brief-responses',
             data=json.dumps({
@@ -151,7 +152,7 @@ class TestCreateBriefResponse(BaseBriefResponseTest, JSONUpdateTestMixin):
         assert data['error']['essentialRequirements'] == 'answer_required'
         assert 'niceToHaveRequirements' in data['error']
 
-    def test_cannot_create_brief_response_without_supplier_id(self, live_framework):
+    def test_cannot_create_brief_response_without_supplier_id(self, update_framework):
         res = self.create_brief_response({
             'briefId': self.brief_id
         })
@@ -159,7 +160,7 @@ class TestCreateBriefResponse(BaseBriefResponseTest, JSONUpdateTestMixin):
         assert res.status_code == 400
         assert 'supplierId' in res.get_data(as_text=True)
 
-    def test_cannot_create_brief_response_without_brief_id(self, live_framework):
+    def test_cannot_create_brief_response_without_brief_id(self, update_framework):
         res = self.create_brief_response({
             'supplierId': 0
         })
@@ -167,7 +168,7 @@ class TestCreateBriefResponse(BaseBriefResponseTest, JSONUpdateTestMixin):
         assert res.status_code == 400
         assert 'briefId' in res.get_data(as_text=True)
 
-    def test_cannot_create_brief_response_with_non_integer_supplier_id(self, live_framework):
+    def test_cannot_create_brief_response_with_non_integer_supplier_id(self, update_framework):
         res = self.create_brief_response({
             'briefId': self.brief_id,
             'supplierId': 'not a number',
@@ -176,7 +177,7 @@ class TestCreateBriefResponse(BaseBriefResponseTest, JSONUpdateTestMixin):
         assert res.status_code == 400
         assert 'Invalid supplier ID' in res.get_data(as_text=True)
 
-    def test_cannot_create_brief_response_with_non_integer_brief_id(self, live_framework):
+    def test_cannot_create_brief_response_with_non_integer_brief_id(self, update_framework):
         res = self.create_brief_response({
             'briefId': 'not a number',
             'supplierId': 0,
@@ -185,7 +186,7 @@ class TestCreateBriefResponse(BaseBriefResponseTest, JSONUpdateTestMixin):
         assert res.status_code == 400
         assert 'Invalid brief ID' in res.get_data(as_text=True)
 
-    def test_cannot_create_brief_response_when_brief_doesnt_exist(self, live_framework):
+    def test_cannot_create_brief_response_when_brief_doesnt_exist(self, update_framework):
         res = self.create_brief_response({
             'briefId': self.brief_id + 100,
             'supplierId': 0
@@ -194,7 +195,7 @@ class TestCreateBriefResponse(BaseBriefResponseTest, JSONUpdateTestMixin):
         assert res.status_code == 400
         assert 'Invalid brief ID' in res.get_data(as_text=True)
 
-    def test_cannot_create_brief_response_when_supplier_doesnt_exist(self, live_framework):
+    def test_cannot_create_brief_response_when_supplier_doesnt_exist(self, update_framework):
         res = self.create_brief_response({
             'briefId': self.brief_id,
             'supplierId': 999
@@ -203,7 +204,7 @@ class TestCreateBriefResponse(BaseBriefResponseTest, JSONUpdateTestMixin):
         assert res.status_code == 400
         assert 'Invalid supplier ID' in res.get_data(as_text=True)
 
-    def test_cannot_create_brief_response_when_supplier_isnt_eligible(self, live_framework):
+    def test_cannot_create_brief_response_when_supplier_isnt_eligible(self, update_framework):
         res = self.create_brief_response({
             'briefId': self.brief_id,
             'supplierId': 1
@@ -212,7 +213,7 @@ class TestCreateBriefResponse(BaseBriefResponseTest, JSONUpdateTestMixin):
         assert res.status_code == 400
         assert 'Supplier not eligible' in res.get_data(as_text=True)
 
-    def test_cannot_respond_to_a_brief_that_isnt_live(self, live_framework):
+    def test_cannot_respond_to_a_brief_that_isnt_live(self, update_framework):
         with self.app.app_context():
             brief = Brief(
                 data={}, status='draft', framework_id=5, lot=Lot.query.get(5)
@@ -230,7 +231,8 @@ class TestCreateBriefResponse(BaseBriefResponseTest, JSONUpdateTestMixin):
         assert res.status_code == 400
         assert "Brief must be live" in res.get_data(as_text=True)
 
-    def test_cannot_respond_to_an_expired_framework_brief(self, expired_framework):
+    @pytest.mark.parametrize('update_framework', [('expired', 'digital-outcomes-and-specialists')], indirect=True)
+    def test_cannot_respond_to_an_expired_framework_brief(self, update_framework):
         res = self.create_brief_response({
             'briefId': self.brief_id,
             'supplierId': 0
@@ -240,7 +242,9 @@ class TestCreateBriefResponse(BaseBriefResponseTest, JSONUpdateTestMixin):
         assert "Brief framework must be live" in res.get_data(as_text=True)
 
     @given(example_listings.brief_response_data())
-    def test_cannot_respond_to_a_brief_more_than_once_from_the_same_supplier(self, live_framework, brief_response_data):
+    def test_cannot_respond_to_a_brief_more_than_once_from_the_same_supplier(
+            self, update_framework, brief_response_data
+    ):
         self.create_brief_response(dict(brief_response_data, **{
             'briefId': self.brief_id,
             'supplierId': 0,
@@ -256,7 +260,9 @@ class TestCreateBriefResponse(BaseBriefResponseTest, JSONUpdateTestMixin):
 
     @given(example_listings.brief_response_data(None, 5).filter(
         lambda x: len(x['essentialRequirements']) != 5 and all(i is not None for i in x['essentialRequirements'])))
-    def test_cannot_respond_to_a_brief_with_wrong_number_of_essential_reqs(self, live_framework, brief_response_data):
+    def test_cannot_respond_to_a_brief_with_wrong_number_of_essential_reqs(
+            self, update_framework, brief_response_data
+    ):
         res = self.create_brief_response(dict(brief_response_data, **{
             'briefId': self.brief_id,
             'supplierId': 0,
@@ -269,7 +275,9 @@ class TestCreateBriefResponse(BaseBriefResponseTest, JSONUpdateTestMixin):
 
     @given(example_listings.brief_response_data(5, None).filter(
         lambda x: len(x['niceToHaveRequirements']) != 5 and all(i is not None for i in x['niceToHaveRequirements'])))
-    def test_cannot_respond_to_a_brief_with_wrong_number_of_nicetohave_reqs(self, live_framework, brief_response_data):
+    def test_cannot_respond_to_a_brief_with_wrong_number_of_nicetohave_reqs(
+            self, update_framework, brief_response_data
+    ):
         res = self.create_brief_response(dict(brief_response_data, **{
             'briefId': self.brief_id,
             'supplierId': 0,
@@ -282,7 +290,7 @@ class TestCreateBriefResponse(BaseBriefResponseTest, JSONUpdateTestMixin):
 
     @given(example_listings.brief_response_data(5, None).filter(
         lambda x: any(i is None for i in x['niceToHaveRequirements'])))
-    def test_cannot_respond_to_a_brief_with_none_reqs_values(self, live_framework, brief_response_data):
+    def test_cannot_respond_to_a_brief_with_none_reqs_values(self, update_framework, brief_response_data):
         res = self.create_brief_response(dict(brief_response_data, **{
             'briefId': self.brief_id,
             'supplierId': 0,
@@ -294,7 +302,7 @@ class TestCreateBriefResponse(BaseBriefResponseTest, JSONUpdateTestMixin):
         assert data['error']['niceToHaveRequirements'] == 'answer_required'
 
     @given(example_listings.specialists_brief_response_data())
-    def test_create_digital_specialists_brief_response(self, live_framework, brief_response_data):
+    def test_create_digital_specialists_brief_response(self, update_framework, brief_response_data):
         res = self.create_brief_response(dict(brief_response_data, **{
             'briefId': self.specialist_brief_id,
             'supplierId': 0,
@@ -305,7 +313,7 @@ class TestCreateBriefResponse(BaseBriefResponseTest, JSONUpdateTestMixin):
         assert res.status_code == 201, data
 
     @given(example_listings.specialists_brief_response_data(min_day_rate=1001, max_day_rate=100000))
-    def test_day_rate_should_be_less_than_service_max_price(self, live_framework, brief_response_data):
+    def test_day_rate_should_be_less_than_service_max_price(self, update_framework, brief_response_data):
         res = self.create_brief_response(dict(brief_response_data, **{
             'briefId': self.specialist_brief_id,
             'supplierId': 0,

--- a/tests/app/views/test_brief_response.py
+++ b/tests/app/views/test_brief_response.py
@@ -86,7 +86,7 @@ class TestCreateBriefResponse(BaseBriefResponseTest, JSONUpdateTestMixin):
     method = 'post'
 
     @given(example_listings.brief_response_data())
-    def test_create_new_brief_response(self, update_framework, brief_response_data):
+    def test_create_new_brief_response(self, update_framework_status, brief_response_data):
         res = self.create_brief_response(dict(brief_response_data, **{
             'briefId': self.brief_id,
             'supplierId': 0,
@@ -99,7 +99,7 @@ class TestCreateBriefResponse(BaseBriefResponseTest, JSONUpdateTestMixin):
         assert data['briefResponses']['briefId'] == self.brief_id
 
     @given(example_listings.brief_response_data())
-    def test_create_brief_response_creates_an_audit_event(self, update_framework, brief_response_data):
+    def test_create_brief_response_creates_an_audit_event(self, update_framework_status, brief_response_data):
         res = self.create_brief_response(dict(brief_response_data, **{
             'briefId': self.brief_id,
             'supplierId': 0,
@@ -121,7 +121,7 @@ class TestCreateBriefResponse(BaseBriefResponseTest, JSONUpdateTestMixin):
             })
         }
 
-    def test_cannot_create_brief_response_with_empty_json(self, update_framework):
+    def test_cannot_create_brief_response_with_empty_json(self, update_framework_status):
         res = self.client.post(
             '/brief-responses',
             data=json.dumps({
@@ -132,7 +132,7 @@ class TestCreateBriefResponse(BaseBriefResponseTest, JSONUpdateTestMixin):
 
         assert res.status_code == 400
 
-    def test_cannot_create_brief_response_with_invalid_json(self, update_framework):
+    def test_cannot_create_brief_response_with_invalid_json(self, update_framework_status):
         res = self.client.post(
             '/brief-responses',
             data=json.dumps({
@@ -152,7 +152,7 @@ class TestCreateBriefResponse(BaseBriefResponseTest, JSONUpdateTestMixin):
         assert data['error']['essentialRequirements'] == 'answer_required'
         assert 'niceToHaveRequirements' in data['error']
 
-    def test_cannot_create_brief_response_without_supplier_id(self, update_framework):
+    def test_cannot_create_brief_response_without_supplier_id(self, update_framework_status):
         res = self.create_brief_response({
             'briefId': self.brief_id
         })
@@ -160,7 +160,7 @@ class TestCreateBriefResponse(BaseBriefResponseTest, JSONUpdateTestMixin):
         assert res.status_code == 400
         assert 'supplierId' in res.get_data(as_text=True)
 
-    def test_cannot_create_brief_response_without_brief_id(self, update_framework):
+    def test_cannot_create_brief_response_without_brief_id(self, update_framework_status):
         res = self.create_brief_response({
             'supplierId': 0
         })
@@ -168,7 +168,7 @@ class TestCreateBriefResponse(BaseBriefResponseTest, JSONUpdateTestMixin):
         assert res.status_code == 400
         assert 'briefId' in res.get_data(as_text=True)
 
-    def test_cannot_create_brief_response_with_non_integer_supplier_id(self, update_framework):
+    def test_cannot_create_brief_response_with_non_integer_supplier_id(self, update_framework_status):
         res = self.create_brief_response({
             'briefId': self.brief_id,
             'supplierId': 'not a number',
@@ -177,7 +177,7 @@ class TestCreateBriefResponse(BaseBriefResponseTest, JSONUpdateTestMixin):
         assert res.status_code == 400
         assert 'Invalid supplier ID' in res.get_data(as_text=True)
 
-    def test_cannot_create_brief_response_with_non_integer_brief_id(self, update_framework):
+    def test_cannot_create_brief_response_with_non_integer_brief_id(self, update_framework_status):
         res = self.create_brief_response({
             'briefId': 'not a number',
             'supplierId': 0,
@@ -186,7 +186,7 @@ class TestCreateBriefResponse(BaseBriefResponseTest, JSONUpdateTestMixin):
         assert res.status_code == 400
         assert 'Invalid brief ID' in res.get_data(as_text=True)
 
-    def test_cannot_create_brief_response_when_brief_doesnt_exist(self, update_framework):
+    def test_cannot_create_brief_response_when_brief_doesnt_exist(self, update_framework_status):
         res = self.create_brief_response({
             'briefId': self.brief_id + 100,
             'supplierId': 0
@@ -195,7 +195,7 @@ class TestCreateBriefResponse(BaseBriefResponseTest, JSONUpdateTestMixin):
         assert res.status_code == 400
         assert 'Invalid brief ID' in res.get_data(as_text=True)
 
-    def test_cannot_create_brief_response_when_supplier_doesnt_exist(self, update_framework):
+    def test_cannot_create_brief_response_when_supplier_doesnt_exist(self, update_framework_status):
         res = self.create_brief_response({
             'briefId': self.brief_id,
             'supplierId': 999
@@ -204,7 +204,7 @@ class TestCreateBriefResponse(BaseBriefResponseTest, JSONUpdateTestMixin):
         assert res.status_code == 400
         assert 'Invalid supplier ID' in res.get_data(as_text=True)
 
-    def test_cannot_create_brief_response_when_supplier_isnt_eligible(self, update_framework):
+    def test_cannot_create_brief_response_when_supplier_isnt_eligible(self, update_framework_status):
         res = self.create_brief_response({
             'briefId': self.brief_id,
             'supplierId': 1
@@ -213,7 +213,7 @@ class TestCreateBriefResponse(BaseBriefResponseTest, JSONUpdateTestMixin):
         assert res.status_code == 400
         assert 'Supplier not eligible' in res.get_data(as_text=True)
 
-    def test_cannot_respond_to_a_brief_that_isnt_live(self, update_framework):
+    def test_cannot_respond_to_a_brief_that_isnt_live(self, update_framework_status):
         with self.app.app_context():
             brief = Brief(
                 data={}, status='draft', framework_id=5, lot=Lot.query.get(5)
@@ -231,8 +231,9 @@ class TestCreateBriefResponse(BaseBriefResponseTest, JSONUpdateTestMixin):
         assert res.status_code == 400
         assert "Brief must be live" in res.get_data(as_text=True)
 
-    @pytest.mark.parametrize('update_framework', [('expired', 'digital-outcomes-and-specialists')], indirect=True)
-    def test_cannot_respond_to_an_expired_framework_brief(self, update_framework):
+    @pytest.mark.parametrize(
+        'update_framework_status', [('expired', 'digital-outcomes-and-specialists')], indirect=True)
+    def test_cannot_respond_to_an_expired_framework_brief(self, update_framework_status):
         res = self.create_brief_response({
             'briefId': self.brief_id,
             'supplierId': 0
@@ -243,7 +244,7 @@ class TestCreateBriefResponse(BaseBriefResponseTest, JSONUpdateTestMixin):
 
     @given(example_listings.brief_response_data())
     def test_cannot_respond_to_a_brief_more_than_once_from_the_same_supplier(
-            self, update_framework, brief_response_data
+            self, update_framework_status, brief_response_data
     ):
         self.create_brief_response(dict(brief_response_data, **{
             'briefId': self.brief_id,
@@ -261,7 +262,7 @@ class TestCreateBriefResponse(BaseBriefResponseTest, JSONUpdateTestMixin):
     @given(example_listings.brief_response_data(None, 5).filter(
         lambda x: len(x['essentialRequirements']) != 5 and all(i is not None for i in x['essentialRequirements'])))
     def test_cannot_respond_to_a_brief_with_wrong_number_of_essential_reqs(
-            self, update_framework, brief_response_data
+            self, update_framework_status, brief_response_data
     ):
         res = self.create_brief_response(dict(brief_response_data, **{
             'briefId': self.brief_id,
@@ -276,7 +277,7 @@ class TestCreateBriefResponse(BaseBriefResponseTest, JSONUpdateTestMixin):
     @given(example_listings.brief_response_data(5, None).filter(
         lambda x: len(x['niceToHaveRequirements']) != 5 and all(i is not None for i in x['niceToHaveRequirements'])))
     def test_cannot_respond_to_a_brief_with_wrong_number_of_nicetohave_reqs(
-            self, update_framework, brief_response_data
+            self, update_framework_status, brief_response_data
     ):
         res = self.create_brief_response(dict(brief_response_data, **{
             'briefId': self.brief_id,
@@ -290,7 +291,7 @@ class TestCreateBriefResponse(BaseBriefResponseTest, JSONUpdateTestMixin):
 
     @given(example_listings.brief_response_data(5, None).filter(
         lambda x: any(i is None for i in x['niceToHaveRequirements'])))
-    def test_cannot_respond_to_a_brief_with_none_reqs_values(self, update_framework, brief_response_data):
+    def test_cannot_respond_to_a_brief_with_none_reqs_values(self, update_framework_status, brief_response_data):
         res = self.create_brief_response(dict(brief_response_data, **{
             'briefId': self.brief_id,
             'supplierId': 0,
@@ -302,7 +303,7 @@ class TestCreateBriefResponse(BaseBriefResponseTest, JSONUpdateTestMixin):
         assert data['error']['niceToHaveRequirements'] == 'answer_required'
 
     @given(example_listings.specialists_brief_response_data())
-    def test_create_digital_specialists_brief_response(self, update_framework, brief_response_data):
+    def test_create_digital_specialists_brief_response(self, update_framework_status, brief_response_data):
         res = self.create_brief_response(dict(brief_response_data, **{
             'briefId': self.specialist_brief_id,
             'supplierId': 0,
@@ -313,7 +314,7 @@ class TestCreateBriefResponse(BaseBriefResponseTest, JSONUpdateTestMixin):
         assert res.status_code == 201, data
 
     @given(example_listings.specialists_brief_response_data(min_day_rate=1001, max_day_rate=100000))
-    def test_day_rate_should_be_less_than_service_max_price(self, update_framework, brief_response_data):
+    def test_day_rate_should_be_less_than_service_max_price(self, update_framework_status, brief_response_data):
         res = self.create_brief_response(dict(brief_response_data, **{
             'briefId': self.specialist_brief_id,
             'supplierId': 0,

--- a/tests/app/views/test_suppliers.py
+++ b/tests/app/views/test_suppliers.py
@@ -1295,30 +1295,10 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest, JSONUpdateTestMixin):
             )
             db.session.add(answers)
 
-            g_cloud_8 = Framework(
-                slug='g-cloud-8',
-                name='G-Cloud 8',
-                framework='g-cloud',
-                framework_agreement_details={'frameworkAgreementVersion': 'v1.0'},
-                status='open',
-                clarification_questions_open=False
-            )
-            db.session.add(g_cloud_8)
-            db.session.commit()
-
             self.client.put(
                 '/suppliers/0/frameworks/g-cloud-8',
                 data=json.dumps({'updated_by': 'interested@example.com'}),
                 content_type='application/json')
-
-    def teardown(self):
-        with self.app.app_context():
-            g_cloud_8 = Framework.query.filter(Framework.slug == 'g-cloud-8').first()
-            SupplierFramework.query.filter(SupplierFramework.framework_id == g_cloud_8.id).delete()
-            Framework.query.filter(Framework.id == g_cloud_8.id).delete()
-            db.session.commit()
-
-        super(TestSupplierFrameworkUpdates, self).teardown()
 
     def supplier_framework_update(self, supplier_id, framework_slug, update={}):
         return self.client.post(
@@ -1330,7 +1310,7 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest, JSONUpdateTestMixin):
                 }),
             content_type='application/json')
 
-    def test_get_supplier_framework_info(self):
+    def test_get_supplier_framework_info(self, add_g_cloud_8):
         response = self.client.get(
             '/suppliers/0/frameworks/g-cloud-4')
 
@@ -1350,19 +1330,19 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest, JSONUpdateTestMixin):
             'uploaderUserId': 20
         }
 
-    def test_get_supplier_framework_info_non_existent_by_framework(self):
+    def test_get_supplier_framework_info_non_existent_by_framework(self, add_g_cloud_8):
         response = self.client.get(
             '/suppliers/0/frameworks/g-cloud-5')
 
         assert response.status_code == 404
 
-    def test_get_supplier_framework_info_non_existent_by_supplier(self):
+    def test_get_supplier_framework_info_non_existent_by_supplier(self, add_g_cloud_8):
         response = self.client.get(
             '/suppliers/123/frameworks/g-cloud-4')
 
         assert response.status_code == 404
 
-    def test_adding_supplier_has_passed(self):
+    def test_adding_supplier_has_passed(self, add_g_cloud_8):
         response = self.supplier_framework_update(
             0,
             'digital-outcomes-and-specialists',
@@ -1379,7 +1359,7 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest, JSONUpdateTestMixin):
         assert data['frameworkInterest']['countersignedAt'] is None
         assert data['frameworkInterest']['agreementDetails'] is None
 
-    def test_adding_supplier_has_not_passed(self):
+    def test_adding_supplier_has_not_passed(self, add_g_cloud_8):
         response = self.supplier_framework_update(
             0,
             'digital-outcomes-and-specialists',
@@ -1391,7 +1371,9 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest, JSONUpdateTestMixin):
         assert data['frameworkInterest']['frameworkSlug'], 'digital-outcomes-and-specialists'
         assert data['frameworkInterest']['onFramework'] is False
 
-    def test_can_set_agreement_returned_without_agreement_details_for_framework_with_no_agreement_version(self):
+    def test_can_set_agreement_returned_without_agreement_details_for_framework_with_no_agreement_version(
+            self, add_g_cloud_8
+    ):
         with freeze_time('2012-12-12'):
             response = self.supplier_framework_update(
                 0,
@@ -1408,7 +1390,9 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest, JSONUpdateTestMixin):
             assert data['frameworkInterest']['countersignedAt'] is None
             assert data['frameworkInterest']['agreementDetails'] is None
 
-    def test_can_set_agreement_returned_with_agreement_details_for_framework_with_agreement_version(self):
+    def test_can_set_agreement_returned_with_agreement_details_for_framework_with_agreement_version(
+            self, add_g_cloud_8
+    ):
         with freeze_time('2012-12-12'):
 
             response = self.supplier_framework_update(
@@ -1440,7 +1424,9 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest, JSONUpdateTestMixin):
                 'frameworkAgreementVersion': 'v1.0'
             }
 
-    def test_can_not_set_agreement_returned_without_agreement_details_for_framework_with_agreement_version(self):
+    def test_can_not_set_agreement_returned_without_agreement_details_for_framework_with_agreement_version(
+            self, add_g_cloud_8
+    ):
         with freeze_time('2012-12-12'):
 
             response = self.supplier_framework_update(
@@ -1456,7 +1442,7 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest, JSONUpdateTestMixin):
                 'signerName': 'answer_required'
             }
 
-    def test_adding_that_agreement_has_been_countersigned(self):
+    def test_adding_that_agreement_has_been_countersigned(self, add_g_cloud_8):
         with freeze_time('2012-12-12'):
             response = self.supplier_framework_update(
                 0,
@@ -1473,7 +1459,7 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest, JSONUpdateTestMixin):
             assert data['frameworkInterest']['countersignedAt'] == "2012-12-12T00:00:00.000000Z"
             assert data['frameworkInterest']['agreementDetails'] is None
 
-    def test_agreement_returned_at_timestamp_cannot_be_set(self):
+    def test_agreement_returned_at_timestamp_cannot_be_set(self, add_g_cloud_8):
         with freeze_time('2012-12-12'):
             response = self.supplier_framework_update(
                 0,
@@ -1484,7 +1470,9 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest, JSONUpdateTestMixin):
             data = json.loads(response.get_data())
             assert data['frameworkInterest']['agreementReturnedAt'] == '2012-12-12T00:00:00.000000Z'
 
-    def test_agreement_returned_at_and_agreement_details_are_unset_when_agreement_returned_is_false(self):
+    def test_agreement_returned_at_and_agreement_details_are_unset_when_agreement_returned_is_false(
+            self, add_g_cloud_8
+    ):
         response = self.supplier_framework_update(
             0, 'g-cloud-8',
             update={
@@ -1509,7 +1497,7 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest, JSONUpdateTestMixin):
         assert data2['frameworkInterest']['agreementReturnedAt'] is None
         assert data2['frameworkInterest']['agreementDetails'] is None
 
-    def test_countersigned_at_timestamp_cannot_be_set(self):
+    def test_countersigned_at_timestamp_cannot_be_set(self, add_g_cloud_8):
         with freeze_time('2012-12-12'):
             response = self.supplier_framework_update(
                 0,
@@ -1524,7 +1512,7 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest, JSONUpdateTestMixin):
             data = json.loads(response.get_data())
             assert data['frameworkInterest']['countersignedAt'] == '2012-12-12T00:00:00.000000Z'
 
-    def test_setting_signer_details_and_then_returning_agreement(self):
+    def test_setting_signer_details_and_then_returning_agreement(self, add_g_cloud_8):
         agreement_details_payload = {
             "signerName": "name",
             "signerRole": "role",
@@ -1561,7 +1549,7 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest, JSONUpdateTestMixin):
             "frameworkAgreementVersion": "v1.0",
         }
 
-    def test_can_not_set_agreement_details_on_frameworks_without_framework_agreement_version(self):
+    def test_can_not_set_agreement_details_on_frameworks_without_framework_agreement_version(self, add_g_cloud_8):
         agreement_details_payload = {
             "signerName": "name",
             "signerRole": "role",
@@ -1578,7 +1566,7 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest, JSONUpdateTestMixin):
         for error_string in strings_we_expect_in_the_error_message:
             assert error_string in data['error']
 
-    def test_can_not_set_agreement_details_with_nonexistent_user_id(self):
+    def test_can_not_set_agreement_details_with_nonexistent_user_id(self, add_g_cloud_8):
         agreement_details_payload = {
             "signerName": "name",
             "signerRole": "role",
@@ -1595,7 +1583,7 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest, JSONUpdateTestMixin):
         for error_string in strings_we_expect_in_the_error_message:
             assert error_string in data['error']
 
-    def test_schema_validation_fails_if_unknown_fields_present_in_agreement_details(self):
+    def test_schema_validation_fails_if_unknown_fields_present_in_agreement_details(self, add_g_cloud_8):
         agreement_details_payload = {
             "signerName": "Normal Person",
             "disallowedKey": "value",
@@ -1613,7 +1601,7 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest, JSONUpdateTestMixin):
         for error_string in strings_we_expect_in_the_error_message:
             assert error_string in data['error']['_form'][0]
 
-    def test_schema_validation_fails_if_empty_object_sent_as_agreement_details(self):
+    def test_schema_validation_fails_if_empty_object_sent_as_agreement_details(self, add_g_cloud_8):
         response = self.supplier_framework_update(
             0, 'g-cloud-8',
             update={'agreementDetails': {}}
@@ -1624,7 +1612,7 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest, JSONUpdateTestMixin):
         error_message = '{} does not have enough properties'
         assert error_message in data['error']['_form'][0]
 
-    def test_schema_validation_fails_if_empty_strings_sent_as_agreement_details(self):
+    def test_schema_validation_fails_if_empty_strings_sent_as_agreement_details(self, add_g_cloud_8):
         agreement_details_payload = {
             "signerName": "",
             "signerRole": "",
@@ -1639,7 +1627,7 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest, JSONUpdateTestMixin):
         expected_error_dict = {'signerName': 'answer_required', 'signerRole': 'answer_required'}
         assert expected_error_dict == data['error']
 
-    def test_cannot_save_if_required_signer_field_is_missing_from_not_yet_set_agreement_details(self):
+    def test_cannot_save_if_required_signer_field_is_missing_from_not_yet_set_agreement_details(self, add_g_cloud_8):
         # missing signerRole
         agreement_details_payload = {
             "signerName": "name",
@@ -1654,7 +1642,7 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest, JSONUpdateTestMixin):
         expected_error_dict = {'signerRole': 'answer_required'}
         assert expected_error_dict == data['error']
 
-    def test_cannot_return_agreement_if_signer_details_fields_are_missing_from_agreement_details(self):
+    def test_cannot_return_agreement_if_signer_details_fields_are_missing_from_agreement_details(self, add_g_cloud_8):
         # missing signerName and signerRole
         agreement_details_payload = {
             "uploaderUserId": 1,
@@ -1672,7 +1660,7 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest, JSONUpdateTestMixin):
         expected_error_dict = {'signerName': 'answer_required', 'signerRole': 'answer_required'}
         assert expected_error_dict == data['error']
 
-    def test_can_manually_override_framework_agreement_version_for_returned_framework_agreement(self):
+    def test_can_manually_override_framework_agreement_version_for_returned_framework_agreement(self, add_g_cloud_8):
         response = self.supplier_framework_update(
             0,
             'g-cloud-8',
@@ -1697,7 +1685,7 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest, JSONUpdateTestMixin):
         data2 = json.loads(response2.get_data())
         assert data2['frameworkInterest']['agreementDetails']['frameworkAgreementVersion'] == 'v2.0'
 
-    def test_changing_on_framework_from_failed_to_passed(self):
+    def test_changing_on_framework_from_failed_to_passed(self, add_g_cloud_8):
         response = self.supplier_framework_update(
             0,
             'digital-outcomes-and-specialists',
@@ -1718,7 +1706,7 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest, JSONUpdateTestMixin):
         assert data['frameworkInterest']['onFramework'] is True
         assert data['frameworkInterest']['agreementReturned'] is False
 
-    def test_changing_on_framework_from_passed_to_failed(self):
+    def test_changing_on_framework_from_passed_to_failed(self, add_g_cloud_8):
         response = self.supplier_framework_update(
             0,
             'digital-outcomes-and-specialists',
@@ -1739,7 +1727,7 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest, JSONUpdateTestMixin):
         assert data['frameworkInterest']['onFramework'] is False
         assert data['frameworkInterest']['agreementReturned'] is False
 
-    def test_changing_on_framework_to_passed_creates_audit_event(self):
+    def test_changing_on_framework_to_passed_creates_audit_event(self, add_g_cloud_8):
         self.supplier_framework_update(
             0,
             'digital-outcomes-and-specialists',

--- a/tests/app/views/test_suppliers.py
+++ b/tests/app/views/test_suppliers.py
@@ -1157,7 +1157,7 @@ class TestGetSupplierFrameworks(BaseApplicationTest):
 
 
 class TestRegisterFrameworkInterest(BaseApplicationTest, JSONUpdateTestMixin):
-    method = "post"
+    method = "put"
     endpoint = "/suppliers/1/frameworks/digital-outcomes-and-specialists"
 
     def setup(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,9 +44,9 @@ def _update_framework(request, app, status, framework_slug):
 
 
 @pytest.fixture(params=[('live', 'digital-outcomes-and-specialists')])
-def update_framework(request, app):
+def update_framework_status(request, app):
 
-    def _update_framework(request, app, status, framework_slug):
+    def _update_framework_status(request, app, status, framework_slug):
         with app.app_context():
             framework = Framework.query.filter(
                 Framework.slug == framework_slug
@@ -69,4 +69,4 @@ def update_framework(request, app):
 
         request.addfinalizer(teardown)
 
-    _update_framework(request, app, request.param[0], request.param[1])
+    _update_framework_status(request, app, request.param[0], request.param[1])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,3 +51,32 @@ def live_framework(request, app):
 @pytest.fixture(params=[('expired', 'digital-outcomes-and-specialists')])
 def expired_framework(request, app):
     _update_framework(request, app, request.param[0], request.param[1])
+
+
+@pytest.fixture()
+def update_framework(request, app):
+    def inner_update_framework(status='live', framework_slug='digital-outcomes-and-specialists'):
+        with app.app_context():
+            framework = Framework.query.filter(
+                Framework.slug == framework_slug
+            ).first()
+            original_framework_status = framework.status
+            framework.status = status
+
+            db.session.add(framework)
+            db.session.commit()
+
+        def teardown():
+            with app.app_context():
+                framework = Framework.query.filter(
+                    Framework.slug == framework_slug
+                ).first()
+                framework.status = original_framework_status
+
+                db.session.add(framework)
+                db.session.commit()
+
+        request.addfinalizer(teardown)
+
+    return inner_update_framework
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,11 +19,10 @@ def app(request):
     return create_app('test')
 
 
-@pytest.fixture()
-def live_framework(request, app, status='live'):
+def _update_framework(request, app, status, framework_slug):
     with app.app_context():
         framework = Framework.query.filter(
-            Framework.slug == 'digital-outcomes-and-specialists'
+            Framework.slug == framework_slug
         ).first()
         original_framework_status = framework.status
         framework.status = status
@@ -34,7 +33,7 @@ def live_framework(request, app, status='live'):
     def teardown():
         with app.app_context():
             framework = Framework.query.filter(
-                Framework.slug == 'digital-outcomes-and-specialists'
+                Framework.slug == framework_slug
             ).first()
             framework.status = original_framework_status
 
@@ -44,6 +43,11 @@ def live_framework(request, app, status='live'):
     request.addfinalizer(teardown)
 
 
-@pytest.fixture()
+@pytest.fixture(params=[('live', 'digital-outcomes-and-specialists')])
+def live_framework(request, app):
+    _update_framework(request, app, request.param[0], request.param[1])
+
+
+@pytest.fixture(params=[('expired', 'digital-outcomes-and-specialists')])
 def expired_framework(request, app):
-    return live_framework(request, app, status='expired')
+    _update_framework(request, app, request.param[0], request.param[1])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,18 +44,9 @@ def _update_framework(request, app, status, framework_slug):
 
 
 @pytest.fixture(params=[('live', 'digital-outcomes-and-specialists')])
-def live_framework(request, app):
-    _update_framework(request, app, request.param[0], request.param[1])
-
-
-@pytest.fixture(params=[('expired', 'digital-outcomes-and-specialists')])
-def expired_framework(request, app):
-    _update_framework(request, app, request.param[0], request.param[1])
-
-
-@pytest.fixture()
 def update_framework(request, app):
-    def inner_update_framework(status='live', framework_slug='digital-outcomes-and-specialists'):
+
+    def _update_framework(request, app, status, framework_slug):
         with app.app_context():
             framework = Framework.query.filter(
                 Framework.slug == framework_slug
@@ -78,5 +69,4 @@ def update_framework(request, app):
 
         request.addfinalizer(teardown)
 
-    return inner_update_framework
-
+    _update_framework(request, app, request.param[0], request.param[1])


### PR DESCRIPTION
Added tests for the `index_services` function that no longer indexes DOS services.

In the process, tried to ameliorate the problem where our tests are relying on Frameworks and Lots to be in the database but not actually taking responsibility for them.

After quite a lot of exploring potential solutions (you can see them if you look at the various commits), I've gone with a fairly straightforward way where we can easily create fixtures for certain frameworks in certain states.  Existing frameworks will have their status temporarily modified and new frameworks will be temporarily created.  Not passing parameters in anymore from the tests themselves because, while it would slim the code for the fixtures, it would fatten the code for the actual unit tests.  Instead, I'm just using meaningfully named fixture functions and tried to lower the overhead as much as possible when creating new ones.  It's the most standard solution (the others mostly involved some degree of hacking about), and pretty much an extension of what @allait started with.

I think all existing tests relying on frameworks could be made to pull in a fixture they need instead of the tacit expectation of a framework already in the database, but I don't really think I can justify doing that right now.  

Would be nice to refactor the tests as we go though.

***

Actually, as an addendum to what I said about how all existing tests could be refactored to pull in a fixture they needed -- this is true for the frameworks in isolation, but it doesn't have much to say about more complex relationships between objects.  For example, if I want an `open` `DOS` framework and I want to have a supplier with a `SupplierFramework` record with `agreementReturnedAt` set to a specific time, currently everything but the framework setup is just a manual process that happens in the test.  Maybe that's okay, but it feels kind of like a limitation we would prefer to have a workaround for.