### PR TITLE
Add temporary countersign route needed for one off script

### DIFF
--- a/tests/app/views/test_agreements.py
+++ b/tests/app/views/test_agreements.py
@@ -778,3 +778,69 @@ class TestPutFrameworkAgreementOnHold(BaseFrameworkAgreementTest):
         assert res.status_code == 400
         error_message = json.loads(res.get_data(as_text=True))['error']
         assert error_message == "Framework agreement must have a 'frameworkAgreementVersion' to be put on hold"
+
+
+class TestTemporaryCountersignRoute(BaseFrameworkAgreementTest):
+    """Test related to temporary counter sign route
+
+    When temporary countersign route is removed, these tests can also be removed
+    """
+    def temp_countersign(self, agreement_id, countersign_path, countersign_returned_at):
+        return self.client.post(
+            '/agreements/{}/countersign-script'.format(agreement_id),
+            data=json.dumps(
+                {
+                    "updated_by": "interested@example.com",
+                    "agreement": {
+                        "countersignedAgreementPath": countersign_path,
+                        "countersignedAgreementReturnedAt": countersign_returned_at
+                    }
+
+                }),
+            content_type='application/json')
+
+    def test_temp_countersign(self, supplier_framework):
+        agreement_id = self.create_agreement(
+            supplier_framework,
+            signed_agreement_returned_at=datetime(2016, 10, 1),
+        )
+
+        res = self.temp_countersign(
+            agreement_id,
+            'example/path/file.pdf',
+            '2016-11-01T00:00:00.000000Z'
+        )
+
+        assert res.status_code == 200, json.loads(res.get_data(as_text=True))
+
+        data = json.loads(res.get_data(as_text=True))
+
+        assert data['agreement'] == {
+            'id': agreement_id,
+            'supplierId': supplier_framework['supplierId'],
+            'frameworkSlug': supplier_framework['frameworkSlug'],
+            'status': 'countersigned',
+            'signedAgreementReturnedAt': '2016-10-01T00:00:00.000000Z',
+            'countersignedAgreementReturnedAt': '2016-11-01T00:00:00.000000Z',
+            'countersignedAgreementPath': 'example/path/file.pdf'
+        }
+
+        with self.app.app_context():
+            agreement = FrameworkAgreement.query.filter(
+                FrameworkAgreement.id == agreement_id
+            ).first()
+
+            audit = AuditEvent.query.filter(
+                AuditEvent.object == agreement
+            ).first()
+
+            assert audit.type == "countersign_agreement"
+            assert audit.user == "interested@example.com"
+            assert audit.data == {
+                'supplierId': supplier_framework['supplierId'],
+                'frameworkSlug': supplier_framework['frameworkSlug'],
+                'update': {
+                    "countersignedAgreementPath": "example/path/file.pdf",
+                    "countersignedAgreementReturnedAt": "2016-11-01T00:00:00.000000Z"
+                }
+            }


### PR DESCRIPTION
Temporary route needed so we can set a user defined timestamp for an agreement to be countersigned (the real route that is still to be created will not allow the user to define the timestamp but will take the current time). This route will also allow us to set the countersigned path. After a one off refactoring script is run then this route will no longer be needed and we can delete it.