### PR TITLE
[#139472449]export_users_for_framework: lazyload a lot of relationships we don't need

### DIFF
--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -235,7 +235,7 @@ def export_users_for_framework(framework_slug):
     if framework.status == 'coming':
         abort(400, 'framework not yet open')
 
-    suppliers_with_a_complete_service = framework.get_supplier_ids_for_completed_service()
+    suppliers_with_a_complete_service = frozenset(framework.get_supplier_ids_for_completed_service())
     supplier_frameworks_and_users = db.session.query(
         SupplierFramework, User
     ).filter(


### PR DESCRIPTION
This *might* fix story https://www.pivotaltracker.com/story/show/139472449

At some point we need to look at how much we overuse eager loading of relationships. It gets more than a bit silly.