### PR TITLE
Add "current" framework agreement and filter by status

### DIFF
--- a/app/main/views/agreements.py
+++ b/app/main/views/agreements.py
@@ -231,7 +231,7 @@ def put_signed_framework_agreement_on_hold(agreement_id):
         data={
             'supplierId': framework_agreement.supplier_id,
             'frameworkSlug': framework_agreement.supplier_framework.framework.slug,
-            'status': 'on hold'
+            'status': 'on-hold'
         },
         db_object=framework_agreement
     )
@@ -260,7 +260,7 @@ def approve_for_countersignature(agreement_id):
 
     updater_json = validate_and_return_updater_request()
 
-    if framework_agreement.status not in ['signed', 'on hold']:
+    if framework_agreement.status not in ['signed', 'on-hold']:
         abort(400, "Framework agreement must have status 'signed' or 'on hold' to be countersigned")
 
     framework_agreement.signed_agreement_put_on_hold_at = None

--- a/app/main/views/agreements.py
+++ b/app/main/views/agreements.py
@@ -17,8 +17,6 @@ from ...utils import (
 from ...supplier_utils import validate_agreement_details_data
 
 
-# This route not currently used and not yet supported by API client
-# It will be brought into use following migration of franmework agreement data
 @main.route('/agreements', methods=['POST'])
 def create_framework_agreement():
     json_payload = get_json_from_request()
@@ -48,7 +46,6 @@ def create_framework_agreement():
         supplier_id=update_json['supplierId'],
         framework_id=framework.id
     )
-
     try:
         db.session.add(framework_agreement)
         db.session.flush()

--- a/app/main/views/agreements.py
+++ b/app/main/views/agreements.py
@@ -40,22 +40,6 @@ def create_framework_agreement():
             )
         )
 
-    # We enforce only one framework agreement per SupplierFramework for the moment
-    # This behaviour will be refactored out later to allow for multiple
-    existing_framework_agreement = FrameworkAgreement.query.filter(
-        FrameworkAgreement.supplier_id == update_json['supplierId']
-    ).filter(
-        Framework.slug == update_json['frameworkSlug']
-    ).first()
-
-    if existing_framework_agreement:
-        abort(
-            400,
-            "supplier_id '{}' already has a framework agreement for framework '{}'".format(
-                update_json['supplierId'], update_json['frameworkSlug']
-            )
-        )
-
     framework = Framework.query.filter(
         Framework.slug == update_json['frameworkSlug']
     ).first_or_404()

--- a/app/main/views/agreements.py
+++ b/app/main/views/agreements.py
@@ -88,7 +88,6 @@ def create_framework_agreement():
     return jsonify(agreement=framework_agreement.serialize()), 201
 
 
-# TODO Do we really need this route?
 @main.route('/agreements/<int:agreement_id>', methods=['GET'])
 def get_framework_agreement(agreement_id):
     framework_agreement = FrameworkAgreement.query.filter(FrameworkAgreement.id == agreement_id).first_or_404()

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -224,10 +224,13 @@ def get_framework_suppliers(framework_slug):
 
     if request.args.get('agreement_returned') is not None or request.args.get('status') is not None:
         requested_statuses = None
+        if request.args.get('status') is not None:
+            requested_statuses = request.args.get('status').split(',')
+
         agreement_returned = request.args.get('agreement_returned')
         if agreement_returned is not None:
             if convert_to_boolean(agreement_returned):
-                requested_statuses = ('signed', 'on-hold', 'countersigned')
+                requested_statuses = requested_statuses or ('signed', 'on-hold', 'countersigned')
             else:
                 supplier_frameworks = [sf for sf in supplier_frameworks if sf.current_framework_agreement is None
                                        or (sf.current_framework_agreement
@@ -235,9 +238,6 @@ def get_framework_suppliers(framework_slug):
                                            )
                                        ]
                 # TODO: The 'or' clause here can be deleted once drafts are excluded from current_framework_agreement
