### PR TITLE
BUGFIX - "approved" agreements have been returned

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -230,7 +230,7 @@ def get_framework_suppliers(framework_slug):
         agreement_returned = request.args.get('agreement_returned')
         if agreement_returned is not None:
             if convert_to_boolean(agreement_returned):
-                requested_statuses = requested_statuses or ('signed', 'on-hold', 'countersigned')
+                requested_statuses = requested_statuses or ('signed', 'on-hold', 'approved', 'countersigned')
             else:
                 supplier_frameworks = [sf for sf in supplier_frameworks if sf.current_framework_agreement is None
                                        or (sf.current_framework_agreement

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -238,6 +238,7 @@ def get_framework_suppliers(framework_slug):
                                            )
                                        ]
                 # TODO: The 'or' clause here can be deleted once drafts are excluded from current_framework_agreement
+                # TODO: Much of the logic here would be better done querying with SQL than manipulating with Python
 
         if requested_statuses:
             supplier_frameworks = [

--- a/tests/app/views/test_frameworks.py
+++ b/tests/app/views/test_frameworks.py
@@ -845,6 +845,28 @@ class TestGetFrameworkSuppliersByFrameworkAgreementStatus(BaseApplicationTest):
             assert len(data['supplierFrameworks']) == 3
             self.assert_supplier_ids(data, (3, 5, 6))
 
+    def test_list_suppliers_by_agreement_returned_true(self, live_g8_framework):
+        with self.app.app_context():
+            response = self.client.get(
+                '/frameworks/g-cloud-8/suppliers?agreement_returned=true'
+            )
+
+            assert response.status_code == 200
+            data = json.loads(response.get_data())
+            assert len(data['supplierFrameworks']) == 7
+            self.assert_supplier_ids(data, (3, 4, 5, 6, 7, 8, 9))
+
+    def test_list_suppliers_by_agreement_returned_false(self, live_g8_framework):
+        with self.app.app_context():
+            response = self.client.get(
+                '/frameworks/g-cloud-8/suppliers?agreement_returned=false'
+            )
+
+            assert response.status_code == 200
+            data = json.loads(response.get_data())
+            assert len(data['supplierFrameworks']) == 3
+            self.assert_supplier_ids(data, (0, 1, 2))
+
     def test_list_suppliers_by_multiple_statuses_and_agreement_returned_true(self, live_g8_framework):
         with self.app.app_context():
             response = self.client.get(

--- a/tests/app/views/test_frameworks.py
+++ b/tests/app/views/test_frameworks.py
@@ -538,69 +538,6 @@ class TestGetFrameworkSuppliers(BaseApplicationTest):
     def setup(self):
         """Sets up supplier frameworks as follows:
 
-        Suppliers with IDs 0-4 have a SupplierFramework record ("have registered interest")
-        Suppliers 3 and 4 have returned their agreements - will be saved in FrameworkAgreement, NOT SupplierFramework
-        No further details are saved in anyone's SupplierFramework record
-        """
-        super(TestGetFrameworkSuppliers, self).setup()
-
-        self.setup_dummy_suppliers(5)
-        with self.app.app_context():
-            db.session.execute("UPDATE frameworks SET status='open' WHERE id=4")
-            db.session.commit()
-            for supplier_id in range(5):
-                response = self.client.put(
-                    '/suppliers/{}/frameworks/g-cloud-7'.format(supplier_id),
-                    data=json.dumps({
-                        'updated_by': 'example'
-                    }),
-                    content_type='application/json')
-                assert response.status_code == 201, response.get_data(as_text=True)
-            for supplier_id in range(3, 5):
-                response = self.client.post(
-                    '/suppliers/{}/frameworks/g-cloud-7'.format(supplier_id),
-                    data=json.dumps({
-                        'updated_by': 'example',
-                        'frameworkInterest': {'agreementReturned': True},
-                    }),
-                    content_type='application/json')
-                assert response.status_code == 200, response.get_data(as_text=True)
-
-    def test_list_suppliers_related_to_a_framework(self):
-        with self.app.app_context():
-            response = self.client.get('/frameworks/g-cloud-7/suppliers')
-
-            assert response.status_code == 200
-            data = json.loads(response.get_data())
-            assert len(data['supplierFrameworks']) == 5
-
-    def test_list_suppliers_with_agreements_returned(self):
-        with self.app.app_context():
-            response = self.client.get('/frameworks/g-cloud-7/suppliers?agreement_returned=true')
-
-            assert response.status_code == 200
-            data = json.loads(response.get_data())
-            assert len(data['supplierFrameworks']) == 2
-
-            times = [parse_time(item['agreementReturnedAt']) for item in data['supplierFrameworks']]
-            assert times[0] < times[1]
-
-    def test_list_suppliers_with_agreements_not_returned(self):
-        with self.app.app_context():
-            response = self.client.get('/frameworks/g-cloud-7/suppliers?agreement_returned=false')
-
-            assert response.status_code == 200
-            data = json.loads(response.get_data())
-            assert len(data['supplierFrameworks']) == 3
-
-            for sf in data['supplierFrameworks']:
-                assert sf['agreementReturnedAt'] is None
-
-
-class TestGetFrameworkSuppliersByFrameworkAgreementStatus(BaseApplicationTest):
-    def setup(self):
-        """Sets up supplier frameworks as follows:
-
         Suppliers with IDs 0-9 have a G-Cloud 8 SupplierFramework record ("have registered interest")
         Supplier 0 has returned a G-Cloud 7 agreement but not G-Cloud 8
         Suppliers 1 and 2 have drafts of G-Cloud 8 agreements
@@ -610,7 +547,7 @@ class TestGetFrameworkSuppliersByFrameworkAgreementStatus(BaseApplicationTest):
         Suppliers 7, 8 and 9 have countersigned agreements
 
         """
-        super(TestGetFrameworkSuppliersByFrameworkAgreementStatus, self).setup()
+        super(TestGetFrameworkSuppliers, self).setup()
 
         self.setup_dummy_suppliers(10)
         self.setup_dummy_user(id=123, role='supplier')
@@ -765,7 +702,7 @@ class TestGetFrameworkSuppliersByFrameworkAgreementStatus(BaseApplicationTest):
                 )
                 assert response.status_code == 200, response.get_data(as_text=True)
 
-    def assert_supplier_ids(self, data, expected_ids):
+    def _assert_supplier_ids(self, data, expected_ids):
         returned_ids = set(sf['supplierId'] for sf in data['supplierFrameworks'])
         assert returned_ids == set(expected_ids)
 
@@ -782,69 +719,6 @@ class TestGetFrameworkSuppliersByFrameworkAgreementStatus(BaseApplicationTest):
             data = json.loads(response.get_data())
             assert len(data['supplierFrameworks']) == 10
 
-    def test_list_suppliers_by_status_draft(self, live_g8_framework):
-        with self.app.app_context():
-            response = self.client.get('/frameworks/g-cloud-8/suppliers?status=draft')
-
-            assert response.status_code == 200
-            data = json.loads(response.get_data())
-            assert len(data['supplierFrameworks']) == 2
-            self.assert_supplier_ids(data, (1, 2))
-
-    def test_list_suppliers_by_status_signed(self, live_g8_framework):
-        with self.app.app_context():
-            response = self.client.get('/frameworks/g-cloud-8/suppliers?status=signed')
-
-            assert response.status_code == 200
-            data = json.loads(response.get_data())
-            assert len(data['supplierFrameworks']) == 2
-            self.assert_supplier_ids(data, (3, 5))
-
-    def test_list_suppliers_by_status_on_hold(self, live_g8_framework):
-        with self.app.app_context():
-            response = self.client.get('/frameworks/g-cloud-8/suppliers?status=on-hold')
-
-            assert response.status_code == 200
-            data = json.loads(response.get_data())
-            assert len(data['supplierFrameworks']) == 1
-            self.assert_supplier_ids(data, (4,))
-
-    def test_list_suppliers_by_status_approved(self, live_g8_framework):
-        with self.app.app_context():
-            response = self.client.get('/frameworks/g-cloud-8/suppliers?status=approved')
-
-            assert response.status_code == 200
-            data = json.loads(response.get_data())
-            assert len(data['supplierFrameworks']) == 1
-            self.assert_supplier_ids(data, (6,))
-
-    def test_list_suppliers_by_status_countersigned(self, live_g8_framework):
-        with self.app.app_context():
-            response = self.client.get('/frameworks/g-cloud-8/suppliers?status=countersigned')
-
-            assert response.status_code == 200
-            data = json.loads(response.get_data())
-            assert len(data['supplierFrameworks']) == 3
-            self.assert_supplier_ids(data, (7, 8, 9))
-
-    def test_list_suppliers_by_multiple_statuses_1(self, live_g8_framework):
-        with self.app.app_context():
-            response = self.client.get('/frameworks/g-cloud-8/suppliers?status=approved,countersigned')
-
-            assert response.status_code == 200
-            data = json.loads(response.get_data())
-            assert len(data['supplierFrameworks']) == 4
-            self.assert_supplier_ids(data, (6, 7, 8, 9))
-
-    def test_list_suppliers_by_multiple_statuses_2(self, live_g8_framework):
-        with self.app.app_context():
-            response = self.client.get('/frameworks/g-cloud-8/suppliers?status=signed,approved')
-
-            assert response.status_code == 200
-            data = json.loads(response.get_data())
-            assert len(data['supplierFrameworks']) == 3
-            self.assert_supplier_ids(data, (3, 5, 6))
-
     def test_list_suppliers_by_agreement_returned_true(self, live_g8_framework):
         with self.app.app_context():
             response = self.client.get(
@@ -854,7 +728,10 @@ class TestGetFrameworkSuppliersByFrameworkAgreementStatus(BaseApplicationTest):
             assert response.status_code == 200
             data = json.loads(response.get_data())
             assert len(data['supplierFrameworks']) == 7
-            self.assert_supplier_ids(data, (3, 4, 5, 6, 7, 8, 9))
+            self._assert_supplier_ids(data, (3, 4, 5, 6, 7, 8, 9))
+
+            times = [parse_time(item['agreementReturnedAt']) for item in data['supplierFrameworks']]
+            assert times[0] < times[1] < times[2] < times[3] < times[4] < times[5] < times[6]
 
     def test_list_suppliers_by_agreement_returned_false(self, live_g8_framework):
         with self.app.app_context():
@@ -865,7 +742,72 @@ class TestGetFrameworkSuppliersByFrameworkAgreementStatus(BaseApplicationTest):
             assert response.status_code == 200
             data = json.loads(response.get_data())
             assert len(data['supplierFrameworks']) == 3
-            self.assert_supplier_ids(data, (0, 1, 2))
+            self._assert_supplier_ids(data, (0, 1, 2))
+            for sf in data['supplierFrameworks']:
+                assert sf['agreementReturnedAt'] is None
+
+    def test_list_suppliers_by_status_draft(self, live_g8_framework):
+        with self.app.app_context():
+            response = self.client.get('/frameworks/g-cloud-8/suppliers?status=draft')
+
+            assert response.status_code == 200
+            data = json.loads(response.get_data())
+            assert len(data['supplierFrameworks']) == 2
+            self._assert_supplier_ids(data, (1, 2))
+
+    def test_list_suppliers_by_status_signed(self, live_g8_framework):
+        with self.app.app_context():
+            response = self.client.get('/frameworks/g-cloud-8/suppliers?status=signed')
+
+            assert response.status_code == 200
+            data = json.loads(response.get_data())
+            assert len(data['supplierFrameworks']) == 2
+            self._assert_supplier_ids(data, (3, 5))
+
+    def test_list_suppliers_by_status_on_hold(self, live_g8_framework):
+        with self.app.app_context():
+            response = self.client.get('/frameworks/g-cloud-8/suppliers?status=on-hold')
+
+            assert response.status_code == 200
+            data = json.loads(response.get_data())
+            assert len(data['supplierFrameworks']) == 1
+            self._assert_supplier_ids(data, (4,))
+
+    def test_list_suppliers_by_status_approved(self, live_g8_framework):
+        with self.app.app_context():
+            response = self.client.get('/frameworks/g-cloud-8/suppliers?status=approved')
+
+            assert response.status_code == 200
+            data = json.loads(response.get_data())
+            assert len(data['supplierFrameworks']) == 1
+            self._assert_supplier_ids(data, (6,))
+
+    def test_list_suppliers_by_status_countersigned(self, live_g8_framework):
+        with self.app.app_context():
+            response = self.client.get('/frameworks/g-cloud-8/suppliers?status=countersigned')
+
+            assert response.status_code == 200
+            data = json.loads(response.get_data())
+            assert len(data['supplierFrameworks']) == 3
+            self._assert_supplier_ids(data, (7, 8, 9))
+
+    def test_list_suppliers_by_multiple_statuses_1(self, live_g8_framework):
+        with self.app.app_context():
+            response = self.client.get('/frameworks/g-cloud-8/suppliers?status=approved,countersigned')
+
+            assert response.status_code == 200
+            data = json.loads(response.get_data())
+            assert len(data['supplierFrameworks']) == 4
+            self._assert_supplier_ids(data, (6, 7, 8, 9))
+
+    def test_list_suppliers_by_multiple_statuses_2(self, live_g8_framework):
+        with self.app.app_context():
+            response = self.client.get('/frameworks/g-cloud-8/suppliers?status=signed,approved')
+
+            assert response.status_code == 200
+            data = json.loads(response.get_data())
+            assert len(data['supplierFrameworks']) == 3
+            self._assert_supplier_ids(data, (3, 5, 6))
 
     def test_list_suppliers_by_multiple_statuses_and_agreement_returned_true(self, live_g8_framework):
         with self.app.app_context():
@@ -876,7 +818,7 @@ class TestGetFrameworkSuppliersByFrameworkAgreementStatus(BaseApplicationTest):
             assert response.status_code == 200
             data = json.loads(response.get_data())
             assert len(data['supplierFrameworks']) == 4
-            self.assert_supplier_ids(data, (6, 7, 8, 9))
+            self._assert_supplier_ids(data, (6, 7, 8, 9))
 
     def test_list_suppliers_by_multiple_statuses_and_agreement_returned_false(self, live_g8_framework):
         with self.app.app_context():


### PR DESCRIPTION
The `agreement_returned` filter was missing the `approved` status.  This fixes it.