### PR TITLE
Add `briefTitle` to `BriefResponse` serialization

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1467,6 +1467,7 @@ class BriefResponse(db.Model):
         data.update({
             'id': self.id,
             'briefId': self.brief_id,
+            'briefTitle': self.brief.data.get('title', ''),
             'supplierId': self.supplier_id,
             'supplierName': self.supplier.name,
             'createdAt': self.created_at.strftime(DATETIME_FORMAT),
@@ -1480,7 +1481,6 @@ class BriefResponse(db.Model):
                 'supplier': url_for(".get_supplier", supplier_id=self.supplier_id),
             }
         })
-
         return purge_nulls_from_data(data)
 
 

--- a/app/models.py
+++ b/app/models.py
@@ -1396,7 +1396,7 @@ class BriefResponse(db.Model):
     created_at = db.Column(db.DateTime, index=True, nullable=False, default=datetime.utcnow)
     submitted_at = db.Column(db.DateTime, nullable=True)
 
-    brief = db.relationship('Brief')
+    brief = db.relationship('Brief', lazy='joined')
     supplier = db.relationship('Supplier', lazy='joined')
 
     @validates('data')
@@ -1481,6 +1481,7 @@ class BriefResponse(db.Model):
                 'supplier': url_for(".get_supplier", supplier_id=self.supplier_id),
             }
         })
+
         return purge_nulls_from_data(data)
 
 

