### PR TITLE
Allow create/update/submit response for expired frameworks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ venv
 *.pyc
 __pycache__
 version_label
+.cache

--- a/app/main/views/brief_responses.py
+++ b/app/main/views/brief_responses.py
@@ -38,8 +38,8 @@ def create_brief_response():
     if brief.status != 'live':
         abort(400, "Brief must be live")
 
-    if brief.framework.status != 'live':
-        abort(400, "Brief framework must be live")
+    if brief.framework.status not in ['live', 'expired']:
+        abort(400, "Brief framework must be live or expired")
 
     supplier = validate_and_return_supplier(brief_response_json)
 
@@ -107,8 +107,8 @@ def update_brief_response(brief_response_id):
     if brief_response.status != 'draft':
         abort(400, "Brief response must be a draft")
 
-    if brief.framework.status != 'live':
-        abort(400, "Brief framework must be live")
+    if brief.framework.status not in ['live', 'expired']:
+        abort(400, "Brief framework must be live or expired")
 
     brief_role = brief.data["specialistRole"] if brief.lot.slug == "digital-specialists" else None
     service_max_day_rate = brief_service.data[brief_role + "PriceMax"] if brief_role else None
@@ -156,8 +156,8 @@ def submit_brief_response(brief_response_id):
     if brief_response.status != 'draft':
         abort(400, "Brief response must be a draft")
 
-    if brief.framework.status != 'live':
-        abort(400, "Brief framework must be live")
+    if brief.framework.status not in ['live', 'expired']:
+        abort(400, "Brief framework must be live or expired")
 
     brief_role = brief.data["specialistRole"] if brief.lot.slug == "digital-specialists" else None
     service_max_day_rate = brief_service.data[brief_role + "PriceMax"] if brief_role else None

--- a/tests/main/views/test_brief_response.py
+++ b/tests/main/views/test_brief_response.py
@@ -261,12 +261,16 @@ class CreateBriefResponseSharedTests(BaseBriefResponseTest, JSONUpdateTestMixin)
         assert res.status_code == 400
         assert 'Supplier is not eligible to apply to this brief' in res.get_data(as_text=True)
 
-    def test_cannot_create_a_brief_response_if_framework_status_is_not_live_or_expired(self, expired_dos_framework):
+    def test_cannot_create_a_brief_response_if_framework_status_is_not_live_or_expired(self, live_dos_framework):
+        framework_id = live_dos_framework['id']
         for framework_status in ['coming', 'open', 'pending', 'standstill']:
             with self.app.app_context():
                 db.session.execute(
-                    "UPDATE frameworks SET status=:status WHERE slug='digital-outcomes-and-specialists'",
-                    {'status': framework_status},
+                    "UPDATE frameworks SET status=:status WHERE id = :framework_id",
+                    {
+                        'status': framework_status,
+                        'framework_id': framework_id,
+                    },
                 )
 
                 res = self.create_brief_response()

--- a/tests/main/views/test_brief_response.py
+++ b/tests/main/views/test_brief_response.py
@@ -142,6 +142,15 @@ class CreateBriefResponseSharedTests(BaseBriefResponseTest, JSONUpdateTestMixin)
         assert data['briefResponses']['supplierName'] == 'Supplier 0'
         assert data['briefResponses']['briefId'] == self.brief_id
 
