### PR TITLE
[#127807225] Add "variations agreed" to framework user export

### DIFF
--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -254,6 +254,7 @@ def export_users_for_framework(framework_slug):
         application_status = ''
         application_result = ''
         framework_agreement = ''
+        variations_agreed = ''
 
         # if framework is pending, live, or expired
         if framework.status != 'open':
@@ -277,6 +278,7 @@ def export_users_for_framework(framework_slug):
             else:
                 application_result = 'pass' if sf.on_framework else 'fail'
             framework_agreement = bool(sf.agreement_returned_at)
+            variations_agreed = sf.agreed_variations.keys() if sf.agreed_variations else []
 
         user_rows.append({
             'user_email': u.email_address,
@@ -285,7 +287,8 @@ def export_users_for_framework(framework_slug):
             'declaration_status': declaration_status,
             'application_status': application_status,
             'framework_agreement': framework_agreement,
-            'application_result': application_result
+            'application_result': application_result,
+            'variations_agreed': variations_agreed
         })
 
     return jsonify(users=[user for user in user_rows])

--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -278,7 +278,7 @@ def export_users_for_framework(framework_slug):
             else:
                 application_result = 'pass' if sf.on_framework else 'fail'
             framework_agreement = bool(sf.agreement_returned_at)
-            variations_agreed = list(sf.agreed_variations.keys()) if sf.agreed_variations else []
+            variations_agreed = ', '.join(sf.agreed_variations.keys()) if sf.agreed_variations else ''
 
         user_rows.append({
             'user_email': u.email_address,

--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -278,7 +278,7 @@ def export_users_for_framework(framework_slug):
             else:
                 application_result = 'pass' if sf.on_framework else 'fail'
             framework_agreement = bool(sf.agreement_returned_at)
-            variations_agreed = sf.agreed_variations.keys() if sf.agreed_variations else []
+            variations_agreed = list(sf.agreed_variations.keys()) if sf.agreed_variations else []
 
         user_rows.append({
             'user_email': u.email_address,

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -280,6 +280,15 @@ class BaseApplicationTest(object):
         Framework.query.filter_by(slug=slug).update({'status': status})
         db.session.commit()
 
+    def set_framework_variation(self, slug):
+        Framework.query.filter_by(slug=slug).update({
+            'framework_agreement_details': {
+                "frameworkAgreementVersion": "v1.0",
+                "variations": {"1": {"createdAt": "2016-08-19T15:31:00.000000Z"}}
+            }
+        })
+        db.session.commit()
+
 
 class JSONTestMixin(object):
     """


### PR DESCRIPTION
Required for this story: https://www.pivotaltracker.com/story/show/127807225

This extra field is required for Admin csv file download, to enable admin to see who has and who hasn't agreed to framework variations.