### PR TITLE
Filter draft brief responses from list

### DIFF
--- a/app/main/views/brief_responses.py
+++ b/app/main/views/brief_responses.py
@@ -147,7 +147,7 @@ def list_brief_responses():
     brief_id = get_int_or_400(request.args, 'brief_id')
     supplier_id = get_int_or_400(request.args, 'supplier_id')
 
-    brief_responses = BriefResponse.query
+    brief_responses = BriefResponse.query.filter(BriefResponse.status == 'submitted')
     if supplier_id is not None:
         brief_responses = brief_responses.filter(BriefResponse.supplier_id == supplier_id)
 

--- a/app/models.py
+++ b/app/models.py
@@ -1304,6 +1304,7 @@ class BriefResponse(db.Model):
     supplier_id = db.Column(db.Integer, db.ForeignKey('suppliers.supplier_id'), nullable=False)
 
     created_at = db.Column(db.DateTime, index=True, nullable=False, default=datetime.utcnow)
+    submitted_at = db.Column(db.DateTime, nullable=True)
 
     brief = db.relationship('Brief')
     supplier = db.relationship('Supplier', lazy='joined')

--- a/app/models.py
+++ b/app/models.py
@@ -1326,6 +1326,12 @@ class BriefResponse(db.Model):
         else:
             return 'draft'
 
+    @status.expression
+    def status(cls):
+        return sql_case([
+            (cls.submitted_at.isnot(None), 'submitted'),
+        ], else_='draft')
+
     def validate(self, enforce_required=True, required_fields=None, max_day_rate=None):
         errs = get_validation_errors(
             'brief-responses-{}-{}'.format(self.brief.framework.slug, self.brief.lot.slug),

--- a/app/models.py
+++ b/app/models.py
@@ -1319,6 +1319,13 @@ class BriefResponse(db.Model):
 
         return data
 
+    @hybrid_property
+    def status(self):
+        if self.submitted_at:
+            return 'submitted'
+        else:
+            return 'draft'
+
     def validate(self, enforce_required=True, required_fields=None, max_day_rate=None):
         errs = get_validation_errors(
             'brief-responses-{}-{}'.format(self.brief.framework.slug, self.brief.lot.slug),
@@ -1357,6 +1364,7 @@ class BriefResponse(db.Model):
             'submittedAt': (
                 self.submitted_at and self.submitted_at.strftime(DATETIME_FORMAT)
             ),
+            'status': self.status,
             'links': {
                 'self': url_for('.get_brief_response', brief_response_id=self.id),
                 'brief': url_for('.get_brief', brief_id=self.brief_id),

--- a/app/models.py
+++ b/app/models.py
@@ -1354,6 +1354,9 @@ class BriefResponse(db.Model):
             'supplierId': self.supplier_id,
             'supplierName': self.supplier.name,
             'createdAt': self.created_at.strftime(DATETIME_FORMAT),
+            'submittedAt': (
+                self.submitted_at and self.submitted_at.strftime(DATETIME_FORMAT)
+            ),
             'links': {
                 'self': url_for('.get_brief_response', brief_response_id=self.id),
                 'brief': url_for('.get_brief', brief_id=self.brief_id),
@@ -1361,7 +1364,7 @@ class BriefResponse(db.Model):
             }
         })
 
-        return data
+        return purge_nulls_from_data(data)
 
 
 class BriefClarificationQuestion(db.Model):

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ SQLAlchemy==1.0.5
 SQLAlchemy-Utils==0.30.5
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@21.4.0#egg=digitalmarketplace-utils==21.4.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@7.3.0#egg=digitalmarketplace-apiclient==7.3.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@7.6.0#egg=digitalmarketplace-apiclient==7.6.0
 
 # For schema validation
 jsonschema==2.5.1

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -475,6 +475,14 @@ class TestBriefResponses(BaseApplicationTest):
 
         assert brief_response.data == {'foo': 'bar', 'bar': ['foo']}
 
+    def test_submitted_status_for_brief_response_with_submitted_at(self):
+        brief_response = BriefResponse(created_at=datetime.utcnow(), submitted_at=datetime.utcnow())
+        assert brief_response.status == 'submitted'
+
+    def test_draft_status_for_brief_response_with_no_submitted_at(self):
+        brief_response = BriefResponse(created_at=datetime.utcnow())
+        assert brief_response.status == 'draft'
+
     def test_brief_response_can_be_serialized(self):
         with self.app.app_context():
             brief_response = BriefResponse(
@@ -492,6 +500,7 @@ class TestBriefResponses(BaseApplicationTest):
                     'supplierName': 'Supplier 0',
                     'createdAt': mock.ANY,
                     'submittedAt': '2016-09-28T00:00:00.000000Z',
+                    'status': 'submitted',
                     'foo': 'bar',
                     'links': {
                         'self': (('.get_brief_response',), {'brief_response_id': brief_response.id}),
@@ -516,6 +525,7 @@ class TestBriefResponses(BaseApplicationTest):
                     'supplierId': 0,
                     'supplierName': 'Supplier 0',
                     'createdAt': mock.ANY,
+                    'status': 'draft',
                     'foo': 'bar',
                     'links': {
                         'self': (('.get_brief_response',), {'brief_response_id': brief_response.id}),


### PR DESCRIPTION
For [this story on Pivotal](https://www.pivotaltracker.com/story/show/129838783).

The first 5 commits in the PR are included in [this PR](https://github.com/alphagov/digitalmarketplace-api/pull/479). This PR needs to be rebase on top of master once the other PR is merged to remove them, but only after [this PR for a data migration has been merged](https://github.com/alphagov/digitalmarketplace-api/pull/480).

Brief responses should only be listed if their status is published. This PR filters out the drafts before returning the list of responses.
