### PR TITLE
Migrate framework agreements to `framework_agreements`

### DIFF
--- a/migrations/versions/740_migrate_supplier_frameworks_to_.py
+++ b/migrations/versions/740_migrate_supplier_frameworks_to_.py
@@ -1,0 +1,38 @@
+"""migrate supplier_frameworks to framework_agreements
+
+Revision ID: 740
+Revises: 730
+Create Date: 2016-09-14 14:23:56.196966
+
+For supplier_framework rows that contain details of returning a framework agreement (indicated
+by non null `agreement_details` or `agreement_returned_at`) and do not yet have a 
+corresponding row in the `framework_agreements` table. 
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '740'
+down_revision = '730'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.execute("""
+	    INSERT INTO framework_agreements(supplier_id, framework_id, signed_agreement_details, signed_agreement_returned_at)
+	    (SELECT sf.supplier_id, sf.framework_id, sf.agreement_details, sf.agreement_returned_at 
+			FROM supplier_frameworks sf
+			LEFT JOIN framework_agreements fa
+			ON sf.supplier_id = fa.supplier_id
+			AND sf.framework_id = fa.framework_id
+			WHERE fa.id IS NULL
+			-- We need to convert JSON to text as JSON null is not the same as SQL null
+			AND (sf.agreement_details::text != 'null' OR sf.agreement_returned_at IS NOT NULL)
+		);
+	""")
+
+
+def downgrade():
+    # No downgrade possible
+    pass


### PR DESCRIPTION
For supplier_framework rows that contain details of returning a framework agreement (indicated
by non null `agreement_details` or `agreement_returned_at`) and do not yet have a
corresponding row in the `framework_agreements` table. Note, we are moving framework agreements regardless of if they have a framework agreement version or not. 

**Not to be merged until [this pull request](https://github.com/alphagov/digitalmarketplace-api/pull/449) has gone through**

### Manual testing
I tested the following scenarios:
- Supplier framework with no agreement_details or agreement_returned_at
- Supplier framework with just signer_details
- Supplier framework with just agreement_returned_at
- Supplier framework with both signer_details and agreement_returned_at
- Supplier framework with agreement_returned_at that already has a corresponding framework agreement

#### Before state
<img width="1182" alt="screen shot 2016-09-14 at 15 27 27" src="https://cloud.githubusercontent.com/assets/7228605/18516950/b1a234a0-7a92-11e6-8520-30867e1f68a9.png">
<img width="561" alt="screen shot 2016-09-14 at 15 28 01" src="https://cloud.githubusercontent.com/assets/7228605/18516952/b32be41a-7a92-11e6-9a3a-b3efc7663d78.png">

#### After migration
<img width="1041" alt="screen shot 2016-09-14 at 15 38 11" src="https://cloud.githubusercontent.com/assets/7228605/18516977/c0ecfd96-7a92-11e6-9678-b625a777a022.png">


