### PR TITLE
Remove Flask-Bootstrap

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,6 +1,5 @@
 from functools import wraps
 from flask import Flask
-from flask.ext.bootstrap import Bootstrap
 from flask.ext.sqlalchemy import SQLAlchemy
 import json
 from sqlalchemy import MetaData
@@ -10,7 +9,6 @@ from dmutils import init_app, flask_featureflags
 
 from config import configs
 
-bootstrap = Bootstrap()
 db = SQLAlchemy(metadata=MetaData(naming_convention={
     "ix": 'ix_%(column_0_label)s',
     "uq": "uq_%(table_name)s_%(column_0_name)s",
@@ -29,7 +27,6 @@ def create_app(config_name):
     init_app(
         application,
         configs[config_name],
-        bootstrap=bootstrap,
         db=db,
         feature_flags=feature_flags,
         search_api_client=search_api_client

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 Flask==0.10.1
 Flask-Bcrypt==0.7.1
-Flask-Bootstrap==3.3.0.1
 Flask-Migrate==2.0.3
 Flask-Script==2.0.5
 Flask-SQLAlchemy==2.1


### PR DESCRIPTION
This was used by the API explorer, but that's gone now so this can be removed.