### PR TITLE
[#128752313] Create more generic framework update route

### DIFF
--- a/app/framework_utils.py
+++ b/app/framework_utils.py
@@ -1,0 +1,14 @@
+from flask import abort
+from .validation import get_validation_errors
+
+
+def validate_framework_agreement_details_data(framework_agreement_details, enforce_required=True, required_fields=None):
+    errs = get_validation_errors(
+        'framework-agreement-details',
+        framework_agreement_details,
+        enforce_required=enforce_required,
+        required_fields=required_fields
+    )
+
+    if errs:
+        abort(400, errs)

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 from flask import jsonify, abort, request, current_app
-from six import text_type
 from sqlalchemy.exc import IntegrityError, DataError
 from .. import main
 from ... import db

--- a/app/models.py
+++ b/app/models.py
@@ -137,7 +137,16 @@ class Framework(db.Model):
 
     @validates('clarification_questions_open')
     def validates_clarification_questions_open(self, key, value):
-        if self.status not in ('coming', 'open', 'pending') and value:
+        # Note that because of an undefined order of setting attributes on this model
+        # (ie, between this `clarification_questions_open` and `status`)
+        # it _is_ possible to be in a state where `clarification_questions_open` is `True`
+        # and the new status is not one of the allowed ones
+        # if `self.status` *at the time of the update* is one of the allowed ones
+        if (
+            self.status is not None and
+            self.status not in ('coming', 'open', 'pending')
+            and value is True
+        ):
             raise ValidationError("Clarification questions are only permitted while the framework is open")
         return value
 

--- a/app/models.py
+++ b/app/models.py
@@ -129,11 +129,17 @@ class Framework(db.Model):
 
     slug_pattern = re.compile("^[\w-]+$")
 
-    @validates("slug")
+    @validates('slug')
     def validates_slug(self, key, slug):
         if not self.slug_pattern.match(slug):
             raise ValidationError("Invalid slug value '{}'".format(slug))
         return slug
+
+    @validates('clarification_questions_open')
+    def validates_clarification_questions_open(self, key, value):
+        if self.status not in ('coming', 'open', 'pending') and value:
+            raise ValidationError("Clarification questions are only permitted while the framework is open")
+        return value
 
     def __repr__(self):
         return '<{}: {} slug={}>'.format(self.__class__.__name__, self.name, self.slug)

--- a/app/validation.py
+++ b/app/validation.py
@@ -16,6 +16,7 @@ MAXIMUM_SERVICE_ID_LENGTH = 20
 JSON_SCHEMAS_PATH = './json_schemas'
 SCHEMA_NAMES = [
     'agreement-details',
+    'framework-agreement-details',
     'brief-clarification-question',
     'briefs-digital-outcomes-and-specialists-digital-outcomes',
     'briefs-digital-outcomes-and-specialists-digital-specialists',

--- a/json_schemas/agreement-details.json
+++ b/json_schemas/agreement-details.json
@@ -26,6 +26,6 @@
     "signerRole",
     "uploaderUserId"
   ],
-  "title": "Agreement Details Schema",
+  "title": "SupplierFramework.agreement_details Schema",
   "type": "object"
 }

--- a/json_schemas/framework-agreement-details.json
+++ b/json_schemas/framework-agreement-details.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "additionalProperties": false,
+  "minProperties": 1,
+  "properties": {
+    "frameworkAgreementVersion": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "variations": {
+      "type": "object"
+    }
+  },
+  "required": [
+    "frameworkAgreementVersion",
+    "variations"
+  ],
+  "title": "Framework.framework_agreement_details Schema",
+  "type": "object"
+}

--- a/json_schemas/framework-agreement-details.json
+++ b/json_schemas/framework-agreement-details.json
@@ -8,6 +8,18 @@
       "type": "string"
     },
     "variations": {
+      "additionalProperties": {
+        "additionalProperties": false,
+        "properties": {
+          "createdAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "createdAt"
+        ],
+        "type": "object"
+      },
       "type": "object"
     }
   },

--- a/tests/app/views/test_frameworks.py
+++ b/tests/app/views/test_frameworks.py
@@ -200,62 +200,56 @@ class TestUpdateFramework(BaseApplicationTest, JSONUpdateTestMixin):
     endpoint = '/frameworks/example'
     method = 'post'
 
