### PR TITLE
Move preview new supplier flow feature flag well into the future

### DIFF
--- a/config.py
+++ b/config.py
@@ -75,7 +75,7 @@ class Live(Config):
 
 class Preview(Live):
     FEATURE_FLAGS_TRANSACTION_ISOLATION = enabled_since('2015-08-27')
-    FEATURE_FLAGS_NEW_SUPPLIER_FLOW = enabled_since('2016-11-29')
+    FEATURE_FLAGS_NEW_SUPPLIER_FLOW = enabled_since('2017-02-01')
 
 
 class Staging(Live):


### PR DESCRIPTION
We do this so functional tests that rely on current behaviour i.e. the legacy brief response flow, won't break on preview. If the feature flag is on then the legacy flow will break. By setting the flag well into the future, we can still use it for testing by individually manipulating briefs and setting their published time after the feature flag.