-
-        elif request.args.get('status') is not None:
-            requested_statuses = request.args.get('status').split(',')
 
         if requested_statuses:
             supplier_frameworks = [

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -441,10 +441,7 @@ def update_supplier_framework_details(supplier_id, framework_slug):
     if 'agreementDetails' in update_json and framework.framework_agreement_details is None:
         abort(400, "Framework '{}' does not accept 'agreementDetails'".format(framework_slug))
 
-    framework_agreement = FrameworkAgreement.query.filter(
-        FrameworkAgreement.supplier_id == supplier.supplier_id,
-        FrameworkAgreement.framework_id == framework.id
-    ).first()
+    framework_agreement = interest_record.current_framework_agreement
 
     if not framework_agreement:
         framework_agreement = FrameworkAgreement(

--- a/app/models.py
+++ b/app/models.py
@@ -360,22 +360,16 @@ class SupplierFramework(db.Model):
             if self.framework_agreements[-1].status == 'draft':
                 return self.framework_agreements[-1]
 
-            def get_most_recent_time(framework_agreement):
-                if framework_agreement.countersigned_agreement_returned_at:
-                    return framework_agreement.countersigned_agreement_returned_at
-                else:
-                    return framework_agreement.signed_agreement_returned_at
-
             most_recently_signed_or_countersigned = self.framework_agreements[-1]
-            most_recent_time = get_most_recent_time(most_recently_signed_or_countersigned)
+            most_recent_time = most_recently_signed_or_countersigned.most_recent_signature_time
 
             for fa in self.framework_agreements:
                 if fa.status == "draft":
                     continue
 
-                if get_most_recent_time(fa) > most_recent_time:
+                if fa.most_recent_signature_time > most_recent_time:
                     most_recently_signed_or_countersigned = fa
-                    most_recent_time = get_most_recent_time(fa)
+                    most_recent_time = fa.most_recent_signature_time
 
             return most_recently_signed_or_countersigned
 
@@ -563,6 +557,14 @@ class FrameworkAgreement(db.Model):
         data = purge_nulls_from_data(data)
 
         return data
+
+    @property
+    def most_recent_signature_time(self):
+        # Time of most recent signing or countersignature
+        if self.countersigned_agreement_returned_at:
+            return self.countersigned_agreement_returned_at
+        else:
+            return self.signed_agreement_returned_at
 
     @hybrid_property
     def status(self):

--- a/app/models.py
+++ b/app/models.py
@@ -571,7 +571,7 @@ class FrameworkAgreement(db.Model):
         elif self.countersigned_agreement_returned_at:
             return 'approved'
         elif self.signed_agreement_put_on_hold_at:
-            return 'on hold'
+            return 'on-hold'
         elif self.signed_agreement_returned_at:
             return 'signed'
         else:

--- a/app/models.py
+++ b/app/models.py
@@ -342,8 +342,42 @@ class SupplierFramework(db.Model):
 
     @property
     def current_framework_agreement(self):
+        """
+        For the moment, we include drafts in the SupplierFramework to keep our interface the same whilst we refactor the
+        frontend to allow multiple framework agreements per supplier framework. This means that if a draft is created
+        after any other framework agreement then it must take precident (as the supplier frontend for the moment only
+        knows about one framework agreement (the current framework agreement) we must expose the draft so it can be
+        edited as they complete the signing flow). Note, as we have no timestamp for framework agreements being created
+        we instead have to use the highest `id`. Also note, this means that for a short while, if someone has
+        signed/countersigned a supplier framework and then starts a new draft then the supplier framework will return to
+        'draft' status and will lose knowledge of the previous signing.
+
+        After the supplier frontend has been refactored so that the signing flow deals with a framework agreement rather
+        than a suqpplier framework then we will be able to ignore drafts and not include them in the current framework
+        agreement
+        """
         if self.framework_agreements:
-            return self.framework_agreements[0]
+            if self.framework_agreements[-1].status == 'draft':
+                return self.framework_agreements[-1]
+
+            def get_most_recent_time(framework_agreement):
+                if framework_agreement.countersigned_agreement_returned_at:
+                    return framework_agreement.countersigned_agreement_returned_at
+                else:
+                    return framework_agreement.signed_agreement_returned_at
+
+            most_recently_signed_or_countersigned = self.framework_agreements[-1]
+            most_recent_time = get_most_recent_time(most_recently_signed_or_countersigned)
+
+            for fa in self.framework_agreements:
+                if fa.status == "draft":
+                    continue
+
+                if get_most_recent_time(fa) > most_recent_time:
+                    most_recently_signed_or_countersigned = fa
+                    most_recent_time = get_most_recent_time(fa)
+
+            return most_recently_signed_or_countersigned
 
     @validates('declaration')
     def validates_declaration(self, key, value):
@@ -507,7 +541,7 @@ class FrameworkAgreement(db.Model):
     supplier_framework = db.relationship(
         SupplierFramework,
         lazy="joined",
-        backref=backref('framework_agreements', lazy="joined")
+        backref=backref('framework_agreements', lazy="joined", order_by="FrameworkAgreement.id")
     )
 
     def update_signed_agreement_details_from_json(self, data):

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ SQLAlchemy==1.0.5
 SQLAlchemy-Utils==0.30.5
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@21.4.0#egg=digitalmarketplace-utils==21.4.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@6.4.0#egg=digitalmarketplace-apiclient==6.4.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@7.3.0#egg=digitalmarketplace-apiclient==7.3.0
 
 # For schema validation
 jsonschema==2.5.1

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -876,7 +876,7 @@ class TestFrameworkAgreements(BaseApplicationTest):
             signed_agreement_returned_at=datetime.utcnow(),
             signed_agreement_put_on_hold_at=datetime.utcnow()
         )
-        assert framework_agreement.status == 'on hold'
+        assert framework_agreement.status == 'on-hold'
 
     def test_approved_framework_agreement_status_is_approved(self):
         framework_agreement = FrameworkAgreement(

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -901,6 +901,24 @@ class TestFrameworkAgreements(BaseApplicationTest):
         )
         assert framework_agreement.status == 'countersigned'
 
+    def test_most_recent_signature_time(self):
+        framework_agreement = FrameworkAgreement(
+            supplier_id=0,
+            framework_id=1,
+        )
+        assert framework_agreement.most_recent_signature_time is None
+
+        framework_agreement.signed_agreement_details = {'agreement': 'details'}
+        framework_agreement.signed_agreement_path = '/path/to/the/agreement.pdf'
+        framework_agreement.signed_agreement_returned_at = datetime(2016, 9, 10, 11, 12, 0, 0)
+
+        assert framework_agreement.most_recent_signature_time == datetime(2016, 9, 10, 11, 12, 0, 0)
+
+        framework_agreement.countersigned_agreement_path = '/path/to/the/countersignedAgreement.pdf'
+        framework_agreement.countersigned_agreement_returned_at = datetime(2016, 10, 11, 10, 12, 0, 0)
+
+        assert framework_agreement.most_recent_signature_time == datetime(2016, 10, 11, 10, 12, 0, 0)
+
 
 class TestCurrentFrameworkAgreement(BaseApplicationTest):
     """

--- a/tests/app/views/test_agreements.py
+++ b/tests/app/views/test_agreements.py
@@ -217,7 +217,7 @@ class TestGetFrameworkAgreement(BaseFrameworkAgreementTest):
             'id': agreement_id,
             'supplierId': supplier_framework['supplierId'],
             'frameworkSlug': supplier_framework['frameworkSlug'],
-            'status': 'on hold',
+            'status': 'on-hold',
             'signedAgreementDetails': {'details': 'here'},
             'signedAgreementPath': 'path',
             'signedAgreementReturnedAt': '2016-10-01T01:01:01.000000Z',
@@ -865,7 +865,7 @@ class TestPutFrameworkAgreementOnHold(BaseFrameworkAgreementTest):
             'id': agreement_id,
             'supplierId': supplier_framework['supplierId'],
             'frameworkSlug': supplier_framework['frameworkSlug'],
-            'status': 'on hold',
+            'status': 'on-hold',
             'signedAgreementReturnedAt': '2016-10-01T00:00:00.000000Z',
             'signedAgreementPutOnHoldAt': '2016-12-12T00:00:00.000000Z'
         }
@@ -884,7 +884,7 @@ class TestPutFrameworkAgreementOnHold(BaseFrameworkAgreementTest):
             assert audit.data == {
                 'supplierId': supplier_framework['supplierId'],
                 'frameworkSlug': supplier_framework['frameworkSlug'],
-                'status': 'on hold'
+                'status': 'on-hold'
             }
 
     @fixture_params('live_example_framework', {'framework_agreement_details': {'frameworkAgreementVersion': 'v1.0'}})
@@ -1012,7 +1012,7 @@ class TestApproveFrameworkAgreement(BaseFrameworkAgreementTest):
         assert on_hold_res.status_code == 200
 
         on_hold_data = json.loads(on_hold_res.get_data(as_text=True))['agreement']
-        assert on_hold_data['status'] == 'on hold'
+        assert on_hold_data['status'] == 'on-hold'
 
         with freeze_time('2016-10-03'):
             res = self.approve_framework_agreement(agreement_id)

--- a/tests/app/views/test_agreements.py
+++ b/tests/app/views/test_agreements.py
@@ -129,27 +129,6 @@ class TestCreateFrameworkAgreement(BaseApplicationTest):
             "Invalid JSON must have 'frameworkSlug' keys"
         )
 
-    def test_can_not_make_more_than_one_framework_agreement_per_supplier_framework(self, supplier_framework):
-        res = self.post_create_agreement(
-            supplier_id=supplier_framework['supplierId'],
-            framework_slug=supplier_framework['frameworkSlug']
-        )
-
-        assert res.status_code == 201
-
-        res = self.post_create_agreement(
-            supplier_id=supplier_framework['supplierId'],
-            framework_slug=supplier_framework['frameworkSlug']
-        )
-
-        assert res.status_code == 400
-        assert (
-            json.loads(res.get_data(as_text=True))['error'] ==
-            "supplier_id '{}' already has a framework agreement for framework '{}'".format(
-                supplier_framework['supplierId'], supplier_framework['frameworkSlug']
-            )
-        )
-
 
 class TestGetFrameworkAgreement(BaseFrameworkAgreementTest):
     def test_it_gets_a_newly_created_framework_agreement_by_id(self, supplier_framework):

--- a/tests/app/views/test_frameworks.py
+++ b/tests/app/views/test_frameworks.py
@@ -585,6 +585,17 @@ class TestGetFrameworkSuppliers(BaseApplicationTest):
             times = [parse_time(item['agreementReturnedAt']) for item in data['supplierFrameworks']]
             assert times[0] > times[1]
 
+    def test_list_suppliers_with_agreements_not_returned(self):
+        with self.app.app_context():
+            response = self.client.get('/frameworks/g-cloud-7/suppliers?agreement_returned=false')
+
+            assert response.status_code == 200
+            data = json.loads(response.get_data())
+            assert len(data['supplierFrameworks']) == 3
+
+            for sf in data['supplierFrameworks']:
+                assert sf['agreementReturnedAt'] is None
+
 
 class TestGetFrameworkInterest(BaseApplicationTest):
     def setup(self):

--- a/tests/app/views/test_frameworks.py
+++ b/tests/app/views/test_frameworks.py
@@ -845,6 +845,27 @@ class TestGetFrameworkSuppliersByFrameworkAgreementStatus(BaseApplicationTest):
             assert len(data['supplierFrameworks']) == 3
             self.assert_supplier_ids(data, (3, 5, 6))
 
+    def test_list_suppliers_by_multiple_statuses_and_agreement_returned_true(self, live_g8_framework):
+        with self.app.app_context():
+            response = self.client.get(
+                '/frameworks/g-cloud-8/suppliers?status=approved,countersigned&agreement_returned=true'
+            )
+
+            assert response.status_code == 200
+            data = json.loads(response.get_data())
+            assert len(data['supplierFrameworks']) == 4
+            self.assert_supplier_ids(data, (6, 7, 8, 9))
+
+    def test_list_suppliers_by_multiple_statuses_and_agreement_returned_false(self, live_g8_framework):
+        with self.app.app_context():
+            response = self.client.get(
+                '/frameworks/g-cloud-8/suppliers?status=approved,countersigned&agreement_returned=false'
+            )
+
+            assert response.status_code == 200
+            data = json.loads(response.get_data())
+            assert len(data['supplierFrameworks']) == 0
+
 
 class TestGetFrameworkInterest(BaseApplicationTest):
     def setup(self):

--- a/tests/app/views/test_frameworks.py
+++ b/tests/app/views/test_frameworks.py
@@ -583,7 +583,7 @@ class TestGetFrameworkSuppliers(BaseApplicationTest):
             assert len(data['supplierFrameworks']) == 2
 
             times = [parse_time(item['agreementReturnedAt']) for item in data['supplierFrameworks']]
-            assert times[0] > times[1]
+            assert times[0] < times[1]
 
     def test_list_suppliers_with_agreements_not_returned(self):
         with self.app.app_context():
@@ -595,6 +595,255 @@ class TestGetFrameworkSuppliers(BaseApplicationTest):
 
             for sf in data['supplierFrameworks']:
                 assert sf['agreementReturnedAt'] is None
+
+
+class TestGetFrameworkSuppliersByFrameworkAgreementStatus(BaseApplicationTest):
+    def setup(self):
+        """Sets up supplier frameworks as follows:
+
+        Suppliers with IDs 0-9 have a G-Cloud 8 SupplierFramework record ("have registered interest")
+        Supplier 0 has returned a G-Cloud 7 agreement but not G-Cloud 8
+        Suppliers 1 and 2 have drafts of G-Cloud 8 agreements
+        Suppliers 3, 4 and 5 have returned their G-Cloud 8 agreements
+        Supplier 4's agreement has been put on hold
+        Supplier 6's has been approved for countersignature but doesn't have a file yet
+        Suppliers 7, 8 and 9 have countersigned agreements
+
+        """
+        super(TestGetFrameworkSuppliersByFrameworkAgreementStatus, self).setup()
+
+        self.setup_dummy_suppliers(10)
+        self.setup_dummy_user(id=123, role='supplier')
+
+        with self.app.app_context():
+            db.session.execute("UPDATE frameworks SET status='open' WHERE slug='g-cloud-7'")
+            db.session.execute("UPDATE frameworks SET status='open' WHERE slug='g-cloud-8'")
+            db.session.commit()
+
+            # Supplier zero is on G-Cloud 7
+            response = self.client.put(
+                '/suppliers/0/frameworks/g-cloud-7',
+                data=json.dumps({
+                    'updated_by': 'example'
+                }),
+                content_type='application/json')
+            assert response.status_code == 201, response.get_data(as_text=True)
+
+            response = self.client.post(
+                '/suppliers/0/frameworks/g-cloud-7',
+                data=json.dumps({
+                    'updated_by': 'example',
+                    'frameworkInterest': {'onFramework': True}
+                }),
+                content_type='application/json')
+            assert response.status_code == 200, response.get_data(as_text=True)
+
+            response = self.client.post(
+                '/agreements',
+                data=json.dumps({
+                    'updated_by': 'example',
+                    'agreement': {'supplierId': 0, 'frameworkSlug': 'g-cloud-7'},
+                }),
+                content_type='application/json')
+            data = json.loads(response.get_data())
+            agreement_id = data['agreement']['id']
+
+            response = self.client.post(
+                '/agreements/{}'.format(agreement_id),
+                data=json.dumps({
+                    'updated_by': 'example',
+                    'agreement': {'signedAgreementPath': '/path-to-g-cloud-7.pdf'},
+                }),
+                content_type='application/json')
+            assert response.status_code == 200, response.get_data(as_text=True)
+
+            response = self.client.post(
+                '/agreements/{}/sign'.format(agreement_id),
+                data=json.dumps({
+                    'updated_by': 'example',
+                    'agreement': {},
+                }),
+                content_type='application/json')
+            assert response.status_code == 200, response.get_data(as_text=True)
+
+            # Everyone is on G-Cloud 8
+            for supplier_id in range(10):
+                response = self.client.put(
+                    '/suppliers/{}/frameworks/g-cloud-8'.format(supplier_id),
+                    data=json.dumps({
+                        'updated_by': 'example'
+                    }),
+                    content_type='application/json')
+                assert response.status_code == 201, response.get_data(as_text=True)
+
+                response = self.client.post(
+                    '/suppliers/{}/frameworks/g-cloud-8'.format(supplier_id),
+                    data=json.dumps({
+                        'updated_by': 'example',
+                        'frameworkInterest': {'onFramework': True}
+                    }),
+                    content_type='application/json')
+                assert response.status_code == 200, response.get_data(as_text=True)
+
+            # Suppliers 1-9 have started to return a G-Cloud 8 agreement (created a draft)
+            agreement_ids = {}
+            for supplier_id in range(1, 10):
+                response = self.client.post(
+                    '/agreements',
+                    data=json.dumps({
+                        'updated_by': 'example',
+                        'agreement': {'supplierId': supplier_id, 'frameworkSlug': 'g-cloud-8'},
+                    }),
+                    content_type='application/json'
+                )
+                data = json.loads(response.get_data())
+                agreement_ids[supplier_id] = data['agreement']['id']
+
+            for supplier_id in range(1, 10):
+                response = self.client.post(
+                    '/agreements/{}'.format(agreement_ids[supplier_id]),
+                    data=json.dumps({
+                        'updated_by': 'example',
+                        'agreement': {
+                            'signedAgreementPath': 'path/to/agreement/{}.pdf'.format(supplier_id),
+                            'signedAgreementDetails': {
+                                'signerName': 'name_{}'.format(supplier_id),
+                                'signerRole': 'job_{}'.format(supplier_id)
+                            },
+                        }
+                    }),
+                    content_type='application/json'
+                )
+                assert response.status_code == 200, response.get_data(as_text=True)
+
+            # Suppliers 3-9 have returned their G-Cloud 8 agreement
+            for supplier_id in range(3, 10):
+                response = self.client.post(
+                    '/agreements/{}/sign'.format(agreement_ids[supplier_id]),
+                    data=json.dumps({
+                        'updated_by': 'example',
+                        'agreement': {'signedAgreementDetails': {
+                            'uploaderUserId': 123,
+                        },
+                        }
+                    }),
+                    content_type='application/json'
+                )
+                assert response.status_code == 200, response.get_data(as_text=True)
+
+            # Supplier 4's agreement has been put on hold
+            response = self.client.post(
+                '/agreements/{}/on-hold'.format(agreement_ids[4]),
+                data=json.dumps({'updated_by': 'example'}),
+                content_type='application/json'
+            )
+            assert response.status_code == 200, response.get_data(as_text=True)
+
+            # Suppliers 6-9 have been approved for countersignature
+            for supplier_id in range(6, 10):
+                response = self.client.post(
+                    '/agreements/{}/approve'.format(agreement_ids[supplier_id]),
+                    data=json.dumps({
+                        'updated_by': 'example',
+                        "agreement": {'userId': 123},
+                    }),
+                    content_type='application/json'
+                )
+                assert response.status_code == 200, response.get_data(as_text=True)
+
+            # Suppliers 7, 8 and 9 have countersigned agreements
+            for supplier_id in range(7, 10):
+                response = self.client.post(
+                    '/agreements/{}'.format(agreement_ids[supplier_id]),
+                    data=json.dumps({
+                        'updated_by': 'example',
+                        'agreement': {
+                            'countersignedAgreementPath': 'path/to/countersigned{}.pdf'.format(supplier_id)
+                        }
+                    }),
+                    content_type='application/json'
+                )
+                assert response.status_code == 200, response.get_data(as_text=True)
+
+    def assert_supplier_ids(self, data, expected_ids):
+        returned_ids = set(sf['supplierId'] for sf in data['supplierFrameworks'])
+        assert returned_ids == set(expected_ids)
+
+    def test_list_suppliers_related_to_a_framework(self, live_g8_framework):
+        with self.app.app_context():
+            # One G7 supplier
+            response = self.client.get('/frameworks/g-cloud-7/suppliers')
+            assert response.status_code == 200
+            data = json.loads(response.get_data())
+            assert len(data['supplierFrameworks']) == 1
+            # Ten G8 suppliers
+            response = self.client.get('/frameworks/g-cloud-8/suppliers')
+            assert response.status_code == 200
+            data = json.loads(response.get_data())
+            assert len(data['supplierFrameworks']) == 10
+
+    def test_list_suppliers_by_status_draft(self, live_g8_framework):
+        with self.app.app_context():
+            response = self.client.get('/frameworks/g-cloud-8/suppliers?status=draft')
+
+            assert response.status_code == 200
+            data = json.loads(response.get_data())
+            assert len(data['supplierFrameworks']) == 2
+            self.assert_supplier_ids(data, (1, 2))
+
+    def test_list_suppliers_by_status_signed(self, live_g8_framework):
+        with self.app.app_context():
+            response = self.client.get('/frameworks/g-cloud-8/suppliers?status=signed')
+
+            assert response.status_code == 200
+            data = json.loads(response.get_data())
+            assert len(data['supplierFrameworks']) == 2
+            self.assert_supplier_ids(data, (3, 5))
+
+    def test_list_suppliers_by_status_on_hold(self, live_g8_framework):
+        with self.app.app_context():
+            response = self.client.get('/frameworks/g-cloud-8/suppliers?status=on-hold')
+
+            assert response.status_code == 200
+            data = json.loads(response.get_data())
+            assert len(data['supplierFrameworks']) == 1
+            self.assert_supplier_ids(data, (4,))
+
+    def test_list_suppliers_by_status_approved(self, live_g8_framework):
+        with self.app.app_context():
+            response = self.client.get('/frameworks/g-cloud-8/suppliers?status=approved')
+
+            assert response.status_code == 200
+            data = json.loads(response.get_data())
+            assert len(data['supplierFrameworks']) == 1
+            self.assert_supplier_ids(data, (6,))
+
+    def test_list_suppliers_by_status_countersigned(self, live_g8_framework):
+        with self.app.app_context():
+            response = self.client.get('/frameworks/g-cloud-8/suppliers?status=countersigned')
+
+            assert response.status_code == 200
+            data = json.loads(response.get_data())
+            assert len(data['supplierFrameworks']) == 3
+            self.assert_supplier_ids(data, (7, 8, 9))
+
+    def test_list_suppliers_by_multiple_statuses_1(self, live_g8_framework):
+        with self.app.app_context():
+            response = self.client.get('/frameworks/g-cloud-8/suppliers?status=approved,countersigned')
+
+            assert response.status_code == 200
+            data = json.loads(response.get_data())
+            assert len(data['supplierFrameworks']) == 4
+            self.assert_supplier_ids(data, (6, 7, 8, 9))
+
+    def test_list_suppliers_by_multiple_statuses_2(self, live_g8_framework):
+        with self.app.app_context():
+            response = self.client.get('/frameworks/g-cloud-8/suppliers?status=signed,approved')
+
+            assert response.status_code == 200
+            data = json.loads(response.get_data())
+            assert len(data['supplierFrameworks']) == 3
+            self.assert_supplier_ids(data, (3, 5, 6))
 
 
 class TestGetFrameworkInterest(BaseApplicationTest):


### PR DESCRIPTION
This adds the "current_framework_agreement" to the supplier_framework and allows filtering the list of supplier_frameworks by their status (signed, countersigned, on-hold).

We currently include draft agreements if they exist, in order to keep the signing flow working.  Once the signing flow is updated to use FrameworkAgreemnts directly, rather than updating via the SupplierFramework, drafts can be excluded.