### PR TITLE
Remove `copied_from_brief_id` from model so migration is separate

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1143,7 +1143,6 @@ class Brief(db.Model):
 
     framework_id = db.Column(db.Integer, db.ForeignKey('frameworks.id'), nullable=False)
     _lot_id = db.Column("lot_id", db.Integer, db.ForeignKey('lots.id'), nullable=False)
-    copied_from_brief_id = db.Column(db.Integer, db.ForeignKey('briefs.id'), nullable=True)
 
     data = db.Column(JSON, nullable=False)
     created_at = db.Column(db.DateTime, index=True, nullable=False,


### PR DESCRIPTION
The model change will be added to a later PR instead so the code change and migration are separate.