### PR TITLE
API tidy up - FrameworkAgreements

### DIFF
--- a/app/main/views/agreements.py
+++ b/app/main/views/agreements.py
@@ -91,12 +91,11 @@ def update_framework_agreement(agreement_id):
         optional_keys=['signedAgreementDetails', 'signedAgreementPath', 'countersignedAgreementPath']
     )
 
-    # TODO Behaviour to be introduced after next step of refactoring
-    # if (
-    #     framework_agreement.signed_agreement_returned_at
-    #     and ('signedAgreementDetails' in update_json or 'signedAgreementPath' in update_json)
-    # ):
-    #     abort(400, "Can not update signedAgreementDetails or signedAgreementPath if agreement has been signed")
+    if (
+        framework_agreement.signed_agreement_returned_at
+        and ('signedAgreementDetails' in update_json or 'signedAgreementPath' in update_json)
+    ):
+        abort(400, "Can not update signedAgreementDetails or signedAgreementPath if agreement has been signed")
 
     if ('countersignedAgreementPath' in update_json and not framework_agreement.countersigned_agreement_returned_at):
         abort(400, "Can not update countersignedAgreementPath if agreement has not been approved for countersigning")

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -232,12 +232,8 @@ def get_framework_suppliers(framework_slug):
             if convert_to_boolean(agreement_returned):
                 requested_statuses = requested_statuses or ('signed', 'on-hold', 'approved', 'countersigned')
             else:
-                supplier_frameworks = [sf for sf in supplier_frameworks if sf.current_framework_agreement is None
-                                       or (sf.current_framework_agreement
-                                           and sf.current_framework_agreement.status == 'draft'
-                                           )
-                                       ]
-                # TODO: The 'or' clause here can be deleted once drafts are excluded from current_framework_agreement
+                supplier_frameworks = [sf for sf in supplier_frameworks if sf.current_framework_agreement is None]
+
                 # TODO: Much of the logic here would be better done querying with SQL than manipulating with Python
 
         if requested_statuses:

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -212,14 +212,13 @@ def get_framework_suppliers(framework_slug):
         Framework.slug == framework_slug
     ).first_or_404()
 
+    # TODO: Work out a way to order by current_framework_agreement.signed_agreement_returned_at
     # Listing agreements is something done for Admin only (suppliers only retrieve their individual agreements)
     # CCS always want to work from the oldest returned date to newest, so order by ascending date
+
+    # TODO: Work out a way to query.filter() on current_framework_agreement rather than manipulating with Python
     supplier_frameworks = SupplierFramework.query.filter(
         SupplierFramework.framework_id == framework.id
-    ).outerjoin(
-        SupplierFramework.framework_agreements
-    ).order_by(
-        FrameworkAgreement.signed_agreement_returned_at.asc()
     )
 
     if request.args.get('agreement_returned') is not None or request.args.get('status') is not None:
@@ -233,8 +232,6 @@ def get_framework_suppliers(framework_slug):
                 requested_statuses = requested_statuses or ('signed', 'on-hold', 'approved', 'countersigned')
             else:
                 supplier_frameworks = [sf for sf in supplier_frameworks if sf.current_framework_agreement is None]
