### PR TITLE
Add 'agreement' key to expected json data to approve an agreement

### DIFF
--- a/app/main/views/agreements.py
+++ b/app/main/views/agreements.py
@@ -254,8 +254,10 @@ def approve_for_countersignature(agreement_id):
     framework_agreement_details = framework_agreement.supplier_framework.framework.framework_agreement_details
 
     json_payload = get_json_from_request()
-    json_has_required_keys(json_payload, ['userId'])
-    approved_by_user_id = json_payload['userId']
+    json_has_required_keys(json_payload, ['agreement'])
+    update_json = json_payload["agreement"]
+    json_has_keys(update_json, required_keys=['userId'])
+    approved_by_user_id = update_json['userId']
 
     updater_json = validate_and_return_updater_request()
 

--- a/tests/app/views/test_agreements.py
+++ b/tests/app/views/test_agreements.py
@@ -928,7 +928,7 @@ class TestApproveFrameworkAgreement(BaseFrameworkAgreementTest):
             data=json.dumps(
                 {
                     'updated_by': 'chris@example.com',
-                    'userId': '1234'
+                    'agreement': {'userId': '1234'}
                 }),
             content_type='application/json')
 


### PR DESCRIPTION
All API calls should have a top level key that represents the object that is being changed. We had forgotten the 'agreement' key and had been sending the framework agreement data in the top level so this has been fixed to be consistent with the rest of our app.

Note, this route is not yet being used in production so it is not an issue to change our API interface like this.