### PR TITLE
Remove plain text logs from live

### DIFF
--- a/config.py
+++ b/config.py
@@ -16,6 +16,7 @@ class Config:
     DM_HTTP_PROTO = 'http'
     # Logging
     DM_LOG_LEVEL = 'DEBUG'
+    DM_PLAIN_TEXT_LOGS = False
     DM_LOG_PATH = None
     DM_APP_NAME = 'api'
     DM_REQUEST_ID_HEADER = 'DM-Request-ID'
@@ -43,6 +44,7 @@ class Test(Config):
     DM_SEARCH_API_AUTH_TOKEN = 'test'
     DM_SEARCH_API_URL = 'http://localhost'
     DEBUG = True
+    DM_PLAIN_TEXT_LOGS = True
     ES_ENABLED = False
     SQLALCHEMY_DATABASE_URI = 'postgresql://localhost/digitalmarketplace_test'
     DM_API_AUTH_TOKENS = 'myToken'
@@ -55,6 +57,7 @@ class Test(Config):
 
 class Development(Config):
     DEBUG = True
+    DM_PLAIN_TEXT_LOGS = True
 
     DM_API_AUTH_TOKENS = 'myToken'
     DM_SEARCH_API_AUTH_TOKEN = 'myToken'

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ psycopg2==2.5.4
 SQLAlchemy==1.1.4
 SQLAlchemy-Utils==0.30.5
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@21.4.0#egg=digitalmarketplace-utils==21.4.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@25.2.0#egg=digitalmarketplace-utils==25.2.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@7.6.0#egg=digitalmarketplace-apiclient==7.6.0
 
 # For schema validation


### PR DESCRIPTION
Trello card: https://trello.com/c/o3Jkp3rK

Version 25.2.0 of the utils will by default only write logs in json
format. If the `DM_PLAIN_TEXT_LOGS` env variable is set True, then the
logs are plain text. This is being set in dev and test to make
developers jobs easier.

The other thing that 25.2.0 does is write logs to stdout instead of to file, unless
`DM_LOG_PATH` is set. This is useful for the PaaS, but also useful for
dev and test environments. To be clear, we're only using this
variable in the ElasticBeanstalk environments where we need to write
logs to files.