### PR TITLE
[#128669753] Add migration to add G8 contract variation agreed-by-CCS details

### DIFF
--- a/migrations/versions/760_ccs_agree_g8_variation.py
+++ b/migrations/versions/760_ccs_agree_g8_variation.py
@@ -1,0 +1,36 @@
+"""Add g-cloud-8 variation 1 countersigner details
+
+Revision ID: 760
+Revises: 750
+Create Date: 2016-09-25 13:00:00.000000
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '760'
+down_revision = '750'
+
+from alembic import op
+
+
+def upgrade():
+    op.execute(
+        "UPDATE frameworks SET framework_agreement_details = '"
+        '{"frameworkAgreementVersion":"v1.0", '
+        '"variations":{"1":'
+        '{"createdAt":"2016-08-19T15:31:00.000000Z", '
+        '"countersignedAt":"2016-10-05T11:00:00.000000Z", '
+        '"countersignedByName":"Dan Saxby", '
+        '"countersignedByRole":"Category Director"'
+        "}}}'::json "
+        "WHERE slug = 'g-cloud-8'"
+    )
+
+
+def downgrade():
+    op.execute("""
+        UPDATE frameworks SET
+            framework_agreement_details =
+            '{"frameworkAgreementVersion":"v1.0", "variations":{"1":{"createdAt":"2016-08-19T15:31:00.000000Z"}}}'::json
+        WHERE slug = 'g-cloud-8'
+    """)


### PR DESCRIPTION
For this story: https://www.pivotaltracker.com/story/show/128669753

**CONTRACT VARIATION IS GO! GO! GO!** 

We are almost ready for the contract variation to come into place.

This migration needs to run when the time comes to set countersigner details on the variation.

This was the neatest way I could figure to make the update readable but not add a load of whitespace and newlines into the database json field.  Open to suggestions if you can see a way to make it prettier.  (My first version was all on one line, which was kind-of fine...)