### PR TITLE
Add countersignerRole to frameworkDetails schema

### DIFF
--- a/json_schemas/framework-agreement-details.json
+++ b/json_schemas/framework-agreement-details.json
@@ -7,6 +7,10 @@
       "minLength": 1,
       "type": "string"
     },
+    "countersignerRole": {
+      "minLength": 1,
+      "type": "string"
+    },
     "frameworkAgreementVersion": {
       "minLength": 1,
       "type": "string"


### PR DESCRIPTION
We need to capture both name and role for populating countersigned files - this is the thing we need to complete details in:

![screen shot 2016-10-05 at 16 57 27](https://cloud.githubusercontent.com/assets/6525554/19121451/76479a84-8b1e-11e6-8029-2ef4991f70e5.png)
