### PR TITLE
copy-my-requirements

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1289,15 +1289,11 @@ class Brief(db.Model):
     def copy(self):
         data = self.data.copy()
         title = data.get('title', '')
-        if len(title) <= 95:
+        if 0 < len(title) <= 95:
             data['title'] = u"{} copy".format(title)
 
-        # do_not_copy = [
-        #     "serviceSummary",
-        #     "termsAndConditionsDocumentURL", "pricingDocumentURL",
-        #     "serviceDefinitionDocumentURL", "sfiaRateDocumentURL"
-        # ]
-        # data = {key: value for key, value in data.items() if key not in do_not_copy}
+        do_not_copy = ["startDate", "questionAndAnswerSessionDetails"]
+        data = {key: value for key, value in data.items() if key not in do_not_copy}
 
         return Brief(
             data=data,

--- a/app/models.py
+++ b/app/models.py
@@ -1292,7 +1292,7 @@ class Brief(db.Model):
         if 0 < len(title) <= 95:
             data['title'] = u"{} copy".format(title)
 
-        do_not_copy = ["startDate", "questionAndAnswerSessionDetails"]
+        do_not_copy = ["startDate", "questionAndAnswerSessionDetails", "researchDates"]
         data = {key: value for key, value in data.items() if key not in do_not_copy}
 
         return Brief(

--- a/app/models.py
+++ b/app/models.py
@@ -1300,10 +1300,15 @@ class Brief(db.Model):
         do_not_copy = ["startDate", "questionAndAnswerSessionDetails", "researchDates"]
         data = {key: value for key, value in data.items() if key not in do_not_copy}
 
+        framework = Framework.query.filter(
+            Framework.framework == self.framework.framework,
+            Framework.status == 'live'
+        ).one()
+
         return Brief(
             data=data,
             copied_from_brief_id=self.id,
-            framework=self.framework,
+            framework=framework,
             lot=self.lot,
             users=self.users
         )

--- a/app/models.py
+++ b/app/models.py
@@ -161,7 +161,11 @@ class Framework(db.Model):
 
     @validates('framework')
     def validates_framework(self, key, framework):
-        if framework not in self.FRAMEWORKS:
+        return Framework.validate_framework(framework)
+
+    @staticmethod
+    def validate_framework(framework):
+        if framework not in Framework.FRAMEWORKS:
             raise ValidationError("Invalid framework value '{}'".format(framework))
         return framework
 

--- a/app/models.py
+++ b/app/models.py
@@ -1287,9 +1287,6 @@ class Brief(db.Model):
         self.data = current_data
 
     def copy(self):
-        if self.framework.status != 'live':
-            raise ValidationError("Framework is not live")
-
         return Brief(
             data=self.data,
             framework=self.framework,

--- a/app/models.py
+++ b/app/models.py
@@ -1287,8 +1287,20 @@ class Brief(db.Model):
         self.data = current_data
 
     def copy(self):
+        data = self.data.copy()
+        title = data.get('title', '')
+        if len(title) <= 95:
+            data['title'] = u"{} copy".format(title)
+
+        # do_not_copy = [
+        #     "serviceSummary",
+        #     "termsAndConditionsDocumentURL", "pricingDocumentURL",
+        #     "serviceDefinitionDocumentURL", "sfiaRateDocumentURL"
+        # ]
+        # data = {key: value for key, value in data.items() if key not in do_not_copy}
+
         return Brief(
-            data=self.data,
+            data=data,
             framework=self.framework,
             lot=self.lot,
             users=self.users

--- a/app/models.py
+++ b/app/models.py
@@ -1143,6 +1143,7 @@ class Brief(db.Model):
 
     framework_id = db.Column(db.Integer, db.ForeignKey('frameworks.id'), nullable=False)
     _lot_id = db.Column("lot_id", db.Integer, db.ForeignKey('lots.id'), nullable=False)
+    copied_from_brief_id = db.Column(db.Integer, db.ForeignKey('briefs.id'), nullable=True)
 
     data = db.Column(JSON, nullable=False)
     created_at = db.Column(db.DateTime, index=True, nullable=False,
@@ -1297,6 +1298,7 @@ class Brief(db.Model):
 
         return Brief(
             data=data,
+            copied_from_brief_id=self.id,
             framework=self.framework,
             lot=self.lot,
             users=self.users

--- a/app/models.py
+++ b/app/models.py
@@ -1340,7 +1340,6 @@ class Brief(db.Model):
             'clarificationQuestions': [
                 question.serialize() for question in self.clarification_questions
             ],
-            'copiedFromBriefId': self.copied_from_brief_id
         })
 
         if self.published_at:
@@ -1357,6 +1356,9 @@ class Brief(db.Model):
             data.update({
                 'withdrawnAt': self.withdrawn_at.strftime(DATETIME_FORMAT)
             })
+
+        if self.copied_from_brief_id:
+            data.update({'copiedFromBriefId': self.copied_from_brief_id})
 
         data['links'] = {
             'self': url_for('.get_brief', brief_id=self.id),

--- a/app/models.py
+++ b/app/models.py
@@ -1340,6 +1340,7 @@ class Brief(db.Model):
             'clarificationQuestions': [
                 question.serialize() for question in self.clarification_questions
             ],
+            'copiedFromBriefId': self.copied_from_brief_id
         })
 
         if self.published_at:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -394,13 +394,13 @@ def live_dos_framework(request, app):
 def expired_dos_framework(request, app):
     return _framework_fixture_inner(request, app, **dict(_dos_framework_defaults, status="expired"))
 
+
 @pytest.fixture()
 def live_dos2_framework(request, app):
     return _framework_fixture_inner(request, app, **dict(_dos2_framework_defaults, status="live"))
 
 
 # Suppliers
-
 
 @pytest.fixture()
 def supplier_basic(request, app):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -214,6 +214,11 @@ _dos_framework_defaults = {
     "framework": "digital-outcomes-and-specialists",
     "framework_agreement_details": None,
 }
+_dos2_framework_defaults = {
+    "slug": "digital-outcomes-and-specialists-2",
+    "framework": "digital-outcomes-and-specialists",
+    "framework_agreement_details": None,
+}
 _example_framework_details = {
     "slug": "example-framework",
     "framework": "g-cloud",
@@ -388,6 +393,10 @@ def live_dos_framework(request, app):
 @pytest.fixture()
 def expired_dos_framework(request, app):
     return _framework_fixture_inner(request, app, **dict(_dos_framework_defaults, status="expired"))
+
+@pytest.fixture()
+def live_dos2_framework(request, app):
+    return _framework_fixture_inner(request, app, **dict(_dos2_framework_defaults, status="live"))
 
 
 # Suppliers

--- a/tests/main/views/test_briefs.py
+++ b/tests/main/views/test_briefs.py
@@ -1070,9 +1070,6 @@ class TestCopyBrief(FrameworkSetupAndTeardown):
 
         assert res.status_code == 201
         assert data["briefs"]["id"] > 1
-        assert data["briefs"]["lot"] == 'digital-specialists'
-        assert data["briefs"]["frameworkSlug"] == 'digital-outcomes-and-specialists'
-        assert data["briefs"]["status"] == 'draft'
 
     def test_make_a_draft_copy_of_a_brief_makes_audit_event(self):
         self.setup_dummy_briefs(1, title="The Title", status="withdrawn")

--- a/tests/main/views/test_briefs.py
+++ b/tests/main/views/test_briefs.py
@@ -1059,25 +1059,6 @@ class TestAddBriefClarificationQuestion(FrameworkSetupAndTeardown):
 
 
 class TestCopyBrief(FrameworkSetupAndTeardown):
-    def test_cannot_make_a_draft_copy_of_a_brief_if_the_framework_is_not_live(self):
-        self.setup_dummy_briefs(1, title="The Title", status="withdrawn")
-
-        for framework_status in [status for status in Framework.STATUSES if status != 'live']:
-            with self.app.app_context():
-                framework = Framework.query.get(5)
-                framework.status = framework_status
-                db.session.add(framework)
-                db.session.commit()
-
-            res = self.client.post(
-                "/briefs/1/copy",
-                data=json.dumps({'updated_by': 'example'}),
-                content_type="application/json")
-            data = json.loads(res.get_data(as_text=True))
-
-            assert res.status_code == 400
-            assert data['error'] == "Framework is not live"
-
     def test_make_a_draft_copy_of_a_brief(self):
         # Set up brief with clarification question
         self.setup_dummy_briefs(1, title="The Title", status="live")

--- a/tests/main/views/test_briefs.py
+++ b/tests/main/views/test_briefs.py
@@ -1060,13 +1060,7 @@ class TestAddBriefClarificationQuestion(FrameworkSetupAndTeardown):
 
 class TestCopyBrief(FrameworkSetupAndTeardown):
     def test_make_a_draft_copy_of_a_brief(self):
-        # Set up brief with clarification question
         self.setup_dummy_briefs(1, title="The Title", status="live")
-        with self.app.app_context():
-            brief = Brief.query.get(1)
-            brief.add_clarification_question('question', 'answer')
-            db.session.add(brief)
-            db.session.commit()
 
         res = self.client.post(
             "/briefs/1/copy",
@@ -1079,8 +1073,6 @@ class TestCopyBrief(FrameworkSetupAndTeardown):
         assert data["briefs"]["lot"] == 'digital-specialists'
         assert data["briefs"]["frameworkSlug"] == 'digital-outcomes-and-specialists'
         assert data["briefs"]["status"] == 'draft'
-        assert data["briefs"]["title"] == 'The Title'
-        assert not data["briefs"]["clarificationQuestions"]
 
     def test_make_a_draft_copy_of_a_brief_makes_audit_event(self):
         self.setup_dummy_briefs(1, title="The Title", status="withdrawn")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -403,23 +403,55 @@ class TestBriefs(BaseApplicationTest, FixtureMixin):
             assert brief.clarification_questions[0].question == "How?"
             assert brief.clarification_questions[1].question == "When"
 
-    def test_copy_brief(self):
+
+class TestCopyBrief(BaseApplicationTest, FixtureMixin):
+
+    def setup(self, *args, **kwargs):
+        super(TestCopyBrief, self).setup(*args, **kwargs)
         with self.app.app_context():
             self.setup_dummy_user(role='buyer')
-
-            brief = Brief(
+            self.framework = Framework.query.filter(Framework.slug == 'digital-outcomes-and-specialists').first()
+            self.lot = self.framework.get_lot('digital-outcomes')
+            self.brief = Brief(
                 data={'title': 'my title'},
                 framework=self.framework,
                 lot=self.lot,
                 users=User.query.all()
             )
 
-        copy = brief.copy()
 
-        assert brief.data == {'title': 'my title'}
-        assert brief.framework == copy.framework
-        assert brief.lot == copy.lot
-        assert brief.users == copy.users
+    def teardown(self, *args, **kwargs):
+        super(TestCopyBrief, self).teardown(*args, **kwargs)
+
+    def test_copy_brief(self):
+
+        copy = self.brief.copy()
+
+        assert copy.framework == self.brief.framework
+        assert copy.lot == self.brief.lot
+        assert copy.users == self.brief.users
+
+    def test_brief_title_under_96_chars_adds_copy_string(self):
+        title = 't' * 95
+        self.brief.data['title'] = title
+        copy = self.brief.copy()
+
+        assert copy.data['title'] == title + ' copy'
+
+    def test_brief_title_over_95_chars_does_not_add_copy_string(self):
+        title = 't' * 96
+        self.brief.data['title'] = title
+        copy = self.brief.copy()
+
+        assert copy.data['title'] == title
+
+    def test_fields_to_remove_are_removed_on_copy(self):
+        pass
+
+    def test_clarification_questions_are_removed(self):
+        pass
+
+
 
 
 class TestBriefResponses(BaseApplicationTest, FixtureMixin):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -483,6 +483,7 @@ class TestCopyBrief(BaseApplicationTest, FixtureMixin):
 
         assert copy.framework == live_framework
 
+
 class TestBriefResponses(BaseApplicationTest, FixtureMixin):
     def setup(self):
         super(TestBriefResponses, self).setup()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -456,7 +456,8 @@ class TestCopyBrief(BaseApplicationTest, FixtureMixin):
         self.brief.data = {
             "other key": "to be kept",
             "startDate": "21-4-2016",
-            "questionAndAnswerSessionDetails": "details"
+            "questionAndAnswerSessionDetails": "details",
+            "researchDates": "some date"
         }
         copy = self.brief.copy()
         assert copy.data == {"other key": "to be kept"}

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -405,7 +405,6 @@ class TestBriefs(BaseApplicationTest, FixtureMixin):
 
     def test_copy_brief(self):
         with self.app.app_context():
-            self.framework.status = 'live'
             self.setup_dummy_user(role='buyer')
 
             brief = Brief(
@@ -421,17 +420,6 @@ class TestBriefs(BaseApplicationTest, FixtureMixin):
         assert brief.framework == copy.framework
         assert brief.lot == copy.lot
         assert brief.users == copy.users
-
-    def test_copy_brief_raises_error_if_framework_is_not_live(self):
-        brief = Brief(
-            data={},
-            framework=self.framework,
-            lot=self.lot
-        )
-        with pytest.raises(ValidationError) as e:
-            copy = brief.copy()
-
-        assert str(e.value.message) == "Framework is not live"
 
 
 class TestBriefResponses(BaseApplicationTest, FixtureMixin):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -410,7 +410,9 @@ class TestCopyBrief(BaseApplicationTest, FixtureMixin):
         super(TestCopyBrief, self).setup(*args, **kwargs)
         self.app.app_context().push()
         self.setup_dummy_user(role='buyer')
-        self.framework = Framework.query.filter(Framework.slug == 'digital-outcomes-and-specialists').first()
+        self.framework = Framework.query.filter(
+            Framework.slug == 'digital-outcomes-and-specialists',
+        ).one()
         self.lot = self.framework.get_lot('digital-outcomes')
 
         self.brief = Brief(
@@ -429,31 +431,39 @@ class TestCopyBrief(BaseApplicationTest, FixtureMixin):
         db.session.add(question)
         db.session.commit()
 
-    def test_copy_brief(self):
-
+    def test_copy_brief(self, live_dos_framework):
         copy = self.brief.copy()
 
         assert copy.framework == self.brief.framework
         assert copy.lot == self.brief.lot
         assert copy.users == self.brief.users
         assert copy.copied_from_brief_id == self.brief.id
+
+    def test_clarification_questions_not_copied(self, live_dos_framework):
+        copy = self.brief.copy()
+
         assert not copy.clarification_questions
 
-    def test_brief_title_under_96_chars_adds_copy_string(self):
+    def test_copied_brief_status_is_draft(self, live_dos_framework):
+        copy = self.brief.copy()
+
+        assert copy.status == 'draft'
+
+    def test_brief_title_under_96_chars_adds_copy_string(self, live_dos_framework):
         title = 't' * 95
         self.brief.data['title'] = title
         copy = self.brief.copy()
 
         assert copy.data['title'] == title + ' copy'
 
-    def test_brief_title_over_95_chars_does_not_add_copy_string(self):
+    def test_brief_title_over_95_chars_does_not_add_copy_string(self, live_dos_framework):
         title = 't' * 96
         self.brief.data['title'] = title
         copy = self.brief.copy()
 
         assert copy.data['title'] == title
 
-    def test_fields_to_remove_are_removed_on_copy(self):
+    def test_fields_to_remove_are_removed_on_copy(self, live_dos_framework):
         self.brief.data = {
             "other key": "to be kept",
             "startDate": "21-4-2016",
@@ -463,10 +473,15 @@ class TestCopyBrief(BaseApplicationTest, FixtureMixin):
         copy = self.brief.copy()
         assert copy.data == {"other key": "to be kept"}
 
-    def test_clarification_questions_are_removed(self):
-        assert self.brief.clarification_questions
-        assert not self.brief.copy().clarification_questions
+    def test_copy_is_put_on_live_framework(self, expired_dos_framework, live_dos2_framework):
+        """If brief is on framework which is not live its copy chould be moved to the live framework."""
+        expired_framework = Framework.query.filter(Framework.id == expired_dos_framework['id']).first()
+        live_framework = Framework.query.filter(Framework.id == live_dos2_framework['id']).first()
+        self.brief.framework = expired_framework
 
+        copy = self.brief.copy()
+
+        assert copy.framework == live_framework
 
 class TestBriefResponses(BaseApplicationTest, FixtureMixin):
     def setup(self):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -436,6 +436,7 @@ class TestCopyBrief(BaseApplicationTest, FixtureMixin):
         assert copy.framework == self.brief.framework
         assert copy.lot == self.brief.lot
         assert copy.users == self.brief.users
+        assert copy.copied_from_brief_id == self.brief.id
         assert not copy.clarification_questions
 
     def test_brief_title_under_96_chars_adds_copy_string(self):


### PR DESCRIPTION
* Update `apps/models.py::Brief::copy`
 * Add copy string to title
 * Specify fields from data to _not_ copy (see ticket)
* Remove `test_cannot_make_a_draft_copy_of_a_brief_if_the_framework_is_not_live`
 * No longer relevant. Framework does not need to be live
* Update tests

The model method here is triggered by the api end point at `digitalmarketplace-api/app/main/views/briefs.py::copy_brief` which didn't need changing.

Migration:
https://github.com/alphagov/digitalmarketplace-api/pull/568