### PR TITLE
Contact information validation

### DIFF
--- a/app/supplier_utils.py
+++ b/app/supplier_utils.py
@@ -9,11 +9,7 @@ def validate_and_return_supplier_request(supplier_id=None):
     json_has_required_keys(json_payload['suppliers'], ['contactInformation'])
 
     # remove unnecessary fields
-    json_payload['suppliers'] = drop_foreign_fields(json_payload['suppliers'], ['links'])
-    json_payload['suppliers']['contactInformation'] = [
-        drop_foreign_fields(contact_data, ['links'])
-        for contact_data in json_payload['suppliers']['contactInformation']
-    ]
+    json_payload['suppliers'] = drop_foreign_fields(json_payload['suppliers'], ['links'], recurse=True)
 
     if supplier_id:
         validate_supplier_json_or_400(json_payload['suppliers'])

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -11,7 +11,8 @@ from app.utils import (display_list,
                        json_has_matching_id,
                        json_has_required_keys,
                        link,
-                       purge_nulls_from_data)
+                       purge_nulls_from_data,
+                       keyfilter_json)
 
 
 def test_link():
@@ -34,6 +35,36 @@ class TestJSONHasMatchingId(BaseApplicationTest):
         with self.app.app_context():
             with pytest.raises(HTTPException):
                 json_has_matching_id(self.data, 78910)
+
+
+class TestKeyFilterJSON(object):
+    def test_null(self):
+        assert keyfilter_json(None, lambda k: True) is None
+        assert keyfilter_json(None, lambda k: False) is None
+
+    def test_recursion(self):
+        assert keyfilter_json({
+            'somelist': [
+                {
+                    'something': 'yes',
+                    'otherthing': 'no'
+                },
+                {
+                    'something': 'maybe',
+                    'otherthing': 'definitely'
+                }
+            ],
+            'something': 'woo'
+        }, lambda k: k != 'something') == {
+            'somelist': [
+                {
+                    'otherthing': 'no'
+                },
+                {
+                    'otherthing': 'definitely'
+                }
+            ],
+        }
 
 
 def test_display_list_two_items():

--- a/tests/app/views/test_suppliers.py
+++ b/tests/app/views/test_suppliers.py
@@ -392,7 +392,8 @@ class TestPutSupplier(BaseApplicationTest, JSONTestMixin):
         response = self.put_import_supplier(payload)
         assert_equal(response.status_code, 400)
         for item in ['JSON was not a valid format',
-                     "is not of type u'array'"]:
+                     'is not of type',
+                     'array']:
             assert_in(item,
                       json.loads(response.get_data())['error'])
 
@@ -963,7 +964,8 @@ class TestPostSupplier(BaseApplicationTest, JSONTestMixin):
         response = self.post_supplier(payload)
         assert_equal(response.status_code, 400)
         for item in ['JSON was not a valid format',
-                     "is not of type u'array'"]:
+                     'is not of type',
+                     'array']:
             assert_in(item,
                       json.loads(response.get_data())['error'])
 

--- a/tests/app/views/test_suppliers.py
+++ b/tests/app/views/test_suppliers.py
@@ -383,6 +383,19 @@ class TestPutSupplier(BaseApplicationTest, JSONTestMixin):
             assert_in(item,
                       json.loads(response.get_data())['error'])
 
+    def test_when_supplier_has_malformed_contact_information(self):
+        payload = self.load_example_listing("Supplier")
+        payload['contactInformation'] = {
+            'wobble': 'woo'
+        }
+
+        response = self.put_import_supplier(payload)
+        assert_equal(response.status_code, 400)
+        for item in ['JSON was not a valid format',
+                     "is not of type u'array'"]:
+            assert_in(item,
+                      json.loads(response.get_data())['error'])
+
     def test_when_supplier_has_a_missing_key(self):
         payload = self.load_example_listing("Supplier")
         payload.pop('id')
@@ -938,6 +951,19 @@ class TestPostSupplier(BaseApplicationTest, JSONTestMixin):
         response = self.post_supplier(payload)
         assert_equal(response.status_code, 400)
         for item in ['Invalid JSON must have', '\'contactInformation\'']:
+            assert_in(item,
+                      json.loads(response.get_data())['error'])
+
+    def test_when_supplier_has_malformed_contact_information(self):
+        payload = self.load_example_listing("new-supplier")
+        payload['contactInformation'] = {
+            'waa': 'woo'
+        }
+
+        response = self.post_supplier(payload)
+        assert_equal(response.status_code, 400)
+        for item in ['JSON was not a valid format',
+                     "is not of type u'array'"]:
             assert_in(item,
                       json.loads(response.get_data())['error'])
 


### PR DESCRIPTION
Allow dropping of 'links' JSON fields in one (recursive) step 
 - by making this generic, we can ensure it works when the data
   is not as expected, e.g. in [#134425439] where we need to
   iterate over a list (of contact information datasets), that
   may (given invalid data) not actually be a list;
 - the actual validation (i.e. checking that the contact information
   is a list) can now be done by the schema-validator. This is
   much tidier than having to add additional schema-like checks
   up-front to make sure we don't crash when stripping 'foreign
   fields' such as 'links'
 - also test cases