### PR TITLE
Add requested buyer email domains to whitelist

### DIFF
--- a/data/buyer-email-domains.txt
+++ b/data/buyer-email-domains.txt
@@ -37,6 +37,7 @@ cwh.org.uk
 dounreay.com
 ekservices.org
 electoralcommission.org.uk
+eoni.org.uk
 equalityhumanrights.com
 esfrs.org
 essexcares.org
@@ -46,6 +47,7 @@ fca.org.uk
 financial-ombudsman.org.uk
 fscs.org.uk
 futureshg.co.uk
+fyldecoastymca.org
 geant.org
 genesisha.org.uk
 genomicsengland.co.uk
@@ -70,14 +72,18 @@ investni.com
 judiciary.uk
 kew.org
 knh.org.uk
+lakesideymca.co.uk
 learningtrust.co.uk
 legalombudsman.org.uk
 lewishamhomes.org.uk
 lfrs.org
 lgfl.net
+library.wales
 liverpoolmh.co.uk
 livin.co.uk
+llgc.org.uk
 llwrsite.com
+llyfrgell.cymru
 llyw.cymru
 londonandpartners.com
 londonlegacy.co.uk
@@ -113,6 +119,7 @@ qualificationswales.org
 rssb.co.uk
 sanctuary-housing.co.uk
 scotent.co.uk
+scotland-excel.org.uk
 scottishwater.co.uk
 sds.co.uk
 sepa.org.uk
@@ -138,5 +145,7 @@ visitengland.org
 wfd.org
 wheatley-group.com
 wwutilities.co.uk
+ymcahousing.org.uk
+ymcayactive.org
 yourhousinggroup.co.uk
 youthsporttrust.org


### PR DESCRIPTION
For the following email domains:

- eoni.org.uk
- fyldecoastymca.org
- lakesideymca.co.uk
- library.wales
- llgc.org.uk
- llyfrgell.cymru
- scotland-excel.org.uk
- ymcahousing.org.uk
- ymcayactive.org
