### PR TITLE
[#141778727]Framework agreement details expansion

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -124,16 +124,19 @@ class Framework(db.Model):
             'name': self.name,
             'slug': self.slug,
             'framework': self.framework,
-            'countersignerName': (self.framework_agreement_details or {}).get("countersignerName"),
-            'frameworkAgreementVersion': (self.framework_agreement_details or {}).get("frameworkAgreementVersion"),
-            'variations': (self.framework_agreement_details or {}).get("variations", {}),
             'status': self.status,
             'clarificationQuestionsOpen': self.clarification_questions_open,
             'lots': [lot.serialize() for lot in self.lots],
             'application_close_date': (
                 self.application_close_date and self.application_close_date.strftime(DATETIME_FORMAT)
             ),
-            'allow_declaration_reuse': self.allow_declaration_reuse
+            'allow_declaration_reuse': self.allow_declaration_reuse,
+            'frameworkAgreementDetails': self.framework_agreement_details or {},
+            # the following are specific extracts of the above frameworkAgreementDetails which were previously used but
+            # should now possibly be deprecated:
+            'countersignerName': (self.framework_agreement_details or {}).get("countersignerName"),
+            'frameworkAgreementVersion': (self.framework_agreement_details or {}).get("frameworkAgreementVersion"),
+            'variations': (self.framework_agreement_details or {}).get("variations", {}),
         }
 
     def get_supplier_ids_for_completed_service(self):

--- a/json_schemas/framework-agreement-details.json
+++ b/json_schemas/framework-agreement-details.json
@@ -15,6 +15,54 @@
       "minLength": 1,
       "type": "string"
     },
+    "frameworkRefDate": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "frameworkStartDate": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "frameworkEndDate": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "frameworkExtensionLength": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "frameworkURL": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "signaturePageNumber": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "pageTotal": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "contractNoticeNumber": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "lotOrder": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "minLength": 1,
+        "type": "string"
+      }
+    },
+    "lotDescriptions": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": {
+        "minLength": 1,
+        "type": "string"
+      }
+    },
     "variations": {
       "additionalProperties": {
         "additionalProperties": false,

--- a/tests/main/views/test_frameworks.py
+++ b/tests/main/views/test_frameworks.py
@@ -324,18 +324,50 @@ class TestUpdateFramework(BaseApplicationTest, JSONUpdateTestMixin):
 
     def test_schema_validation_for_framework_agreement_details(self, open_example_framework):
         invalid_framework_agreement_details = [
-            # should be a string
-            {'frameworkAgreementVersion': 1},
-            # cannot be empty
-            {'frameworkAgreementVersion': ""},
-            # should be an object
-            {'variations': 1},
-            # object must have 'createdAt' key
-            {'variations': {"created_at": "today"}},
-            # countersigner cannot be empty
-            {'countersignerName': ""},
+            # frameworkAgreementVersion should be a string
+            {
+                'variations': {},
+                'frameworkAgreementVersion': 1,
+            },
+            # can't have a numeric lotDescription
+            {
+                'variations': {},
+                'frameworkAgreementVersion': "1",
+                'lotDescriptions': {"test-lot": 4321},
+            },
+            # can't have empty lotOrder
+            {
+                'variations': {},
+                'frameworkAgreementVersion': "1",
+                'lotOrder': [],
+            },
+            # frameworkAgreementVersion cannot be empty
+            {
+                'variations': {},
+                'frameworkAgreementVersion': "",
+            },
+            # variations should be an object
+            {
+                'variations': 1,
+                'frameworkAgreementVersion': "1.1.1",
+            },
+            # variations object must have 'createdAt' key
+            {
+                'frameworkAgreementVersion': "2",
+                'variations': {"created_at": "today"},
+            },
+            # countersignerName cannot be empty
+            {
+                'variations': {},
+                'frameworkAgreementVersion': "1",
+                'countersignerName': "",
+            },
             # invalid key
-            {'frameworkAgreementDessert': "Portuguese tart"},
+            {
+                'variations': {},
+                'frameworkAgreementVersion': "1",
+                'frameworkAgreementDessert': "Portuguese tart",
+            },
             # empty update
             {}
         ]

--- a/tests/main/views/test_frameworks.py
+++ b/tests/main/views/test_frameworks.py
@@ -24,6 +24,7 @@ class TestListFrameworks(BaseApplicationTest):
                     'clarificationQuestionsOpen',
                     'framework',
                     'frameworkAgreementVersion',
+                    'frameworkAgreementDetails',
                     'id',
                     'lots',
                     'name',
@@ -32,7 +33,7 @@ class TestListFrameworks(BaseApplicationTest):
                     'variations',
                     'countersignerName',
                     'application_close_date',
-                    'allow_declaration_reuse'
+                    'allow_declaration_reuse',
                 ]))
 
 
@@ -270,14 +271,15 @@ class TestUpdateFramework(BaseApplicationTest, JSONUpdateTestMixin):
                 assert response.status_code == 200
                 post_data = json.loads(response.get_data())['frameworks']
 
-                # `frameworkAgreementDetails` is not included in Framework.serialize() itself, but instead
-                # each (key, value) in `frameworkAgreementDetails` is un-nested and returned with other top-level keys
+                # certain keys of `frameworkAgreementDetails` are un-nested and returned with other top-level keys
                 if isinstance(value, dict):
                     for nested_key, nested_value in value.items():
-                        assert post_data[nested_key] == nested_value
-                else:
-                    assert post_data[key] == value
+                        if nested_key in ("countersignerName", "frameworkAgreementVersion", "variations",):
+                            assert post_data[nested_key] == nested_value
 
+                assert post_data[key] == value
+
+                # check the same data was actually persisted
                 get_data = json.loads(
                     self.client.get('/frameworks/example-framework').get_data()
                 )['frameworks']

--- a/tests/main/views/test_frameworks.py
+++ b/tests/main/views/test_frameworks.py
@@ -221,11 +221,12 @@ class TestUpdateFramework(BaseApplicationTest, JSONUpdateTestMixin):
                     "toblerone": {
                         "createdAt": "2016-07-06T21:09:09.000000Z",
                     },
-                }
+                },
+                "lotOrder": ['iaas', 'scs', 'saas', 'paas'],
             },
             'status': "standstill",
             'clarificationQuestionsOpen': False,
-            'lots': ['saas', 'paas', 'iaas', 'scs']
+            'lots': ['saas', 'paas', 'iaas', 'scs'],
         }
 
         self.attribute_whitelist = [


### PR DESCRIPTION
Story https://www.pivotaltracker.com/story/show/141778727

Ok, so, we're going to need to be able to actually *use* a whole load more keys in the `frameworkAgreementDetails` dictionary and pulling out specific ones and flattening them into the toplevel returned dictionary isn't going to cut it - at least having them returned under a specific `frameworkAgreementDetails` object gives us an amount of namespacing for these relatively obscure variables.

Another obstacle is that `frameworkAgreementDetails` itself has a json schema. Should we enforce the format of these new, obscure, variables or just open the schema to any `additionalProperties`? This strawman PR proposes the former.

Thoughts?