### PR TITLE
Speed up get_framework_suppliers endpoint

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -227,6 +227,11 @@ def get_framework_suppliers(framework_slug):
 
     supplier_frameworks = supplier_frameworks.filter(
         SupplierFramework.framework_id == framework.id
+    ).options(
+        db.defaultload(SupplierFramework.framework).lazyload("*"),
+        db.defaultload(SupplierFramework.supplier).lazyload("*"),
+        db.defaultload(SupplierFramework.prefill_declaration_from_framework).lazyload("*"),
+        db.lazyload(SupplierFramework.framework_agreements),
     ).order_by(
         # Listing agreements is something done for Admin only (suppliers only retrieve their individual agreements)
         # and CCS always want to work from the oldest returned date to newest, so order by ascending date


### PR DESCRIPTION
Admin app listing of suppliers on a framework has been intermittently timing out.

This patch will hopefully help by speeding up the API request.

Local testing looks promising... timing 5000 requests using the API client `find_framework_suppliers` method with various different params set (G7, G8, with and without agreement returned, with statuses set) results were as follows:
Unpatched (current master branch): 04:42.557284
Patched (this branch):  02:34.732294

i.e. almost halved the time taken for 5000 requests.

I have a feeling the admin app processing might also be an issue for this page, this should hopefully help a bit though.