### PR TITLE
135223377-application_status

### DIFF
--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -234,6 +234,7 @@ def export_users_for_framework(framework_slug):
     if framework.status == 'coming':
         abort(400, 'framework not yet open')
 
+    suppliers_with_a_complete_service = framework.get_supplier_ids_for_completed_service()
     supplier_frameworks_and_users = db.session.query(
         SupplierFramework, User
     ).join(
@@ -250,6 +251,9 @@ def export_users_for_framework(framework_slug):
 
         # always get the declaration status
         declaration_status = sf.declaration.get('status') if sf.declaration else 'unstarted'
+        application_status = 'application' if (
+            declaration_status == 'complete' and sf.supplier_id in suppliers_with_a_complete_service
+        ) else 'no_application'
         application_result = ''
         framework_agreement = ''
         variations_agreed = ''
@@ -268,7 +272,7 @@ def export_users_for_framework(framework_slug):
             'user_name': u.name,
             'supplier_id': sf.supplier_id,
             'declaration_status': declaration_status,
-            'application_status': '',
+            'application_status': application_status,
             'framework_agreement': framework_agreement,
             'application_result': application_result,
             'variations_agreed': variations_agreed

--- a/app/models.py
+++ b/app/models.py
@@ -119,6 +119,19 @@ class Framework(db.Model):
             'lots': [lot.serialize() for lot in self.lots],
         }
 
+    def get_supplier_ids_for_completed_service(self):
+        """Only suppliers whose service has a status of submitted or failed."""
+        unpack_list_of_lists = lambda l: set(item for sublist in l for item in sublist)
+        results = db.session.query(
+            DraftService
+        ).filter(
+            DraftService.status.in_(('submitted', 'failed')),
+            DraftService.framework_id == self.id
+        ).with_entities(
+            DraftService.supplier_id
+        ).distinct()
+        return unpack_list_of_lists(results)
+
     @validates('status')
     def validates_status(self, key, value):
         if value not in self.STATUSES:

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -12,7 +12,9 @@ from app.models import (
     Supplier, SupplierFramework, FrameworkAgreement,
     Brief, BriefResponse,
     ValidationError,
-    BriefClarificationQuestion
+    BriefClarificationQuestion,
+    DraftService,
+    FrameworkLot
 )
 
 from .helpers import BaseApplicationTest
@@ -892,6 +894,104 @@ class TestLot(BaseApplicationTest):
                 u'unitSingular': u'lab',
                 u'unitPlural': u'labs',
             }
