### PR TITLE
Add migration to drop now-unused supplier_framework columns

### DIFF
--- a/migrations/versions/780_remove_unused_cols.py
+++ b/migrations/versions/780_remove_unused_cols.py
@@ -1,0 +1,30 @@
+"""Remove agreement_returned_at, countersigned_at and agreement_details
+   columns from supplier_framework table as they are no longer used
+
+Revision ID: 780
+Revises: 770
+Create Date: 2016-11-07 10:14:00.000000
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '780'
+down_revision = '770'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.drop_column('supplier_frameworks', 'agreement_returned_at')
+    op.drop_column('supplier_frameworks', 'countersigned_at')
+    op.drop_column('supplier_frameworks', 'agreement_details')
+
+
+def downgrade():
+    # Downgrade reinstates the columns but does not populate them with data.
+    # These fields could be populated with data from the "current framework agreement" after being reinstated.
+    # That would be better (or at least more easily) done by a script than by this migration if necessary.
+    op.add_column('supplier_frameworks', sa.Column('agreement_returned_at', sa.DateTime(), nullable=True))
+    op.add_column('supplier_frameworks', sa.Column('countersigned_at', sa.DateTime(), nullable=True))
+    op.add_column('supplier_frameworks', sa.Column('agreement_details', sa.dialects.postgresql.JSON(), nullable=True))


### PR DESCRIPTION
This will need to be merged AFTER:
 - [x] https://github.com/alphagov/digitalmarketplace-api/pull/484

The recent addition of the framework_agreement table means that these columns
are no longer needed. (They are no longer referred to anywhere in the API code.)

For the downgrade I've spent much of the morning experimenting with trying to get the "current framework agreement" data back in to the SupplierFramework table but had no real success.  Rather than lose more time I'd rather have the downgrade reinstate the dropped columns, and if we ever need to do it we can script an update to populate them with the most recent data.