-
-                # TODO: Much of the logic here would be better done querying with SQL than manipulating with Python
 
         if requested_statuses:
             supplier_frameworks = [

--- a/app/models.py
+++ b/app/models.py
@@ -330,13 +330,6 @@ class SupplierFramework(db.Model):
     on_framework = db.Column(db.Boolean, nullable=True)
     agreed_variations = db.Column(JSON)
 
-    # The following three fields are deprecated and MUST NOT BE USED
-    # Data may be outdated and should not be used for reading/updating
-    # The framework_agreements table is now the source of truth for this data
-    agreement_returned_at = db.Column(db.DateTime, index=False, unique=False, nullable=True)
-    countersigned_at = db.Column(db.DateTime, index=False, unique=False, nullable=True)
-    agreement_details = db.Column(JSON)
-
     supplier = db.relationship(Supplier, lazy='joined', innerjoin=True)
     framework = db.relationship(Framework, lazy='joined', innerjoin=True)
 

--- a/app/models.py
+++ b/app/models.py
@@ -520,7 +520,7 @@ class FrameworkAgreement(db.Model):
     supplier_framework = db.relationship(
         SupplierFramework,
         lazy="joined",
-        backref=backref('framework_agreements', lazy="joined", order_by="FrameworkAgreement.id")
+        backref=backref('framework_agreements', lazy="joined")
     )
 
     def update_signed_agreement_details_from_json(self, data):

--- a/app/models.py
+++ b/app/models.py
@@ -1,5 +1,5 @@
 import random
-from datetime import datetime, timedelta
+from datetime import datetime
 import re
 
 from flask import current_app
@@ -332,7 +332,7 @@ class SupplierFramework(db.Model):
 
     # The following three fields are deprecated and MUST NOT BE USED
     # Data may be outdated and should not be used for reading/updating
-    # This framework_agreements table is now the source of truth for this data
+    # The framework_agreements table is now the source of truth for this data
     agreement_returned_at = db.Column(db.DateTime, index=False, unique=False, nullable=True)
     countersigned_at = db.Column(db.DateTime, index=False, unique=False, nullable=True)
     agreement_details = db.Column(JSON)
@@ -343,30 +343,15 @@ class SupplierFramework(db.Model):
     @property
     def current_framework_agreement(self):
         """
-        For the moment, we include drafts in the SupplierFramework to keep our interface the same whilst we refactor the
-        frontend to allow multiple framework agreements per supplier framework. This means that if a draft is created
-        after any other framework agreement then it must take precident (as the supplier frontend for the moment only
-        knows about one framework agreement (the current framework agreement) we must expose the draft so it can be
-        edited as they complete the signing flow). Note, as we have no timestamp for framework agreements being created
-        we instead have to use the highest `id`. Also note, this means that for a short while, if someone has
-        signed/countersigned a supplier framework and then starts a new draft then the supplier framework will return to
-        'draft' status and will lose knowledge of the previous signing.
-
-        After the supplier frontend has been refactored so that the signing flow deals with a framework agreement rather
-        than a suqpplier framework then we will be able to ignore drafts and not include them in the current framework
-        agreement
+        The most recently signed or countersigned agreement.
+        Draft agreements are never returned as the "current" agreement.
         """
-        if self.framework_agreements:
-            if self.framework_agreements[-1].status == 'draft':
-                return self.framework_agreements[-1]
-
-            most_recently_signed_or_countersigned = self.framework_agreements[-1]
+        signed_framework_agreements = [fa for fa in self.framework_agreements if fa.status != 'draft']
+        if signed_framework_agreements:
+            most_recently_signed_or_countersigned = signed_framework_agreements[0]
             most_recent_time = most_recently_signed_or_countersigned.most_recent_signature_time
 
-            for fa in self.framework_agreements:
-                if fa.status == "draft":
-                    continue
-
+            for fa in signed_framework_agreements:
                 if fa.most_recent_signature_time > most_recent_time:
                     most_recently_signed_or_countersigned = fa
                     most_recent_time = fa.most_recent_signature_time

--- a/app/models.py
+++ b/app/models.py
@@ -1140,24 +1140,24 @@ class Brief(db.Model):
                 '2 weeks 23:59:59', INTERVAL))
 
     @hybrid_property
-    def clarification_questions_closed_at(self):
-        if self.published_at is None:
+    def clarification_questions_closed_at(self_or_cls):
+        if self_or_cls.published_at is None:
             return None
-        brief_publishing_date_and_length = self._build_date_and_length_data()
+        brief_publishing_date_and_length = self_or_cls._build_date_and_length_data()
 
         return get_publishing_dates(brief_publishing_date_and_length)['questions_close']
 
     @hybrid_property
-    def clarification_questions_published_by(self):
-        if self.published_at is None:
+    def clarification_questions_published_by(self_or_cls):
+        if self_or_cls.published_at is None:
             return None
-        brief_publishing_date_and_length = self._build_date_and_length_data()
+        brief_publishing_date_and_length = self_or_cls._build_date_and_length_data()
 
         return get_publishing_dates(brief_publishing_date_and_length)['answers_close']
 
     @hybrid_property
-    def clarification_questions_are_closed(self):
-        return datetime.utcnow() > self.clarification_questions_closed_at
+    def clarification_questions_are_closed(self_or_cls):
+        return datetime.utcnow() > self_or_cls.clarification_questions_closed_at
 
     @hybrid_property
     def status(self):

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -859,6 +859,23 @@ class TestSupplierFrameworks(BaseApplicationTest):
 
         assert supplier_framework.declaration == {'foo': 'bar', 'bar': '', 'other': ''}
 
