### PR TITLE
Add Framework agreement status and route to set `FrameworkAgreement` as on hold

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -435,6 +435,7 @@ class SupplierFramework(db.Model):
                     agreement.countersigned_agreement_returned_at and
                     agreement.countersigned_agreement_returned_at.strftime(DATETIME_FORMAT)
                 ),
+                'agreementStatus': agreement.status
             })
         else:
             supplier_framework.update({
@@ -443,6 +444,7 @@ class SupplierFramework(db.Model):
                 "agreementDetails": None,
                 "countersigned": False,
                 "countersignedAt": None,
+                "agreementStatus": None
             })
 
         if supplier_framework['agreementDetails'] and supplier_framework['agreementDetails'].get('uploaderUserId'):

--- a/app/models.py
+++ b/app/models.py
@@ -505,11 +505,23 @@ class FrameworkAgreement(db.Model):
 
         return data
 
+    @hybrid_property
+    def status(self):
+        if self.countersigned_agreement_returned_at:
+            return 'countersigned'
+        elif self.signed_agreement_put_on_hold_at:
+            return 'on hold'
+        elif self.signed_agreement_returned_at:
+            return 'signed'
+        else:
+            return 'draft'
+
     def serialize(self):
         return purge_nulls_from_data({
             'id': self.id,
             'supplierId': self.supplier_id,
             'frameworkSlug': self.supplier_framework.framework.slug,
+            'status': self.status,
             'signedAgreementDetails': self.signed_agreement_details,
             'signedAgreementPath': self.signed_agreement_path,
             'signedAgreementReturnedAt': (

--- a/app/models.py
+++ b/app/models.py
@@ -466,6 +466,7 @@ class FrameworkAgreement(db.Model):
     signed_agreement_details = db.Column(JSON)
     signed_agreement_path = db.Column(db.String)
     signed_agreement_returned_at = db.Column(db.DateTime)
+    signed_agreement_put_on_hold_at = db.Column(db.DateTime)
     countersigned_agreement_details = db.Column(JSON)
     countersigned_agreement_path = db.Column(db.String)
     countersigned_agreement_returned_at = db.Column(db.DateTime)
@@ -514,6 +515,10 @@ class FrameworkAgreement(db.Model):
             'signedAgreementReturnedAt': (
                 self.signed_agreement_returned_at and
                 self.signed_agreement_returned_at.strftime(DATETIME_FORMAT)
+            ),
+            'signedAgreementPutOnHoldAt': (
+                self.signed_agreement_put_on_hold_at and
+                self.signed_agreement_put_on_hold_at.strftime(DATETIME_FORMAT)
             ),
             'countersignedAgreementDetails': self.countersigned_agreement_details,
             'countersignedAgreementReturnedAt': (

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -843,3 +843,48 @@ class TestFrameworkAgreements(BaseApplicationTest):
 
             with pytest.raises(IntegrityError):
                 db.session.commit()
+
+    def test_new_framework_agreement_status_is_draft(self):
+        framework_agreement = FrameworkAgreement(supplier_id=0, framework_id=1)
+        assert framework_agreement.status == 'draft'
+
+    def test_partially_signed_framework_agreement_status_is_draft(self):
+        framework_agreement = FrameworkAgreement(
+            supplier_id=0,
+            framework_id=1,
+            signed_agreement_details={'agreement': 'details'},
+            signed_agreement_path='path'
+        )
+        assert framework_agreement.status == 'draft'
+
+    def test_signed_framework_agreement_status_is_signed(self):
+        framework_agreement = FrameworkAgreement(
+            supplier_id=0,
+            framework_id=1,
+            signed_agreement_details={'agreement': 'details'},
+            signed_agreement_path='path',
+            signed_agreement_returned_at=datetime.utcnow()
+        )
+        assert framework_agreement.status == 'signed'
+
+    def test_on_hold_framework_agreement_status_is_on_hold(self):
+        framework_agreement = FrameworkAgreement(
+            supplier_id=0,
+            framework_id=1,
+            signed_agreement_details={'agreement': 'details'},
+            signed_agreement_path='path',
+            signed_agreement_returned_at=datetime.utcnow(),
+            signed_agreement_put_on_hold_at=datetime.utcnow()
+        )
+        assert framework_agreement.status == 'on hold'
+
+    def test_countersigned_framework_agreement_status_is_countersigned(self):
+        framework_agreement = FrameworkAgreement(
+            supplier_id=0,
+            framework_id=1,
+            signed_agreement_details={'agreement': 'details'},
+            signed_agreement_path='path',
+            signed_agreement_returned_at=datetime.utcnow(),
+            countersigned_agreement_returned_at=datetime.utcnow()
+        )
+        assert framework_agreement.status == 'countersigned'

--- a/tests/app/views/test_agreements.py
+++ b/tests/app/views/test_agreements.py
@@ -50,6 +50,7 @@ class TestCreateFrameworkAgreement(BaseApplicationTest):
         assert res_agreement_json['id'] > 0
         assert res_agreement_json['supplierId'] == supplier_framework['supplierId']
         assert res_agreement_json['frameworkSlug'] == supplier_framework['frameworkSlug']
+        assert res_agreement_json['status'] == 'draft'
 
         res2 = self.client.get('/agreements/{}'.format(res_agreement_json['id']))
 
@@ -161,7 +162,8 @@ class TestGetFrameworkAgreement(BaseFrameworkAgreementTest):
         assert json.loads(res.get_data(as_text=True))['agreement'] == {
             'id': agreement_id,
             'supplierId': supplier_framework['supplierId'],
-            'frameworkSlug': supplier_framework['frameworkSlug']
+            'frameworkSlug': supplier_framework['frameworkSlug'],
+            'status': 'draft'
         }
 
     def test_it_returns_a_framework_agreement_with_details_only(self, supplier_framework):
@@ -177,6 +179,7 @@ class TestGetFrameworkAgreement(BaseFrameworkAgreementTest):
             'supplierId': supplier_framework['supplierId'],
             'frameworkSlug': supplier_framework['frameworkSlug'],
             'signedAgreementDetails': {'details': 'here'},
+            'status': 'draft'
         }
 
     def test_it_gets_a_signed_framework_agreement_by_id(self, supplier_framework):
@@ -193,6 +196,7 @@ class TestGetFrameworkAgreement(BaseFrameworkAgreementTest):
             'id': agreement_id,
             'supplierId': supplier_framework['supplierId'],
             'frameworkSlug': supplier_framework['frameworkSlug'],
+            'status': 'signed',
             'signedAgreementDetails': {'details': 'here'},
             'signedAgreementPath': 'path',
             'signedAgreementReturnedAt': '2016-10-01T01:01:01.000000Z',
@@ -213,6 +217,7 @@ class TestGetFrameworkAgreement(BaseFrameworkAgreementTest):
             'id': agreement_id,
             'supplierId': supplier_framework['supplierId'],
             'frameworkSlug': supplier_framework['frameworkSlug'],
+            'status': 'on hold',
             'signedAgreementDetails': {'details': 'here'},
             'signedAgreementPath': 'path',
             'signedAgreementReturnedAt': '2016-10-01T01:01:01.000000Z',
@@ -235,6 +240,7 @@ class TestGetFrameworkAgreement(BaseFrameworkAgreementTest):
             'id': agreement_id,
             'supplierId': supplier_framework['supplierId'],
             'frameworkSlug': supplier_framework['frameworkSlug'],
+            'status': 'countersigned',
             'signedAgreementDetails': {'details': 'here'},
             'signedAgreementPath': 'path',
             'signedAgreementReturnedAt': '2016-10-01T01:01:01.000000Z',
@@ -259,6 +265,7 @@ class TestGetFrameworkAgreement(BaseFrameworkAgreementTest):
             'id': agreement_id,
             'supplierId': supplier_framework['supplierId'],
             'frameworkSlug': supplier_framework['frameworkSlug'],
+            'status': 'countersigned',
             'signedAgreementDetails': {'details': 'here'},
             'signedAgreementPath': 'path',
             'signedAgreementReturnedAt': '2016-10-01T01:01:01.000000Z',
@@ -319,6 +326,7 @@ class TestUpdateFrameworkAgreement(BaseFrameworkAgreementTest):
             'id': agreement_id,
             'supplierId': supplier_framework['supplierId'],
             'frameworkSlug': supplier_framework['frameworkSlug'],
+            'status': 'draft',
             'signedAgreementDetails': {
                 'signerName': 'name',
                 'signerRole': 'role',
@@ -344,6 +352,7 @@ class TestUpdateFrameworkAgreement(BaseFrameworkAgreementTest):
             'id': agreement_id,
             'supplierId': supplier_framework['supplierId'],
             'frameworkSlug': supplier_framework['frameworkSlug'],
+            'status': 'draft',
             'signedAgreementPath': '/example.pdf'
         }
         assert data['agreement'] == expected_agreement_json
@@ -370,6 +379,7 @@ class TestUpdateFrameworkAgreement(BaseFrameworkAgreementTest):
             'id': agreement_id,
             'supplierId': supplier_framework['supplierId'],
             'frameworkSlug': supplier_framework['frameworkSlug'],
+            'status': 'draft',
             'signedAgreementPath': '/example.pdf',
             'signedAgreementDetails': {
                 'signerName': 'name',
@@ -513,6 +523,7 @@ class TestSignFrameworkAgreementThatHasFrameworkAgreementVersion(BaseFrameworkAg
                 'id': agreement_id,
                 'supplierId': supplier_framework['supplierId'],
                 'frameworkSlug': supplier_framework['frameworkSlug'],
+                'status': 'signed',
                 'signedAgreementPath': '/example.pdf',
                 'signedAgreementDetails': {
                     'signerName': 'name',
@@ -570,6 +581,7 @@ class TestSignFrameworkAgreementThatHasFrameworkAgreementVersion(BaseFrameworkAg
                 'id': agreement_id,
                 'supplierId': supplier_framework['supplierId'],
                 'frameworkSlug': supplier_framework['frameworkSlug'],
+                'status': 'signed',
                 'signedAgreementPath': '/example.pdf',
                 'signedAgreementDetails': {
                     'signerName': 'name',
@@ -640,6 +652,7 @@ class TestSignFrameworkAgreementThatHasNoFrameworkAgreementVersion(BaseFramework
                 'id': agreement_id,
                 'supplierId': supplier_framework['supplierId'],
                 'frameworkSlug': supplier_framework['frameworkSlug'],
+                'status': 'signed',
                 'signedAgreementReturnedAt': '2016-12-12T00:00:00.000000Z'
             }
 
@@ -678,5 +691,6 @@ class TestSignFrameworkAgreementThatHasNoFrameworkAgreementVersion(BaseFramework
                 'id': agreement_id,
                 'supplierId': supplier_framework['supplierId'],
                 'frameworkSlug': supplier_framework['frameworkSlug'],
+                'status': 'signed',
                 'signedAgreementReturnedAt': '2016-12-12T00:00:00.000000Z'
             }

--- a/tests/app/views/test_agreements.py
+++ b/tests/app/views/test_agreements.py
@@ -198,6 +198,27 @@ class TestGetFrameworkAgreement(BaseFrameworkAgreementTest):
             'signedAgreementReturnedAt': '2016-10-01T01:01:01.000000Z',
         }
 
+    def test_it_gets_an_on_hold_framework_agreement_by_id(self, supplier_framework):
+        agreement_id = self.create_agreement(
+            supplier_framework,
+            signed_agreement_returned_at=datetime(2016, 10, 1, 1, 1, 1),
+            signed_agreement_details={'details': 'here'},
+            signed_agreement_path='path',
+            signed_agreement_put_on_hold_at=datetime(2016, 11, 1, 1, 1, 1),
+        )
+        res = self.client.get('/agreements/{}'.format(agreement_id))
+
+        assert res.status_code == 200
+        assert json.loads(res.get_data(as_text=True))['agreement'] == {
+            'id': agreement_id,
+            'supplierId': supplier_framework['supplierId'],
+            'frameworkSlug': supplier_framework['frameworkSlug'],
+            'signedAgreementDetails': {'details': 'here'},
+            'signedAgreementPath': 'path',
+            'signedAgreementReturnedAt': '2016-10-01T01:01:01.000000Z',
+            'signedAgreementPutOnHoldAt': '2016-11-01T01:01:01.000000Z',
+        }
+
     def test_it_gets_a_countersigned_framework_agreement_by_id(self, supplier_framework):
         agreement_id = self.create_agreement(
             supplier_framework,

--- a/tests/app/views/test_suppliers.py
+++ b/tests/app/views/test_suppliers.py
@@ -1109,6 +1109,7 @@ class TestGetSupplierFrameworks(BaseApplicationTest):
                         'agreementDetails': None,
                         'countersigned': False,
                         'countersignedAt': None,
+                        'agreementStatus': None,
                         'agreedVariations': {},
                     }
                 ]
@@ -1137,6 +1138,7 @@ class TestGetSupplierFrameworks(BaseApplicationTest):
                         'agreementDetails': None,
                         'countersigned': False,
                         'countersignedAt': None,
+                        'agreementStatus': None,
                         'agreedVariations': {},
                     }
                 ]
@@ -1289,6 +1291,7 @@ class TestSupplierFrameworkResponse(BaseApplicationTest):
         assert data['frameworkInterest']['countersigned'] is False
         assert data['frameworkInterest']['countersignedAt'] is None
         assert data['frameworkInterest']['agreementDetails'] is None
+        assert data['frameworkInterest']['agreementStatus'] is None
 
     def test_get_supplier_framework_returns_framework_agreement(self, supplier_framework):
         with self.app.app_context():
@@ -1329,6 +1332,7 @@ class TestSupplierFrameworkResponse(BaseApplicationTest):
                 'signerRole': 'thing 2',
                 'uploaderUserId': 30
             },
+            'agreementStatus': 'draft',
             'agreedVariations': {}
         }
 
@@ -1373,6 +1377,7 @@ class TestSupplierFrameworkResponse(BaseApplicationTest):
                 'signerRole': 'thing 2',
                 'uploaderUserId': 30
             },
+            'agreementStatus': 'signed',
             'agreedVariations': {}
         }
 
@@ -1421,6 +1426,7 @@ class TestSupplierFrameworkResponse(BaseApplicationTest):
             },
             'countersigned': True,
             'countersignedAt': '2017-02-01T01:01:01.000000Z',
+            'agreementStatus': 'countersigned',
             'agreedVariations': {}
         }
 


### PR DESCRIPTION
- Adds the `signed_agreement_put_on_hold` field to the `FrameworkAgreement` model from the above mentioned pull request and it's serialization.
- Adds a `status` property to a `FrameworkAgreement`. This is done in a similar way to the `status` field for `Brief`'s.
- Adds a route to set a framework agreement as `on hold`.
- Add `agreementStatus` field to `SupplierFramework.serialize`

#### Decided not needed/in scope (although may be added later)
- Set `FrameworkAgreement fields`, such as `signed_agreement_returned_at` or `signed_agreement_put_on_hold_at` using the `status` field? The `Brief` model currently does this.
- Add ability to query framework agreements using the `status` field. Again, the `Brief` model currently does this.
- Add `signedAgreementPutOnHold` field to `SupplierFramework.serialize`