### PR TITLE
SQLAlchemy upgrade 

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -645,7 +645,7 @@ class User(db.Model):
     failed_login_count = db.Column(db.Integer, nullable=False, default=0)
 
     # used by frontends to determine whether view access should be allowed
-    role = db.Column(db.Enum(ROLES, name='user_roles_enum'), index=False, unique=False, nullable=False)
+    role = db.Column(db.Enum(*ROLES, name='user_roles_enum'), index=False, unique=False, nullable=False)
 
     supplier_id = db.Column(db.BigInteger,
                             db.ForeignKey('suppliers.supplier_id'),

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ Flask-Migrate==1.3.1
 Flask-Script==2.0.5
 Flask-SQLAlchemy==2.0
 psycopg2==2.5.4
-SQLAlchemy==1.0.5
+SQLAlchemy==1.1.4
 SQLAlchemy-Utils==0.30.5
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@21.4.0#egg=digitalmarketplace-utils==21.4.0


### PR DESCRIPTION
 Upgrading sqlalchemy in the hope of fixing [#135220913]
 - updated calling convention for enum definition (sqlalchemy 1.1 change)
 - seems they made a backward-incompatible change, but the docs always had string-based enums requiring `*args` as far back as 0.9