### PR TITLE
Create endpoint for countersigning framework_agreements

### DIFF
--- a/app/main/views/agreements.py
+++ b/app/main/views/agreements.py
@@ -285,7 +285,7 @@ def approve_for_countersignature(agreement_id):
         data={
             'supplierId': framework_agreement.supplier_id,
             'frameworkSlug': framework_agreement.supplier_framework.framework.slug,
-            'status': 'countersigned'
+            'status': 'approved'
         },
         db_object=framework_agreement
     )

--- a/app/main/views/agreements.py
+++ b/app/main/views/agreements.py
@@ -265,7 +265,7 @@ def countersign_agreement(agreement_id):
     framework_agreement.countersigned_agreement_returned_at = datetime.utcnow()
 
     countersigner_details = framework_agreement_details.get('agreementCountersignerDetails', {})
-    countersigner_details.update(updater_json)
+    countersigner_details.update({'updatedBy': updater_json['updated_by']})
     framework_agreement.countersigned_agreement_details = countersigner_details
 
     audit_event = AuditEvent(

--- a/app/main/views/agreements.py
+++ b/app/main/views/agreements.py
@@ -264,7 +264,7 @@ def countersign_agreement(agreement_id):
     framework_agreement.signed_agreement_put_on_hold_at = None
     framework_agreement.countersigned_agreement_returned_at = datetime.utcnow()
 
-    countersigner_details = framework_agreement_details.get('agreementCountersignerDetails', {})
+    countersigner_details = {'countersignerName': framework_agreement_details.get('countersignerName', '')}
     countersigner_details.update({'updatedBy': updater_json['updated_by']})
     framework_agreement.countersigned_agreement_details = countersigner_details
 

--- a/app/main/views/agreements.py
+++ b/app/main/views/agreements.py
@@ -247,6 +247,7 @@ def put_signed_framework_agreement_on_hold(agreement_id):
 
     return jsonify(agreement=framework_agreement.serialize())
 
+
 @main.route('/agreements/<int:agreement_id>/countersign', methods=['POST'])
 def countersign_agreement(agreement_id):
     framework_agreement = FrameworkAgreement.query.filter(FrameworkAgreement.id == agreement_id).first_or_404()
@@ -263,7 +264,7 @@ def countersign_agreement(agreement_id):
     framework_agreement.signed_agreement_put_on_hold_at = None
     framework_agreement.countersigned_agreement_returned_at = datetime.utcnow()
 
-    countersigner_details = framework_agreement_details.get('agreement_countersigner_details', {})
+    countersigner_details = framework_agreement_details.get('agreementCountersignerDetails', {})
     countersigner_details.update(updater_json)
     framework_agreement.countersigned_agreement_details = countersigner_details
 

--- a/app/main/views/agreements.py
+++ b/app/main/views/agreements.py
@@ -248,8 +248,8 @@ def put_signed_framework_agreement_on_hold(agreement_id):
     return jsonify(agreement=framework_agreement.serialize())
 
 
-@main.route('/agreements/<int:agreement_id>/countersign', methods=['POST'])
-def countersign_agreement(agreement_id):
+@main.route('/agreements/<int:agreement_id>/approve', methods=['POST'])
+def approve_for_countersignature(agreement_id):
     framework_agreement = FrameworkAgreement.query.filter(FrameworkAgreement.id == agreement_id).first_or_404()
     framework_agreement_details = framework_agreement.supplier_framework.framework.framework_agreement_details
 

--- a/app/main/views/agreements.py
+++ b/app/main/views/agreements.py
@@ -255,7 +255,7 @@ def countersign_agreement(agreement_id):
 
     json_payload = get_json_from_request()
     json_has_required_keys(json_payload, ['userId'])
-    updater_id = json_payload['userId']
+    approved_by_user_id = json_payload['userId']
 
     updater_json = validate_and_return_updater_request()
 
@@ -276,7 +276,7 @@ def countersign_agreement(agreement_id):
                 'countersignerRole': framework_agreement_details['countersignerRole']
             })
 
