### PR TITLE
Keep SupplierFrameworks consistent with FrameworkAgreements

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -485,16 +485,22 @@ def update_supplier_framework_details(supplier_id, framework_slug):
                 abort(400, "No user found with id '{}'".format(update_json['agreementDetails']['uploaderUserId']))
 
         framework_agreement.signed_agreement_details = agreement_details or None
+        interest_record.agreement_details = agreement_details or None
 
     if 'agreementReturned' in update_json:
         if update_json["agreementReturned"] is False:
             framework_agreement.signed_agreement_returned_at = None
             framework_agreement.signed_agreement_details = None
+            interest_record.agreement_returned_at = None
+            interest_record.agreement_details = None
         else:
-            framework_agreement.signed_agreement_returned_at = datetime.utcnow()
+            uniform_now = datetime.utcnow()
+            framework_agreement.signed_agreement_returned_at = uniform_now
+            interest_record.agreement_returned_at = uniform_now
 
     try:
         db.session.add(framework_agreement)
+        db.session.add(interest_record)
         db.session.flush()
     except IntegrityError as e:
         db.session.rollback()


### PR DESCRIPTION
While we are using a combination of both tables to store agreement details we should keep the data in both places consistent.

This will fix a bug with unsetting `agreementReturnedAt` where it gets updated in FrameworkAgreement but not in SupplierFrameworks, and so continues to be returned by the list framework agreements endpoint for `agreement_returned=true` even though it has been unset.