### PR TITLE
Update brief response

### DIFF
--- a/app/main/views/brief_responses.py
+++ b/app/main/views/brief_responses.py
@@ -85,6 +85,60 @@ def create_brief_response():
     return jsonify(briefResponses=brief_response.serialize()), 201
 
 
+@main.route('/brief-responses/<int:brief_response_id>', methods=['POST'])
+def update_brief_response(brief_response_id):
+    json_payload = get_json_from_request()
+    updater_json = validate_and_return_updater_request()
+    page_questions = get_request_page_questions()
+
+    json_has_required_keys(json_payload, ['briefResponses'])
+    brief_response_json = json_payload['briefResponses']
+
+    brief_response = BriefResponse.query.filter(
+        BriefResponse.id == brief_response_id
+    ).first_or_404()
+
+    brief = brief_response.brief
+    supplier = brief_response.supplier
+    brief_service = get_supplier_service_eligible_for_brief(supplier, brief)
+    if not brief_service:
+        abort(400, "Supplier is not eligible to apply to this brief")
+
+    if brief_response.status != 'draft':
+        abort(400, "Brief response must be a draft")
+
+    if brief.framework.status != 'live':
+        abort(400, "Brief framework must be live")
+
+    brief_role = brief.data["specialistRole"] if brief.lot.slug == "digital-specialists" else None
+    service_max_day_rate = brief_service.data[brief_role + "PriceMax"] if brief_role else None
+
+    brief_response.update_from_json(brief_response_json)
+
+    brief_response.validate(enforce_required=False, required_fields=page_questions, max_day_rate=service_max_day_rate)
+
+    audit = AuditEvent(
+        audit_type=AuditTypes.update_brief_response,
+        user=updater_json['updated_by'],
+        data={
+            'briefResponseId': brief_response.id,
+            'briefResponseData': brief_response_json
+        },
+        db_object=brief_response,
+    )
+
+    db.session.add(brief_response)
+    db.session.add(audit)
+
+    try:
+        db.session.commit()
+    except IntegrityError as e:
+        db.session.rollback()
+        abort(400, e.orig)
+
+    return jsonify(briefResponses=brief_response.serialize()), 200
+
+
 @main.route('/brief-responses/<int:brief_response_id>/submit', methods=['POST'])
 def submit_brief_response(brief_response_id):
     updater_json = validate_and_return_updater_request()

--- a/app/main/views/brief_responses.py
+++ b/app/main/views/brief_responses.py
@@ -202,7 +202,12 @@ def list_brief_responses():
     brief_id = get_int_or_400(request.args, 'brief_id')
     supplier_id = get_int_or_400(request.args, 'supplier_id')
 
-    brief_responses = BriefResponse.query
+    if request.args.get('status'):
+        statuses = request.args['status'].split(',')
+    else:
+        statuses = ['submitted']
+    brief_responses = BriefResponse.query.filter(BriefResponse.status.in_(statuses))
+
     if supplier_id is not None:
         brief_responses = brief_responses.filter(BriefResponse.supplier_id == supplier_id)
 

--- a/app/main/views/brief_responses.py
+++ b/app/main/views/brief_responses.py
@@ -10,7 +10,7 @@ from ...models import db, Brief, BriefResponse, AuditEvent
 from ...utils import (
     get_json_from_request, json_has_required_keys, get_int_or_400,
     pagination_links, get_valid_page_or_1, url_for,
-    validate_and_return_updater_request,
+    validate_and_return_updater_request, get_request_page_questions
 )
 
 from ...brief_utils import get_supplier_service_eligible_for_brief
@@ -21,6 +21,7 @@ from ...service_utils import validate_and_return_supplier
 def create_brief_response():
     json_payload = get_json_from_request()
     updater_json = validate_and_return_updater_request()
+    page_questions = get_request_page_questions()
 
     json_has_required_keys(json_payload, ['briefResponses'])
     brief_response_json = json_payload['briefResponses']
@@ -59,7 +60,7 @@ def create_brief_response():
     brief_role = brief.data["specialistRole"] if brief.lot.slug == "digital-specialists" else None
     service_max_day_rate = brief_service.data[brief_role + "PriceMax"] if brief_role else None
 
-    brief_response.validate(max_day_rate=service_max_day_rate)
+    brief_response.validate(enforce_required=False, required_fields=page_questions, max_day_rate=service_max_day_rate)
 
     db.session.add(brief_response)
     try:

--- a/app/models.py
+++ b/app/models.py
@@ -1341,18 +1341,23 @@ class BriefResponse(db.Model):
         )
 
         if (
+            (required_fields and 'essentialRequirements' in required_fields or enforce_required) and
             'essentialRequirements' not in errs and
             len(self.data.get('essentialRequirements', [])) != len(self.brief.data['essentialRequirements'])
         ):
             errs['essentialRequirements'] = 'answer_required'
 
         if (
+            (required_fields and 'niceToHaveRequirements' in required_fields or enforce_required) and
             'niceToHaveRequirements' not in errs and
             len(self.data.get('niceToHaveRequirements', [])) != len(self.brief.data.get('niceToHaveRequirements', []))
         ):
             errs['niceToHaveRequirements'] = 'answer_required'
 
-        if max_day_rate and 'dayRate' not in errs:
+        if (
+            (required_fields and 'dayRate' in required_fields or enforce_required) and
+            max_day_rate and 'dayRate' not in errs
+        ):
             if float(self.data['dayRate']) > float(max_day_rate):
                 errs['dayRate'] = 'max_less_than_min'
 

--- a/app/models.py
+++ b/app/models.py
@@ -1319,6 +1319,12 @@ class BriefResponse(db.Model):
 
         return data
 
+    def update_from_json(self, data):
+        current_data = dict(self.data.items())
+        current_data.update(data)
+
+        self.data = current_data
+
     @hybrid_property
     def status(self):
         if self.submitted_at:


### PR DESCRIPTION
For [this pivotal story](https://www.pivotaltracker.com/story/show/129838783)

- Validate only requested page questions when creating brief response
- Add update brief response route
- Filter brief responses list by status (by default, only including submitted responses)

#### Relies on
- [x] [Supplier front end pull request](https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/545) that sends back a list of `page_questions` when creating a brief response.
- [x] [API migration](https://github.com/alphagov/digitalmarketplace-api/pull/480) that sets `submitted_at` for all existing brief responses. When migration is merged then will need to rebase.
