### PR TITLE
SupplierFramework.serialize: set with_users kwarg default to False

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -250,9 +250,8 @@ def get_framework_suppliers(framework_slug):
             cfa.status.in_(status.split(","))
         )
 
-    with_users = convert_to_boolean(request.args.get("with_users", default="false"))
     return jsonify(supplierFrameworks=[
-        supplier_framework.serialize(with_users=with_users) for supplier_framework in supplier_frameworks
+        supplier_framework.serialize(with_users=False) for supplier_framework in supplier_frameworks
     ])
 
 

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -324,12 +324,12 @@ def get_supplier_frameworks_info(supplier_id):
     ).all()
 
     return jsonify(frameworkInterest=[
-        framework.serialize({
-            'drafts_count': service_counts.get((framework.framework_id, 'not-submitted'), 0),
-            'complete_drafts_count': service_counts.get((framework.framework_id, 'submitted'), 0),
-            'services_count': service_counts.get((framework.framework_id, 'published'), 0)
+        supplier_framework.serialize({
+            'drafts_count': service_counts.get((supplier_framework.framework_id, 'not-submitted'), 0),
+            'complete_drafts_count': service_counts.get((supplier_framework.framework_id, 'submitted'), 0),
+            'services_count': service_counts.get((supplier_framework.framework_id, 'published'), 0)
         })
-        for framework in supplier_frameworks]
+        for supplier_framework in supplier_frameworks]
     )
 
 

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -341,7 +341,7 @@ def get_supplier_framework_info(supplier_id, framework_slug):
     if supplier_framework is None:
         abort(404)
 
-    return jsonify(frameworkInterest=supplier_framework.serialize())
+    return jsonify(frameworkInterest=supplier_framework.serialize(with_users=True))
 
 
 @main.route('/suppliers/<supplier_id>/frameworks/<framework_slug>', methods=['PUT'])

--- a/app/models.py
+++ b/app/models.py
@@ -403,7 +403,7 @@ class SupplierFramework(db.Model):
             "agreedUserEmail": user.email_address,
         })
 
-    def serialize(self, data=None, with_users=True):
+    def serialize(self, data=None, with_users=False):
         agreed_variations = {
             k: self.serialize_agreed_variation(v, with_users=with_users)
             for k, v in iteritems(self.agreed_variations or {})

--- a/app/models.py
+++ b/app/models.py
@@ -388,7 +388,7 @@ class SupplierFramework(db.Model):
         }
 
     @staticmethod
-    def serialize_agreed_variation(agreed_variation, with_users=True):
+    def serialize_agreed_variation(agreed_variation, with_users=False):
         if not (with_users and agreed_variation.get("agreedUserId")):
             return agreed_variation
 

--- a/tests/app/views/test_agreements.py
+++ b/tests/app/views/test_agreements.py
@@ -1128,7 +1128,7 @@ class TestApproveFrameworkAgreement(BaseFrameworkAgreementTest):
 
         with self.app.app_context():
             agreement = FrameworkAgreement.query.filter(FrameworkAgreement.id == agreement_id).first()
-            supplier_framework = agreement.supplier_framework.serialize()
+            supplier_framework = agreement.supplier_framework.serialize(with_users=True)
 
         assert supplier_framework['countersignedDetails']['approvedByUserName'] == 'Chris'
         assert supplier_framework['countersignedDetails']['approvedByUserEmail'] == 'chris@example.com'

--- a/tests/app/views/test_suppliers.py
+++ b/tests/app/views/test_suppliers.py
@@ -1699,10 +1699,13 @@ class TestSupplierFrameworkVariation(BaseApplicationTest):
 
         expected_variation = {
             "agreedUserId": 1,
-            "agreedUserEmail": "test+1@digital.gov.uk",
-            "agreedUserName": "my name",
             "agreedAt": "2016-06-06T00:00:00.000000Z",
         }
+        expected_variation_with_user = dict(
+            expected_variation,
+            agreedUserEmail="test+1@digital.gov.uk",
+            agreedUserName="my name",
+        )
 
         assert response.status_code == 200
         response_json = json.loads(response.get_data())
@@ -1711,7 +1714,7 @@ class TestSupplierFrameworkVariation(BaseApplicationTest):
         response2 = self.client.get("/suppliers/1/frameworks/g-cloud-8")
         assert response2.status_code == 200
         assert json.loads(response2.get_data())["frameworkInterest"]["agreedVariations"] == {
-            "banana": expected_variation,
+            "banana": expected_variation_with_user,
         }
 
         with app.app_context():
@@ -1749,10 +1752,13 @@ class TestSupplierFrameworkVariation(BaseApplicationTest):
 
         expected_variation_toblerone = {
             "agreedUserId": 2,
-            "agreedUserEmail": "test+2@digital.gov.uk",
-            "agreedUserName": "my name",
             "agreedAt": "2016-06-06T00:00:00.000000Z",
         }
+        expected_variation_toblerone_with_user = dict(
+            expected_variation_toblerone,
+            agreedUserEmail="test+2@digital.gov.uk",
+            agreedUserName="my name",
+        )
 
         assert response.status_code == 200
         response_json = json.loads(response.get_data())
@@ -1761,7 +1767,7 @@ class TestSupplierFrameworkVariation(BaseApplicationTest):
         response2 = self.client.get("/suppliers/2/frameworks/g-cloud-8")
         assert response2.status_code == 200
         assert json.loads(response2.get_data())["frameworkInterest"]["agreedVariations"] == {
-            "toblerone": expected_variation_toblerone,
+            "toblerone": expected_variation_toblerone_with_user,
         }
 
         # check we've left the other supplier alone
@@ -1779,10 +1785,13 @@ class TestSupplierFrameworkVariation(BaseApplicationTest):
 
         expected_variation_banana = {
             "agreedUserId": 2,
-            "agreedUserEmail": "test+2@digital.gov.uk",
-            "agreedUserName": "my name",
             "agreedAt": "2016-07-07T00:00:00.000000Z",
         }
+        expected_variation_banana_with_user = dict(
+            expected_variation_banana,
+            agreedUserEmail="test+2@digital.gov.uk",
+            agreedUserName="my name",
+        )
 
         assert response4.status_code == 200
         response4_json = json.loads(response4.get_data())
@@ -1791,8 +1800,8 @@ class TestSupplierFrameworkVariation(BaseApplicationTest):
         response5 = self.client.get("/suppliers/2/frameworks/g-cloud-8")
         assert response5.status_code == 200
         assert json.loads(response5.get_data())["frameworkInterest"]["agreedVariations"] == {
-            "banana": expected_variation_banana,
-            "toblerone": expected_variation_toblerone,
+            "banana": expected_variation_banana_with_user,
+            "toblerone": expected_variation_toblerone_with_user,
         }
 
         # check we can't agree a second time
@@ -1808,8 +1817,8 @@ class TestSupplierFrameworkVariation(BaseApplicationTest):
         response7 = self.client.get("/suppliers/2/frameworks/g-cloud-8")
         assert response7.status_code == 200
         assert json.loads(response7.get_data())["frameworkInterest"]["agreedVariations"] == {
-            "banana": expected_variation_banana,
-            "toblerone": expected_variation_toblerone,
+            "banana": expected_variation_banana_with_user,
+            "toblerone": expected_variation_toblerone_with_user,
         }
 
         with app.app_context():


### PR DESCRIPTION
This should placate @allait 

All views except `get_supplier_frameworks_info` should now return no extended user details.