### PR TITLE
Remove old snake_case keys

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -127,10 +127,15 @@ class Framework(db.Model):
             'status': self.status,
             'clarificationQuestionsOpen': self.clarification_questions_open,
             'lots': [lot.serialize() for lot in self.lots],
+            # TODO: Remove snake_case keys after frontend update to use the new camelCase versions
             'application_close_date': (
                 self.application_close_date and self.application_close_date.strftime(DATETIME_FORMAT)
             ),
             'allow_declaration_reuse': self.allow_declaration_reuse,
+            'applicationCloseDate': (
+                self.application_close_date and self.application_close_date.strftime(DATETIME_FORMAT)
+            ),
+            'allowDeclarationReuse': self.allow_declaration_reuse,
             'frameworkAgreementDetails': self.framework_agreement_details or {},
             # the following are specific extracts of the above frameworkAgreementDetails which were previously used but
             # should now possibly be deprecated:

--- a/app/models.py
+++ b/app/models.py
@@ -127,11 +127,6 @@ class Framework(db.Model):
             'status': self.status,
             'clarificationQuestionsOpen': self.clarification_questions_open,
             'lots': [lot.serialize() for lot in self.lots],
-            # TODO: Remove snake_case keys after frontend update to use the new camelCase versions
-            'application_close_date': (
-                self.application_close_date and self.application_close_date.strftime(DATETIME_FORMAT)
-            ),
-            'allow_declaration_reuse': self.allow_declaration_reuse,
             'applicationCloseDate': (
                 self.application_close_date and self.application_close_date.strftime(DATETIME_FORMAT)
             ),

--- a/tests/main/views/test_frameworks.py
+++ b/tests/main/views/test_frameworks.py
@@ -34,6 +34,8 @@ class TestListFrameworks(BaseApplicationTest):
                     'countersignerName',
                     'application_close_date',
                     'allow_declaration_reuse',
+                    'applicationCloseDate',
+                    'allowDeclarationReuse',
                 ]))
 
 

--- a/tests/main/views/test_frameworks.py
+++ b/tests/main/views/test_frameworks.py
@@ -32,8 +32,6 @@ class TestListFrameworks(BaseApplicationTest):
                     'status',
                     'variations',
                     'countersignerName',
-                    'application_close_date',
-                    'allow_declaration_reuse',
                     'applicationCloseDate',
                     'allowDeclarationReuse',
                 ]))


### PR DESCRIPTION
Final part of this bugfix: https://www.pivotaltracker.com/story/show/141950783

This follows on from: 
 - [ ] https://github.com/alphagov/digitalmarketplace-api/pull/553

And should only be merged after the release of:
 - [ ] https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/684