### PR TITLE
Update user research participants brief response schema to allow availability question

### DIFF
--- a/json_schemas/brief-responses-digital-outcomes-and-specialists-user-research-participants.json
+++ b/json_schemas/brief-responses-digital-outcomes-and-specialists-user-research-participants.json
@@ -2,6 +2,11 @@
   "$schema": "http://json-schema.org/schema#",
   "additionalProperties": false,
   "properties": {
+    "availability": {
+      "maxLength": 100,
+      "minLength": 1,
+      "type": "string"
+    },
     "essentialRequirements": {
       "items": {
         "additionalProperties": false,
@@ -88,6 +93,7 @@
     }
   },
   "required": [
+    "availability",
     "essentialRequirements",
     "essentialRequirementsMet",
     "respondToEmailAddress"


### PR DESCRIPTION
Part of this story on Pivotal [https://www.pivotaltracker.com/story/show/135599725](https://www.pivotaltracker.com/story/show/135599725)
See complimentary PR on the frameworks here: [https://github.com/alphagov/digitalmarketplace-frameworks/pull/354](https://github.com/alphagov/digitalmarketplace-frameworks/pull/354)
See complimentary PR no the supplier frontend here: [https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/586](https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/586)

Previously suppliers did not need to answer the availability question if applying to a user research participants brief, unlike for specialists or outcomes.

The PR on the frameworks repo adds the availability question for user research participants. This means that the json schema on the api needs updating to allow availability to be stored.