### PR TITLE
Revert change from services to products for G9 lots

### DIFF
--- a/migrations/versions/820_untweak_g9_lots.py
+++ b/migrations/versions/820_untweak_g9_lots.py
@@ -1,0 +1,30 @@
+"""no lots are products for G-Cloud 9 - they are all services
+
+Revision ID: 820
+Revises: 810
+Create Date: 2017-02-01 11:20:00.000000
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '820'
+down_revision = '810'
+
+from alembic import op
+
+
+def upgrade():
+    # Update G-Cloud 9 lot records
+
+    op.execute("""
+        UPDATE lots SET data = '{"unitSingular": "service", "unitPlural": "services"}'
+        WHERE slug in ('cloud-hosting', 'cloud-software');
+    """)
+
+
+def downgrade():
+
+    op.execute("""
+            UPDATE lots SET data = '{"unitSingular": "product", "unitPlural": "products"}'
+            WHERE slug in ('cloud-hosting', 'cloud-software');
+        """)


### PR DESCRIPTION
As confirmed at standup this morning - directive from CCS and lawyers - it must be "services".

No one is going to change their minds about this ever again, 100% guaranteed.