### PR TITLE
[#129838783] Add `submitted_at` migration to `brief_responses` table

### DIFF
--- a/migrations/versions/760_brief_response_submitted_at.py
+++ b/migrations/versions/760_brief_response_submitted_at.py
@@ -1,0 +1,22 @@
+"""brief response submitted at
+
+Revision ID: 760
+Revises: 750
+Create Date: 2016-10-24 14:16:29.951023
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '760'
+down_revision = '750'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('brief_responses', sa.Column('submitted_at', sa.DateTime(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('brief_responses', 'submitted_at')


### PR DESCRIPTION
Represents when a brief response has been submitted and is therefore a complete response, as opposed to one that may be in a draft form. Note, we chose not to use the word "published" as a brief response is not published publicly.

This field can then be used to decide the status of a brief response.