### PR TITLE
Speed up get_framework_interest endpoint

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -276,6 +276,11 @@ def get_framework_interest(framework_slug):
 
     supplier_frameworks = SupplierFramework.query.filter(
         SupplierFramework.framework_id == framework.id
+    ).options(
+        db.defaultload(SupplierFramework.framework).lazyload("*"),
+        db.defaultload(SupplierFramework.supplier).lazyload("*"),
+        db.defaultload(SupplierFramework.prefill_declaration_from_framework).lazyload("*"),
+        db.lazyload(SupplierFramework.framework_agreements),
     ).order_by(SupplierFramework.supplier_id).all()
 
     supplier_ids = [supplier_framework.supplier_id for supplier_framework in supplier_frameworks]


### PR DESCRIPTION
The script to countersign G-Cloud 9 agreements is failing with a 502 from production API on `/frameworks/g-cloud-9/interest`.

This patch will hopefully help by speeding up the API request.

Local testing looks promising... timing 600 requests using the API client `get_interested_suppliers` method (100 each for G6, G7, G8, G9, DOS and DOS2) results were as follows:
Unpatched (current master branch): 01:57.958328
Patched (this branch):  0:00:30.681378

i.e. only a quarter of the time taken for the same 600 requests.