### PR TITLE
Add `.cache/` to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ venv
 *.pyc
 __pycache__
 version_label
+.cache/


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/7228605/18267108/8dd72e78-7415-11e6-8b80-359b3c99104d.png)

`.cache/` has been showing in my git diff recently (not sure why, Rob and I hypothesised that it could be due to a new version of pytest). I have added it to the gitignore so it's not accidentally committed