### PR TITLE
[#130991743] Remove application_status from framework users export

### DIFF
--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -244,35 +244,18 @@ def export_users_for_framework(framework_slug):
         User.active.is_(True)
     ).all()
 
-    submitted_draft_counts_per_supplier = {}
     user_rows = []
 
     for sf, s, u in supplier_frameworks_and_suppliers_and_users:
 
         # always get the declaration status
         declaration_status = sf.declaration.get('status') if sf.declaration else 'unstarted'
-        application_status = ''
         application_result = ''
         framework_agreement = ''
         variations_agreed = ''
 
         # if framework is pending, live, or expired
         if framework.status != 'open':
-
-            # get number of completed draft services per supplier
-            # `application_status` is based on a complete declaration and at least one completed draft service
-            if sf.supplier_id not in submitted_draft_counts_per_supplier.keys():
-                submitted_draft_counts_per_supplier[sf.supplier_id] = db.session.query(
-                    func.count()
-                ).filter(
-                    DraftService.supplier_id == sf.supplier_id,
-                    DraftService.framework_id == sf.framework_id,
-                    DraftService.status == 'submitted'
-                ).scalar()
-
-            submitted_draft_count = submitted_draft_counts_per_supplier[sf.supplier_id]
-            application_status = \
-                'application' if submitted_draft_count and declaration_status == 'complete' else 'no_application'
             if sf.on_framework is None:
                 application_result = 'no result'
             else:
@@ -285,7 +268,7 @@ def export_users_for_framework(framework_slug):
             'user_name': u.name,
             'supplier_id': s.supplier_id,
             'declaration_status': declaration_status,
-            'application_status': application_status,
+            'application_status': '',
             'framework_agreement': framework_agreement,
             'application_result': application_result,
             'variations_agreed': variations_agreed

--- a/tests/app/views/test_users.py
+++ b/tests/app/views/test_users.py
@@ -1229,7 +1229,7 @@ class TestUsersExport(BaseUserTest):
     def _assert_things_about_export_response(self, row, parameters=None):
         _parameters = {
             'application_result': 'no result',
-            'application_status': 'no_application',
+            'application_status': '',
             'declaration_status': 'unstarted',
             'framework_agreement': False,
         }
@@ -1310,7 +1310,7 @@ class TestUsersExport(BaseUserTest):
         for datum in data:
             self._assert_things_about_export_response(datum, parameters={
                 'declaration_status': 'complete',
-                'application_status': 'application'
+                'application_status': ''
             })
 
     # Test users for supplier with completed declaration one draft but framework still open
@@ -1339,7 +1339,7 @@ class TestUsersExport(BaseUserTest):
         for datum in data:
             self._assert_things_about_export_response(datum, parameters={
                 'declaration_status': 'complete',
-                'application_status': 'application',
+                'application_status': '',
                 'framework_agreement': True
             })
 
@@ -1354,7 +1354,7 @@ class TestUsersExport(BaseUserTest):
         for datum in data:
             self._assert_things_about_export_response(datum, parameters={
                 'declaration_status': 'complete',
-                'application_status': 'application',
+                'application_status': '',
                 'framework_agreement': True,
                 'application_result': 'pass'
             })
@@ -1369,7 +1369,7 @@ class TestUsersExport(BaseUserTest):
         for datum in data:
             self._assert_things_about_export_response(datum, parameters={
                 'declaration_status': 'complete',
-                'application_status': 'application',
+                'application_status': '',
                 'framework_agreement': False,
                 'application_result': 'fail'
             })
@@ -1421,7 +1421,7 @@ class TestUsersExport(BaseUserTest):
         for datum in data:
             self._assert_things_about_export_response(datum, parameters={
                 'declaration_status': 'complete',
-                'application_status': 'application',
+                'application_status': '',
                 'application_result': 'pass',
                 'framework_agreement': True,
                 'agreed_variations': '1'


### PR DESCRIPTION
Current implementation of application_status check requires N+1 queries to request draft services for each framework supplier. This is timing out due to the number of suppliers in production.

As a temporary workaround, since we're mainly interested in exports for live frameworks at the moment we're removing application status values from the export.