### PR TITLE
Save framework agreement information in `framework_agreements` table

### DIFF
--- a/app/main/views/agreements.py
+++ b/app/main/views/agreements.py
@@ -1,9 +1,10 @@
+from datetime import datetime
 from flask import jsonify, abort
 from .. import main
 from sqlalchemy.exc import IntegrityError
 from dmapiclient.audit import AuditTypes
 from ...models import (
-    db, FrameworkAgreement, AuditEvent
+    AuditEvent, db, FrameworkAgreement, User
 )
 
 from ...utils import (
@@ -65,6 +66,57 @@ def update_framework_agreement(agreement_id):
             'supplierId': framework_agreement.supplier_id,
             'frameworkSlug': framework_agreement.supplier_framework.framework.slug,
             'update': update_json},
+        db_object=framework_agreement
+    )
+
+    try:
+        db.session.add(framework_agreement)
+        db.session.add(audit_event)
+        db.session.commit()
+    except IntegrityError as e:
+        db.session.rollback()
+        return jsonify(message="Database Error: {0}".format(e)), 400
+
+    return jsonify(agreement=framework_agreement.serialize())
+
+
+@main.route('/agreements/<int:agreement_id>/sign', methods=['POST'])
+def sign_framework_agreement(agreement_id):
+    framework_agreement = FrameworkAgreement.query.filter(FrameworkAgreement.id == agreement_id).first_or_404()
+    framework_agreement_details = framework_agreement.supplier_framework.framework.framework_agreement_details
+
+    json_payload = get_json_from_request()
+    updater_json = validate_and_return_updater_request()
+    update_json = None
+
+    if framework_agreement_details and framework_agreement_details.get('frameworkAgreementVersion'):
+        json_has_required_keys(json_payload, ["agreement"])
+        update_json = json_payload["agreement"]
+
+        json_has_keys(update_json, required_keys=['signedAgreementDetails'])
+
+        framework_agreement.update_signed_agreement_details_from_json(update_json['signedAgreementDetails'])
+        framework_agreement.update_signed_agreement_details_from_json(
+            {'frameworkAgreementVersion': framework_agreement_details['frameworkAgreementVersion']}
+        )
+        validate_agreement_details_data(
+            framework_agreement.signed_agreement_details,
+            enforce_required=True
+        )
+
+        user = User.query.filter(User.id == update_json['signedAgreementDetails']['uploaderUserId']).first()
+        if not user:
+            abort(400, "No user found with id '{}'".format(update_json['signedAgreementDetails']['uploaderUserId']))
+
+    framework_agreement.signed_agreement_returned_at = datetime.utcnow()
+
+    audit_event = AuditEvent(
+        audit_type=AuditTypes.sign_agreement,
+        user=updater_json['updated_by'],
+        data=dict({
+            'supplierId': framework_agreement.supplier_id,
+            'frameworkSlug': framework_agreement.supplier_framework.framework.slug,
+        }, **({'update': update_json} if update_json else {})),
         db_object=framework_agreement
     )
 

--- a/app/main/views/agreements.py
+++ b/app/main/views/agreements.py
@@ -17,6 +17,8 @@ from ...utils import (
 from ...supplier_utils import validate_agreement_details_data
 
 
+# This route not currently used and not yet supported by API client
+# It will be brought into use following migration of franmework agreement data
 @main.route('/agreements', methods=['POST'])
 def create_framework_agreement():
     json_payload = get_json_from_request()
@@ -174,8 +176,7 @@ def sign_framework_agreement(agreement_id):
             enforce_required=True
         )
 
-        user = User.query.filter(User.id == update_json['signedAgreementDetails']['uploaderUserId']).first()
-        if not user:
+        if not User.query.filter(User.id == update_json['signedAgreementDetails']['uploaderUserId']).first():
             abort(400, "No user found with id '{}'".format(update_json['signedAgreementDetails']['uploaderUserId']))
 
     framework_agreement.signed_agreement_returned_at = datetime.utcnow()

