### PR TITLE
copy-my-requirements-migration

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1143,6 +1143,7 @@ class Brief(db.Model):
 
     framework_id = db.Column(db.Integer, db.ForeignKey('frameworks.id'), nullable=False)
     _lot_id = db.Column("lot_id", db.Integer, db.ForeignKey('lots.id'), nullable=False)
+    copied_from_brief_id = db.Column(db.Integer, db.ForeignKey('briefs.id'), nullable=True)
 
     data = db.Column(JSON, nullable=False)
     created_at = db.Column(db.DateTime, index=True, nullable=False,

--- a/migrations/versions/890_add_copied_from_brief_id_field_to_brief.py
+++ b/migrations/versions/890_add_copied_from_brief_id_field_to_brief.py
@@ -1,0 +1,29 @@
+"""Add new copied_from_brief_id column to briefs table to indicate where brief was cloned from.
+
+Revision ID: 890
+Revises: 880
+Create Date: 2017-05-03
+"""
+
+# revision identifiers, used by Alembic.
+revision = '890'
+down_revision = '880'
+
+from alembic import op
+from sqlalchemy import Column, ForeignKey, INTEGER
+
+
+def upgrade():
+    """Add new copied_from_brief_id column to briefs table to indicate where brief was cloned from."""
+    op.add_column(
+        'briefs',
+        Column('copied_from_brief_id', INTEGER, ForeignKey('briefs.id'))
+    )
+
+
+def downgrade():
+    """Drop column."""
+    op.drop_column(
+        'briefs',
+        'copied_from_brief_id'
+    )


### PR DESCRIPTION
We need to store whether or not a brief is a clone of another brief, and if so, which brief.
This has been done here with a nullable foreign key to the briefs table indicating 'copied_from_brief_id.

*  Add field `copied_from_brief_id ` to `Briefs` model and migrate