### PR TITLE
Sort out db's `naming_convention`

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -3,6 +3,7 @@ from flask import Flask
 from flask.ext.bootstrap import Bootstrap
 from flask.ext.sqlalchemy import SQLAlchemy
 import json
+from sqlalchemy import MetaData
 
 import dmapiclient
 from dmutils import init_app, flask_featureflags
@@ -10,7 +11,13 @@ from dmutils import init_app, flask_featureflags
 from config import configs
 
 bootstrap = Bootstrap()
-db = SQLAlchemy()
+db = SQLAlchemy(metadata=MetaData(naming_convention={
+    "ix": 'ix_%(column_0_label)s',
+    "uq": "uq_%(table_name)s_%(column_0_name)s",
+    "ck": "ck_%(table_name)s_%(constraint_name)s",
+    "fk": "fk_%(table_name)s_%(column_0_name)s_%(referred_table_name)s",
+    "pk": "pk_%(table_name)s",
+}))
 search_api_client = dmapiclient.SearchAPIClient()
 feature_flags = flask_featureflags.FeatureFlag()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 Flask==0.10.1
 Flask-Bcrypt==0.7.1
 Flask-Bootstrap==3.3.0.1
-Flask-Migrate==1.3.1
+Flask-Migrate==2.0.3
 Flask-Script==2.0.5
-Flask-SQLAlchemy==2.0
+Flask-SQLAlchemy==2.1
 psycopg2==2.5.4
 SQLAlchemy==1.1.4
 SQLAlchemy-Utils==0.30.5


### PR DESCRIPTION
@allait pokety poke

It might be the SQLAlchemy 1.1 upgrade that has stopped our migrations auto-generating predictable constraint names. Either way, this seems to be the current recommended way of specifying our `naming_convention`, requiring a `Flask-SQLAlchemy` version bump to accept the `metadata=` argument.

I've included a version bump for `Flask-Migrate` at the same time because it was depending on a 3 year old version (which is what pulls in alembic for us).