### PR TITLE
40 delete start dates on draft requirements

### DIFF
--- a/migrations/versions/870_remove_invalid_draft_dos2_brief_dates.py
+++ b/migrations/versions/870_remove_invalid_draft_dos2_brief_dates.py
@@ -1,0 +1,65 @@
+"""Remove dates from draft dos2 briefs.
+
+Revision ID: 870
+Revises: 860
+Create Date: 2016-04-07
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '870'
+down_revision = '860'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+frameworks_table = sa.Table(
+    'frameworks',
+    sa.MetaData(),
+    sa.Column('id', sa.Integer, primary_key=True),
+    sa.Column('slug', sa.String, nullable=False, unique=True, index=True)
+)
+
+briefs_table = sa.Table(
+    'briefs',
+    sa.MetaData(),
+    sa.Column('id', sa.Integer, primary_key=True),
+    sa.Column('framework_id', sa.Integer, nullable=False),
+    sa.Column('published_at', sa.DateTime, nullable=True),
+    sa.Column('data', sa.JSON, nullable=True)
+)
+
+
+def upgrade():
+    """Remove question and answer for startDate from briefs.data for draft dos2 briefs."""
+    conn = op.get_bind()
+
+    # SELECT id, data
+    # FROM briefs JOIN frameworks ON briefs.framework_id = frameworks.id
+    # WHERE frameworks.slug = 'digital-outcomes-and-specialists-2' AND briefs.published_at IS null;
+    query = briefs_table.join(
+        frameworks_table,
+        briefs_table.c.framework_id == frameworks_table.c.id
+    ).select(
+        sa.and_(
+            frameworks_table.c.slug == 'digital-outcomes-and-specialists-2',
+            briefs_table.c.published_at == sa.null()
+        )
+    ).with_only_columns(
+        (
+            briefs_table.c.id,
+            briefs_table.c.data
+        )
+    )
+    results = conn.execute(query).fetchall()
+
+    for brief_id, brief_data in results:
+        if brief_data.pop('startDate', None) is not None:
+            # UPDATE briefs SET data = _brief_data WHERE id = _brief_id;
+            query = briefs_table.update().where(briefs_table.c.id==brief_id).values(data=brief_data)
+            conn.execute(query)
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
## 40-delete-start-dates-on-draft-requirements

Single migration to delete dos2 draft brief start dates that will no
longer be in the correct format.

Context: Change of date format means draft requirement dates will not
longer be in the right format to be published.

Delete start dates on all draft requirements so buyers can re-enter
dates before they are published.

Acceptance criteria
Given that I have entered a latest start date in my draft requirement,
when I try to publish my requirement, then I need to re-enter the latest
start date.

https://trello.com/c/BA5KSAvm/40-delete-start-dates-on-draft-requirements