### PR TITLE
Add a status to brief responses

### DIFF
--- a/app/main/views/brief_responses.py
+++ b/app/main/views/brief_responses.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from flask import jsonify, abort, request, current_app
 from sqlalchemy.exc import IntegrityError, DataError
 
@@ -42,7 +44,7 @@ def create_brief_response():
 
     brief_service = get_supplier_service_eligible_for_brief(supplier, brief)
     if not brief_service:
-        abort(400, "Supplier not eligible")
+        abort(400, "Supplier is not eligible to apply to this brief")
 
     # Check if brief response already exists from this supplier
     if BriefResponse.query.filter(BriefResponse.supplier == supplier, BriefResponse.brief == brief).first():
@@ -80,6 +82,54 @@ def create_brief_response():
     db.session.commit()
 
     return jsonify(briefResponses=brief_response.serialize()), 201
+
+
+@main.route('/brief-responses/<int:brief_response_id>/submit', methods=['POST'])
+def submit_brief_response(brief_response_id):
+    updater_json = validate_and_return_updater_request()
+
+    brief_response = BriefResponse.query.filter(
+        BriefResponse.id == brief_response_id
+    ).first_or_404()
+
+    brief = brief_response.brief
+    supplier = brief_response.supplier
+    brief_service = get_supplier_service_eligible_for_brief(supplier, brief)
+    if not brief_service:
+        abort(400, "Supplier is not eligible to apply to this brief")
+
+    if brief_response.status != 'draft':
+        abort(400, "Brief response must be a draft")
+
+    if brief.framework.status != 'live':
+        abort(400, "Brief framework must be live")
+
+    brief_role = brief.data["specialistRole"] if brief.lot.slug == "digital-specialists" else None
+    service_max_day_rate = brief_service.data[brief_role + "PriceMax"] if brief_role else None
+
+    brief_response.validate(max_day_rate=service_max_day_rate)
+
+    brief_response.submitted_at = datetime.utcnow()
+
+    audit = AuditEvent(
+        audit_type=AuditTypes.submit_brief_response,
+        user=updater_json['updated_by'],
+        data={
+            'briefResponseId': brief_response.id
+        },
+        db_object=brief_response,
+    )
+
+    db.session.add(brief_response)
+    db.session.add(audit)
+
+    try:
+        db.session.commit()
+    except IntegrityError as e:
+        db.session.rollback()
+        abort(400, e.orig)
+
+    return jsonify(briefResponses=brief_response.serialize()), 200
 
 
 @main.route('/brief-responses/<int:brief_response_id>', methods=['GET'])

--- a/app/models.py
+++ b/app/models.py
@@ -1304,6 +1304,7 @@ class BriefResponse(db.Model):
     supplier_id = db.Column(db.Integer, db.ForeignKey('suppliers.supplier_id'), nullable=False)
 
     created_at = db.Column(db.DateTime, index=True, nullable=False, default=datetime.utcnow)
+    submitted_at = db.Column(db.DateTime, nullable=True)
 
     brief = db.relationship('Brief')
     supplier = db.relationship('Supplier', lazy='joined')

--- a/app/models.py
+++ b/app/models.py
@@ -1326,6 +1326,12 @@ class BriefResponse(db.Model):
         else:
             return 'draft'
 