+
+
+class TestFrameworkSupplierIds(BaseApplicationTest):
+    """Test getting supplier ids for framework."""
+
+    def test_1_supplier(self, draft_service):
+        """Test that when one supplier exists in the framework that only supplier is shown."""
+        with self.app.app_context():
+            ds = DraftService.query.filter(DraftService.service_id == draft_service['serviceId']).first()
+            f = Framework.query.filter(Framework.id == ds.framework_id).first()
+            supplier_ids_with_completed_service = f.get_supplier_ids_for_completed_service()
+            assert len(supplier_ids_with_completed_service) == 1
+            assert ds.supplier.supplier_id in supplier_ids_with_completed_service
+
+    def test_submitted_shows(self, draft_service):
+        """Test sevice with status 'submitted' is shown."""
+        with self.app.app_context():
+            ds = DraftService.query.filter(DraftService.service_id == draft_service['serviceId']).first()
+            f = Framework.query.filter(Framework.id == ds.framework_id).first()
+            supplier_ids_with_completed_service = f.get_supplier_ids_for_completed_service()
+            assert ds.status == 'submitted'
+            assert ds.supplier.supplier_id in supplier_ids_with_completed_service
+
+    def test_failed_shows(self, draft_service):
+        """Test sevice with status 'failed' is shown."""
+        with self.app.app_context():
+            ds = DraftService.query.filter(DraftService.service_id == draft_service['serviceId']).first()
+            ds.status = 'failed'
+            db.session.add(ds)
+            db.session.commit()
+            f = Framework.query.filter(Framework.id == ds.framework_id).first()
+            supplier_ids_with_completed_service = f.get_supplier_ids_for_completed_service()
+            assert ds.status == 'failed'
+            assert ds.supplier.supplier_id in supplier_ids_with_completed_service
+
+    def test_not_submitted_does_not_show(self, draft_service):
+        """Test sevice with status 'not-submitted' is not shown."""
+        with self.app.app_context():
+            ds = DraftService.query.filter(DraftService.service_id == draft_service['serviceId']).first()
+            ds.status = 'not-submitted'
+            db.session.add(ds)
+            db.session.commit()
+            f = Framework.query.filter(Framework.id == ds.framework_id).first()
+            supplier_ids_with_completed_service = f.get_supplier_ids_for_completed_service()
+            assert ds.status == 'not-submitted'
+            assert ds.supplier.supplier_id not in supplier_ids_with_completed_service
+
+    def test_no_suppliers(self, open_example_framework):
+        """Test a framework with no suppliers on it returns no submitted services."""
+        with self.app.app_context():
+            f = Framework.query.filter(Framework.id == open_example_framework['id']).first()
+            supplier_ids_with_completed_service = f.get_supplier_ids_for_completed_service()
+            assert len(supplier_ids_with_completed_service) == 0
+
+
+class TestFrameworkSupplierIdsMany(BaseApplicationTest):
+    """Test multiple suppliers, multiple services."""
+
+    def test_multiple_services(self):
+        with self.app.app_context():
+            self.setup_dos_2_framework()
+            lot = Lot.query.first()
+            self.fl_query = {
+                'framework_id': 101,
+                'lot_id': lot.id
+            }
+            fl = FrameworkLot(**self.fl_query)
+            db.session.add(fl)
+            db.session.commit()
+
+            # Set u 5 dummy suppliers
+            self.setup_dummy_suppliers(5)
+            supplier_ids = range(5)
+            # 5 sets of statuses for their respective services.
+            service_status_choices = [
+                ('failed',),
+                ('not-submitted',),
+                ('failed', 'failed', 'failed', 'not-submitted', 'submitted', 'submitted', 'not-submitted', 'failed'),
+                (),
+                ('not-submitted', 'submitted', 'not-submitted', 'not-submitted', 'failed')
+            ]
+            # For the supplier, service_status sets create the services and draft services.
+            count = 0
+            for supplier_id, service_statuses in zip(supplier_ids, service_status_choices):
+                for service_status in service_statuses:
+                    service_id = str(count)*10
+                    count += 1
+                    service = self.setup_dummy_service(service_id, supplier_id=supplier_id, **self.fl_query)
+
+                    db.session.commit()
+                    with mock.patch('app.models.url_for', autospec=lambda i, **values: 'test.url/test'):
+                        ds = DraftService.from_service(Service.query.filter(Service.service_id == service_id).first())
+                        ds.status = service_status
+                    db.session.add(ds)
+                    db.session.commit()
+            # Assert that only those suppliers whose service_status list contains failed and/ or submitted are returned.
+            framework = Framework.query.filter(Framework.id == 101).first()
+            assert sorted(framework.get_supplier_ids_for_completed_service()) == [0, 2, 4]
 
 
 class TestFrameworkAgreements(BaseApplicationTest):

--- a/tests/app/views/test_users.py
+++ b/tests/app/views/test_users.py
@@ -1260,7 +1260,7 @@ class TestUsersExport(BaseUserTest):
     def _assert_things_about_export_response(self, row, parameters=None):
         _parameters = {
             'application_result': 'no result',
-            'application_status': '',
+            'application_status': 'no_application',
             'declaration_status': 'unstarted',
             'framework_agreement': False,
         }
@@ -1341,7 +1341,7 @@ class TestUsersExport(BaseUserTest):
         for datum in data:
             self._assert_things_about_export_response(datum, parameters={
                 'declaration_status': 'complete',
-                'application_status': ''
+                'application_status': 'application'
             })
 
     # Test users for supplier with completed declaration one draft but framework still open
@@ -1354,7 +1354,7 @@ class TestUsersExport(BaseUserTest):
         for datum in data:
             self._assert_things_about_export_response(datum, parameters={
                 'declaration_status': 'complete',
-                'application_status': '',
+                'application_status': 'application',
                 'application_result': '',
                 'framework_agreement': ''
             })
@@ -1370,7 +1370,7 @@ class TestUsersExport(BaseUserTest):
         for datum in data:
             self._assert_things_about_export_response(datum, parameters={
                 'declaration_status': 'complete',
-                'application_status': '',
+                'application_status': 'application',
                 'framework_agreement': True,
                 'application_result': 'pass'
             })
@@ -1385,7 +1385,7 @@ class TestUsersExport(BaseUserTest):
         for datum in data:
             self._assert_things_about_export_response(datum, parameters={
                 'declaration_status': 'complete',
-                'application_status': '',
+                'application_status': 'application',
                 'framework_agreement': False,
                 'application_result': 'fail'
             })
@@ -1437,7 +1437,7 @@ class TestUsersExport(BaseUserTest):
         for datum in data:
             self._assert_things_about_export_response(datum, parameters={
                 'declaration_status': 'complete',
-                'application_status': '',
+                'application_status': 'application',
                 'application_result': 'pass',
                 'framework_agreement': True,
                 'agreed_variations': '1'


### PR DESCRIPTION
This adds a method on Framework to get all supplier id's who have managed to successfully complete inputting a service.
This info is added to the `export_users_for_framework` view in `views/users.py`.

It also adds a new `py.test` fixture in `conftest.py` which supplies a draft service.