### PR TITLE
[129838783] Add migration that sets `submitted_at` for old brief responses

### DIFF
--- a/migrations/versions/770_set_submitted_at_for_old_brief_responses.py
+++ b/migrations/versions/770_set_submitted_at_for_old_brief_responses.py
@@ -1,0 +1,27 @@
+"""set submitted at for old brief responses
+
+Revision ID: 770
+Revises: 760
+Create Date: 2016-10-25 11:10:53.245586
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '770'
+down_revision = '760'
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+def upgrade():
+	op.execute("""
+        UPDATE brief_responses 
+		SET submitted_at = created_at
+		WHERE submitted_at IS NULL
+    """)
+
+
+def downgrade():
+	# No downgrade
+	pass


### PR DESCRIPTION
For [this pivotal story](https://www.pivotaltracker.com/story/show/129838783)

For any brief response that does not have a `submitted_at` time, we add one based on the `created_at` time. As we will now be looking at `submitted_at` rather than `created_at` to indicate a submitted brief response, we need to migrate all older brief responses to have a `submitted_at` time.

This pull request should not be merged until [this pull request](https://github.com/alphagov/digitalmarketplace-api/pull/479) has been deployed.
#### Before

<img width="679" alt="screen shot 2016-10-25 at 11 22 16" src="https://cloud.githubusercontent.com/assets/7228605/19689682/11ee60a6-9ac6-11e6-869e-b87e13e9ef17.png">
#### After (note the order has swapped)

<img width="680" alt="screen shot 2016-10-25 at 11 23 27" src="https://cloud.githubusercontent.com/assets/7228605/19689684/13baf1c4-9ac6-11e6-8046-eada16a00c4e.png">
