### PR TITLE
[#147424377]list_audits: add earliest_for_each_object option

### DIFF
--- a/app/main/views/audits.py
+++ b/app/main/views/audits.py
@@ -116,6 +116,17 @@ def list_audits():
         abort(400, 'object-id cannot be provided without object-type')
 
     if earliest_for_each_object:
+        if not (
+                acknowledged and
+                acknowledged != 'all' and
+                audit_type == "update_service" and
+                object_type == "services"
+                ):
+            current_app.logger.warning(
+                "earliest_for_each_object option currently intended for use on acknowledged update_service events. "
+                "If use with any other events is to be regular, the scope of the corresponding partial index "
+                "should be expanded to cover it."
+            )
         # we need to join the built-up subquery back onto the AuditEvent table to retrieve the rest of the row
         audits_subquery = audits.order_by(
             AuditEvent.object_type,

--- a/app/main/views/audits.py
+++ b/app/main/views/audits.py
@@ -118,11 +118,8 @@ def list_audits():
 
         audits = AuditEvent.query.join(audits_subquery, audits_subquery.c.id == AuditEvent.id)
 
-    audits = audits.order_by(
-        desc(AuditEvent.created_at)
-        if convert_to_boolean(request.args.get('latest_first'))
-        else asc(AuditEvent.created_at)
-    )
+    sort_order = db.desc if convert_to_boolean(request.args.get('latest_first')) else db.asc
+    audits = audits.order_by(sort_order(AuditEvent.created_at), sort_order(AuditEvent.id))
 
     audits = audits.paginate(
         page=page,

--- a/tests/main/views/test_audits.py
+++ b/tests/main/views/test_audits.py
@@ -144,6 +144,15 @@ class TestAuditEvents(BaseTestAuditEvents):
         assert_equal(len(data['auditEvents']), 1)
         assert_equal(data['auditEvents'][0]['user'], 'rob')
 
+    def test_should_get_audit_events_by_object_type(self):
+        self.add_audit_events_with_db_object()
+
+        response = self.client.get('/audit-events?object-type=suppliers')
+        data = json.loads(response.get_data())
+
+        assert_equal(response.status_code, 200)
+        assert_equal(len(data["auditEvents"]), 3)
+
     def test_get_audit_event_for_missing_object_returns_404(self):
         self.add_audit_events_with_db_object()
 
@@ -182,13 +191,6 @@ class TestAuditEvents(BaseTestAuditEvents):
         self.add_audit_events_with_db_object()
 
         response = self.client.get('/audit-events?object-type=invalid&object-id=1')
-
-        assert_equal(response.status_code, 400)
-
-    def test_should_reject_object_type_if_no_object_id_is_given(self):
-        self.add_audit_events_with_db_object()
-
-        response = self.client.get('/audit-events?object-type=suppliers')
 
         assert_equal(response.status_code, 400)
 


### PR DESCRIPTION
Story https://www.pivotaltracker.com/story/show/147424377

If we want https://github.com/alphagov/digitalmarketplace-admin-frontend/pull/269 to be safely performant, we're going to have to do the grouping/`DISTINCT ON` server-side.

I've called this mode `earliest_for_each_object`, I'm not totally set on the name, but think the way I've added the feature is sensibly generic.

Also allowed the endpoint to filter by `object_type` without requiring `object_id`. This will be needed in forthcoming stories.

Added `AuditEvent.id` as minor ordering tie-breaker to ensure deterministic ordering and ensure `latest_first=true` returns the exact reverse result of `latest_first=false`.

I haven't split out the migrations as a separate PR as they are both db changes which should be mostly transparent to the app. But if we wanted to be obsessive about that I could.