+    def test_create_supplier_framework(self):
+        # the intention of this test is to ensure a SupplierFramework without any FrameworkAgreements is visible through
+        # the default query - i.e. none of our custom relationships are causing it to do an inner join which would
+        # cause such a SupplierFramework to be invisible
+        with self.app.app_context():
+            self.setup_dummy_suppliers(1)
+
+            supplier_framework = SupplierFramework(supplier_id=0, framework_id=1)
+            db.session.add(supplier_framework)
+            db.session.commit()
+
+            assert len(
+                SupplierFramework.query.filter(
+                    SupplierFramework.supplier_id == 0
+                ).all()
+            ) == 1
+
 
 class TestLot(BaseApplicationTest):
     def test_lot_data_is_serialized(self):

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -1018,7 +1018,7 @@ class TestCurrentFrameworkAgreement(BaseApplicationTest):
             db.session.add(FrameworkAgreement(id=5, **self.BASE_AGREEMENT_KWARGS))
             db.session.commit()
             supplier_framework = self.get_supplier_framework()
-            assert supplier_framework.current_framework_agreement.id == 5
+            assert supplier_framework.current_framework_agreement is None
 
     def test_current_framework_agreement_with_multiple_drafts(self):
         with self.app.app_context():
@@ -1026,7 +1026,7 @@ class TestCurrentFrameworkAgreement(BaseApplicationTest):
             db.session.add(FrameworkAgreement(id=6, **self.BASE_AGREEMENT_KWARGS))
             db.session.commit()
             supplier_framework = self.get_supplier_framework()
-            assert supplier_framework.current_framework_agreement.id == 6
+            assert supplier_framework.current_framework_agreement is None
 
     def test_current_framework_agreement_with_one_signed(self):
         with self.app.app_context():
@@ -1047,9 +1047,7 @@ class TestCurrentFrameworkAgreement(BaseApplicationTest):
             supplier_framework = self.get_supplier_framework()
             assert supplier_framework.current_framework_agreement.id == 6
 
