### PR TITLE
SupplierFramework.serialize: add with_users kwarg

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -250,8 +250,9 @@ def get_framework_suppliers(framework_slug):
             cfa.status.in_(status.split(","))
         )
 
+    with_users = convert_to_boolean(request.args.get("with_users", default="false"))
     return jsonify(supplierFrameworks=[
-        supplier_framework.serialize() for supplier_framework in supplier_frameworks
+        supplier_framework.serialize(with_users=with_users) for supplier_framework in supplier_frameworks
     ])
 
 


### PR DESCRIPTION
This should speed things up considerably when called with `with_users=False`.