-    countersigner_details.update({'updatedById': updater_id})
+    countersigner_details.update({'approvedByUserId': approved_by_user_id})
     framework_agreement.countersigned_agreement_details = countersigner_details
 
     audit_event = AuditEvent(

--- a/app/main/views/agreements.py
+++ b/app/main/views/agreements.py
@@ -258,13 +258,14 @@ def countersign_agreement(agreement_id):
     if framework_agreement.status not in ['signed', 'on hold']:
         abort(400, "Framework agreement must have status 'signed' or 'on hold' to be countersigned")
 
-    if not framework_agreement_details or not framework_agreement_details.get('frameworkAgreementVersion'):
-        abort(400, "Framework agreement must have a 'frameworkAgreementVersion' to be countersigned")
-
     framework_agreement.signed_agreement_put_on_hold_at = None
     framework_agreement.countersigned_agreement_returned_at = datetime.utcnow()
 
-    countersigner_details = {'countersignerName': framework_agreement_details.get('countersignerName', '')}
+    if framework_agreement_details and framework_agreement_details.get('countersignerName'):
+        countersigner_details = {'countersignerName': framework_agreement_details['countersignerName']}
+    else:
+        countersigner_details = {}
+
     countersigner_details.update({'updatedBy': updater_json['updated_by']})
     framework_agreement.countersigned_agreement_details = countersigner_details
 

--- a/app/models.py
+++ b/app/models.py
@@ -532,8 +532,10 @@ class FrameworkAgreement(db.Model):
 
     @hybrid_property
     def status(self):
-        if self.countersigned_agreement_returned_at:
+        if self.countersigned_agreement_path:
             return 'countersigned'
+        elif self.countersigned_agreement_returned_at:
+            return 'approved'
         elif self.signed_agreement_put_on_hold_at:
             return 'on hold'
         elif self.signed_agreement_returned_at:

--- a/app/models.py
+++ b/app/models.py
@@ -469,6 +469,16 @@ class SupplierFramework(db.Model):
                 supplier_framework['agreementDetails']['uploaderUserName'] = user.name
                 supplier_framework['agreementDetails']['uploaderUserEmail'] = user.email_address
 
+        if supplier_framework['countersignedDetails'] \
+                and supplier_framework['countersignedDetails'].get('approvedByUserId'):
+            user = User.query.filter(
+                User.id == supplier_framework['countersignedDetails']['approvedByUserId']
+            ).first()
+
+            if user:
+                supplier_framework['countersignedDetails']['approvedByUserName'] = user.name
+                supplier_framework['countersignedDetails']['approvedByUserEmail'] = user.email_address
+
         return supplier_framework
 
 

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -878,7 +878,7 @@ class TestFrameworkAgreements(BaseApplicationTest):
         )
         assert framework_agreement.status == 'on hold'
 
-    def test_countersigned_framework_agreement_status_is_countersigned(self):
+    def test_countersigned_framework_agreement_status_is_approved(self):
         framework_agreement = FrameworkAgreement(
             supplier_id=0,
             framework_id=1,
@@ -886,5 +886,17 @@ class TestFrameworkAgreements(BaseApplicationTest):
             signed_agreement_path='path',
             signed_agreement_returned_at=datetime.utcnow(),
             countersigned_agreement_returned_at=datetime.utcnow()
+        )
+        assert framework_agreement.status == 'approved'
+
+    def test_countersigned_framework_agreement_status_is_countersigned(self):
+        framework_agreement = FrameworkAgreement(
+            supplier_id=0,
+            framework_id=1,
+            signed_agreement_details={'agreement': 'details'},
+            signed_agreement_path='path',
+            signed_agreement_returned_at=datetime.utcnow(),
+            countersigned_agreement_returned_at=datetime.utcnow(),
+            countersigned_agreement_path='/path/to/the/countersignedAgreement.pdf'
         )
         assert framework_agreement.status == 'countersigned'

