### PR TITLE
[#128843567] Add countersignature details to framework table

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -105,6 +105,9 @@ class Framework(db.Model):
             'name': self.name,
             'slug': self.slug,
             'framework': self.framework,
+            'countersignerName': (
+                self.framework_agreement_details or {}
+            ).get("countersignerName"),
             'frameworkAgreementVersion': (
                 self.framework_agreement_details or {}
             ).get("frameworkAgreementVersion"),

--- a/json_schemas/framework-agreement-details.json
+++ b/json_schemas/framework-agreement-details.json
@@ -3,6 +3,10 @@
   "additionalProperties": false,
   "minProperties": 1,
   "properties": {
+    "countersignerName": {
+      "minLength": 1,
+      "type": "string"
+    },
     "frameworkAgreementVersion": {
       "minLength": 1,
       "type": "string"

--- a/tests/app/views/test_frameworks.py
+++ b/tests/app/views/test_frameworks.py
@@ -29,6 +29,7 @@ class TestListFrameworks(BaseApplicationTest):
                     'slug',
                     'status',
                     'variations',
+                    'countersignerName',
                 ]))
 
 
@@ -207,6 +208,7 @@ class TestUpdateFramework(BaseApplicationTest, JSONUpdateTestMixin):
             'slug': "example-framework-2",
             'framework': "dos",
             'frameworkAgreementDetails': {
+                "countersignerName": "Dan Saxby",
                 "frameworkAgreementVersion": "v1.0",
                 "variations": {
                     "banana": {
@@ -324,6 +326,8 @@ class TestUpdateFramework(BaseApplicationTest, JSONUpdateTestMixin):
             {'variations': 1},
             # object must have 'createdAt' key
             {'variations': {"created_at": "today"}},
+            # countersigner cannot be empty
+            {'countersignerName': ""},
             # invalid key
             {'frameworkAgreementDessert': "Portuguese tart"},
             # empty update


### PR DESCRIPTION
This pull request adds the `countersignerName` key to `Framework.framework_agreement_details`, and then returns it in the `serialize()` method if it finds it.

Planning to add just a string that says `"Dan Saxby"` to G8 in all environments once this is merged and deployed.