### PR TITLE
paradigmhousing.co.uk added to buyer-email-domains

### DIFF
--- a/data/buyer-email-domains.txt
+++ b/data/buyer-email-domains.txt
@@ -116,6 +116,7 @@ npl.co.uk
 ofcom.org.uk
 originhousing.org.uk
 os.uk
+paradigmhousing.co.uk
 parliament.uk
 pbat.co.uk
 pharmacyregulation.org


### PR DESCRIPTION
Related Trello card: https://trello.com/c/XklQ3dnd/276-add-additional-buyer-email-domains-for-buyer-accounts