--- a/tests/app/views/test_agreements.py
+++ b/tests/app/views/test_agreements.py
@@ -982,7 +982,7 @@ class TestApproveFrameworkAgreement(BaseFrameworkAgreementTest):
             assert audit.data == {
                 'supplierId': supplier_framework['supplierId'],
                 'frameworkSlug': supplier_framework['frameworkSlug'],
-                'status': 'countersigned'
+                'status': 'approved'
             }
 
     @fixture_params(

--- a/tests/app/views/test_agreements.py
+++ b/tests/app/views/test_agreements.py
@@ -896,9 +896,9 @@ class TestPutFrameworkAgreementOnHold(BaseFrameworkAgreementTest):
 
 
 class TestCountersignFrameworkAgreement(BaseFrameworkAgreementTest):
-    def countersign_framework_agreement(self, agreement_id):
+    def approve_framework_agreement(self, agreement_id):
         return self.client.post(
-            '/agreements/{}/countersign'.format(agreement_id),
+            '/agreements/{}/approve'.format(agreement_id),
             data=json.dumps(
                 {
                     'updated_by': 'chris@example.com',
@@ -915,14 +915,14 @@ class TestCountersignFrameworkAgreement(BaseFrameworkAgreementTest):
             }
         }
     )
-    def test_can_countersign_signed_framework_agreement(self, supplier_framework):
+    def test_can_approve_signed_framework_agreement(self, supplier_framework):
         agreement_id = self.create_agreement(
             supplier_framework,
             signed_agreement_returned_at=datetime(2016, 10, 1),
         )
 
         with freeze_time('2016-12-12'):
-            res = self.countersign_framework_agreement(agreement_id)
+            res = self.approve_framework_agreement(agreement_id)
 
         assert res.status_code == 200
 
@@ -968,7 +968,7 @@ class TestCountersignFrameworkAgreement(BaseFrameworkAgreementTest):
             }
         }
     )
-    def test_can_countersign_on_hold_framework_agreement(self, supplier_framework):
+    def test_can_approve_on_hold_framework_agreement(self, supplier_framework):
         agreement_id = self.create_agreement(
             supplier_framework,
             signed_agreement_returned_at=datetime(2016, 10, 1),
@@ -985,7 +985,7 @@ class TestCountersignFrameworkAgreement(BaseFrameworkAgreementTest):
         assert on_hold_res.status_code == 200
 
         with freeze_time('2016-10-03'):
-            res = self.countersign_framework_agreement(agreement_id)
+            res = self.approve_framework_agreement(agreement_id)
         assert res.status_code == 200
 
         data = json.loads(res.get_data(as_text=True))
@@ -1006,22 +1006,22 @@ class TestCountersignFrameworkAgreement(BaseFrameworkAgreementTest):
         }
 
     @fixture_params('live_example_framework', {'framework_agreement_details': {'frameworkAgreementVersion': 'v1.0'}})
-    def test_can_not_countersign_unsigned_framework_agreement(self, supplier_framework):
+    def test_can_not_approve_unsigned_framework_agreement(self, supplier_framework):
         agreement_id = self.create_agreement(supplier_framework)
-        res = self.countersign_framework_agreement(agreement_id)
+        res = self.approve_framework_agreement(agreement_id)
 
         assert res.status_code == 400
         error_message = json.loads(res.get_data(as_text=True))['error']
         assert error_message == "Framework agreement must have status 'signed' or 'on hold' to be countersigned"
 
-    def test_can_countersign_framework_agreement_that_has_no_framework_agreement_version(self, supplier_framework):
+    def test_can_approve_framework_agreement_that_has_no_framework_agreement_version(self, supplier_framework):
         agreement_id = self.create_agreement(
             supplier_framework,
             signed_agreement_returned_at=datetime(2016, 10, 1)
         )
 
         with freeze_time('2016-10-03'):
-            res = self.countersign_framework_agreement(agreement_id)
+            res = self.approve_framework_agreement(agreement_id)
         assert res.status_code == 200
 
         data = json.loads(res.get_data(as_text=True))
@@ -1036,21 +1036,15 @@ class TestCountersignFrameworkAgreement(BaseFrameworkAgreementTest):
             'countersignedAgreementDetails': {'approvedByUserId': '1234'}
         }
 
-    @fixture_params(
-        'live_example_framework', {
-            'framework_agreement_details': {
-                'frameworkAgreementVersion': 'v1.0'
-            }
-        }
-    )
-    def test_can_countersign_framework_agreement_with_agreement_version_but_no_name_or_role(self, supplier_framework):
+    @fixture_params('live_example_framework', {'framework_agreement_details': {'frameworkAgreementVersion': 'v1.0'}})
+    def test_can_approve_framework_agreement_with_agreement_version_but_no_name_or_role(self, supplier_framework):
         agreement_id = self.create_agreement(
             supplier_framework,
             signed_agreement_returned_at=datetime(2016, 10, 1)
         )
 
         with freeze_time('2016-10-03'):
-            res = self.countersign_framework_agreement(agreement_id)
+            res = self.approve_framework_agreement(agreement_id)
         assert res.status_code == 200
 
         data = json.loads(res.get_data(as_text=True))
