### PR TITLE
hwfire.org.uk and wimborneacademytrust.org added to buyer domains

### DIFF
--- a/data/buyer-email-domains.txt
+++ b/data/buyer-email-domains.txt
@@ -72,6 +72,7 @@ homegroup.org.uk
 housing-ombudsman.org.uk
 hrp.org.uk
 hs2.org.uk
+hwfire.org.uk
 ico.org.uk
 iicsa.org.uk
 investni.com
@@ -162,6 +163,7 @@ visitscotland.com
 wfd.org
 wheatley-group.com
 whgrp.co.uk
+wimborneacademytrust.org
 wmfs.net
 wwutilities.co.uk
 ymcahousing.org.uk


### PR DESCRIPTION
Trello: https://trello.com/c/wuwc3jvk/483-add-additional-buyer-email-domains-for-buyer-accounts

biglotteryfund.org.uk was already on the list