### PR TITLE
Remove old 'dos' allowed value for `framework.framework`

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -87,7 +87,6 @@ class Framework(db.Model):
     )
     FRAMEWORKS = (
         'g-cloud',
-        'dos',
         'digital-outcomes-and-specialists',
     )
 


### PR DESCRIPTION
framework.framework has now been migrated to be 'digital-outcomes-and-specialists' rather than 'dos'. The line removed was to maintain backwards compatibility whilst that migration was rolled out.

For reference: original backwards compatibility API PR - https://github.com/alphagov/digitalmarketplace-api/pull/527