-    def setup(self):
-        super(TestUpdateFramework, self).setup()
-        framework = Framework()
-        framework.name = 'Example G-Cloud framework'
-        framework.framework = 'g-cloud'
-        framework.slug = 'example'
-        framework.status = 'open'
-
+    def test_framework_updated(self, open_example_framework):
         with self.app.app_context():
-            db.session.add(framework)
-            db.session.commit()
-
-    def teardown(self):
-        with self.app.app_context():
-            Framework.query.filter(Framework.slug == 'example').delete()
-            db.session.commit()
-
-    def test_framework_updated(self):
-        with self.app.app_context():
-            response = self.client.post('/frameworks/example',
-                                        data=json.dumps({'frameworks': {
-                                            'status': 'expired',
-                                            'clarificationQuestionsOpen': False,
-                                        }, 'updated_by': 'example user'}),
-                                        content_type="application/json")
+            response = self.client.post(
+                '/frameworks/example-framework',
+                data=json.dumps({'frameworks': {
+                    'status': 'expired',
+                    'clarificationQuestionsOpen': False,
+                }, 'updated_by': 'example user'}),
+                content_type="application/json"
+            )
 
             assert response.status_code == 200
 
-            framework = Framework.query.filter(Framework.slug == 'example').first()
+            framework = Framework.query.filter(Framework.slug == 'example-framework').first()
             assert framework.status == "expired"
             assert not framework.clarification_questions_open
 
-    def test_returns_404_on_non_existent_framework(self):
+    def test_returns_404_on_non_existent_framework(self, open_example_framework):
         with self.app.app_context():
-            response = self.client.post('/frameworks/example2',
-                                        data=json.dumps({'frameworks': {'status': 'expired'},
-                                                         'updated_by': 'example user'}),
-                                        content_type="application/json")
+            response = self.client.post(
+                '/frameworks/example-framework-2',
+                data=json.dumps({'frameworks': {
+                    'status': 'expired'
+                }, 'updated_by': 'example user'}),
+                content_type="application/json"
+            )
 
             assert response.status_code == 404
 
-    def test_cannot_update_framework_with_invalid_status(self):
+    def test_cannot_update_framework_with_invalid_status(self, open_example_framework):
         with self.app.app_context():
-            response = self.client.post('/frameworks/example',
-                                        data=json.dumps({'frameworks': {'status': 'invalid'},
-                                                         'updated_by': 'example user'}),
-                                        content_type="application/json")
+            response = self.client.post(
+                '/frameworks/example-framework',
+                data=json.dumps({'frameworks': {
+                    'status': 'invalid'
+                }, 'updated_by': 'example user'}),
+                content_type="application/json"
+            )
 
             assert response.status_code == 400
 
-    def test_cannot_update_fields_other_than_status(self):
+    def test_cannot_update_non_whitelisted_fields(self, open_example_framework):
         with self.app.app_context():
-            response = self.client.post('/frameworks/example',
-                                        data=json.dumps({'frameworks': {'status': 'expired', 'name': 'Blah blah'},
-                                                         'updated_by': 'example user'}),
-                                        content_type="application/json")
+            response = self.client.post(
+                '/frameworks/example-framework',
+                data=json.dumps({'frameworks': {
+                    'status': 'expired', 'name': 'Blah blah'
+                }, 'updated_by': 'example user'}),
+                content_type="application/json"
+            )
 
             assert response.status_code == 400
 

--- a/tests/app/views/test_frameworks.py
+++ b/tests/app/views/test_frameworks.py
@@ -228,18 +228,6 @@ class TestUpdateFramework(BaseApplicationTest, JSONUpdateTestMixin):
             content_type="application/json"
         )
 