@@ -1074,7 +1068,7 @@ class TestCountersignFrameworkAgreement(BaseFrameworkAgreementTest):
             }
         }
     )
-    def test_serialized_supplier_framework_contains_updater_details_after_countersign(self, supplier_framework):
+    def test_serialized_supplier_framework_contains_updater_details_after_approval(self, supplier_framework):
         with self.app.app_context():
             user = User(
                 id=1234,

--- a/tests/app/views/test_agreements.py
+++ b/tests/app/views/test_agreements.py
@@ -901,7 +901,8 @@ class TestCountersignFrameworkAgreement(BaseFrameworkAgreementTest):
             '/agreements/{}/countersign'.format(agreement_id),
             data=json.dumps(
                 {
-                    'updated_by': 'chris@example.com'
+                    'updated_by': 'chris@example.com',
+                    'userId': '1234'
                 }),
             content_type='application/json')
 
@@ -909,7 +910,8 @@ class TestCountersignFrameworkAgreement(BaseFrameworkAgreementTest):
         'live_example_framework', {
             'framework_agreement_details': {
                 'frameworkAgreementVersion': 'v1.0',
-                'countersignerName': 'The Boss'
+                'countersignerName': 'The Boss',
+                'countersignerRole': 'Director of Strings'
             }
         }
     )
@@ -933,7 +935,11 @@ class TestCountersignFrameworkAgreement(BaseFrameworkAgreementTest):
             'status': 'countersigned',
             'signedAgreementReturnedAt': '2016-10-01T00:00:00.000000Z',
             'countersignedAgreementReturnedAt': '2016-12-12T00:00:00.000000Z',
-            'countersignedAgreementDetails': {'countersignerName': 'The Boss', 'updatedBy': 'chris@example.com'}
+            'countersignedAgreementDetails': {
+                'countersignerName': 'The Boss',
+                'countersignerRole': 'Director of Strings',
+                'updatedById': '1234'
+            }
         }
 
         with self.app.app_context():
@@ -957,7 +963,8 @@ class TestCountersignFrameworkAgreement(BaseFrameworkAgreementTest):
         'live_example_framework', {
             'framework_agreement_details': {
                 'frameworkAgreementVersion': 'v1.0',
-                'countersignerName': 'The Boss'
+                'countersignerName': 'The Boss',
+                'countersignerRole': 'Director of Strings'
             }
         }
     )
@@ -991,7 +998,11 @@ class TestCountersignFrameworkAgreement(BaseFrameworkAgreementTest):
             'status': 'countersigned',
             'signedAgreementReturnedAt': '2016-10-01T00:00:00.000000Z',
             'countersignedAgreementReturnedAt': '2016-10-03T00:00:00.000000Z',
-            'countersignedAgreementDetails': {'countersignerName': 'The Boss', 'updatedBy': 'chris@example.com'}
+            'countersignedAgreementDetails': {
+                'countersignerName': 'The Boss',
+                'countersignerRole': 'Director of Strings',
+                'updatedById': '1234'
+            }
         }
 
     @fixture_params('live_example_framework', {'framework_agreement_details': {'frameworkAgreementVersion': 'v1.0'}})
@@ -1022,7 +1033,7 @@ class TestCountersignFrameworkAgreement(BaseFrameworkAgreementTest):
             'status': 'countersigned',
             'signedAgreementReturnedAt': '2016-10-01T00:00:00.000000Z',
             'countersignedAgreementReturnedAt': '2016-10-03T00:00:00.000000Z',
-            'countersignedAgreementDetails': {'updatedBy': 'chris@example.com'}
+            'countersignedAgreementDetails': {'updatedById': '1234'}
         }
 
     @fixture_params(
@@ -1032,7 +1043,7 @@ class TestCountersignFrameworkAgreement(BaseFrameworkAgreementTest):
             }
         }
     )
-    def test_can_countersign_framework_agreement_with_agreement_version_but_no_name(self, supplier_framework):
+    def test_can_countersign_framework_agreement_with_agreement_version_but_no_name_or_role(self, supplier_framework):
         agreement_id = self.create_agreement(
             supplier_framework,
             signed_agreement_returned_at=datetime(2016, 10, 1)
@@ -1051,5 +1062,5 @@ class TestCountersignFrameworkAgreement(BaseFrameworkAgreementTest):
             'status': 'countersigned',
             'signedAgreementReturnedAt': '2016-10-01T00:00:00.000000Z',
             'countersignedAgreementReturnedAt': '2016-10-03T00:00:00.000000Z',
-            'countersignedAgreementDetails': {'updatedBy': 'chris@example.com'}
+            'countersignedAgreementDetails': {'updatedById': '1234'}
         }

