### PR TITLE
Make bootstrap.sh idempotent

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -8,7 +8,7 @@
 set -o pipefail
 
 if [ ! $VIRTUAL_ENV ]; then
-  virtualenv ./venv
+  make virtualenv
   . ./venv/bin/activate
 fi
 


### PR DESCRIPTION
currently overwrites the virtualenv if none is active which breaks pip