### PR TITLE
Build error messages for dynamic_list questions

### DIFF
--- a/app/validation.py
+++ b/app/validation.py
@@ -150,10 +150,15 @@ def validates_against_schema(validator_name, submitted_json):
 def get_validation_errors(validator_name, json_data,
                           enforce_required=True,
                           required_fields=None):
-    error_map = {}
     validator = get_validator(validator_name, enforce_required,
                               required_fields)
     errors = validator.iter_errors(json_data)
+
+    return translate_json_schema_errors(errors, json_data)
+
+
+def translate_json_schema_errors(errors, json_data):
+    error_map = {}
     form_errors = []
     for error in errors:
         # validate follow-up questions are answered: eg evidence given for a 'yes' nice-to-have


### PR DESCRIPTION
Errors for dynamic_list questions need to be linked to the field
that is failing the validation: either the primary question or a
follow-up question (depending on the value of the primary question).
eg if we answer 'yes' to the question about having the essential
requirement, we then have to have a value for 'evidence'.

To achieve this, we're putting one extra key into the `errors_map`
dictionary indicating which field failed the validation.

 --

This pull request adds capacity without changing existing behaviour, but notably, it doesn't have any tests written for it. :sweat_smile: :sweat_smile: :sweat_smile:

Should be fine.