### PR TITLE
[#127806845]Framework variations

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ SQLAlchemy==1.0.5
 SQLAlchemy-Utils==0.30.5
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@21.4.0#egg=digitalmarketplace-utils==21.4.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@5.2.0#egg=digitalmarketplace-apiclient==5.2.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@6.1.0#egg=digitalmarketplace-apiclient==6.1.0
 
 # For schema validation
 jsonschema==2.5.1

--- a/tests/app/views/test_frameworks.py
+++ b/tests/app/views/test_frameworks.py
@@ -30,6 +30,7 @@ class TestListFrameworks(BaseApplicationTest):
                     'name',
                     'slug',
                     'status',
+                    'variations',
                 ]))
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,14 @@
 from __future__ import absolute_import
 
+from datetime import datetime
+from itertools import product
 from six import iteritems, iterkeys
 import pytest
 
 from .app import setup, teardown
 
 from app import create_app
-from app.models import db, Framework, SupplierFramework
+from app.models import db, Framework, SupplierFramework, Supplier, User, ContactInformation
 
 
 @pytest.fixture(autouse=True, scope='session')
@@ -107,6 +109,101 @@ _dos_framework_defaults = {
 }
 
 
+def _supplierframework_fixture_inner(request, app, sf_kwargs=None):
+    sf_kwargs = sf_kwargs or {}
+    supplier_framework_id_pairs = set()
+    with app.app_context():
+        for framework, supplier in product(Framework.query.all(), Supplier.query.all()):
+            supplier_framework = SupplierFramework(
+                supplier=supplier,
+                framework=framework,
+                **sf_kwargs
+            )
+            supplier_framework_id_pairs.add((supplier.supplier_id, framework.id,))
+            db.session.add(supplier_framework)
+
+        db.session.commit()
+
+    def teardown():
+        with app.app_context():
+            for supplier_id, framework_id in supplier_framework_id_pairs:
+                SupplierFramework.query.filter(
+                    SupplierFramework.supplier_id == supplier_id,
+                    SupplierFramework.framework_id == framework_id,
+                ).delete()
+            db.session.commit()
+    request.addfinalizer(teardown)
+
+
+def _supplier_fixture_inner(request, app, supplier_kwargs=None, ci_kwargs=None):
+    supplier_kwargs = supplier_kwargs or {}
+    supplier_kwargs = dict({
+        "name": "Supplier {}".format(supplier_kwargs.get("supplier_id", "")),
+        "description": "some description",
+    }, **supplier_kwargs)
+
+    with app.app_context():
+        supplier = Supplier(**supplier_kwargs)
+        db.session.add(supplier)
+        db.session.flush()
+
+        ci_kwargs = ci_kwargs or {}
+        ci_kwargs = dict({
+            "contact_name": "Contact for supplier {}".format(supplier.supplier_id),
+            "email": "{}@contact.com".format(supplier.supplier_id),
+            "postcode": "SW1A 1AA",
+            "supplier_id": supplier.supplier_id,
+        }, **ci_kwargs)
+
+        contact_information = ContactInformation(**ci_kwargs)
+        db.session.add(contact_information)
+
+        db.session.commit()
+
+        supplier_id = supplier.supplier_id
+        contact_information_id = contact_information.id
+
+    def teardown():
+        with app.app_context():
+            ContactInformation.query.filter(ContactInformation.id == contact_information_id).delete()
+            Supplier.query.filter(Supplier.id == supplier_id).delete()
+            db.session.commit()
+    request.addfinalizer(teardown)
+    return supplier_id
+
+
+def _user_fixture_inner(request, app, user_kwargs=None):
+    user_kwargs = user_kwargs or {}
+    user_kwargs = dict({
+        "email_address": "test+{}@digital.gov.uk".format(user_kwargs.get("id", "replaceme")),
+        "active": True,
+        "password": "fake password",
+        "password_changed_at": datetime.now(),
+        "name": "my name",
+    }, **user_kwargs)
+
+    with app.app_context():
+        user = User(**user_kwargs)
+        db.session.add(user)
+        db.session.commit()
+
+        # if we didn't know the user id at insert time and didn't have an email we should replace it now
+        # so we don't end up with collisions
+        if user.email_address == "test+replaceme@digital.gov.uk":
+            user.email_address = "test+{}@digital.gov.uk".format(user.id)
+            db.session.add(user)
+            db.session.commit()
+
+        user_id = user.id
+
+    def teardown():
+        with app.app_context():
+            User.query.filter(User.id == user_id).delete()
+            db.session.commit()
+    request.addfinalizer(teardown)
+    return user_id
+
+
 # G8
 
 
