### PR TITLE
Add tetrust.org and visitscotland.com to buyer email domains

### DIFF
--- a/data/buyer-email-domains.txt
+++ b/data/buyer-email-domains.txt
@@ -145,6 +145,7 @@ sqa.org.uk
 stockporthomes.org
 sypte.co.uk
 tate.org.uk
+tetrust.org
 tfgm.com
 theipsa.org.uk
 traffordhousingtrust.co.uk
@@ -155,6 +156,7 @@ ukti-invest.com
 viridianhousing.org.uk
 visitbritain.org
 visitengland.org
+visitscotland.com
 wfd.org
 wheatley-group.com
 whgrp.co.uk


### PR DESCRIPTION
Trello: https://trello.com/c/BOS1EMMh/411-add-additional-buyer-email-domains-for-buyer-accounts