### PR TITLE
Validate dynamic list `essentialRequirements`

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1370,7 +1370,6 @@ class BriefResponse(db.Model):
         )
 
         if (
-            legacy and
             (required_fields and 'essentialRequirements' in required_fields or enforce_required) and
             'essentialRequirements' not in errs and
             len(self.data.get('essentialRequirements', [])) != len(self.brief.data['essentialRequirements'])

--- a/app/utils.py
+++ b/app/utils.py
@@ -136,17 +136,15 @@ def display_list(l):
 
 
 def strip_whitespace_from_data(data):
-    for key, value in data.items():
-        if isinstance(value, list):
-            # Strip whitespace and remove empty items from lists
-            data[key] = list(
-                filter(lambda x: x != '',
-                       map(lambda x: x.strip() if isinstance(x, string_types) else x, value))
-            )
-        elif isinstance(value, string_types):
-            # Strip whitespace from strings
-            data[key] = value.strip()
-    return data
+    """Recursively strips whitespace and removes empty items from lists"""
+    if isinstance(data, string_types):
+        return data.strip()
+    elif isinstance(data, dict):
+        return {key: strip_whitespace_from_data(value) for key, value in data.items()}
+    elif isinstance(data, list):
+        return list(filter(lambda x: x != '', map(strip_whitespace_from_data, data)))
+    else:
+        return data
 
 
 def purge_nulls_from_data(data):

--- a/json_schemas/brief-responses-digital-outcomes-and-specialists-digital-outcomes.json
+++ b/json_schemas/brief-responses-digital-outcomes-and-specialists-digital-outcomes.json
@@ -12,6 +12,22 @@
         true
       ]
     },
+    "essentialRequirements": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "evidence": {
+            "minLength": 1,
+            "pattern": "^(?:\\S+\\s+){0,99}\\S+$",
+            "type": "string"
+          }
+        },
+        "type": "object",
+        "required": ["evidence"]
+      },
+      "minItems": 0,
+      "type": "array"
+    },
     "niceToHaveRequirements": {
       "items": {
         "type": "boolean"
@@ -29,6 +45,7 @@
   "required": [
     "availability",
     "essentialRequirementsMet",
+    "essentialRequirements",
     "respondToEmailAddress"
   ],
   "title": "Digital Outcomes and Specialists Digital outcomes Brief Response Schema",

--- a/json_schemas/brief-responses-digital-outcomes-and-specialists-digital-specialists.json
+++ b/json_schemas/brief-responses-digital-outcomes-and-specialists-digital-specialists.json
@@ -16,6 +16,22 @@
         true
       ]
     },