--- a/app/models.py
+++ b/app/models.py
@@ -1467,7 +1467,7 @@ class BriefResponse(db.Model):
         data.update({
             'id': self.id,
             'briefId': self.brief_id,
-            'briefTitle': self.brief.data.get('title', ''),
+            'briefTitle': self.brief.data['title'],
             'supplierId': self.supplier_id,
             'supplierName': self.supplier.name,
             'createdAt': self.created_at.strftime(DATETIME_FORMAT),

--- a/tests/example_listings.py
+++ b/tests/example_listings.py
@@ -82,6 +82,7 @@ def specialists_brief_response_data(min_day_rate=1, max_day_rate=1000):
 
 def brief_data(essential_count=5, nice_to_have_count=5):
     return fixed_dictionaries({
+        'title': just('My Test Brief Title'),
         'specialistRole': just('developer'),
         'location': text(min_size=1, average_size=10, alphabet='abcdefghijkl'),
         'essentialRequirements': requirements_list(essential_count),

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -490,7 +490,8 @@ class TestBriefResponses(BaseApplicationTest, FixtureMixin):
         with self.app.app_context():
             framework = Framework.query.filter(Framework.slug == 'digital-outcomes-and-specialists').first()
             lot = framework.get_lot('digital-outcomes')
-            self.brief = Brief(data={}, framework=framework, lot=lot)
+            self.brief_title = 'My Test Brief.'
+            self.brief = Brief(data={'title': self.brief_title}, framework=framework, lot=lot)
             db.session.add(self.brief)
             db.session.commit()
             self.brief_id = self.brief.id
@@ -574,6 +575,7 @@ class TestBriefResponses(BaseApplicationTest, FixtureMixin):
                 assert brief_response.serialize() == {
                     'id': brief_response.id,
                     'briefId': self.brief.id,
+                    'briefTitle': self.brief_title,
                     'supplierId': 0,
                     'supplierName': 'Supplier 0',
                     'createdAt': mock.ANY,
@@ -600,6 +602,7 @@ class TestBriefResponses(BaseApplicationTest, FixtureMixin):
                 assert brief_response.serialize() == {
                     'id': brief_response.id,
                     'briefId': self.brief.id,
+                    'briefTitle': self.brief_title,
                     'supplierId': 0,
                     'supplierName': 'Supplier 0',
                     'createdAt': mock.ANY,
@@ -611,7 +614,6 @@ class TestBriefResponses(BaseApplicationTest, FixtureMixin):
                         'supplier': (('.get_supplier',), {'supplier_id': 0}),
                     }
                 }
-
 
 class TestBriefClarificationQuestion(BaseApplicationTest):
     def setup(self):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -490,7 +490,7 @@ class TestBriefResponses(BaseApplicationTest, FixtureMixin):
         with self.app.app_context():
             framework = Framework.query.filter(Framework.slug == 'digital-outcomes-and-specialists').first()
             lot = framework.get_lot('digital-outcomes')
-            self.brief_title = 'My Test Brief.'
+            self.brief_title = 'My Test Brief Title'
             self.brief = Brief(data={'title': self.brief_title}, framework=framework, lot=lot)
             db.session.add(self.brief)
             db.session.commit()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -615,6 +615,7 @@ class TestBriefResponses(BaseApplicationTest, FixtureMixin):
                     }
                 }
 
+
 class TestBriefClarificationQuestion(BaseApplicationTest):
     def setup(self):
         super(TestBriefClarificationQuestion, self).setup()


### PR DESCRIPTION
Make `Brief` joined against brief response object. `BriefResponse` isn't very useful on its own.
`brief-response` view has no more queries but can now include the `data.title` of the `brief` it relates to.

To back up my decision to put the objects parents related data on the object itself I'd evidence...

Services serialization including:
```'supplierId', 'supplierName', 'frameworkSlug', 'frameworkName', 'lotSlug', 'lotName'```

Briefs serialization including:
```'frameworkSlug', 'frameworkName', 'lotSlug', 'lotName'```

SupplierFramework serialization including:
```'supplierId', 'supplierName', 'frameworkSlug', 'frameworkFramework'```


Here is the proof that it works (found using https://stackoverflow.com/questions/12369295/flask-sqlalchemy-display-queries-for-debug)

### SQL AFTER THIS PR:

```
select version()
{}
select current_schema()
{}
SELECT CAST('test plain returns' AS VARCHAR(60)) AS anon_1
{}
SELECT CAST('test unicode returns' AS VARCHAR(60)) AS anon_1
{}
show standard_conforming_strings
{}
BEGIN (implicit)
SELECT anon_1.brief_responses_id AS anon_1_brief_responses_id, anon_1.brief_responses_data AS anon_1_brief_responses_data, anon_1.brief_responses_brief_id AS anon_1_brief_responses_brief_id, anon_1.brief_responses_supplier_id AS anon_1_brief_responses_supplier_id, anon_1.brief_responses_created_at AS anon_1_brief_responses_created_at, anon_1.brief_responses_submitted_at AS anon_1_brief_responses_submitted_at, briefs_1.lot_id AS briefs_1_lot_id, lots_1.id AS lots_1_id, lots_1.slug AS lots_1_slug, lots_1.name AS lots_1_name, lots_1.one_service_limit AS lots_1_one_service_limit, lots_1.data AS lots_1_data, frameworks_1.id AS frameworks_1_id, frameworks_1.slug AS frameworks_1_slug, frameworks_1.name AS frameworks_1_name, frameworks_1.framework AS frameworks_1_framework, frameworks_1.framework_agreement_details AS frameworks_1_framework_agreement_details, frameworks_1.status AS frameworks_1_status, frameworks_1.clarification_questions_open AS frameworks_1_clarification_questions_open, frameworks_1.allow_declaration_reuse AS frameworks_1_allow_declaration_reuse, frameworks_1.application_close_date AS frameworks_1_application_close_date, lots_2.id AS lots_2_id, lots_2.slug AS lots_2_slug, lots_2.name AS lots_2_name, lots_2.one_service_limit AS lots_2_one_service_limit, lots_2.data AS lots_2_data, briefs_1.id AS briefs_1_id, briefs_1.framework_id AS briefs_1_framework_id, briefs_1.copied_from_brief_id AS briefs_1_copied_from_brief_id, briefs_1.data AS briefs_1_data, briefs_1.created_at AS briefs_1_created_at, briefs_1.updated_at AS briefs_1_updated_at, briefs_1.published_at AS briefs_1_published_at, briefs_1.withdrawn_at AS briefs_1_withdrawn_at, contact_information_1.id AS contact_information_1_id, contact_information_1.supplier_id AS contact_information_1_supplier_id, contact_information_1.contact_name AS contact_information_1_contact_name, contact_information_1.phone_number AS contact_information_1_phone_number, contact_information_1.email AS contact_information_1_email, contact_information_1.website AS contact_information_1_website, contact_information_1.address1 AS contact_information_1_address1, contact_information_1.address2 AS contact_information_1_address2, contact_information_1.city AS contact_information_1_city, contact_information_1.country AS contact_information_1_country, contact_information_1.postcode AS contact_information_1_postcode, suppliers_1.id AS suppliers_1_id, suppliers_1.supplier_id AS suppliers_1_supplier_id, suppliers_1.name AS suppliers_1_name, suppliers_1.description AS suppliers_1_description, suppliers_1.duns_number AS suppliers_1_duns_number, suppliers_1.esourcing_id AS suppliers_1_esourcing_id, suppliers_1.companies_house_number AS suppliers_1_companies_house_number, suppliers_1.clients AS suppliers_1_clients
FROM (SELECT brief_responses.id AS brief_responses_id, brief_responses.data AS brief_responses_data, brief_responses.brief_id AS brief_responses_brief_id, brief_responses.supplier_id AS brief_responses_supplier_id, brief_responses.created_at AS brief_responses_created_at, brief_responses.submitted_at AS brief_responses_submitted_at
FROM brief_responses
WHERE CASE WHEN (brief_responses.submitted_at IS NOT NULL) THEN %(param_1)s ELSE %(param_2)s END IN (%(param_3)s)
 LIMIT %(param_4)s OFFSET %(param_5)s) AS anon_1 LEFT OUTER JOIN briefs AS briefs_1 ON briefs_1.id = anon_1.brief_responses_brief_id LEFT OUTER JOIN frameworks AS frameworks_1 ON frameworks_1.id = briefs_1.framework_id LEFT OUTER JOIN (framework_lots AS framework_lots_1 JOIN lots AS lots_1 ON lots_1.id = framework_lots_1.lot_id) ON frameworks_1.id = framework_lots_1.framework_id LEFT OUTER JOIN lots AS lots_2 ON lots_2.id = briefs_1.lot_id LEFT OUTER JOIN suppliers AS suppliers_1 ON suppliers_1.supplier_id = anon_1.brief_responses_supplier_id LEFT OUTER JOIN contact_information AS contact_information_1 ON suppliers_1.supplier_id = contact_information_1.supplier_id ORDER BY lots_1.id
{'param_5': 0, 'param_4': 100, 'param_1': 'submitted', 'param_3': 'submitted', 'param_2': 'draft'}
ROLLBACK
```

### SQL BEFORE THIS PR:

```


OLD:

select version()
{}
select current_schema()
{}
SELECT CAST('test plain returns' AS VARCHAR(60)) AS anon_1
{}
SELECT CAST('test unicode returns' AS VARCHAR(60)) AS anon_1
{}
show standard_conforming_strings
{}
BEGIN (implicit)
SELECT anon_1.brief_responses_id AS anon_1_brief_responses_id, anon_1.brief_responses_data AS anon_1_brief_responses_data, anon_1.brief_responses_brief_id AS anon_1_brief_responses_brief_id, anon_1.brief_responses_supplier_id AS anon_1_brief_responses_supplier_id, anon_1.brief_responses_created_at AS anon_1_brief_responses_created_at, anon_1.brief_responses_submitted_at AS anon_1_brief_responses_submitted_at, contact_information_1.id AS contact_information_1_id, contact_information_1.supplier_id AS contact_information_1_supplier_id, contact_information_1.contact_name AS contact_information_1_contact_name, contact_information_1.phone_number AS contact_information_1_phone_number, contact_information_1.email AS contact_information_1_email, contact_information_1.website AS contact_information_1_website, contact_information_1.address1 AS contact_information_1_address1, contact_information_1.address2 AS contact_information_1_address2, contact_information_1.city AS contact_information_1_city, contact_information_1.country AS contact_information_1_country, contact_information_1.postcode AS contact_information_1_postcode, suppliers_1.id AS suppliers_1_id, suppliers_1.supplier_id AS suppliers_1_supplier_id, suppliers_1.name AS suppliers_1_name, suppliers_1.description AS suppliers_1_description, suppliers_1.duns_number AS suppliers_1_duns_number, suppliers_1.esourcing_id AS suppliers_1_esourcing_id, suppliers_1.companies_house_number AS suppliers_1_companies_house_number, suppliers_1.clients AS suppliers_1_clients
FROM (SELECT brief_responses.id AS brief_responses_id, brief_responses.data AS brief_responses_data, brief_responses.brief_id AS brief_responses_brief_id, brief_responses.supplier_id AS brief_responses_supplier_id, brief_responses.created_at AS brief_responses_created_at, brief_responses.submitted_at AS brief_responses_submitted_at
FROM brief_responses
WHERE CASE WHEN (brief_responses.submitted_at IS NOT NULL) THEN %(param_1)s ELSE %(param_2)s END IN (%(param_3)s)
 LIMIT %(param_4)s OFFSET %(param_5)s) AS anon_1 LEFT OUTER JOIN suppliers AS suppliers_1 ON suppliers_1.supplier_id = anon_1.brief_responses_supplier_id LEFT OUTER JOIN contact_information AS contact_information_1 ON suppliers_1.supplier_id = contact_information_1.supplier_id
{'param_5': 0, 'param_4': 100, 'param_1': 'submitted', 'param_3': 'submitted', 'param_2': 'draft'}
ROLLBACK
```

### HOW IT WOULD BE AFTER THIS PR WITHOUT THE JOIN (N+1):

```
select version()
{}
select current_schema()
{}
SELECT CAST('test plain returns' AS VARCHAR(60)) AS anon_1
{}
SELECT CAST('test unicode returns' AS VARCHAR(60)) AS anon_1
{}
show standard_conforming_strings
{}
BEGIN (implicit)
SELECT anon_1.brief_responses_id AS anon_1_brief_responses_id, anon_1.brief_responses_data AS anon_1_brief_responses_data, anon_1.brief_resp
onses_brief_id AS anon_1_brief_responses_brief_id, anon_1.brief_responses_supplier_id AS anon_1_brief_responses_supplier_id, anon_1.brief_responses_created_at AS anon_1_brief_responses_created_at, an
on_1.brief_responses_submitted_at AS anon_1_brief_responses_submitted_at, contact_information_1.id AS contact_information_1_id, contact_information_1.supplier_id AS contact_information_1_supplier_id,
 contact_information_1.contact_name AS contact_information_1_contact_name, contact_information_1.phone_number AS contact_information_1_phone_number, contact_information_1.email AS contact_information
_1_email, contact_information_1.website AS contact_information_1_website, contact_information_1.address1 AS contact_information_1_address1, contact_information_1.address2 AS contact_information_1_add
ress2, contact_information_1.city AS contact_information_1_city, contact_information_1.country AS contact_information_1_country, contact_information_1.postcode AS contact_information_1_postcode, supp
liers_1.id AS suppliers_1_id, suppliers_1.supplier_id AS suppliers_1_supplier_id, suppliers_1.name AS suppliers_1_name, suppliers_1.description AS suppliers_1_description, suppliers_1.duns_number AS
suppliers_1_duns_number, suppliers_1.esourcing_id AS suppliers_1_esourcing_id, suppliers_1.companies_house_number AS suppliers_1_companies_house_number, suppliers_1.clients AS suppliers_1_clients
FROM (SELECT brief_responses.id AS brief_responses_id, brief_responses.data AS brief_responses_data, brief_responses.brief_id AS brief_responses_brief_id, brief_responses.supplier_id AS brief_respons
es_supplier_id, brief_responses.created_at AS brief_responses_created_at, brief_responses.submitted_at AS brief_responses_submitted_at
FROM brief_responses
WHERE CASE WHEN (brief_responses.submitted_at IS NOT NULL) THEN %(param_1)s ELSE %(param_2)s END IN (%(param_3)s)
 LIMIT %(param_4)s OFFSET %(param_5)s) AS anon_1 LEFT OUTER JOIN suppliers AS suppliers_1 ON suppliers_1.supplier_id = anon_1.brief_responses_supplier_id LEFT OUTER JOIN contact_information AS contac
t_information_1 ON suppliers_1.supplier_id = contact_information_1.supplier_id
{'param_5': 0, 'param_4': 100, 'param_1': 'submitted', 'param_3': 'submitted', 'param_2': 'draft'}
SELECT briefs.lot_id AS briefs_lot_id, briefs.id AS briefs_id, briefs.framework_id AS briefs_framework_id, briefs.copied_from_brief_id AS br
iefs_copied_from_brief_id, briefs.data AS briefs_data, briefs.created_at AS briefs_created_at, briefs.updated_at AS briefs_updated_at, briefs.published_at AS briefs_published_at, briefs.withdrawn_at AS briefs_withdrawn_at, lots_1.id AS lots_1_id, lots_1.slug AS lots_1_slug, lots_1.name AS lots_1_name, lots_1.one_service_limit AS lots_1_one_service_limit, lots_1.data AS lots_1_data, frameworks_1.id AS frameworks_1_id, frameworks_1.slug AS frameworks_1_slug, frameworks_1.name AS frameworks_1_name, frameworks_1.framework AS frameworks_1_framework, frameworks_1.framework_agreement_details AS frameworks_1_framework_agreement_details, frameworks_1.status AS frameworks_1_status, frameworks_1.clarification_questions_open AS frameworks_1_clarification_questions_open, frameworks_1.allow_declaration_reuse AS frameworks_1_allow_declaration_reuse, frameworks_1.application_close_date AS frameworks_1_application_close_date, lots_2.id AS lots_2_id, lots_2.slug AS lots_2_slug, lots_2.name AS lots_2_name, lots_2.one_service_limit AS lots_2_one_service_limit, lots_2.data AS lots_2_data
FROM briefs LEFT OUTER JOIN frameworks AS frameworks_1 ON frameworks_1.id = briefs.framework_id LEFT OUTER JOIN (framework_lots AS framework_lots_1 JOIN lots AS lots_1 ON lots_1.id = framework_lots_1.lot_id) ON frameworks_1.id = framework_lots_1.framework_id LEFT OUTER JOIN lots AS lots_2 ON lots_2.id = briefs.lot_id
WHERE briefs.id = %(param_1)s ORDER BY lots_1.id
{'param_1': 2397}
SELECT briefs.lot_id AS briefs_lot_id, briefs.id AS briefs_id, briefs.framework_id AS briefs_framework_id, briefs.copied_from_brief_id AS briefs_copied_from_brief_id, briefs.data AS briefs_data, briefs.created_at AS briefs_created_at, briefs.updated_at AS briefs_updated_at, briefs.published_at AS briefs_published_at, briefs.withdrawn_at AS briefs_withdrawn_at, lots_1.id AS lots_1_id, lots_1.slug AS lots_1_slug, lots_1.name AS lots_1_name, lots_1.one_service_limit AS lots_1_one_service_limit, lots_1.data AS lots_1_data, frameworks_1.id AS frameworks_1_id, frameworks_1.slug AS frameworks_1_slug, frameworks_1.name AS frameworks_1_name, frameworks_1.framework AS frameworks_1_framework, frameworks_1.framework_agreement_details AS frameworks_1_framework_agreement_details, frameworks_1.status AS frameworks_1_status, frameworks_1.clarification_questions_open AS frameworks_1_clarification_questions_open, frameworks_1.allow_declaration_reuse AS frameworks_1_allow_declaration_reuse, frameworks_1.application_close_date AS frameworks_1_application_close_date, lots_2.id AS lots_2_id, lots_2.slug AS lots_2_slug, lots_2.name AS lots_2_name, lots_2.one_service_limit AS lots_2_one_service_limit, lots_2.data AS lots_2_data
FROM briefs LEFT OUTER JOIN frameworks AS frameworks_1 ON frameworks_1.id = briefs.framework_id LEFT OUTER JOIN (framework_lots AS framework_lots_1 JOIN lots AS lots_1 ON lots_1.id = framework_lots_1.lot_id) ON frameworks_1.id = framework_lots_1.framework_id LEFT OUTER JOIN lots AS lots_2 ON lots_2.id = briefs.lot_id
WHERE briefs.id = %(param_1)s ORDER BY lots_1.id
{'param_1': 2399}
SELECT briefs.lot_id AS briefs_lot_id, briefs.id AS briefs_id, briefs.framework_id AS briefs_framework_id, briefs.copied_from_brief_id AS briefs_copied_from_brief_id, briefs.data AS briefs_data, briefs.created_at AS briefs_created_at, briefs.updated_at AS briefs_updated_at, briefs.published_at AS briefs_published_at, briefs.withdrawn_at AS briefs_withdrawn_at, lots_1.id AS lots_1_id, lots_1.slug AS lots_1_slug, lots_1.name AS lots_1_name, lots_1.one_service_limit AS lots_1_one_service_limit, lots_1.data AS lots_1_data, frameworks_1.id AS frameworks_1_id, frameworks_1.slug AS frameworks_1_slug, frameworks_1.name AS frameworks_1_name, frameworks_1.framework AS frameworks_1_framework, frameworks_1.framework_agreement_details AS frameworks_1_framework_agreement_details, frameworks_1.status AS frameworks_1_status, frameworks_1.clarification_questions_open AS frameworks_1_clarification_questions_open, frameworks_1.allow_declaration_reuse AS frameworks_1_allow_declaration_reuse, frameworks_1.application_close_date AS frameworks_1_application_close_date, lots_2.id AS lots_2_id, lots_2.slug AS lots_2_slug, lots_2.name AS lots_2_name, lots_2.one_service_limit AS lots_2_one_service_limit, lots_2.data AS lots_2_data
FROM briefs LEFT OUTER JOIN frameworks AS frameworks_1 ON frameworks_1.id = briefs.framework_id LEFT OUTER JOIN (framework_lots AS framework_lots_1 JOIN lots AS lots_1 ON lots_1.id = framework_lots_1.lot_id) ON frameworks_1.id = framework_lots_1.framework_id LEFT OUTER JOIN lots AS lots_2 ON lots_2.id = briefs.lot_id
WHERE briefs.id = %(param_1)s ORDER BY lots_1.id
{'param_1': 2401}
SELECT briefs.lot_id AS briefs_lot_id, briefs.id AS briefs_id, briefs.framework_id AS briefs_framework_id, briefs.copied_from_brief_id AS briefs_copied_from_brief_id, briefs.data AS briefs_data, briefs.created_at AS briefs_created_at, briefs.updated_at AS briefs_updated_at, briefs.published_at AS briefs_published_at, briefs.withdrawn_at AS briefs_withdrawn_at, lots_1.id AS lots_1_id, lots_1.slug AS lots_1_slug, lots_1.name AS lots_1_name, lots_1.one_service_limit AS lots_1_one_service_limit, lots_1.data AS lots_1_data, frameworks_1.id AS frameworks_1_id, frameworks_1.slug AS frameworks_1_slug, frameworks_1.name AS frameworks_1_name, frameworks_1.framework AS frameworks_1_framework, frameworks_1.framework_agreement_details AS frameworks_1_framework_agreement_details, frameworks_1.status AS frameworks_1_status, frameworks_1.clarification_questions_open AS frameworks_1_clarification_questions_open, frameworks_1.allow_declaration_reuse AS frameworks_1_allow_declaration_reuse, frameworks_1.application_close_date AS frameworks_1_application_close_date, lots_2.id AS lots_2_id, lots_2.slug AS lots_2_slug, lots_2.name AS lots_2_name, lots_2.one_service_limit AS lots_2_one_service_limit, lots_2.data AS lots_2_data
FROM briefs LEFT OUTER JOIN frameworks AS frameworks_1 ON frameworks_1.id = briefs.framework_id LEFT OUTER JOIN (framework_lots AS framework_lots_1 JOIN lots AS lots_1 ON lots_1.id = framework_lots_1.lot_id) ON frameworks_1.id = framework_lots_1.framework_id LEFT OUTER JOIN lots AS lots_2 ON lots_2.id = briefs.lot_id
WHERE briefs.id = %(param_1)s ORDER BY lots_1.id
{'param_1': 2405}
ROLLBACK
```
