### PR TITLE
Add rmg.co.uk to buyer email domains

### DIFF
--- a/data/buyer-email-domains.txt
+++ b/data/buyer-email-domains.txt
@@ -126,6 +126,7 @@ police.uk
 postoffice.co.uk
 psha.org.uk
 qualificationswales.org
+rmg.co.uk
 rssb.co.uk
 sanctuary-housing.co.uk
 scope.org.uk


### PR DESCRIPTION
Trello: https://trello.com/c/cK8XlvhY/454-add-additional-buyer-email-domains-for-buyer-accounts