### PR TITLE
Add links to `get_framework_suppliers` response

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -252,12 +252,15 @@ def get_framework_suppliers(framework_slug):
 
     with_declarations = convert_to_boolean(request.args.get("with_declarations", "true"))
 
-    return jsonify(supplierFrameworks=[
-        supplier_framework.serialize(
-            with_users=False,
-            with_declaration=with_declarations,
-        ) for supplier_framework in supplier_frameworks
-    ])
+    return jsonify(
+        supplierFrameworks=[
+            supplier_framework.serialize(
+                with_users=False,
+                with_declaration=with_declarations,
+            ) for supplier_framework in supplier_frameworks
+        ],
+        links=dict()
+    )
 
 
 @main.route('/frameworks/<string:framework_slug>/interest', methods=['GET'])

--- a/tests/main/views/test_frameworks.py
+++ b/tests/main/views/test_frameworks.py
@@ -805,6 +805,7 @@ class TestGetFrameworkSuppliers(BaseApplicationTest, FixtureMixin):
         self._subtest_list_suppliers_by_multiple_statuses_2()
         self._subtest_list_suppliers_by_multiple_statuses_and_agreement_returned_true()
         self._subtest_list_suppliers_by_multiple_statuses_and_agreement_returned_false()
+        self._subtest_response_contains_links()
 
     def _subtest_list_suppliers_related_to_a_framework(self):
         # One G7 supplier
@@ -925,6 +926,12 @@ class TestGetFrameworkSuppliers(BaseApplicationTest, FixtureMixin):
         assert response.status_code == 200
         data = json.loads(response.get_data())
         assert len(data['supplierFrameworks']) == 0
+
+    def _subtest_response_contains_links(self):
+        response = self.client.get('/frameworks/g-cloud-8/suppliers')
+        assert response.status_code == 200
+        data = json.loads(response.get_data())
+        assert data['links'] == {}
 
 
 class TestGetFrameworkInterest(BaseApplicationTest, FixtureMixin):


### PR DESCRIPTION
This endpoint previously didn't add the `links` key to its serialized
response. Although this endpoint is not paginated and has no links to
add, we need the links key to ensure that `make_iter_method` on the
apiclient works with the `find_framework_suppliers` method, also on the
apiclient.