### PR TITLE
Simplify users export query and avoid calling sf.serialize

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -340,6 +340,11 @@ class SupplierFramework(db.Model):
     supplier = db.relationship(Supplier, lazy='joined', innerjoin=True)
     framework = db.relationship(Framework, lazy='joined', innerjoin=True)
 
+    @property
+    def current_framework_agreement(self):
+        if self.framework_agreements:
+            return self.framework_agreements[0]
+
     @validates('declaration')
     def validates_declaration(self, key, value):
         value = strip_whitespace_from_data(value)
@@ -421,8 +426,8 @@ class SupplierFramework(db.Model):
             "agreedVariations": agreed_variations,
         }, **(data or {}))
 
-        if self.framework_agreements:
-            agreement = self.framework_agreements[0]
+        agreement = self.current_framework_agreement
+        if agreement:
             supplier_framework.update({
                 'agreementId': agreement.id,
                 'agreementReturned': bool(agreement.signed_agreement_returned_at),


### PR DESCRIPTION
Export endpoint is still timing out in production. Looking at the recent changes it seems that serializing supplier_framework records to check for framework agreement status might be slowing down the API response.

The query time in production is ~6s, so it doesn't feel like it's the main cause of 30s timeouts.

This simplifies the database query and replaces `sf.serialize` with an attribute check.

#### Add `SupplierFramework.current_framework_agreement` property
Allows looking up the current framework agreement for the supplier.
Right now the only way to access this is either using `agreements[0]` from the view (which would break in the future) or calling `supplier_framework.serialize()`.

Adding a property encapsulates the current agreement logic in a model property, which should make it easy to use in other views.