### PR TITLE
Add framework status to API /_status

### DIFF
--- a/app/status/views.py
+++ b/app/status/views.py
@@ -1,9 +1,9 @@
-import os
 from flask import jsonify, current_app, request
 from sqlalchemy.exc import SQLAlchemyError
 
 from . import status
 from . import utils
+from ..models import Framework
 from dmutils.status import get_flags
 
 
@@ -20,6 +20,7 @@ def status_no_db():
     try:
         return jsonify(
             status="ok",
+            frameworks={f.slug: f.status for f in Framework.query.all()},
             version=version,
             db_version=utils.get_db_version(),
             flags=get_flags(current_app)


### PR DESCRIPTION
To figure out current framework statuses for the given environment you either need access to the API token or you'd have to look through a number of frontend pages to infer the status from.

Framework status is a part of almost every request to the API, so it should always be available for a working API instance and it makes sense to add it to the /_status page.

Adding it to the /_status page creates an easier way to get the list of all framework statuses.