--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -277,7 +277,7 @@ def export_users_for_framework(framework_slug):
                 application_result = 'no result'
             else:
                 application_result = 'pass' if sf.on_framework else 'fail'
-            framework_agreement = bool(sf.agreement_returned_at)
+            framework_agreement = bool(sf.serialize()['agreementReturnedAt'])
             variations_agreed = ', '.join(sf.agreed_variations.keys()) if sf.agreed_variations else ''
 
         user_rows.append({

--- a/app/models.py
+++ b/app/models.py
@@ -519,7 +519,7 @@ class FrameworkAgreement(db.Model):
         return purge_nulls_from_data({
             'id': self.id,
             'supplierId': self.supplier_id,
-            'frameworkId': self.framework_id,
+            'frameworkSlug': self.supplier_framework.framework.slug,
             'signedAgreementDetails': self.signed_agreement_details,
             'signedAgreementPath': self.signed_agreement_path,
             'signedAgreementReturnedAt': (

--- a/app/models.py
+++ b/app/models.py
@@ -459,9 +459,9 @@ class SupplierFramework(db.Model):
                 "countersignedAt": countersigned_at,
             })
 
-        if self.agreement_details and self.agreement_details.get('uploaderUserId'):
+        if supplier_framework['agreementDetails'] and supplier_framework['agreementDetails'].get('uploaderUserId'):
             user = User.query.filter(
-                User.id == self.agreement_details.get('uploaderUserId')
+                User.id == supplier_framework['agreementDetails']['uploaderUserId']
             ).first()
 
             if user:

--- a/app/models.py
+++ b/app/models.py
@@ -510,6 +510,9 @@ class FrameworkAgreement(db.Model):
 
     @validates('signed_agreement_details')
     def validates_signed_agreement_details(self, key, data):
+        if data is None:
+            return data
+
         data = strip_whitespace_from_data(data)
         data = purge_nulls_from_data(data)
 

--- a/tests/app/views/test_agreements.py
+++ b/tests/app/views/test_agreements.py
@@ -5,8 +5,7 @@ from app.models import AuditEvent, db, FrameworkAgreement
 from ..helpers import BaseApplicationTest, fixture_params
 
 
-class TestGetFrameworkAgreement(BaseApplicationTest):
-
+class BaseFrameworkAgreementTest(BaseApplicationTest):
     def create_agreement(self, supplier_framework, **framework_agreement_kwargs):
         with self.app.app_context():
             agreement = FrameworkAgreement(
@@ -18,6 +17,8 @@ class TestGetFrameworkAgreement(BaseApplicationTest):
 
             return agreement.id
 
+
+class TestGetFrameworkAgreement(BaseFrameworkAgreementTest):
     def test_it_gets_a_newly_created_framework_agreement_by_id(self, supplier_framework):
         agreement_id = self.create_agreement(
             supplier_framework
@@ -114,18 +115,7 @@ class TestGetFrameworkAgreement(BaseApplicationTest):
         }
 
 
-class TestUpdateFrameworkAgreement(BaseApplicationTest):
-    def create_agreement(self, supplier_framework, **framework_agreement_kwargs):
-        with self.app.app_context():
-            agreement = FrameworkAgreement(
-                supplier_id=supplier_framework['supplier_id'],
-                framework_id=supplier_framework['framework_id'],
-                **framework_agreement_kwargs)
-            db.session.add(agreement)
-            db.session.commit()
-
-            return agreement.id
-
+class TestUpdateFrameworkAgreement(BaseFrameworkAgreementTest):
     def post_agreement_update(self, agreement_id, agreement):
         return self.client.post(
             '/agreements/{}'.format(agreement_id),

--- a/tests/app/views/test_frameworks.py
+++ b/tests/app/views/test_frameworks.py
@@ -536,6 +536,12 @@ class TestFrameworkStats(BaseApplicationTest):
 
 class TestGetFrameworkSuppliers(BaseApplicationTest):
     def setup(self):
+        """Sets up supplier frameworks as follows:
+
+        Suppliers with IDs 0-4 have a SupplierFramework record ("have registered interest")
+        Suppliers 3 and 4 have returned their agreements - will be saved in FrameworkAgreement, NOT SupplierFramework
+        No further details are saved in anyone's SupplierFramework record
+        """
         super(TestGetFrameworkSuppliers, self).setup()
 
         self.setup_dummy_suppliers(5)
@@ -606,7 +612,8 @@ class TestGetFrameworkSuppliers(BaseApplicationTest):
 
     def test_list_suppliers_with_agreements_returned_includes_those_with_only_supplier_framework(self):
         with self.app.app_context():
-            # Set supplier 2 to have their agreement returned information only set in the SupplierFramework table
+            # Set supplier 2 to have their agreement returned information set in the SupplierFramework table
+            # (NOT in the FrameworkAgreement table, like suppliers 3 and 4 have)
             db.session.execute(
                 "UPDATE supplier_frameworks SET agreement_returned_at='{}' WHERE supplier_id=2".format(
                     datetime.datetime.utcnow())

--- a/tests/app/views/test_frameworks.py
+++ b/tests/app/views/test_frameworks.py
@@ -560,13 +560,6 @@ class TestGetFrameworkSuppliers(BaseApplicationTest):
                     content_type='application/json')
                 assert response.status_code == 200, response.get_data(as_text=True)
 
-    def teardown(self):
-        super(TestGetFrameworkSuppliers, self).teardown()
-
-        with self.app.app_context():
-            db.session.execute("UPDATE frameworks SET status='open' WHERE id=4")
-            db.session.commit()
-
     def test_list_suppliers_related_to_a_framework(self):
         with self.app.app_context():
             response = self.client.get('/frameworks/g-cloud-7/suppliers')
@@ -585,6 +578,50 @@ class TestGetFrameworkSuppliers(BaseApplicationTest):
 
             times = [parse_time(item['agreementReturnedAt']) for item in data['supplierFrameworks']]
             assert times[0] > times[1]
+
+    def test_list_suppliers_with_agreements_returned_uses_framework_agreement_timestamp(self):
+        with self.app.app_context():
+            # Set supplier 3 agreement_returned_at as the highest time of suppliers 3 and 4 so we can test that
+            # FrameworkAgreement.signed_agreement_returned_at takes priority over
+            # SupplierFramework.agreement_returned_at when ordering by time
+            db.session.execute(
+                "UPDATE supplier_frameworks SET agreement_returned_at='{}' WHERE supplier_id=3".format(
+                    datetime.datetime.utcnow())
+            )
+            db.session.commit()
+
+            response = self.client.get('/frameworks/g-cloud-7/suppliers?agreement_returned=true')
+
+            assert response.status_code == 200
+            data = json.loads(response.get_data())
+            assert len(data['supplierFrameworks']) == 2
+
+            times = [parse_time(item['agreementReturnedAt']) for item in data['supplierFrameworks']]
+            assert times[0] > times[1]
+
+            # Check SupplierFramework.agreement_returned_at is not used (indicated by supplier 4
+            # appearing before supplier 3 in our results)
+            supplier_ids = [item['supplierId'] for item in data['supplierFrameworks']]
+            assert supplier_ids[0] > supplier_ids[1]
+
+    def test_list_suppliers_with_agreements_returned_includes_those_with_only_supplier_framework(self):
+        with self.app.app_context():
+            # Set supplier 2 to have their agreement returned information only set in the SupplierFramework table
+            db.session.execute(
+                "UPDATE supplier_frameworks SET agreement_returned_at='{}' WHERE supplier_id=2".format(
+                    datetime.datetime.utcnow())
+            )
+            db.session.commit()
+
+            response = self.client.get('/frameworks/g-cloud-7/suppliers?agreement_returned=true')
+
+            assert response.status_code == 200
+            data = json.loads(response.get_data())
+            assert len(data['supplierFrameworks']) == 3
+
+            # Check supplier 2 is included and is the top result (as their agreement returned time is the most recent)
+            supplier_ids = [item['supplierId'] for item in data['supplierFrameworks']]
+            assert supplier_ids[0] == 2
 
 
 class TestGetFrameworkInterest(BaseApplicationTest):

--- a/tests/app/views/test_suppliers.py
+++ b/tests/app/views/test_suppliers.py
@@ -1435,13 +1435,13 @@ class TestSupplierFrameworkResponse(BaseApplicationTest):
             'agreedVariations': {}
         }
 
-    def test_get_supplier_framework_info_non_existent_by_framework(self, supplier_framework):
+    def test_get_supplier_framework_info_with_non_existent_framework(self, supplier_framework):
         response = self.client.get(
             '/suppliers/{}/frameworks/{}'.format(supplier_framework['supplierId'], 'g-cloud-5'))
 
         assert response.status_code == 404
 
-    def test_get_supplier_framework_info_non_existent_by_supplier(self, supplier_framework):
+    def test_get_supplier_framework_info_with_non_existent_supplier(self, supplier_framework):
         response = self.client.get(
             '/suppliers/{}/frameworks/{}'.format(0, supplier_framework['frameworkSlug']))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,7 +43,7 @@ def supplier_framework(request, app, supplier, live_example_framework):
         sf = SupplierFramework(
             supplier_id=supplier['id'],
             framework_id=live_example_framework['id'],
-            on_framework=request.param['on_framework'],
+            **request.param
         )
         db.session.add(sf)
         db.session.commit()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,8 +48,7 @@ def supplier_framework(request, app, supplier, live_example_framework):
         db.session.add(sf)
         db.session.commit()
 
-        return {'supplier_id': sf.supplier_id, 'framework_id': sf.framework_id}
-
+        return sf.serialize()
 
 _framework_kwargs_whitelist = set(("status", "framework", "framework_agreement_details",))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -143,12 +143,6 @@ _example_framework_details = {
     "framework_agreement_details": None
 }
 
-_example_framework_details = {
-    "slug": "example-framework",
-    "framework": "g-cloud",
-    "framework_agreement_details": None
-}
-
 
 def _supplierframework_fixture_inner(request, app, sf_kwargs=None):
     sf_kwargs = sf_kwargs or {}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,12 +37,13 @@ def supplier(request, app):
         return {'id': s.supplier_id}
 
 
-@pytest.fixture()
+@pytest.fixture(params=[{'on_framework': True}])
 def supplier_framework(request, app, supplier, live_example_framework):
     with app.app_context():
         sf = SupplierFramework(
             supplier_id=supplier['id'],
-            framework_id=live_example_framework['id']
+            framework_id=live_example_framework['id'],
+            on_framework=request.param['on_framework'],
         )
         db.session.add(sf)
         db.session.commit()


### PR DESCRIPTION
### First step of data migration from supplier_frameworks to framework_agreements table
#### Saving data
We continue to update framework agreement information through the update supplier framework route, however this no longer stores the data in the `supplier_frameworks` table but instead in the `framework_agreements` table. 

If a record already exists in the `framework_agreement` table then we will update it. If a record does not yet exist in the `framework_agreement` table, then we will create a new record using any existing data from the `supplier_frameworks` table. This enforces a one to one relationship between a `SupplierFramework` and a `FrameworkAgreement`.

This will give us framework agreement information stored across both of the tables for the moment (managed by `SupplierFramework.serialize()` to make sure we access the correct information we need). The next step will be to do a database migration and move all remaining information from the `supplier_frameworks` table to the `framework_agreements` table.

#### Squashed a few bugs related to having information stored in two locations
With framework agreement information stored in both tables, there were a few knock on effects that needed to be dealt with, such as exporting user information and filtering framework suppliers by if they have returned their agreement. See individual commits for further information.

===

### FrameworkAgreements
- Change from exposing a `frameworkId` to exposing a `frameworkSlug` to keep consistency with the rest of our API
- Added new routes to create and sign a `FrameworkAgreement` in `views/agreements`

===

### Unfortunately
Sorry, commits ended up getting quite tangled up, in particular around tests, and I wasn't easily able to rebase this into two separate pull requests! Also, please do take a look at the full commit messages as they contain more information about the changes made.

