### PR TITLE
Follow up questions

### DIFF
--- a/app/validation.py
+++ b/app/validation.py
@@ -168,7 +168,7 @@ def translate_json_schema_errors(errors, json_data):
     form_errors = []
     for error in errors:
         # validate follow-up questions are answered: eg evidence given for a 'yes' nice-to-have
-        if error.validator == 'oneOf':
+        if error.validator == 'oneOf' and error.path:
             key, index = error.path
             if key not in error_map:
                 error_map[key] = []
@@ -194,6 +194,15 @@ def translate_json_schema_errors(errors, json_data):
                     'index': index,
                     'error': error.message
                 })
+
+        elif error.validator == 'oneOf':
+            required_contexts = [e for e in error.context if e.validator == 'required']
+            if required_contexts:
+                field = re.search(r"'(.*)'", required_contexts[0].message).group(1)
+                error_map[field] = 'answer_required'
+            else:
+                field = re.search(r"'([^']*)'", error.message).group(1)
+                error_map[field] = error.message
 
         # validate fields two deep that have required properties e.g. no evidence given for essentialRequirements[1]
         elif error.path and len(error.path) == 2 and error.validator == 'required':

--- a/app/validation.py
+++ b/app/validation.py
@@ -201,8 +201,7 @@ def translate_json_schema_errors(errors, json_data):
                 field = re.search(r"'(.*)'", required_contexts[0].message).group(1)
                 error_map[field] = 'answer_required'
             else:
-                field = re.search(r"'([^']*)'", error.message).group(1)
-                error_map[field] = error.message
+                form_errors.append(error.message)
 
         # validate fields two deep that have required properties e.g. no evidence given for essentialRequirements[1]
         elif error.path and len(error.path) == 2 and error.validator == 'required':

--- a/json_schemas/brief-responses-digital-outcomes-and-specialists-2-digital-outcomes.json
+++ b/json_schemas/brief-responses-digital-outcomes-and-specialists-2-digital-outcomes.json
@@ -22,7 +22,7 @@
         ],
         "type": "object"
       },
-      "minItems": 0,
+      "minItems": 1,
       "type": "array"
     },
     "essentialRequirementsMet": {
@@ -46,17 +46,10 @@
                       false
                     ]
                   }
-                },
-                "required": [
-                  "yesNo"
-                ]
+                }
               },
               {
                 "properties": {
-                  "evidence": {
-                    "minLength": 1,
-                    "type": "string"
-                  },
                   "yesNo": {
                     "enum": [
                       true
@@ -81,6 +74,9 @@
             "type": "boolean"
           }
         },
+        "required": [
+          "yesNo"
+        ],
         "type": "object"
       },
       "minItems": 0,

--- a/json_schemas/brief-responses-digital-outcomes-and-specialists-2-digital-specialists.json
+++ b/json_schemas/brief-responses-digital-outcomes-and-specialists-2-digital-specialists.json
@@ -26,7 +26,7 @@
         ],
         "type": "object"
       },
-      "minItems": 0,
+      "minItems": 1,
       "type": "array"
     },
     "essentialRequirementsMet": {
@@ -50,17 +50,10 @@
                       false
                     ]
                   }
-                },
-                "required": [
-                  "yesNo"
-                ]
+                }
               },
               {
                 "properties": {
-                  "evidence": {
-                    "minLength": 1,
-                    "type": "string"
-                  },
                   "yesNo": {
                     "enum": [
                       true
@@ -85,6 +78,9 @@
             "type": "boolean"
           }
         },
+        "required": [
+          "yesNo"
+        ],
         "type": "object"
       },
       "minItems": 0,

--- a/json_schemas/brief-responses-digital-outcomes-and-specialists-2-user-research-participants.json
+++ b/json_schemas/brief-responses-digital-outcomes-and-specialists-2-user-research-participants.json
@@ -22,7 +22,7 @@
         ],
         "type": "object"
       },
-      "minItems": 0,
+      "minItems": 1,
       "type": "array"
     },
     "essentialRequirementsMet": {
@@ -46,17 +46,10 @@
                       false
                     ]
                   }
-                },
-                "required": [
-                  "yesNo"
-                ]
+                }
               },
               {
                 "properties": {
-                  "evidence": {
-                    "minLength": 1,
-                    "type": "string"
-                  },
                   "yesNo": {
                     "enum": [
                       true
@@ -81,6 +74,9 @@
             "type": "boolean"
           }
         },
+        "required": [
+          "yesNo"
+        ],
         "type": "object"
       },
       "minItems": 0,

--- a/json_schemas/brief-responses-digital-outcomes-and-specialists-digital-outcomes.json
+++ b/json_schemas/brief-responses-digital-outcomes-and-specialists-digital-outcomes.json
@@ -22,7 +22,7 @@
         ],
         "type": "object"
       },