@@ -118,6 +215,22 @@ def open_g8_framework(request, app):
 @pytest.fixture()
 def live_g8_framework(request, app):
     _framework_fixture_inner(request, app, **dict(_g8_framework_defaults, status="live"))
+
+
+@pytest.fixture()
+def live_g8_framework_2_variations(request, app):
+    _framework_fixture_inner(request, app, **dict(
+        _g8_framework_defaults,
+        status="live",
+        framework_agreement_details=dict(_generic_framework_agreement_details, variations={
+            "banana": {
+                "createdAt": "2016-06-06T20:01:34.000000Z",
+            },
+            "toblerone": {
+                "createdAt": "2016-07-06T21:09:09.000000Z",
+            },
+        }),
+    ))
 
 
 # G6
@@ -149,3 +262,81 @@ def live_dos_framework(request, app):
 @pytest.fixture()
 def expired_dos_framework(request, app):
     _framework_fixture_inner(request, app, **dict(_dos_framework_defaults, status="expired"))
+
+
+# Suppliers
+
+
+@pytest.fixture()
+def supplier_basic(request, app):
+    return _supplier_fixture_inner(request, app, supplier_kwargs={"supplier_id": 1})
+
+
+@pytest.fixture()
+def supplier_basic_alt(request, app):
+    return _supplier_fixture_inner(request, app, supplier_kwargs={"supplier_id": 2})
+
+
+# Users
+
+
+@pytest.fixture()
+def user_role_supplier(request, app, supplier_basic):
+    return _user_fixture_inner(request, app, user_kwargs={
+        "id": 1,
+        "role": "supplier",
+        "supplier_id": supplier_basic,
+    })
+
+
+@pytest.fixture()
+def user_role_supplier_alt(request, app, supplier_basic_alt):
+    return _user_fixture_inner(request, app, user_kwargs={
+        "id": 2,
+        "role": "supplier",
+        "supplier_id": supplier_basic_alt,
+    })
+
+
+# Frameworks & Suppliers with some SupplierFrameworks setup
+
+
+@pytest.fixture()
+def live_g8_framework_2_variations_suppliers_not_on_framework(
+        request,
+        app,
+        live_g8_framework_2_variations,
+        user_role_supplier,
+        ):
+    _supplierframework_fixture_inner(request, app)
+
+
+@pytest.fixture()
+def live_g8_framework_2_variations_suppliers_on_framework(
+        request,
+        app,
+        live_g8_framework_2_variations,
+        user_role_supplier,
+        ):
+    _supplierframework_fixture_inner(request, app, sf_kwargs={"on_framework": True})
+
+
+@pytest.fixture()
+def live_g8_framework_2_variations_suppliers_on_framework_with_alt(
+        request,
+        app,
+        live_g8_framework_2_variations,
+        user_role_supplier,
+        user_role_supplier_alt,
+        ):
+    _supplierframework_fixture_inner(request, app, sf_kwargs={"on_framework": True})
+
+
+@pytest.fixture()
+def live_g8_framework_suppliers_on_framework(
+        request,
+        app,
+        live_g8_framework,
+        user_role_supplier,
+        ):
+    _supplierframework_fixture_inner(request, app, sf_kwargs={"on_framework": True})


### PR DESCRIPTION
Story https://www.pivotaltracker.com/story/show/127806845

Corresponding migration in PR #434, **don't be surprised if the tests don't pass initially** because this branch is currently missing the migration.

A single endpoint added for allowing a caller to agree to a variation. Variations are referenced by "slug". Valid variations are looked up against `Framework.framework_agreement_details["variations"]`, which is expected to be a dict of the form:

```
{
            "banana": {
                "createdAt": "2016-06-06T20:01:34.000000Z",
            },
            "toblerone": {
                "createdAt": "2016-07-06T21:09:09.000000Z",
            }
},
```

For two example variation slugs `banana` and `toblerone`. No methods for updating the framework variations are currently included - this can probably be done manually using existing general purpose endpoints.

`SupplierFramework`'s serialization gains a new `agreedVariations` key which will contain a dict looking something like:

```
{
    "banana": {
            "agreedUserId": 2,
            "agreedUserEmail": "test+2@digital.gov.uk",
            "agreedUserName": "my name",
            "agreedAt": "2016-06-06T00:00:00.000000Z",
        }
}
```

For a supplier that has agreed to variation `banana`. Variations which are not agreed to should have no entry in this dict.

To agree to a variation, a caller should `PUT` to the endpoint `/suppliers/<int:supplier_id>/frameworks/<framework_slug>/variation/<variation_slug>` json of the form:

```
           {
                "updated_by": "<updater>",
                "agreedVariation": {
                    "agreedUserId": 1234,
                },
            }
```

Examples of all of this in action can be seen in the tests.