### PR TITLE
Migrate draft DOS1 briefs to draft DOS2 briefs

### DIFF
--- a/migrations/versions/840_migrate_draft_dos1_briefs_to_draft_dos2.py
+++ b/migrations/versions/840_migrate_draft_dos1_briefs_to_draft_dos2.py
@@ -1,0 +1,26 @@
+"""Migrate draft DOS1 briefs to draft DOS2 briefs
+
+Revision ID: 840
+Revises: 830
+Create Date: 2017-02-07 15:31:50.715832
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '840'
+down_revision = '830'
+
+from alembic import op
+
+def upgrade():
+    # Change framework of draft DOS1 briefs from DOS1 (framework_id == 5) to DOS2 (framework_id == 7)
+    op.execute("""
+        UPDATE briefs
+        SET framework_id = 7
+        WHERE framework_id = 5 AND published_at IS NULL
+    """)
+
+
+def downgrade():
+    # No downgrade
+    pass

--- a/migrations/versions/840_migrate_draft_dos1_briefs_to_draft_dos2.py
+++ b/migrations/versions/840_migrate_draft_dos1_briefs_to_draft_dos2.py
@@ -18,13 +18,13 @@ def upgrade():
 
     dos1_res = conn.execute("""
         SELECT id FROM frameworks
-        WHERE name = 'Digital Outcomes and Specialists'
+        WHERE slug = 'digital-outcomes-and-specialists'
     """)
     dos1_framework_id = dos1_res.fetchall()[0][0]
 
     dos2_res = conn.execute("""
         SELECT id FROM frameworks
-        WHERE name = 'Digital Outcomes and Specialists 2'
+        WHERE slug = 'digital-outcomes-and-specialists-2'
     """)
 
     # DOS2 framework was not created with a migration, it was created via the API. This means that when the tests run
@@ -66,8 +66,6 @@ def upgrade():
         SET framework_id = :dos2_id
         WHERE framework_id = :dos1_id AND published_at IS NULL
     """), **framework_ids)
-
-
 
 def downgrade():
     # No downgrade

--- a/migrations/versions/840_migrate_draft_dos1_briefs_to_draft_dos2.py
+++ b/migrations/versions/840_migrate_draft_dos1_briefs_to_draft_dos2.py
@@ -42,10 +42,31 @@ def upgrade():
     }
 
     conn.execute(text("""
+        INSERT INTO audit_events (
+            type,
+            created_at,
+            "user",
+            data,
+            object_type,
+            object_id,
+            acknowledged
+        ) SELECT
+            'update_brief_framework_id',
+            NOW(),
+            'Migration 840',
+            '{ "previousFrameworkId": :dos1_id, "newFrameworkId": :dos2_id }',
+            'Brief',
+            briefs.id,
+            false
+        FROM briefs WHERE framework_id = :dos1_id AND published_at IS NULL
+    """), **framework_ids)
+
+    conn.execute(text("""
         UPDATE briefs
         SET framework_id = :dos2_id
         WHERE framework_id = :dos1_id AND published_at IS NULL
     """), **framework_ids)
+
 
 
 def downgrade():

--- a/migrations/versions/840_migrate_draft_dos1_briefs_to_draft_dos2.py
+++ b/migrations/versions/840_migrate_draft_dos1_briefs_to_draft_dos2.py
@@ -11,6 +11,7 @@ revision = '840'
 down_revision = '830'
 
 from alembic import op
+from sqlalchemy.sql import text
 
 def upgrade():
     conn = op.get_bind()
@@ -35,11 +36,16 @@ def upgrade():
 
     dos2_framework_id = query_results[0][0]
 
-    op.execute("""
+    framework_ids = {
+        "dos1_id": dos1_framework_id,
+        "dos2_id": dos2_framework_id
+    }
+
+    conn.execute(text("""
         UPDATE briefs
-        SET framework_id = {}
-        WHERE framework_id = {} AND published_at IS NULL
-    """.format(dos2_framework_id, dos1_framework_id))
+        SET framework_id = :dos2_id
+        WHERE framework_id = :dos1_id AND published_at IS NULL
+    """), **framework_ids)
 
 
 def downgrade():

--- a/migrations/versions/860_migrate_draft_dos1_briefs_to_draft_dos2.py
+++ b/migrations/versions/860_migrate_draft_dos1_briefs_to_draft_dos2.py
@@ -1,14 +1,14 @@
 """Migrate draft DOS1 briefs to draft DOS2 briefs
 
-Revision ID: 840
-Revises: 830
+Revision ID: 860
+Revises: 850
 Create Date: 2017-02-07 15:31:50.715832
 
 """
 
 # revision identifiers, used by Alembic.
-revision = '840'
-down_revision = '830'
+revision = '860'
+down_revision = '850'
 
 from alembic import op
 from sqlalchemy.sql import text
@@ -53,7 +53,7 @@ def upgrade():
         ) SELECT
             'update_brief_framework_id',
             NOW(),
-            'Migration 840',
+            'Migration 860',
             '{ "previousFrameworkId": :dos1_id, "newFrameworkId": :dos2_id }',
             'Brief',
             briefs.id,


### PR DESCRIPTION
NOT TO BE MERGED UNTIL DOS2 IS LIVE AND DOS1 IS CLOSED FOR BRIEF SUBMISSIONS

For this story on Pivotal [https://www.pivotaltracker.com/story/show/137359003](https://www.pivotaltracker.com/story/show/137359003)

When DOS1 is closed for brief submissions and DOS2 opens, any supplier
who has a draft DOS1 brief will effectively lose it, as they'll be
unable to publish it.

This migration will move all draft DOS1 briefs to be draft DOS2 briefs,
allowing them to be published. Which framework the brief
goes into doesn't affect buyers - they are eligible by default.

This will need to be run immediately after DOS1 is closed so that no
buyer attempt to publish their DOS1 brief in the period between DOS1
closing and the migration happening.

UPDATE:
This migration was breaking all of the tests. To make this migration agnostic of the environment, it checks the id's of the DOS1 and DOS2 frameworks and uses those id's to update the rows it needs to. DOS1 was created with a migration so it is present in the db when this migration runs. DOS2 however was set up via the API and so it NOT present. Doing a `fetchall()` on the response from the database for an SQL statement that didn't find anything returns a list, and trying to access an index of that list is what broke the tests.

To fix this, I've set the migration up to bail out if it doesn't get a response from querying the id of DOS2. This feels a bit weird. There's another option, which is to import `current_app` from flask and check the environment variable in the config. If it's `test` then skip the migration. Again, feels a bit weird.

Another option would be to hard code the framework id's depending on the environment (accessed as mentioned above), so that the database doesn't need to be queried in the migration. It then wouldn't find any frameworks with that id when trying to perform the update so shouldn't kick an error.

Any thoughts are more than welcome.