-      "minItems": 0,
+      "minItems": 1,
       "type": "array"
     },
     "essentialRequirementsMet": {
@@ -46,17 +46,10 @@
                       false
                     ]
                   }
-                },
-                "required": [
-                  "yesNo"
-                ]
+                }
               },
               {
                 "properties": {
-                  "evidence": {
-                    "minLength": 1,
-                    "type": "string"
-                  },
                   "yesNo": {
                     "enum": [
                       true
@@ -81,6 +74,9 @@
             "type": "boolean"
           }
         },
+        "required": [
+          "yesNo"
+        ],
         "type": "object"
       },
       "minItems": 0,

--- a/json_schemas/brief-responses-digital-outcomes-and-specialists-digital-specialists.json
+++ b/json_schemas/brief-responses-digital-outcomes-and-specialists-digital-specialists.json
@@ -26,7 +26,7 @@
         ],
         "type": "object"
       },
-      "minItems": 0,
+      "minItems": 1,
       "type": "array"
     },
     "essentialRequirementsMet": {
@@ -50,17 +50,10 @@
                       false
                     ]
                   }
-                },
-                "required": [
-                  "yesNo"
-                ]
+                }
               },
               {
                 "properties": {
-                  "evidence": {
-                    "minLength": 1,
-                    "type": "string"
-                  },
                   "yesNo": {
                     "enum": [
                       true
@@ -85,6 +78,9 @@
             "type": "boolean"
           }
         },
+        "required": [
+          "yesNo"
+        ],
         "type": "object"
       },
       "minItems": 0,

--- a/json_schemas/brief-responses-digital-outcomes-and-specialists-user-research-participants.json
+++ b/json_schemas/brief-responses-digital-outcomes-and-specialists-user-research-participants.json
@@ -22,7 +22,7 @@
         ],
         "type": "object"
       },
-      "minItems": 0,
+      "minItems": 1,
       "type": "array"
     },
     "essentialRequirementsMet": {
@@ -46,17 +46,10 @@
                       false
                     ]
                   }