-    def test_current_framework_agreement_with_signed_and_old_draft(self):
-        # THIS IS GOING TO DIE ONCE WE STOP RETURNING DRAFTS IN SUPPLIER FRAMEWORK
-        # RELATIVE AGE IS DETERMINED BY ID ORDER
+    def test_current_framework_agreement_with_signed_and_old_draft_does_not_return_draft(self):
         with self.app.app_context():
             db.session.add(FrameworkAgreement(id=5, **self.BASE_AGREEMENT_KWARGS))
             db.session.add(FrameworkAgreement(
@@ -1058,16 +1056,14 @@ class TestCurrentFrameworkAgreement(BaseApplicationTest):
             supplier_framework = self.get_supplier_framework()
             assert supplier_framework.current_framework_agreement.id == 6
 
-    def test_current_framework_agreement_with_signed_and_new_draft(self):
-        # THIS IS GOING TO DIE ONCE WE STOP RETURNING DRAFTS IN SUPPLIER FRAMEWORK
-        # RELATIVE AGE IS DETERMINED BY ID ORDER
+    def test_current_framework_agreement_with_signed_and_new_draft_does_not_return_draft(self):
         with self.app.app_context():
             db.session.add(FrameworkAgreement(id=6, **self.BASE_AGREEMENT_KWARGS))
             db.session.add(FrameworkAgreement(
                 id=5, signed_agreement_returned_at=datetime(2016, 10, 10, 12, 00, 00), **self.BASE_AGREEMENT_KWARGS)
             )
             supplier_framework = self.get_supplier_framework()
-            assert supplier_framework.current_framework_agreement.id == 6
+            assert supplier_framework.current_framework_agreement.id == 5
 
     def test_current_framework_agreement_with_signed_and_new_countersigned(self):
         with self.app.app_context():

--- a/tests/app/views/test_agreements.py
+++ b/tests/app/views/test_agreements.py
@@ -434,6 +434,29 @@ class TestUpdateFrameworkAgreement(BaseFrameworkAgreementTest):
             }
 
     @fixture_params('live_example_framework', {'framework_agreement_details': {'frameworkAgreementVersion': 'v1.0'}})
+    def test_can_not_set_framework_agreement_version_directly(self, supplier_framework):
+        agreement_id = self.create_agreement(supplier_framework)
+        res = self.post_agreement_update(agreement_id, {
+            'frameworkAgreementVersion': 'v23.4'
+        })
+        assert res.status_code == 400
+        assert json.loads(res.get_data(as_text=True)) == {
+            'error': "Invalid JSON should not have 'frameworkAgreementVersion' keys"
+        }
+
+    @fixture_params('live_example_framework', {'framework_agreement_details': {'frameworkAgreementVersion': 'v1.0'}})
+    def test_agreement_returned_at_timestamp_cannot_be_set(self, supplier_framework):
+        agreement_id = self.create_agreement(supplier_framework)
+        res = self.post_agreement_update(agreement_id, {
+            'signedAgreementReturnedAt': '2013-13-13T00:00:00.000000Z'
+        })
+
+        assert res.status_code == 400
+        assert json.loads(res.get_data(as_text=True)) == {
+            'error': "Invalid JSON should not have 'signedAgreementReturnedAt' keys"
+        }
+
+    @fixture_params('live_example_framework', {'framework_agreement_details': {'frameworkAgreementVersion': 'v1.0'}})
     def test_400_cannot_update_signed_agreement(self, supplier_framework):
         agreement_id = self.create_agreement(supplier_framework, signed_agreement_returned_at=datetime.utcnow())
         res = self.post_agreement_update(agreement_id, {
@@ -446,7 +469,7 @@ class TestUpdateFrameworkAgreement(BaseFrameworkAgreementTest):
         }
 
     @fixture_params('live_example_framework', {'framework_agreement_details': {'frameworkAgreementVersion': 'v1.0'}})
-    def test_400_if_some_random_key_in_update_json(self, supplier_framework):
+    def test_400_if_unknown_field_present_in_update_json(self, supplier_framework):
         agreement_id = self.create_agreement(supplier_framework)
         res = self.post_agreement_update(agreement_id, {
             'signedRandomKey': 'banana'
@@ -458,7 +481,7 @@ class TestUpdateFrameworkAgreement(BaseFrameworkAgreementTest):
         }
 
     @fixture_params('live_example_framework', {'framework_agreement_details': {'frameworkAgreementVersion': 'v1.0'}})
-    def test_400_if_signed_agreement_details_contains_some_random_key(self, supplier_framework):
+    def test_400_if_unknown_field_present_in_signed_agreement_details(self, supplier_framework):
         agreement_id = self.create_agreement(supplier_framework)
         res = self.post_agreement_update(agreement_id, {
             'signedAgreementDetails': {

--- a/tests/app/views/test_agreements.py
+++ b/tests/app/views/test_agreements.py
@@ -433,18 +433,17 @@ class TestUpdateFrameworkAgreement(BaseFrameworkAgreementTest):
                 }
             }
 
-    # TODO Behaviour to be introduced after next step of refactoring
-    # @fixture_params('live_example_framework', {'framework_agreement_details': {'frameworkAgreementVersion': 'v1.0'}})
-    # def test_400_cannot_update_signed_agreement(self, supplier_framework):
-    #     agreement_id = self.create_agreement(supplier_framework, signed_agreement_returned_at=datetime.utcnow())
-    #     res = self.post_agreement_update(agreement_id, {
-    #         'signedAgreementPath': '/example.pdf'
-    #     })
+    @fixture_params('live_example_framework', {'framework_agreement_details': {'frameworkAgreementVersion': 'v1.0'}})
+    def test_400_cannot_update_signed_agreement(self, supplier_framework):
+        agreement_id = self.create_agreement(supplier_framework, signed_agreement_returned_at=datetime.utcnow())
+        res = self.post_agreement_update(agreement_id, {
+            'signedAgreementPath': '/example.pdf'
+        })
 
-    #     assert res.status_code == 400
-    #     assert json.loads(res.get_data(as_text=True)) == {
-    #         'error': 'Can not update signedAgreementDetails or signedAgreementPath if agreement has been signed'
-    #     }
+        assert res.status_code == 400
+        assert json.loads(res.get_data(as_text=True)) == {
+            'error': 'Can not update signedAgreementDetails or signedAgreementPath if agreement has been signed'
+        }
 
     @fixture_params('live_example_framework', {'framework_agreement_details': {'frameworkAgreementVersion': 'v1.0'}})
     def test_400_if_some_random_key_in_update_json(self, supplier_framework):

--- a/tests/app/views/test_frameworks.py
+++ b/tests/app/views/test_frameworks.py
@@ -746,15 +746,6 @@ class TestGetFrameworkSuppliers(BaseApplicationTest):
             for sf in data['supplierFrameworks']:
                 assert sf['agreementReturnedAt'] is None
 
-    def test_list_suppliers_by_status_draft(self, live_g8_framework):
-        with self.app.app_context():
-            response = self.client.get('/frameworks/g-cloud-8/suppliers?status=draft')
-
-            assert response.status_code == 200
-            data = json.loads(response.get_data())
-            assert len(data['supplierFrameworks']) == 2
-            self._assert_supplier_ids(data, (1, 2))
-
     def test_list_suppliers_by_status_signed(self, live_g8_framework):
         with self.app.app_context():
             response = self.client.get('/frameworks/g-cloud-8/suppliers?status=signed')

--- a/tests/app/views/test_suppliers.py
+++ b/tests/app/views/test_suppliers.py
@@ -1301,7 +1301,7 @@ class TestSupplierFrameworkResponse(BaseApplicationTest):
         assert data['frameworkInterest']['agreementDetails'] is None
         assert data['frameworkInterest']['agreementStatus'] is None
 
-    def test_get_supplier_framework_returns_framework_agreement(self, supplier_framework):
+    def test_get_supplier_framework_does_not_return_draft_framework_agreement(self, supplier_framework):
         with self.app.app_context():
             supplier_framework_object = SupplierFramework.find_by_supplier_and_framework(
                 supplier_framework['supplierId'], supplier_framework['frameworkSlug']
@@ -1334,20 +1334,16 @@ class TestSupplierFrameworkResponse(BaseApplicationTest):
                 'frameworkSlug': supplier_framework['frameworkSlug'],
                 'declaration': {'an_answer': 'Yes it is'},
                 'onFramework': True,
-                'agreementId': framework_agreement.id,
+                'agreementId': None,
                 'agreementReturned': False,
                 'agreementReturnedAt': None,
-                'agreementDetails': {
-                    'signerName': 'thing 2',
-                    'signerRole': 'thing 2',
-                    'uploaderUserId': 30
-                },
+                'agreementDetails': None,
                 'agreementPath': None,
                 'countersigned': False,
                 'countersignedAt': None,
                 'countersignedDetails': None,
                 'countersignedPath': None,
-                'agreementStatus': 'draft',
+                'agreementStatus': None,
                 'agreedVariations': {}
             }
 
@@ -1615,44 +1611,6 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest):
         assert data2['frameworkInterest']['agreementReturned'] is False
         assert data2['frameworkInterest']['agreementReturnedAt'] is None
         assert data2['frameworkInterest']['agreementDetails'] is None
-
-    @fixture_params('live_example_framework', {'framework_agreement_details': {'frameworkAgreementVersion': 'v1.0'}})
-    def test_setting_signer_details_and_then_returning_agreement(self, user_role_supplier, supplier_framework):
-        agreement_details_payload = {
-            "signerName": "name",
-            "signerRole": "role",
-        }
-        response = self.supplier_framework_interest(
-            supplier_framework, update={'agreementDetails': agreement_details_payload}
-        )
-
-        assert response.status_code == 200
-        data = json.loads(response.get_data())
-        assert data['frameworkInterest']['agreementDetails'] == agreement_details_payload
-
-        # while we're at it let's test the agreementDetails partial updating behaviour
-        agreement_details_update_payload = {
-            "uploaderUserId": 1,
-        }
-        response2 = self.supplier_framework_interest(
-            supplier_framework,
-            update={
-                'agreementReturned': True,
-                'agreementDetails': agreement_details_update_payload
-            }
-        )
-
-        agreement_details_payload.update(agreement_details_update_payload)
-        assert response2.status_code == 200
-        data2 = json.loads(response2.get_data())
-        assert data2['frameworkInterest']['agreementDetails'] == {
-            "signerName": "name",
-            "signerRole": "role",
-            "uploaderUserId": 1,
-            "uploaderUserName": "my name",
-            "uploaderUserEmail": "test+1@digital.gov.uk",
-            "frameworkAgreementVersion": "v1.0",
-        }
 
     def test_can_not_set_agreement_details_on_frameworks_without_framework_agreement_version(self, supplier_framework):
         agreement_details_payload = {


### PR DESCRIPTION
Now that FrameworkAgreements are updated directly by the frontend apps the API should no longer allow setting and unsetting agreement details through the SupplierFramework update route, so that functionality is removed here.

This also means that we should no longer include "draft" agreements in the SupplierFramework response - only signed/on-hold/countersigned agreements are counted as possible "current framework agreements".  This also means that there is no need to order FAs by id, as that was only used for selecting the "most recent" draft to include.

Three now-unused fields have been removed from the SupplierFramework model - database migration to come in separate PR.  These code changes will need to go in before the migration though.

I have replaced the `current_framework_agreement` property with a `db.relationship`, but I haven't been able to get it to order SupplierFrameworks by current_framework_agreement date.

We have agreed that for now we will not order the SupplierFrameworks returned from the list endpoint, and will instead do the ordering in the Admin frontend where the list response is used.

I have added `TODO`s as it would be nice to get this working at some point in the near future.