+    "essentialRequirements": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "evidence": {
+            "minLength": 1,
+            "pattern": "^(?:\\S+\\s+){0,99}\\S+$",
+            "type": "string"
+          }
+        },
+        "type": "object",
+        "required": ["evidence"]
+      },
+      "minItems": 0,
+      "type": "array"
+    },
     "niceToHaveRequirements": {
       "items": {
         "type": "boolean"
@@ -34,6 +50,7 @@
     "availability",
     "dayRate",
     "essentialRequirementsMet",
+    "essentialRequirements",
     "respondToEmailAddress"
   ],
   "title": "Digital Outcomes and Specialists Digital specialists Brief Response Schema",

--- a/json_schemas/brief-responses-digital-outcomes-and-specialists-user-research-participants.json
+++ b/json_schemas/brief-responses-digital-outcomes-and-specialists-user-research-participants.json
@@ -2,6 +2,22 @@
   "$schema": "http://json-schema.org/schema#",
   "additionalProperties": false,
   "properties": {
+    "essentialRequirements": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "evidence": {
+            "minLength": 1,
+            "pattern": "^(?:\\S+\\s+){0,99}\\S+$",
+            "type": "string"
+          }
+        },
+        "type": "object",
+        "required": ["evidence"]
+      },
+      "minItems": 0,
+      "type": "array"
+    },
     "essentialRequirementsMet": {
       "enum": [
         true
@@ -23,6 +39,7 @@
   },
   "required": [
     "essentialRequirementsMet",
+    "essentialRequirements",
     "respondToEmailAddress"
   ],
   "title": "Digital Outcomes and Specialists User research participants Brief Response Schema",

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -474,9 +474,9 @@ class TestBriefResponses(BaseApplicationTest):
 
     def test_whitespace_is_stripped_from_brief_response_data(self):
         brief_response = BriefResponse(data={})
-        brief_response.data = {'foo': ' bar ', 'bar': ['', '  foo']}
+        brief_response.data = {'foo': ' bar ', 'bar': ['', '  foo', {'evidence': ' some '}]}
 
-        assert brief_response.data == {'foo': 'bar', 'bar': ['foo']}
+        assert brief_response.data == {'foo': 'bar', 'bar': ['foo', {'evidence': 'some'}]}
 
     def test_submitted_status_for_brief_response_with_submitted_at(self):
         brief_response = BriefResponse(created_at=datetime.utcnow(), submitted_at=datetime.utcnow())

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -79,13 +79,23 @@ def test_display_list_three_items():
     assert display_list(test_list) == expected
 
 
-def test_strip_whitespace_from_data():
+def test_strip_whitespace_from_data_with_string_data():
     struct = {"eggs": "  ham "}
     assert strip_whitespace_from_data(struct)['eggs'] == "ham"
+
+
+def test_strip_whitespace_from_data_with_list_data():
     struct_with_list = {"eggs": ["  spam  ", "  ham  ", "  eggs "]}
     after_strip = strip_whitespace_from_data(struct_with_list)
     for item in after_strip['eggs']:
         assert " " not in item
+
+
+def test_strip_whitespace_from_data_with_dict_data():
+    struct = {"eggs": [{'evidence': ' whitespace in here '}, {'evidence': 'no white space'}]}
+    assert strip_whitespace_from_data(struct) == {
+        "eggs": [{'evidence': 'whitespace in here'}, {'evidence': 'no white space'}]
+    }
 
 
 def test_purge_nulls():

--- a/tests/app/test_validation.py
+++ b/tests/app/test_validation.py
@@ -490,6 +490,37 @@ def test_max_price_larger_than_min_does_not_overwrite_previous_errors():
     assert_equal(errors, {'developerPriceMax': 'max_less_than_min'})
 
 
+def test_brief_response_essential_requirements():
+    assert get_validation_errors(
+        "brief-responses-digital-outcomes-and-specialists-digital-specialists",
+        {
+            "availability": "valid start date",
+            "dayRate": "100",
+            "essentialRequirementsMet": True,
+            "essentialRequirements": [
+                {"evidence": "valid evidence"},
+                {"evidence": "word " * 100},
+                {"evidence": "some more valid evidence"},
+                {}
+            ],
+            "respondToEmailAddress": "valid@email.com"
+        }
+    ) == {
+        'essentialRequirements': [
+            {
+                'error': 'under_100_words',
+                'field': u'evidence',
+                'index': 1
+            },
+            {
+                'error': 'answer_required',
+                'field': u'evidence',
+                'index': 3
+            },
+        ]
+    }
+
+
 def test_api_type_is_optional():
     data = load_example_listing("G6-PaaS")
     del data["apiType"]

--- a/tests/app/views/test_brief_response.py
+++ b/tests/app/views/test_brief_response.py
@@ -608,8 +608,12 @@ class TestUpdateBriefResponseForBriefCreatedAfterFeatureFlag(UpdateBriefResponse
             self.brief_response_id, {'essentialRequirements': [True, True, True, True, True]}
         )
         assert res.status_code == 400
+
         data = json.loads(res.get_data(as_text=True))
-        assert "'essentialRequirements' was unexpected" in data["error"]["_form"][0]
+        message = data['error']['essentialRequirements']
+
+        assert 'True is not of type' in message
+        assert 'object' in message
 
     def test_brief_response_can_be_updated_with_non_legacy_data(self, live_dos_framework):
         res = self._update_brief_response(
@@ -781,6 +785,7 @@ class TestSubmitBriefReponseWhenFeatureFlagIsOff(TestSubmitBriefReponseForBriefC
 class TestSubmitBriefReponseForBriefCreatedAfterFeatureFlag(SubmitBriefResponseSharedTests):
     valid_brief_response_data = {
         'essentialRequirementsMet': True,
+        'essentialRequirements': [{'evidence': 'text'}] * 5,
         'niceToHaveRequirements': [True, False, True, False, True],
         'availability': u'a',
         'respondToEmailAddress': 'supplier@email.com'
@@ -807,6 +812,7 @@ class TestSubmitBriefReponseForBriefCreatedAfterFeatureFlag(SubmitBriefResponseS
         assert data == {
             'error': {
                 'availability': 'answer_required',
+                'essentialRequirements': 'answer_required',
                 'essentialRequirementsMet': 'answer_required',
                 'niceToHaveRequirements': 'answer_required',
                 'respondToEmailAddress': 'answer_required'
@@ -833,11 +839,14 @@ class TestSubmitBriefReponseForBriefCreatedAfterFeatureFlag(SubmitBriefResponseS
         self.app.config["FEATURE_FLAGS_NEW_SUPPLIER_FLOW"] = self.feature_flag_date
 
         submit_res = self._submit_brief_response(brief_response_id)
-        data = json.loads(submit_res.get_data(as_text=True))
-
         assert submit_res.status_code == 400
-        assert "'essentialRequirements' was unexpected" in data['error']['_form'][0]
+
+        data = json.loads(submit_res.get_data(as_text=True))
         assert data['error']['essentialRequirementsMet'] == "answer_required"
+
+        message = data['error']['essentialRequirements']
+        assert 'True is not of type' in message
+        assert 'object' in message
 
 
 class TestGetBriefResponse(BaseBriefResponseTest):

--- a/tests/app/views/test_brief_response.py
+++ b/tests/app/views/test_brief_response.py
@@ -481,6 +481,26 @@ class TestCreateBriefResponseForBriefCreatedAfterFeatureFlag(CreateBriefResponse
         data = json.loads(res.get_data(as_text=True))
         assert res.status_code == 400
 
+    def test_cannot_respond_to_a_brief_with_wrong_number_of_essential_reqs(self, live_dos_framework):
+        res = self.client.post(
+            '/brief-responses',
+            data=json.dumps({
+                'updated_by': 'test@example.com',
+                'briefResponses': {
+                    "supplierId": 0,
+                    "briefId": self.brief_id,
+                    "essentialRequirements": [{'evidence': 'Some'}]
+                },
+                'page_questions': ["essentialRequirements"]
+            }),
+            content_type='application/json'
+        )
+
+        data = json.loads(res.get_data(as_text=True))
+
+        assert res.status_code == 400, res.get_data(as_text=True)
+        assert data['error']['essentialRequirements'] == 'answer_required'
+
 
 class UpdateBriefResponseSharedTests(BaseBriefResponseTest):
     def setup(self):

--- a/tests/app/views/test_brief_response.py
+++ b/tests/app/views/test_brief_response.py
@@ -653,6 +653,7 @@ class TestUpdateBriefResponseForBriefCreatedAfterFeatureFlag(UpdateBriefResponse
             self.brief_response_id, {'essentialRequirementsMet': False}
         )
         assert res.status_code == 400
+
         data = json.loads(res.get_data(as_text=True))
         assert data["error"] == {'essentialRequirementsMet': 'not_required_value'}
 


### PR DESCRIPTION
#### Work done
Pivotal story - https://www.pivotaltracker.com/story/show/129841565

- Update JSON schemas for new brief response flow including the `essentialRequirements` dynamic list question
- Validate `essentialRequirements` question, see test for an example of how the validation works. Note, if you do not answer the evidence question on the front end then we send an empty dict to the API which is covered in our test.
- Validate correct number of essential requirements in brief response as per [this story](https://www.pivotaltracker.com/story/show/136045527)

#### Further thought
- Not sure on if we are happy with validation messages for when booleans are passed instead of objects. This is not expected input from the front end but someone could post this directly to the API.

```
"essentialRequirements": [
        {"evidence": "valid evidence"},
        True
],
```
gives validation error:
```
{u'essentialRequirements': u"True is not of type u'object'"}
```

Is it worth the effort of trying to make it 
```
{
    'essentialRequirements': [
        {
            'error': u"True is not of type u'object'",
            'index': 1
        },
    ]
}
```