+    def test_create_new_brief_response_with_expired_framework(self, expired_dos_framework):
+        res = self.create_brief_response()
+
+        data = json.loads(res.get_data(as_text=True))
+
+        assert res.status_code == 201, data
+        assert data['briefResponses']['supplierName'] == 'Supplier 0'
+        assert data['briefResponses']['briefId'] == self.brief_id
+
     def test_create_new_brief_response_with_missing_answer_to_page_question_will_error(self, live_dos_framework):
         res = self.client.post(
             '/brief-responses',
@@ -252,6 +261,20 @@ class CreateBriefResponseSharedTests(BaseBriefResponseTest, JSONUpdateTestMixin)
         assert res.status_code == 400
         assert 'Supplier is not eligible to apply to this brief' in res.get_data(as_text=True)
 
+    def test_cannot_create_a_brief_response_if_framework_status_is_not_live_or_expired(self, expired_dos_framework):
+        for framework_status in ['coming', 'open', 'pending', 'standstill']:
+            with self.app.app_context():
+                db.session.execute(
+                    "UPDATE frameworks SET status=:status WHERE slug='digital-outcomes-and-specialists'",
+                    {'status': framework_status},
+                )
+
+                res = self.create_brief_response()
+                data = json.loads(res.get_data(as_text=True))
+
+                assert res.status_code == 400
+                assert data == {'error': 'Brief framework must be live or expired'}
+
     def test_cannot_respond_to_a_brief_that_isnt_live(self, live_dos_framework):
         with self.app.app_context():
             brief = Brief(
@@ -264,12 +287,6 @@ class CreateBriefResponseSharedTests(BaseBriefResponseTest, JSONUpdateTestMixin)
 
             assert res.status_code == 400
             assert "Brief must be live" in res.get_data(as_text=True)
-
-    def test_cannot_respond_to_an_expired_framework_brief(self, expired_dos_framework):
-        res = self.create_brief_response()
-
-        assert res.status_code == 400
-        assert "Brief framework must be live" in res.get_data(as_text=True)
 
     def test_cannot_respond_to_a_brief_more_than_once_from_the_same_supplier(self, live_dos_framework):
         self.create_brief_response()
@@ -528,19 +545,31 @@ class UpdateBriefResponseSharedTests(BaseBriefResponseTest):
             'briefResponseData': {'respondToEmailAddress': 'newemail@email.com'}
         }
 
+    def test_update_brief_response_with_expired_framework(self, expired_dos_framework):
+        res = self._update_brief_response(self.brief_response_id, {'respondToEmailAddress': 'newemail@email.com'})
+
+        assert res.status_code == 200
+
     def test_update_brief_response_that_does_not_exist_will_404(self, live_dos_framework):
         res = self._update_brief_response(100, {'respondToEmailAddress': 'newemail@email.com'})
         assert res.status_code == 404
 
-    def test_can_not_update_brief_response_for_framework_that_is_not_live(self, live_dos_framework):
-        with self.app.app_context():
-            # Change live framework to be expired
-            db.session.execute("UPDATE frameworks SET status='expired' WHERE slug='digital-outcomes-and-specialists'")
+    def test_can_not_update_brief_response_for_framework_that_is_not_live_or_expired(self, live_dos_framework):
+        for framework_status in ['coming', 'open', 'pending', 'standstill']:
+            with self.app.app_context():
+                db.session.execute(
+                    "UPDATE frameworks SET status=:status WHERE slug='digital-outcomes-and-specialists'",
+                    {'status': framework_status},
+                )
 
-            res = self._update_brief_response(self.brief_response_id, {'respondToEmailAddress': 'newemail@email.com'})
-            data = json.loads(res.get_data(as_text=True))
-            assert res.status_code == 400
-            assert data == {'error': 'Brief framework must be live'}
+                res = self._update_brief_response(
+                    self.brief_response_id,
+                    {'respondToEmailAddress': 'newemail@email.com'}
+                )
+
+                data = json.loads(res.get_data(as_text=True))
+                assert res.status_code == 400
+                assert data == {'error': 'Brief framework must be live or expired'}
 
     def test_can_not_update_brief_response_if_supplier_is_ineligible_for_brief(self, live_dos_framework):
         with mock.patch('app.main.views.brief_responses.get_supplier_service_eligible_for_brief') as mock_patch:
@@ -688,7 +717,19 @@ class SubmitBriefResponseSharedTests(BaseBriefResponseTest):
         assert res.status_code == 201
         self.brief_response_id = json.loads(res.get_data(as_text=True))['briefResponses']['id']
 
-    def test_valid_draft_brief_response_can_be_submitted(self, live_dos_framework):
+    def test_valid_draft_brief_response_can_be_submitted_for_live_framework(self, live_dos_framework):
+        self._setup_existing_brief_response()
+
+        with freeze_time('2016-9-28'):
+            res = self._submit_brief_response(self.brief_response_id)
+        assert res.status_code == 200
+
+        brief_response = json.loads(res.get_data(as_text=True))['briefResponses']
+
+        assert brief_response['status'] == 'submitted'
+        assert brief_response['submittedAt'] == '2016-09-28T00:00:00.000000Z'
+
+    def test_valid_draft_brief_response_can_be_submitted_for_expired_framework(self, expired_dos_framework):
         self._setup_existing_brief_response()
 
         with freeze_time('2016-9-28'):
@@ -729,16 +770,32 @@ class SubmitBriefResponseSharedTests(BaseBriefResponseTest):
         data = json.loads(repeat_res.get_data(as_text=True))
         assert data == {'error': 'Brief response must be a draft'}
 
-    def test_can_not_submit_a_brief_response_for_a_framework_that_is_not_live(self, live_dos_framework):
-        self._setup_existing_brief_response()
-        with self.app.app_context():
-            # Change live framework to be expired
-            db.session.execute("UPDATE frameworks SET status='expired' WHERE slug='digital-outcomes-and-specialists'")
+    def test_can_not_submit_a_brief_response_for_a_framework_that_is_not_live_or_expired(self, live_dos_framework):
+            with self.app.app_context():
+                for framework_status in ['coming', 'open', 'pending', 'standstill']:
 
-            res = self._submit_brief_response(self.brief_response_id)
-            data = json.loads(res.get_data(as_text=True))
-            assert res.status_code == 400
-            assert data == {'error': 'Brief framework must be live'}
+                    # If a brief response already exists delete the last one. Suppliers can only have one response.
+                    existing_brief_response = db.session.query(BriefResponse).all()
+                    if existing_brief_response:
+                        db.session.delete(existing_brief_response[-1])
+                        db.session.commit()
+
+                    # Make framework live so a brief response can be created.
+                    db.session.execute(
+                        "UPDATE frameworks SET status='live' WHERE slug='digital-outcomes-and-specialists'"
+                    )
+                    self._setup_existing_brief_response()
+
+                    # Set framework status to the invalid status currently under test.
+                    db.session.execute(
+                        "UPDATE frameworks SET status=:status WHERE slug='digital-outcomes-and-specialists'",
+                        {'status': framework_status},
+                    )
+
+                    res = self._submit_brief_response(self.brief_response_id)
+                    data = json.loads(res.get_data(as_text=True))
+                    assert res.status_code == 400
+                    assert data == {'error': 'Brief framework must be live or expired'}
 
     def test_can_not_submit_response_if_supplier_is_ineligble_for_brief(self, live_dos_framework):
         self._setup_existing_brief_response()

--- a/tests/main/views/test_briefs.py
+++ b/tests/main/views/test_briefs.py
@@ -12,10 +12,9 @@ from app import db
 from app.models import Brief, Framework
 
 
-class TestBriefs(BaseApplicationTest, FixtureMixin):
-
+class FrameworkSetupAndTeardown(BaseApplicationTest, FixtureMixin):
     def setup(self):
-        super(TestBriefs, self).setup()
+        super(FrameworkSetupAndTeardown, self).setup()
         self.user_id = self.setup_dummy_user(role='buyer')
 
         with self.app.app_context():
@@ -33,8 +32,10 @@ class TestBriefs(BaseApplicationTest, FixtureMixin):
 
             db.session.add(framework)
             db.session.commit()
-        super(TestBriefs, self).teardown()
+        super(FrameworkSetupAndTeardown, self).teardown()
 
+
+class TestCreateBrief(FrameworkSetupAndTeardown):
     def test_create_brief_with_no_data(self):
         res = self.client.post(
             '/briefs',
@@ -98,34 +99,6 @@ class TestBriefs(BaseApplicationTest, FixtureMixin):
 
         assert res.status_code == 400
         assert data['error'] == {'title': 'answer_required'}
-
-    def test_can_only_create_briefs_on_live_frameworks(self):
-        with self.app.app_context():
-            framework = Framework.query.filter(Framework.slug == 'digital-outcomes-and-specialists').first()
-            self._original_framework_status = framework.status
-            framework.status = 'open'
-
-            db.session.add(framework)
-            db.session.commit()
-
-        res = self.client.post(
-            '/briefs',
-            data=json.dumps({
-                'briefs': {
-                    'userId': self.user_id,
-                    'frameworkSlug': 'digital-outcomes-and-specialists',
-                    'lot': 'digital-specialists',
-                    'title': 'the title',
-                },
-                'update_details': {
-                    'updated_by': 'example'
-                }
-            }),
-            content_type='application/json')
-        data = json.loads(res.get_data(as_text=True))
-
-        assert res.status_code == 400
-        assert data['error'] == 'Framework must be live'
 
     def test_create_brief_creates_audit_event(self):
         self.client.post(
@@ -206,6 +179,35 @@ class TestBriefs(BaseApplicationTest, FixtureMixin):
         assert res.status_code == 400
         assert json.loads(res.get_data(as_text=True))['error'] == "Framework 'not-exists' does not exist"
 
+    def test_create_brief_fails_if_framework_not_live(self):
+        for framework_status in ['coming', 'open', 'pending', 'standstill', 'expired']:
+            with self.app.app_context():
+                framework = Framework.query.filter(Framework.slug == 'digital-outcomes-and-specialists').first()
+                self._original_framework_status = framework.status
+                framework.status = framework_status
+
+                db.session.add(framework)
+                db.session.commit()
+
+            res = self.client.post(
+                '/briefs',
+                data=json.dumps({
+                    'briefs': {
+                        'userId': self.user_id,
+                        'frameworkSlug': 'digital-outcomes-and-specialists',
+                        'lot': 'digital-specialists',
+                        'title': 'the title',
+                    },
+                    'update_details': {
+                        'updated_by': 'example'
+                    }
+                }),
+                content_type='application/json')
+            data = json.loads(res.get_data(as_text=True))
+
+            assert res.status_code == 400
+            assert data['error'] == 'Framework must be live'
+
     def test_create_brief_fails_if_lot_does_not_exist(self):
         res = self.client.post(
             '/briefs',
@@ -223,6 +225,8 @@ class TestBriefs(BaseApplicationTest, FixtureMixin):
         assert json.loads(res.get_data(as_text=True))['error'] == \
             "Incorrect lot 'not-exists' for framework 'digital-outcomes-and-specialists'"
 
+
+class TestUpdateBrief(FrameworkSetupAndTeardown):
     def test_update_brief(self):
         self.setup_dummy_briefs(1)
 
@@ -403,6 +407,8 @@ class TestBriefs(BaseApplicationTest, FixtureMixin):
 
         assert res.status_code == 404
 
+
+class TestGetBrief(FrameworkSetupAndTeardown):
     def test_get_brief(self):
         self.setup_dummy_briefs(1, title="I need a Developer")
         res = self.client.get('/briefs/1')
@@ -462,6 +468,8 @@ class TestBriefs(BaseApplicationTest, FixtureMixin):
 
         assert res.status_code == 404
 
+
+class TestListBrief(FrameworkSetupAndTeardown):
     def test_list_briefs(self):
         self.setup_dummy_briefs(3)
 
@@ -687,6 +695,8 @@ class TestBriefs(BaseApplicationTest, FixtureMixin):
         assert len(data['briefs']) == 7
         assert data['links'] == {}
 
+
+class TestPublishAndWithdrawBrief(FrameworkSetupAndTeardown):
     def test_publish_a_brief(self):
         self.setup_dummy_briefs(1, title='The Title')
 
@@ -782,25 +792,26 @@ class TestBriefs(BaseApplicationTest, FixtureMixin):
         withdrawn_at = json.loads(res.get_data(as_text=True))['briefs']['withdrawnAt']
         assert withdrawn_at == original_withdrawn_at
 
-    def test_cannot_publish_a_brief_if_the_framework_is_no_longer_live(self):
+    def test_cannot_publish_a_brief_if_the_framework_is_not_live(self):
         self.setup_dummy_briefs(1, title='The title')
 
-        with self.app.app_context():
-            framework = Framework.query.get(5)
-            framework.status = 'expired'
-            db.session.add(framework)
-            db.session.commit()
+        for framework_status in ['coming', 'open', 'pending', 'standstill', 'expired']:
+            with self.app.app_context():
+                framework = Framework.query.get(5)
+                framework.status = framework_status
+                db.session.add(framework)
+                db.session.commit()
 
-        res = self.client.post(
-            '/briefs/1/publish',
-            data=json.dumps({
-                'updated_by': 'example'
-            }),
-            content_type='application/json')
-        data = json.loads(res.get_data(as_text=True))
+            res = self.client.post(
+                '/briefs/1/publish',
+                data=json.dumps({
+                    'updated_by': 'example'
+                }),
+                content_type='application/json')
+            data = json.loads(res.get_data(as_text=True))
 
-        assert res.status_code == 400
-        assert data['error'] == "Framework is not live"
+            assert res.status_code == 400
+            assert data['error'] == "Framework is not live"
 
     def test_publish_brief_makes_audit_event(self):
         self.setup_dummy_briefs(1, title='The Title')
@@ -848,6 +859,8 @@ class TestBriefs(BaseApplicationTest, FixtureMixin):
             'briefStatus': 'withdrawn',
         }
 
+
+class TestDeleteBrief(FrameworkSetupAndTeardown):
     def test_can_delete_a_draft_brief(self):
         res = self.client.post(
             '/briefs',
@@ -933,6 +946,8 @@ class TestBriefs(BaseApplicationTest, FixtureMixin):
         )
         assert res.status_code == 404
 
+
+class TestAddBriefClarificationQuestion(FrameworkSetupAndTeardown):
     def test_add_clarification_question(self):
         self.setup_dummy_briefs(1, title="The Title", status="live")
 
@@ -1042,23 +1057,26 @@ class TestBriefs(BaseApplicationTest, FixtureMixin):
             "answer": "That",
         }
 
-    def test_cannot_make_a_draft_copy_of_a_brief_if_the_framework_is_closed(self):
+
+class TestCopyBrief(FrameworkSetupAndTeardown):
+    def test_cannot_make_a_draft_copy_of_a_brief_if_the_framework_is_not_live(self):
         self.setup_dummy_briefs(1, title="The Title", status="withdrawn")
 
-        with self.app.app_context():
-            framework = Framework.query.get(5)
-            framework.status = 'expired'
-            db.session.add(framework)
-            db.session.commit()
+        for framework_status in ['coming', 'open', 'pending', 'standstill', 'expired']:
+            with self.app.app_context():
+                framework = Framework.query.get(5)
+                framework.status = framework_status
+                db.session.add(framework)
+                db.session.commit()
 
-        res = self.client.post(
-            "/briefs/1/copy",
-            data=json.dumps({'updated_by': 'example'}),
-            content_type="application/json")
-        data = json.loads(res.get_data(as_text=True))
+            res = self.client.post(
+                "/briefs/1/copy",
+                data=json.dumps({'updated_by': 'example'}),
+                content_type="application/json")
+            data = json.loads(res.get_data(as_text=True))
 
-        assert res.status_code == 400
-        assert data['error'] == "Framework is not live"
+            assert res.status_code == 400
+            assert data['error'] == "Framework is not live"
 
     def test_make_a_draft_copy_of_a_brief(self):
         # Set up brief with clarification question

--- a/tests/main/views/test_briefs.py
+++ b/tests/main/views/test_briefs.py
@@ -180,7 +180,7 @@ class TestCreateBrief(FrameworkSetupAndTeardown):
         assert json.loads(res.get_data(as_text=True))['error'] == "Framework 'not-exists' does not exist"
 
     def test_create_brief_fails_if_framework_not_live(self):
-        for framework_status in ['coming', 'open', 'pending', 'standstill', 'expired']:
+        for framework_status in [status for status in Framework.STATUSES if status != 'live']:
             with self.app.app_context():
                 framework = Framework.query.filter(Framework.slug == 'digital-outcomes-and-specialists').first()
                 self._original_framework_status = framework.status
@@ -795,7 +795,7 @@ class TestPublishAndWithdrawBrief(FrameworkSetupAndTeardown):
     def test_cannot_publish_a_brief_if_the_framework_is_not_live(self):
         self.setup_dummy_briefs(1, title='The title')
 
-        for framework_status in ['coming', 'open', 'pending', 'standstill', 'expired']:
+        for framework_status in [status for status in Framework.STATUSES if status != 'live']:
             with self.app.app_context():
                 framework = Framework.query.get(5)
                 framework.status = framework_status
@@ -1062,7 +1062,7 @@ class TestCopyBrief(FrameworkSetupAndTeardown):
     def test_cannot_make_a_draft_copy_of_a_brief_if_the_framework_is_not_live(self):
         self.setup_dummy_briefs(1, title="The Title", status="withdrawn")
 
-        for framework_status in ['coming', 'open', 'pending', 'standstill', 'expired']:
+        for framework_status in [status for status in Framework.STATUSES if status != 'live']:
             with self.app.app_context():
                 framework = Framework.query.get(5)
                 framework.status = framework_status


### PR DESCRIPTION
Part of this story: [https://www.pivotaltracker.com/story/show/139283847](https://www.pivotaltracker.com/story/show/139283847)

When we expire DOS1, suppliers will still need to be able to apply to live DOS1 briefs. This means that the api needs to allow brief responses to be created/updated/published for frameworks who's status is `expired`.

This does that.

Also see this PR on the supplier frontend: [https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/619](https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/619)