### PR TITLE
Add tests for bugfixes in #453

### DIFF
--- a/tests/app/views/test_suppliers.py
+++ b/tests/app/views/test_suppliers.py
@@ -1871,7 +1871,6 @@ class TestSupplierFrameworkAgreementsDataMigration(BaseApplicationTest):
                 framework_id=framework.id)
             db.session.add(agreement)
             db.session.commit()
-            agreement_id = agreement.id
 
             with freeze_time('2016-06-06'):
                 response = self.client.post(
@@ -1894,7 +1893,7 @@ class TestSupplierFrameworkAgreementsDataMigration(BaseApplicationTest):
         'agreement_details': {'signerName': 'name', 'signerRole': 'role', 'uploaderUserId': 1}
         }
     )
-    def test_if_framework_agreement_does_not_exists_then_it_is_created(self, supplier_framework):
+    def test_if_framework_agreement_does_not_exist_then_it_is_created(self, supplier_framework):
         with self.app.app_context():
             framework = Framework.query.filter(
                 Framework.slug == supplier_framework['frameworkSlug']

--- a/tests/app/views/test_suppliers.py
+++ b/tests/app/views/test_suppliers.py
@@ -1861,6 +1861,20 @@ class TestSupplierFrameworkAgreementsDataMigration(BaseApplicationTest):
     # data is fully migrated from the supplier frameworks table to the
     # framework_agreements table then these tests can be removed
 
+    def supplier_framework_update(self, supplier_framework):
+        url = '/suppliers/{}/frameworks/{}'.format(
+            supplier_framework['supplierId'], supplier_framework['frameworkSlug'])
+
+        # Update the SupplierFramework record
+        return self.client.post(
+            url,
+            data=json.dumps(
+                {
+                    'updated_by': 'interested@example.com',
+                    'frameworkInterest': {'agreementReturned': True}
+                }),
+            content_type='application/json')
+
     def test_if_framework_agreement_already_exists_then_it_is_updated(self, supplier_framework):
         with self.app.app_context():
             # Create framework agreement
@@ -1873,15 +1887,7 @@ class TestSupplierFrameworkAgreementsDataMigration(BaseApplicationTest):
             db.session.commit()
 
             with freeze_time('2016-06-06'):
-                response = self.client.post(
-                    '/suppliers/{}/frameworks/{}'.format(
-                        supplier_framework['supplierId'], supplier_framework['frameworkSlug']),
-                    data=json.dumps(
-                        {
-                            'updated_by': 'interested@example.com',
-                            'frameworkInterest': {'agreementReturned': True}
-                        }),
-                    content_type='application/json')
+                response = self.supplier_framework_update(supplier_framework)
                 assert response.status_code == 200
 
             # Check framework agreement is updated
@@ -1906,16 +1912,8 @@ class TestSupplierFrameworkAgreementsDataMigration(BaseApplicationTest):
             assert not agreements.count()
 
             with freeze_time('2016-06-06'):
-                    response = self.client.post(
-                        '/suppliers/{}/frameworks/{}'.format(
-                            supplier_framework['supplierId'], supplier_framework['frameworkSlug']),
-                        data=json.dumps(
-                            {
-                                'updated_by': 'interested@example.com',
-                                'frameworkInterest': {'agreementReturned': True}
-                            }),
-                        content_type='application/json')
-                    assert response.status_code == 200
+                response = self.supplier_framework_update(supplier_framework)
+                assert response.status_code == 200
 
             agreements = FrameworkAgreement.query.filter(
                 FrameworkAgreement.supplier_id == supplier_framework['supplierId'],
@@ -1958,15 +1956,7 @@ class TestSupplierFrameworkAgreementsDataMigration(BaseApplicationTest):
             assert not example_agreement_query.first()
 
             with freeze_time('2016-06-06'):
-                response = self.client.post(
-                    '/suppliers/{}/frameworks/{}'.format(
-                        supplier_framework['supplierId'], supplier_framework['frameworkSlug']),
-                    data=json.dumps(
-                        {
-                            'updated_by': 'interested@example.com',
-                            'frameworkInterest': {'agreementReturned': True}
-                        }),
-                    content_type='application/json')
+                response = self.supplier_framework_update(supplier_framework)
                 assert response.status_code == 200
 
             # Check framework agreement exists for the right framework with the right timestamp

--- a/tests/app/views/test_suppliers.py
+++ b/tests/app/views/test_suppliers.py
@@ -1837,7 +1837,7 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest):
     def test_changing_on_framework_to_passed_creates_audit_event(self, supplier_framework):
         self.supplier_framework_interest(
             supplier_framework,
-            update={'onFramework': True, 'agreementReturned': True}
+            update={'onFramework': True}
         )
         with self.app.app_context():
             supplier = Supplier.query.filter(
@@ -1853,7 +1853,6 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest):
             assert audit.data['supplierId'] == supplier_framework['supplierId']
             assert audit.data['frameworkSlug'] == supplier_framework['frameworkSlug']
             assert audit.data['update']['onFramework'] is True
-            assert audit.data['update']['agreementReturned'] is True
 
 
 class TestSupplierFrameworkAgreementsDataMigration(BaseApplicationTest):


### PR DESCRIPTION
Adds tests for two of the bugfixes shipped out in pull request #453.

Specifically,
- checks that the correct `supplier_id` is added to the audit event created on a generic framework update
- makes sure that the wrong `FrameworkAgreement` will not be updated 

***

In the latter case, the problem was that the previous code would look for any `FrameworkAgreement` belonging to a supplier and update it.  This meant that if 
- a framework agreement existed for a supplier
- a framework agreement update came in for a _different_ framework
the framework agreement for the first framework would always be returned and updated.  A new framework agreement would never be created.

This test verifies that even if a framework agreement for another framework exists, a new framework agreement is always created.