-    def test_framework_updated(self, open_example_framework):
-        with self.app.app_context():
-            response = self.post_framework_update({
-                'status': 'expired',
-                'clarificationQuestionsOpen': False
-            })
-            assert response.status_code == 200
-
-            framework = Framework.query.filter(Framework.slug == 'example-framework').first()
-            assert framework.status == "expired"
-            assert not framework.clarification_questions_open
-
     def test_returns_404_on_non_existent_framework(self, open_example_framework):
         with self.app.app_context():
             response = self.client.post(

--- a/tests/app/views/test_frameworks.py
+++ b/tests/app/views/test_frameworks.py
@@ -206,7 +206,17 @@ class TestUpdateFramework(BaseApplicationTest, JSONUpdateTestMixin):
             'name': "Example Framework 2",
             'slug': "example-framework-2",
             'framework': "dos",
-            'frameworkAgreementDetails': {"frameworkAgreementVersion": "v1.0"},
+            'frameworkAgreementDetails': {
+                "frameworkAgreementVersion": "v1.0",
+                "variations": {
+                    "banana": {
+                        "createdAt": "2016-06-06T20:01:34.000000Z",
+                    },
+                    "toblerone": {
+                        "createdAt": "2016-07-06T21:09:09.000000Z",
+                    },
+                }
+            },
             'status': "standstill",
             'clarificationQuestionsOpen': False,
             'lots': ['saas', 'paas', 'iaas', 'scs']
@@ -309,11 +319,13 @@ class TestUpdateFramework(BaseApplicationTest, JSONUpdateTestMixin):
             # should be a string
             {'frameworkAgreementVersion': 1},
             # cannot be empty
-            {'frameworkAgreementVersion': ''},
+            {'frameworkAgreementVersion': ""},
             # should be an object
             {'variations': 1},
+            # object must have 'createdAt' key
+            {'variations': {"created_at": "today"}},
             # invalid key
-            {'frameworkAgreementDessert': 'Portuguese tart'},
+            {'frameworkAgreementDessert': "Portuguese tart"},
             # empty update
             {}
         ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -108,6 +108,12 @@ _dos_framework_defaults = {
     "framework_agreement_details": None,
 }
 
+_example_framework_details = {
+    "slug": "example-framework",
+    "framework": "g-cloud",
+    "framework_agreement_details": None
+}
+
 
 def _supplierframework_fixture_inner(request, app, sf_kwargs=None):
     sf_kwargs = sf_kwargs or {}
@@ -203,8 +209,12 @@ def _user_fixture_inner(request, app, user_kwargs=None):
     request.addfinalizer(teardown)
     return user_id
 
+# Frameworks
 
-# G8
+
+@pytest.fixture()
+def open_example_framework(request, app):
+    _framework_fixture_inner(request, app, **dict(_example_framework_details, status="open"))
 
 
 @pytest.fixture()
@@ -233,9 +243,6 @@ def live_g8_framework_2_variations(request, app):
     ))
 
 
-# G6
-
-
 @pytest.fixture()
 def open_g6_framework(request, app):
     _framework_fixture_inner(request, app, **dict(_g6_framework_defaults, status="open"))
@@ -244,9 +251,6 @@ def open_g6_framework(request, app):
 @pytest.fixture()
 def expired_g6_framework(request, app):
     _framework_fixture_inner(request, app, **dict(_g6_framework_defaults, status="expired"))
-
-
-# DOS
 
 
 @pytest.fixture()


### PR DESCRIPTION
Currently, we can't do many updates to existing Framework database records except through migrations (and we'd like to move away from those).
The updates we _can_ do are to a framework's status and whether or not the period for clarification questions are open.

As part of the countersigning thing, we need to store the current countersigner's name in the Framework.framework_agreement_details.  Instead of doing a migration, it'll be nicer to ship out a more generic 'update' endpoint that can update the agreement_details as well as the statuses and clarification question thing (which is what this is).

This PR:
- Does the general framework update route
- Adds a `framework-agreement-details` schema for things that we currently know about (namely, the `frameworkAgreementVersion` and `variations`)

This PR does not:
- Add in a `countersignerName` field (or whatever) to the `framework_agreement_details`.  
  - (That story can be found [here](https://www.pivotaltracker.com/story/show/128843567).)

***

Worth pointing out that in order to update the existing `framework_agreement_details`, we need to include every key in the update data.  This may possibly be too restrictive sometime in the future, but for now, our one framework that has the agreement details also has an entry for all the keys.