-                },
-                "required": [
-                  "yesNo"
-                ]
+                }
               },
               {
                 "properties": {
-                  "evidence": {
-                    "minLength": 1,
-                    "type": "string"
-                  },
                   "yesNo": {
                     "enum": [
                       true
@@ -81,6 +74,9 @@
             "type": "boolean"
           }
         },
+        "required": [
+          "yesNo"
+        ],
         "type": "object"
       },
       "minItems": 0,

--- a/json_schemas/services-g-cloud-9-cloud-hosting.json
+++ b/json_schemas/services-g-cloud-9-cloud-hosting.json
@@ -1,6 +1,102 @@
 {
   "$schema": "http://json-schema.org/schema#",
   "additionalProperties": false,
+  "allOf": [
+    {
+      "oneOf": [
+        {
+          "properties": {
+            "freeVersionLink": {
+              "type": "null"
+            },
+            "freeVersionTrialOption": {
+              "enum": [
+                false
+              ]
+            }
+          }
+        },
+        {
+          "properties": {
+            "freeVersionTrialOption": {
+              "enum": [
+                true
+              ]
+            }
+          },
+          "required": [
+            "freeVersionTrialOption"
+          ]
+        }
+      ]
+    },
+    {
+      "oneOf": [
+        {
+          "properties": {
+            "freeVersionDescription": {
+              "type": "null"
+            },
+            "freeVersionTrialOption": {
+              "enum": [
+                false
+              ]
+            }
+          }
+        },
+        {
+          "properties": {
+            "freeVersionTrialOption": {
+              "enum": [
+                true
+              ]
+            }
+          },
+          "required": [
+            "freeVersionTrialOption",
+            "freeVersionDescription"
+          ]
+        }
+      ]
+    },
+    {
+      "oneOf": [
+        {
+          "properties": {
+            "securityGovernanceStandards": {
+              "items": {
+                "enum": [
+                  "CSA CCM v3.0",
+                  "ISO/IEC 27001"
+                ]
+              }
+            },
+            "securityGovernanceStandardsOther": {
+              "type": "null"
+            }
+          }
+        },
+        {
+          "properties": {
+            "securityGovernanceStandards": {
+              "not": {
+                "items": {
+                  "enum": [
+                    "CSA CCM v3.0",
+                    "ISO/IEC 27001"
+                  ]
+                }
+              }
+            }
+          },
+          "required": [
+            "securityGovernanceStandards",
+            "securityGovernanceStandardsOther"
+          ]
+        }
+      ]
+    }
+  ],
   "properties": {
     "API": {
       "type": "boolean"
@@ -962,7 +1058,6 @@
     "endOfContractDataExtraction",
     "energyEfficientDatacentres",
     "equipmentDisposalApproach",
-    "freeVersionDescription",
     "freeVersionTrialOption",
     "gettingStarted",
     "guaranteedAvailability",
@@ -1000,7 +1095,6 @@
     "securityGovernanceAccreditation",
     "securityGovernanceApproach",
     "securityGovernanceStandards",
-    "securityGovernanceStandardsOther",
     "serviceBackups",
     "serviceBackupsDatacentre",
     "serviceBackupsRecovery",

--- a/json_schemas/services-g-cloud-9-cloud-software.json
+++ b/json_schemas/services-g-cloud-9-cloud-software.json
@@ -1,6 +1,102 @@
 {
   "$schema": "http://json-schema.org/schema#",
   "additionalProperties": false,
+  "allOf": [
+    {
+      "oneOf": [
+        {
+          "properties": {
+            "freeVersionLink": {
+              "type": "null"
+            },
+            "freeVersionTrialOption": {
+              "enum": [
+                false
+              ]
+            }
+          }
+        },
+        {
+          "properties": {
+            "freeVersionTrialOption": {
+              "enum": [
+                true
+              ]
+            }
+          },
+          "required": [
+            "freeVersionTrialOption"
+          ]
+        }
+      ]
+    },
+    {
+      "oneOf": [
+        {
+          "properties": {
+            "freeVersionDescription": {
+              "type": "null"
+            },
+            "freeVersionTrialOption": {
+              "enum": [
+                false
+              ]
+            }
+          }
+        },
+        {
+          "properties": {
+            "freeVersionTrialOption": {
+              "enum": [
+                true
+              ]
+            }
+          },
+          "required": [
+            "freeVersionTrialOption",
+            "freeVersionDescription"
+          ]
+        }
+      ]
+    },
+    {
+      "oneOf": [
+        {
+          "properties": {
+            "securityGovernanceStandards": {
+              "items": {
+                "enum": [
+                  "CSA CCM v3.0",
+                  "ISO/IEC 27001"
+                ]
+              }
+            },
+            "securityGovernanceStandardsOther": {
+              "type": "null"
+            }
+          }
+        },
+        {
+          "properties": {
+            "securityGovernanceStandards": {
+              "not": {
+                "items": {
+                  "enum": [
+                    "CSA CCM v3.0",
+                    "ISO/IEC 27001"
+                  ]
+                }
+              }
+            }
+          },
+          "required": [
+            "securityGovernanceStandards",
+            "securityGovernanceStandardsOther"
+          ]
+        }
+      ]
+    }
+  ],
   "properties": {
     "API": {
       "type": "boolean"
@@ -938,7 +1034,6 @@
     "endOfContractDataExtraction",
     "endOfContractProcess",
     "equipmentDisposalApproach",
-    "freeVersionDescription",
     "freeVersionTrialOption",
     "gettingStarted",
     "guaranteedAvailability",
@@ -978,7 +1073,6 @@
     "securityGovernanceAccreditation",
     "securityGovernanceApproach",
     "securityGovernanceStandards",
-    "securityGovernanceStandardsOther",
     "serviceAddOnDetails",
     "serviceAddOnType",
     "serviceBenefits",

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -646,7 +646,7 @@ def test_g9_followup_questions():
             "freeVersionLink": "https://gov.uk",
         }
         yield check, schema_name, ["freeVersionTrialOption"], data, {
-            'freeVersionLink': u'{} is not valid under any of the given schemas'.format(data)
+            '_form': [u'{} is not valid under any of the given schemas'.format(data)]
         }
 
         data = {
@@ -654,7 +654,7 @@ def test_g9_followup_questions():
             "freeVersionDescription": "description",
         }
         yield check, schema_name, ["freeVersionTrialOption"], data, {
-            'freeVersionDescription': u'{} is not valid under any of the given schemas'.format(data)
+            '_form': [u'{} is not valid under any of the given schemas'.format(data)]
         }
 
         # Followup answers when the original question answer is missing
@@ -690,7 +690,7 @@ def test_g9_followup_questions():
             "securityGovernanceStandardsOther": "some other standards"
         }
         yield check, schema_name, ["securityGovernanceStandards"], data, {
-            "securityGovernanceStandardsOther": u'{} is not valid under any of the given schemas'.format(data)
+            "_form": [u'{} is not valid under any of the given schemas'.format(data)]
         }
 
         # Followup answers when the original question answer is missing

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -593,6 +593,115 @@ def test_brief_response_nice_to_have_requirements():
         assert "object" in error_messages
 
 
+def test_g9_followup_questions():
+
+    def check(schema, required_fields, data, errors):
+        api_errors = get_validation_errors(
+            schema_name, data, enforce_required=False, required_fields=required_fields)
+
+        assert api_errors == errors
+
+    for schema_name in ("services-g-cloud-9-cloud-software", "services-g-cloud-9-cloud-hosting"):
+
+        # Valid responses for boolean question with followup
+
+        yield check, schema_name, ["freeVersionTrial"], {
+            "freeVersionTrialOption": False
+        }, {}
+
+        yield check, schema_name, ["freeVersionTrialOption"], {
+            "freeVersionTrialOption": True,
+            "freeVersionDescription": "description",
+            "freeVersionLink": "https://gov.uk",
+        }, {}
+
+        # Missing followup answers
+
+        yield check, schema_name, ["freeVersionTrialOption"], {
+            "freeVersionTrialOption": True,
+        }, {
+            "freeVersionDescription": "answer_required",
+        }
+
+        yield check, schema_name, ["freeVersionTrialOption"], {
+            "freeVersionTrialOption": True,
+            "freeVersionLink": "https://gov.uk",
+        }, {
+            "freeVersionDescription": "answer_required",
+        }
+
+        # Missing followup question is not required if it's optional
+
+        yield check, schema_name, ["freeVersionTrialOption"], {
+            "freeVersionTrialOption": True,
+            "freeVersionDescription": "description",
+        }, {}
+
+        # Followup answers when none should be present. These return the original
+        # schema error since they shouldn't happen when request is coming from the
+        # frontend app so we don't need to display an error message.
+
+        data = {
+            "freeVersionTrialOption": False,
+            "freeVersionLink": "https://gov.uk",
+        }
+        yield check, schema_name, ["freeVersionTrialOption"], data, {
+            'freeVersionLink': u'{} is not valid under any of the given schemas'.format(data)
+        }
+
+        data = {
+            "freeVersionTrialOption": False,
+            "freeVersionDescription": "description",
+        }
+        yield check, schema_name, ["freeVersionTrialOption"], data, {
+            'freeVersionDescription': u'{} is not valid under any of the given schemas'.format(data)
+        }
+
+        # Followup answers when the original question answer is missing
+
+        yield check, schema_name, ["freeVersionTrialOption"], {
+            "freeVersionDescription": "description",
+            "freeVersionLink": "https://gov.uk",
+        }, {"freeVersionTrialOption": "answer_required"}
+
+        # Valid responses for checkbox question with followups
+
+        yield check, schema_name, ["securityGovernanceStandards"], {
+            "securityGovernanceStandards": ["CSA CCM v3.0"]
+        }, {}
+
+        yield check, schema_name, ["securityGovernanceStandards"], {
+            "securityGovernanceStandards": ["CSA CCM v3.0", "Other"],
+            "securityGovernanceStandardsOther": "some other standards"
+        }, {}
+
+        # Missing followup answers for checkbox question
+
+        yield check, schema_name, ["securityGovernanceStandards"], {
+            "securityGovernanceStandards": ["CSA CCM v3.0", "Other"]
+        }, {
+            "securityGovernanceStandardsOther": "answer_required"
+        }
+
+        # Followup answers when none should be present
+
+        data = {
+            "securityGovernanceStandards": ["CSA CCM v3.0"],
+            "securityGovernanceStandardsOther": "some other standards"
+        }
+        yield check, schema_name, ["securityGovernanceStandards"], data, {
+            "securityGovernanceStandardsOther": u'{} is not valid under any of the given schemas'.format(data)
+        }
+
+        # Followup answers when the original question answer is missing
+
+        yield check, schema_name, ["securityGovernanceStandards"], {
+            "securityGovernanceStandardsOther": "some other standards"
+        }, {
+            "securityGovernanceStandards": "answer_required"
+        }
+
+
 def test_api_type_is_optional():
     data = load_example_listing("G6-PaaS")
     del data["apiType"]


### PR DESCRIPTION
### Update brief responses schemas with new followup rules

Changes to the followup schema generation preserve the existing
behaviour but move some of the rules around to work when used in
the API.

Eg dropping the lead-in question.id from the oneOf schema required
lists allows us to use page_questions and partial service updates,
which raised validation errors otherwise. Instead, it moves the
lead-in question to the parent schema's required list, since if it's
not optional then it's required in both cases.

Another change is dropping the property description for the followup
question from the oneOf subschema. The property is described in the
parent schema, which has access to the question type to generate a
correct one, so the only thing we need to add is to mark it as
required.

### Add validation errors for G9 follow-up questions

Adds JSON schema error translation for top-level oneOf validator
errors, which are used by the G9 schemas.

Adds tests using the existing G9 followup question.