### PR TITLE
SupplierFramework model: make prefill_declaration_from_supplier_framework relationship viewonly

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -383,6 +383,8 @@ class SupplierFramework(db.Model):
         lazy="select",
         foreign_keys=(supplier_id, prefill_declaration_from_framework_id,),
         remote_side=(supplier_id, framework_id,),
+        # we probably don't want people inadvertantly flipping the supplier_id through writing to this relationship
+        viewonly=True,
     )
 
     # vvvv current_framework_agreement defined further down (after FrameworkAgreement) vvvv


### PR DESCRIPTION
A quick fix following https://github.com/alphagov/digitalmarketplace-api/pull/526

This should silence a warning from sqlalchemy about a collision of multiple
relationships being able to write to `supplier_id` - we probably don't want
people being able to inadvertantly flip the `supplier_id` through setting
`prefill_declaration_from_supplier_framework` anyway