+    @status.expression
+    def status(cls):
+        return sql_case([
+            (cls.submitted_at.isnot(None), 'submitted'),
+        ], else_='draft')
+
     def validate(self, enforce_required=True, required_fields=None, max_day_rate=None):
         errs = get_validation_errors(
             'brief-responses-{}-{}'.format(self.brief.framework.slug, self.brief.lot.slug),

--- a/app/models.py
+++ b/app/models.py
@@ -1319,6 +1319,13 @@ class BriefResponse(db.Model):
 
         return data
 
+    @hybrid_property
+    def status(self):
+        if self.submitted_at:
+            return 'submitted'
+        else:
+            return 'draft'
+
     def validate(self, enforce_required=True, required_fields=None, max_day_rate=None):
         errs = get_validation_errors(
             'brief-responses-{}-{}'.format(self.brief.framework.slug, self.brief.lot.slug),
@@ -1357,6 +1364,7 @@ class BriefResponse(db.Model):
             'submittedAt': (
                 self.submitted_at and self.submitted_at.strftime(DATETIME_FORMAT)
             ),
+            'status': self.status,
             'links': {
                 'self': url_for('.get_brief_response', brief_response_id=self.id),
                 'brief': url_for('.get_brief', brief_id=self.brief_id),

--- a/app/models.py
+++ b/app/models.py
@@ -1354,6 +1354,9 @@ class BriefResponse(db.Model):
             'supplierId': self.supplier_id,
             'supplierName': self.supplier.name,
             'createdAt': self.created_at.strftime(DATETIME_FORMAT),
+            'submittedAt': (
+                self.submitted_at and self.submitted_at.strftime(DATETIME_FORMAT)
+            ),
             'links': {
                 'self': url_for('.get_brief_response', brief_response_id=self.id),
                 'brief': url_for('.get_brief', brief_id=self.brief_id),
@@ -1361,7 +1364,7 @@ class BriefResponse(db.Model):
             }
         })
 
-        return data
+        return purge_nulls_from_data(data)
 
 
 class BriefClarificationQuestion(db.Model):

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ SQLAlchemy==1.0.5
 SQLAlchemy-Utils==0.30.5
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@21.4.0#egg=digitalmarketplace-utils==21.4.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@7.3.0#egg=digitalmarketplace-apiclient==7.3.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@7.6.0#egg=digitalmarketplace-apiclient==7.6.0
 
 # For schema validation
 jsonschema==2.5.1

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -475,6 +475,14 @@ class TestBriefResponses(BaseApplicationTest):
 
         assert brief_response.data == {'foo': 'bar', 'bar': ['foo']}
 
+    def test_submitted_status_for_brief_response_with_submitted_at(self):
+        brief_response = BriefResponse(created_at=datetime.utcnow(), submitted_at=datetime.utcnow())
+        assert brief_response.status == 'submitted'
+
+    def test_draft_status_for_brief_response_with_no_submitted_at(self):
+        brief_response = BriefResponse(created_at=datetime.utcnow())
+        assert brief_response.status == 'draft'
+
     def test_brief_response_can_be_serialized(self):
         with self.app.app_context():
             brief_response = BriefResponse(
@@ -492,6 +500,7 @@ class TestBriefResponses(BaseApplicationTest):
                     'supplierName': 'Supplier 0',
                     'createdAt': mock.ANY,
                     'submittedAt': '2016-09-28T00:00:00.000000Z',
+                    'status': 'submitted',
                     'foo': 'bar',
                     'links': {
                         'self': (('.get_brief_response',), {'brief_response_id': brief_response.id}),
@@ -516,6 +525,7 @@ class TestBriefResponses(BaseApplicationTest):
                     'supplierId': 0,
                     'supplierName': 'Supplier 0',
                     'createdAt': mock.ANY,
+                    'status': 'draft',
                     'foo': 'bar',
                     'links': {
                         'self': (('.get_brief_response',), {'brief_response_id': brief_response.id}),

--- a/tests/app/views/test_brief_response.py
+++ b/tests/app/views/test_brief_response.py
@@ -1,7 +1,9 @@
 import json
 import pytest
+import mock
 
 from hypothesis import given
+from freezegun import freeze_time
 
 from ..helpers import BaseApplicationTest, JSONUpdateTestMixin
 from ... import example_listings
@@ -211,7 +213,7 @@ class TestCreateBriefResponse(BaseBriefResponseTest, JSONUpdateTestMixin):
         })
 
         assert res.status_code == 400
-        assert 'Supplier not eligible' in res.get_data(as_text=True)
+        assert 'Supplier is not eligible to apply to this brief' in res.get_data(as_text=True)
 
     def test_cannot_respond_to_a_brief_that_isnt_live(self, live_dos_framework):
         with self.app.app_context():
@@ -322,6 +324,125 @@ class TestCreateBriefResponse(BaseBriefResponseTest, JSONUpdateTestMixin):
 
         assert res.status_code == 400, data
         assert data == {'error': {'dayRate': 'max_less_than_min'}}
+
+
+class TestSubmitBriefResponse(BaseBriefResponseTest):
+
+    def _setup_existing_brief_response(self, brief_response_data):
+        res = self.create_brief_response(dict(brief_response_data, **{
+            'briefId': self.brief_id,
+            'supplierId': 0,
+        }))
+        assert res.status_code == 201
+
+        self.brief_response_id = json.loads(res.get_data(as_text=True))['briefResponses']['id']
+
+    def _submit_brief_response(self, brief_response_id):
+        return self.client.post(
+            '/brief-responses/{}/submit'.format(brief_response_id),
+            data=json.dumps({
+                'updated_by': 'test@example.com',
+            }),
+            content_type='application/json'
+        )
+
+    @given(example_listings.brief_response_data())
+    def test_valid_draft_brief_response_can_be_submitted(self, live_dos_framework, brief_response_data):
+        self._setup_existing_brief_response(brief_response_data)
+
+        with freeze_time('2016-9-28'):
+            res = self._submit_brief_response(self.brief_response_id)
+        assert res.status_code == 200
+
+        brief_response = json.loads(res.get_data(as_text=True))['briefResponses']
+
+        assert brief_response['status'] == 'submitted'
+        assert brief_response['submittedAt'] == '2016-09-28T00:00:00.000000Z'
+
+    @given(example_listings.brief_response_data())
+    def test_submit_brief_response_creates_an_audit_event(self, live_dos_framework, brief_response_data):
+        self._setup_existing_brief_response(brief_response_data)
+
+        res = self._submit_brief_response(self.brief_response_id)
+
+        with self.app.app_context():
+            audit_events = AuditEvent.query.filter(
+                AuditEvent.type == AuditTypes.submit_brief_response.value
+            ).all()
+
+        assert len(audit_events) == 1
+        assert audit_events[0].data == {
+            'briefResponseId': self.brief_response_id
+        }
+
+    def test_submit_brief_response_that_doesnt_exist_will_404(self):
+        res = self._submit_brief_response(100)
+        assert res.status_code == 404
+
+    @given(example_listings.brief_response_data())
+    def test_can_not_submit_a_brief_response_that_already_been_submitted(self, live_dos_framework, brief_response_data):
+        self._setup_existing_brief_response(brief_response_data)
+
+        res = self._submit_brief_response(self.brief_response_id)
+        assert res.status_code == 200
+
+        repeat_res = self._submit_brief_response(self.brief_response_id)
+        assert repeat_res.status_code == 400
+
+        data = json.loads(repeat_res.get_data(as_text=True))
+        assert data == {'error': 'Brief response must be a draft'}
+
+    @given(example_listings.brief_response_data())
+    def test_can_not_submit_a_brief_response_for_a_framework_that_is_not_live(
+        self, live_dos_framework, brief_response_data
+    ):
+        self._setup_existing_brief_response(brief_response_data)
+
+        with self.app.app_context():
+            # Change live framework to be expired
+            db.session.execute("UPDATE frameworks SET status='expired' WHERE slug='digital-outcomes-and-specialists'")
+
+            res = self._submit_brief_response(self.brief_response_id)
+            data = json.loads(res.get_data(as_text=True))
+            assert res.status_code == 400
+            assert data == {'error': 'Brief framework must be live'}
+
+    @given(example_listings.brief_response_data())
+    def test_can_not_submit_response_if_supplier_is_ineligble_for_brief(self, live_dos_framework, brief_response_data):
+        self._setup_existing_brief_response(brief_response_data)
+
+        with mock.patch('app.main.views.brief_responses.get_supplier_service_eligible_for_brief') as mock_patch:
+            mock_patch.return_value = None
+
+            res = self._submit_brief_response(self.brief_response_id)
+            data = json.loads(res.get_data(as_text=True))
+
+            assert res.status_code == 400
+            assert data == {'error': 'Supplier is not eligible to apply to this brief'}
+
+    @given(example_listings.brief_response_data())
+    def test_can_not_submit_an_invalid_brief_response(
+        self, live_dos_framework, brief_response_data
+    ):
+        self._setup_existing_brief_response(brief_response_data)
+
+        with self.app.app_context():
+            # Set data to make brief_response invalid.
+            # TODO When we change the create_brief_response to not enforce all questions when validating, we can instead
+            # create a half complete brief response
+            db.session.execute("UPDATE brief_responses SET data='{}' WHERE id={}".format({}, self.brief_response_id))
+
+            res = self._submit_brief_response(self.brief_response_id)
+            data = json.loads(res.get_data(as_text=True))
+            assert res.status_code == 400
+            assert data == {
+                'error': {
+                    'availability': 'answer_required',
+                    'essentialRequirements': 'answer_required',
+                    'niceToHaveRequirements': 'answer_required',
+                    'respondToEmailAddress': 'answer_required'
+                }
+            }
 
 
 class TestGetBriefResponse(BaseBriefResponseTest):


### PR DESCRIPTION
For [this story on Pivotal](https://www.pivotaltracker.com/story/show/129838783).

As part of the story around changing the supplier flow for applying to a brief, briefs can be in an unsubmitted state (draft). 

Brief responses can now have a submitted_at field, which is used to deduce their status. 

We provide a submit brief response route to mark a brief response as submitted.


Next steps:
- Current front end one page flow will use the submit brief response route whenever a brief response is submitted in addition to the create brief response route it already uses.
- A migration will be done on all old brief responses to mark them as submitted.
- Brief responses will need to not include drafts when being listed. 