### PR TITLE
Deprecate SupplierFramework fields

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -221,15 +221,12 @@ def get_framework_suppliers(framework_slug):
     if agreement_returned is not None:
         if convert_to_boolean(agreement_returned):
             supplier_frameworks = supplier_frameworks.filter(
-                SupplierFramework.agreement_returned_at.isnot(None) |
                 FrameworkAgreement.signed_agreement_returned_at.isnot(None)
-            ).order_by(func.coalesce(
-                FrameworkAgreement.signed_agreement_returned_at,
-                SupplierFramework.agreement_returned_at
-            ).desc())
+            ).order_by(
+                FrameworkAgreement.signed_agreement_returned_at.desc()
+            )
         else:
             supplier_frameworks = supplier_frameworks.filter(
-                SupplierFramework.agreement_returned_at.is_(None) &
                 FrameworkAgreement.signed_agreement_returned_at.is_(None)
             )
 

--- a/tests/app/views/test_frameworks.py
+++ b/tests/app/views/test_frameworks.py
@@ -585,51 +585,6 @@ class TestGetFrameworkSuppliers(BaseApplicationTest):
             times = [parse_time(item['agreementReturnedAt']) for item in data['supplierFrameworks']]
             assert times[0] > times[1]
 
-    def test_list_suppliers_with_agreements_returned_uses_framework_agreement_timestamp(self):
-        with self.app.app_context():
-            # Set supplier 3 agreement_returned_at as the highest time of suppliers 3 and 4 so we can test that
-            # FrameworkAgreement.signed_agreement_returned_at takes priority over
-            # SupplierFramework.agreement_returned_at when ordering by time
-            db.session.execute(
-                "UPDATE supplier_frameworks SET agreement_returned_at='{}' WHERE supplier_id=3".format(
-                    datetime.datetime.utcnow())
-            )
-            db.session.commit()
-
-            response = self.client.get('/frameworks/g-cloud-7/suppliers?agreement_returned=true')
-
-            assert response.status_code == 200
-            data = json.loads(response.get_data())
-            assert len(data['supplierFrameworks']) == 2
-
-            times = [parse_time(item['agreementReturnedAt']) for item in data['supplierFrameworks']]
-            assert times[0] > times[1]
-
-            # Check SupplierFramework.agreement_returned_at is not used (indicated by supplier 4
-            # appearing before supplier 3 in our results)
-            supplier_ids = [item['supplierId'] for item in data['supplierFrameworks']]
-            assert supplier_ids[0] > supplier_ids[1]
-
-    def test_list_suppliers_with_agreements_returned_includes_those_with_only_supplier_framework(self):
-        with self.app.app_context():
-            # Set supplier 2 to have their agreement returned information set in the SupplierFramework table
-            # (NOT in the FrameworkAgreement table, like suppliers 3 and 4 have)
-            db.session.execute(
-                "UPDATE supplier_frameworks SET agreement_returned_at='{}' WHERE supplier_id=2".format(
-                    datetime.datetime.utcnow())
-            )
-            db.session.commit()
-
-            response = self.client.get('/frameworks/g-cloud-7/suppliers?agreement_returned=true')
-
-            assert response.status_code == 200
-            data = json.loads(response.get_data())
-            assert len(data['supplierFrameworks']) == 3
-
-            # Check supplier 2 is included and is the top result (as their agreement returned time is the most recent)
-            supplier_ids = [item['supplierId'] for item in data['supplierFrameworks']]
-            assert supplier_ids[0] == 2
-
 
 class TestGetFrameworkInterest(BaseApplicationTest):
     def setup(self):


### PR DESCRIPTION
This pull request can not be merged until: 
 - [x] https://github.com/alphagov/digitalmarketplace-api/pull/455
has been deployed.

`agreement_returned_at`, `agreement_details` and `countersigned_at` have been deprecated for the `supplier_frameworks` database table. These details are now being stored in the `framework_agreements` table.

Any existing information in these deprecated fields has already been migrated to the `framework_agreements` table.

As we no longer should be using these fields, we remove their direct usage around the codebase. Note, that the `SupplierFramework` serialized interface remains exactly the same as it will retrieve this information from the `framework_agreements` table.