### PR TITLE
update dos framework.framework to be 'digital-outcomes-and-specialists'

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -88,6 +88,7 @@ class Framework(db.Model):
     FRAMEWORKS = (
         'g-cloud',
         'dos',
+        'digital-outcomes-and-specialists',
     )
 
     id = db.Column(db.Integer, primary_key=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -211,7 +211,7 @@ _g6_framework_defaults = {
 }
 _dos_framework_defaults = {
     "slug": "digital-outcomes-and-specialists",
-    "framework": "dos",
+    "framework": "digital-outcomes-and-specialists",
     "framework_agreement_details": None,
 }
 _example_framework_details = {

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -223,7 +223,7 @@ class FixtureMixin(object):
                     id=101,
                     slug=u'digital-outcomes-and-specialists-2',
                     name=u'Digital Outcomes and Specialists 2',
-                    framework=u'dos',
+                    framework=u'digital-outcomes-and-specialists',
                     status=status,
                     clarification_questions_open=clarifications,
                     lots=[Lot.query.filter(Lot.slug == 'digital-outcomes').first(),

--- a/tests/main/views/test_briefs.py
+++ b/tests/main/views/test_briefs.py
@@ -414,7 +414,7 @@ class TestBriefs(BaseApplicationTest, FixtureMixin):
                 'id': 1,
                 'status': 'draft',
                 'frameworkSlug': 'digital-outcomes-and-specialists',
-                'frameworkFramework': 'dos',
+                'frameworkFramework': 'digital-outcomes-and-specialists',
                 'frameworkName': 'Digital Outcomes and Specialists',
                 'frameworkStatus': 'live',
                 'lot': 'digital-specialists',

--- a/tests/main/views/test_briefs.py
+++ b/tests/main/views/test_briefs.py
@@ -409,14 +409,18 @@ class TestBriefs(BaseApplicationTest, FixtureMixin):
 
         assert res.status_code == 200
         expected_data = COMPLETE_DIGITAL_SPECIALISTS_BRIEF.copy()
+
+        with self.app.app_context():
+            framework = Framework.query.filter(Framework.slug == 'digital-outcomes-and-specialists').first()
+
         expected_data.update(
             {
                 'id': 1,
                 'status': 'draft',
-                'frameworkSlug': 'digital-outcomes-and-specialists',
-                'frameworkFramework': 'digital-outcomes-and-specialists',
-                'frameworkName': 'Digital Outcomes and Specialists',
-                'frameworkStatus': 'live',
+                'frameworkSlug': framework.slug,
+                'frameworkFramework': framework.framework,
+                'frameworkName': framework.name,
+                'frameworkStatus': framework.status,
                 'lot': 'digital-specialists',
                 'lotSlug': 'digital-specialists',
                 'lotName': 'Digital specialists',

--- a/tests/main/views/test_frameworks.py
+++ b/tests/main/views/test_frameworks.py
@@ -207,7 +207,7 @@ class TestUpdateFramework(BaseApplicationTest, JSONUpdateTestMixin):
             'id': 1,
             'name': "Example Framework 2",
             'slug': "example-framework-2",
-            'framework': "dos",
+            'framework': "digital-outcomes-and-specialists",
             'frameworkAgreementDetails': {
                 "countersignerName": "Dan Saxby",
                 "frameworkAgreementVersion": "v1.0",


### PR DESCRIPTION
We need to rename `framework.framework` for dos frameworks. It will be renamed from 'dos' to 'digital-outcomes-and-specialists'.

This code change precedes the migration. There will be similar pull requests on the buyer and supplier frontend to ensure backwards compatbility. After the migration we can then remove 'dos' from our apps.