### PR TITLE
FrameworkAgreement: add lazy join to backref of FrameworkAgreement-SupplierFramework relationship too

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -11,7 +11,7 @@ from sqlalchemy import func
 from sqlalchemy.dialects.postgresql import JSON, INTERVAL
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.ext.hybrid import hybrid_property
-from sqlalchemy.orm import validates
+from sqlalchemy.orm import validates, backref
 from sqlalchemy.orm.session import Session
 from sqlalchemy.sql.expression import case as sql_case
 from sqlalchemy.sql.expression import cast as sql_cast
@@ -492,7 +492,11 @@ class FrameworkAgreement(db.Model):
         {}
     )
 
-    supplier_framework = db.relationship(SupplierFramework, lazy='joined', backref='framework_agreements')
+    supplier_framework = db.relationship(
+        SupplierFramework,
+        lazy="joined",
+        backref=backref('framework_agreements', lazy="joined")
+    )
 
     def update_signed_agreement_details_from_json(self, data):
         if self.signed_agreement_details:


### PR DESCRIPTION
This should fix timeouts of `get_framework_suppliers` calls.

Though I do slightly wonder if it's a bit dangerous to blanket-add this join implicitly to all queries. It may add unnecessary weight to `SupplierFramework` queries that don't need `FrameworkAgreement` information. But... then again... I suppose seeing as the information is pulled in by `serialize`, any time we're going to be getting a `SupplierFramework` to `serialize` we're going to need it. Meh.