--- a/tests/app/views/test_agreements.py
+++ b/tests/app/views/test_agreements.py
@@ -909,9 +909,8 @@ class TestCountersignFrameworkAgreement(BaseFrameworkAgreementTest):
         'live_example_framework', {
             'framework_agreement_details': {
                 'frameworkAgreementVersion': 'v1.0',
-                'agreementCountersignerDetails': {
-                    'countersignerName': 'The Boss'}
-                }
+                'countersignerName': 'The Boss'
+            }
         }
     )
     def test_can_countersign_signed_framework_agreement(self, supplier_framework):
@@ -958,8 +957,7 @@ class TestCountersignFrameworkAgreement(BaseFrameworkAgreementTest):
         'live_example_framework', {
             'framework_agreement_details': {
                 'frameworkAgreementVersion': 'v1.0',
-                'agreementCountersignerDetails': {
-                    'countersignerName': 'The Boss'}
+                'countersignerName': 'The Boss'
             }
         }
     )

--- a/tests/app/views/test_agreements.py
+++ b/tests/app/views/test_agreements.py
@@ -934,7 +934,7 @@ class TestCountersignFrameworkAgreement(BaseFrameworkAgreementTest):
             'status': 'countersigned',
             'signedAgreementReturnedAt': '2016-10-01T00:00:00.000000Z',
             'countersignedAgreementReturnedAt': '2016-12-12T00:00:00.000000Z',
-            'countersignedAgreementDetails': {'countersignerName': 'The Boss', 'updated_by': 'chris@example.com'}
+            'countersignedAgreementDetails': {'countersignerName': 'The Boss', 'updatedBy': 'chris@example.com'}
         }
 
         with self.app.app_context():
@@ -993,7 +993,7 @@ class TestCountersignFrameworkAgreement(BaseFrameworkAgreementTest):
             'status': 'countersigned',
             'signedAgreementReturnedAt': '2016-10-01T00:00:00.000000Z',
             'countersignedAgreementReturnedAt': '2016-10-03T00:00:00.000000Z',
-            'countersignedAgreementDetails': {'countersignerName': 'The Boss', 'updated_by': 'chris@example.com'}
+            'countersignedAgreementDetails': {'countersignerName': 'The Boss', 'updatedBy': 'chris@example.com'}
         }
 
     @fixture_params('live_example_framework', {'framework_agreement_details': {'frameworkAgreementVersion': 'v1.0'}})

--- a/tests/app/views/test_suppliers.py
+++ b/tests/app/views/test_suppliers.py
@@ -1422,6 +1422,7 @@ class TestSupplierFrameworkResponse(BaseApplicationTest):
                     'some': 'data'
                 },
                 countersigned_agreement_returned_at=datetime(2017, 2, 1, 1, 1, 1),
+                countersigned_agreement_path='path'
             )
             db.session.add(framework_agreement)
             db.session.commit()
@@ -1454,7 +1455,7 @@ class TestSupplierFrameworkResponse(BaseApplicationTest):
                 'countersigned': True,
                 'countersignedAt': '2017-02-01T01:01:01.000000Z',
                 'countersignedDetails': {'some': 'data'},
-                'countersignedPath': None,
+                'countersignedPath': 'path',
                 'agreementStatus': 'countersigned',
                 'agreedVariations': {}
             }


### PR DESCRIPTION
For (this story on Pivotal)[https://www.pivotaltracker.com/story/show/121577487]

This PR creates and endpoint on the API to allow framework_agreements to be countersigned.

The details of the official countersigner for the framework need to be recorded however we're not entirely sure how that's going to work at present. The approach taken for now is to look in the `framework_agreement_details` on the framework and copy `agreementCountersignerDetails` if it exists and update it with the logged in user (to record who actually clicked the button). This may need to change in future.

The other point of note is that if a framework_agreement is on hold, that timestamp needs resetting. This is done by just setting it to `None`

Next up is to hook up the button on the admin app to hit this endpoint.
