### PR TITLE
Change constraint naming convention

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -14,9 +14,9 @@ bootstrap = Bootstrap()
 db = SQLAlchemy(metadata=MetaData(naming_convention={
     "ix": 'ix_%(column_0_label)s',
     "uq": "uq_%(table_name)s_%(column_0_name)s",
-    "ck": "ck_%(table_name)s_%(constraint_name)s",
-    "fk": "fk_%(table_name)s_%(column_0_name)s_%(referred_table_name)s",
-    "pk": "pk_%(table_name)s",
+    "ck": "%(constraint_name)s",
+    "fk": "%(table_name)s_%(column_0_name)s_fkey",
+    "pk": "%(table_name)s_pkey",
 }))
 search_api_client = dmapiclient.SearchAPIClient()
 feature_flags = flask_featureflags.FeatureFlag()

--- a/migrations/versions/530_add_frameworks_and_lots_to_briefs.py
+++ b/migrations/versions/530_add_frameworks_and_lots_to_briefs.py
@@ -19,7 +19,7 @@ def upgrade():
     op.add_column('briefs', sa.Column('lot_id', sa.Integer(), nullable=False))
     op.create_foreign_key(None, 'briefs', 'frameworks', ['framework_id'], ['id'])
     op.create_foreign_key(None, 'briefs', 'lots', ['lot_id'], ['id'])
-    op.create_foreign_key(None, 'briefs', 'framework_lots', ['framework_id', 'lot_id'], ['framework_id', 'lot_id'])
+    op.create_foreign_key('briefs_framework_id_fkey1', 'briefs', 'framework_lots', ['framework_id', 'lot_id'], ['framework_id', 'lot_id'])
 
 
 def downgrade():


### PR DESCRIPTION
## Change naming convention to match existing names

After upgrading SQLAlchemy to 1.1 it seems that migrations stopped
generating predictable names, so a naming convention was introduced. See
here: #524 

This created an issue however if you are importing a db dump from
prod/stating/preview to a local, upgraded db. The local db will have had
all migrations applied using the new naming convention where as the dump
won't have. The schemas won't match.

When importing the dump the first thing it does is to drop all tables
and constraints it knows about before it rebuilds them. This means it
tries to drop constraints in the local db that don't exist, leading to
errors.

Changing the naming convention to match the original constraint name
pattern prevents this.

## 	Explicitly name briefs framework_lots foreign keys in migration 530

Due to the new naming convention which now matches the original pattern,
when this migration was applied to an empty database it tried to create
two foreign key constraints with the same name.

Before, when the naming was left to SQLAlchemy, the name was
auto-incremented to be prepended with a '1' to prevent a clash. Now that
a naming convention is defined this doesn't happen so an error is
thrown.

Explicitly naming this constraint stops this clash and also keeps the
name in sync with the prod database, even when applying the migration to
a clean database.