### PR TITLE
Filter brief responses by list of framework slugs

### DIFF
--- a/app/main/views/brief_responses.py
+++ b/app/main/views/brief_responses.py
@@ -6,7 +6,7 @@ from sqlalchemy.exc import IntegrityError, DataError
 from dmapiclient.audit import AuditTypes
 
 from .. import main
-from ...models import db, Brief, BriefResponse, AuditEvent
+from ...models import db, Brief, BriefResponse, AuditEvent, Framework
 from ...utils import (
     get_json_from_request, json_has_required_keys, get_int_or_400,
     pagination_links, get_valid_page_or_1, url_for,
@@ -219,6 +219,13 @@ def list_brief_responses():
         db.defaultload(BriefResponse.brief).defaultload(Brief.lot).lazyload("*"),
         db.defaultload(BriefResponse.supplier).lazyload("*"),
     )
+
+    if request.args.get('framework'):
+        brief_responses = brief_responses.join(BriefResponse.brief).join(Brief.framework).filter(
+            Brief.framework.has(Framework.slug.in_(
+                framework_slug.strip() for framework_slug in request.args["framework"].split(",")
+            ))
+        )
 
     if brief_id or supplier_id:
         return jsonify(

--- a/app/models.py
+++ b/app/models.py
@@ -1467,7 +1467,7 @@ class BriefResponse(db.Model):
     def serialize(self):
         data = self.data.copy()
         parent_brief = self.brief.serialize()
-        parent_brief_fields = ['id', 'title', 'status', 'applicationsClosedAt']
+        parent_brief_fields = ['id', 'title', 'status', 'applicationsClosedAt', 'frameworkSlug']
         data.update({
             'id': self.id,
             'brief': {key: parent_brief[key] for key in parent_brief_fields if key in parent_brief},

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -175,11 +175,29 @@ def _add_framework(request, app, slug, **kwargs):
 
     def teardown():
         with app.app_context():
+            FrameworkLot.query.filter(FrameworkLot.framework_id == framework.id).delete()
             Framework.query.filter(Framework.slug == slug).delete()
             db.session.commit()
 
     request.addfinalizer(teardown)
     return framework.serialize()
+
+
+def _add_lots_for_framework(request, app, framework_slug, lot_slugs):
+    for lot_slug in lot_slugs:
+        _add_lot_for_framework(request, app, framework_slug, lot_slug)
+
+
+def _add_lot_for_framework(request, app, framework_slug, lot_slug):
+    with app.app_context():
+        framework = Framework.query.filter(Framework.slug == framework_slug).first()
+        lot = Lot.query.filter(Lot.slug == lot_slug).first()
+        if not FrameworkLot.query.filter(FrameworkLot.framework_id == framework.id). \
+                filter(FrameworkLot.lot_id == lot.id).first():
+            framework_lot = FrameworkLot(framework_id=framework.id, lot_id=lot.id)
+            db.session.add(framework_lot)
+            db.session.commit()
+            return framework_lot
 
 
 def _framework_fixture_inner(request, app, slug, **kwargs):
@@ -224,6 +242,7 @@ _example_framework_details = {
     "framework": "g-cloud",
     "framework_agreement_details": None
 }
+_dos_framework_lots = ["digital-specialists", "digital-outcomes", "user-research-participants", "user-research-studios"]
 
 
 def _supplierframework_fixture_inner(request, app, sf_kwargs=None):
@@ -382,22 +401,30 @@ def expired_g6_framework(request, app):
 
 @pytest.fixture()
 def open_dos_framework(request, app):
-    return _framework_fixture_inner(request, app, **dict(_dos_framework_defaults, status="open"))
+    fw = _framework_fixture_inner(request, app, **dict(_dos_framework_defaults, status="open"))
+    _add_lots_for_framework(request, app, _dos_framework_defaults["slug"], _dos_framework_lots)
+    return fw
 
 
 @pytest.fixture()
 def live_dos_framework(request, app):
-    return _framework_fixture_inner(request, app, **dict(_dos_framework_defaults, status="live"))
+    fw = _framework_fixture_inner(request, app, **dict(_dos_framework_defaults, status="live"))
+    _add_lots_for_framework(request, app, _dos_framework_defaults["slug"], _dos_framework_lots)
+    return fw
 
 
 @pytest.fixture()
 def expired_dos_framework(request, app):
-    return _framework_fixture_inner(request, app, **dict(_dos_framework_defaults, status="expired"))
+    fw = _framework_fixture_inner(request, app, **dict(_dos_framework_defaults, status="expired"))
+    _add_lots_for_framework(request, app, _dos_framework_defaults["slug"], _dos_framework_lots)
+    return fw
 
 
 @pytest.fixture()
 def live_dos2_framework(request, app):
-    return _framework_fixture_inner(request, app, **dict(_dos2_framework_defaults, status="live"))
+    fw = _framework_fixture_inner(request, app, **dict(_dos2_framework_defaults, status="live"))
+    _add_lots_for_framework(request, app, _dos2_framework_defaults["slug"], _dos_framework_lots)
+    return fw
 
 
 # Suppliers

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -176,7 +176,7 @@ def _add_framework(request, app, slug, **kwargs):
     def teardown():
         with app.app_context():
             FrameworkLot.query.filter(FrameworkLot.framework_id == framework.id).delete()
-            Framework.query.filter(Framework.slug == slug).delete()
+            Framework.query.filter(Framework.id == framework.id).delete()
             db.session.commit()
 
     request.addfinalizer(teardown)
@@ -192,8 +192,10 @@ def _add_lot_for_framework(request, app, framework_slug, lot_slug):
     with app.app_context():
         framework = Framework.query.filter(Framework.slug == framework_slug).first()
         lot = Lot.query.filter(Lot.slug == lot_slug).first()
-        if not FrameworkLot.query.filter(FrameworkLot.framework_id == framework.id). \
-                filter(FrameworkLot.lot_id == lot.id).first():
+        existing_framework_lot = FrameworkLot.query.filter(
+            FrameworkLot.framework_id == framework.id, FrameworkLot.lot_id == lot.id
+        ).first()
+        if not existing_framework_lot:
             framework_lot = FrameworkLot(framework_id=framework.id, lot_id=lot.id)
             db.session.add(framework_lot)
             db.session.commit()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -584,7 +584,8 @@ class TestBriefResponses(BaseApplicationTest, FixtureMixin):
                         'applicationsClosedAt': '2016-03-10T23:59:59.000000Z',
                         'id': self.brief.id,
                         'status': self.brief.status,
-                        'title': self.brief_title
+                        'title': self.brief_title,
+                        'frameworkSlug': self.brief.framework.slug
                     },
                     'briefId': self.brief.id,
                     'supplierId': 0,
@@ -617,7 +618,8 @@ class TestBriefResponses(BaseApplicationTest, FixtureMixin):
                         'applicationsClosedAt': '2016-03-10T23:59:59.000000Z',
                         'id': self.brief.id,
                         'status': self.brief.status,
-                        'title': self.brief_title
+                        'title': self.brief_title,
+                        'frameworkSlug': self.brief.framework.slug
                     },
                     'supplierId': 0,
                     'supplierName': 'Supplier 0',


### PR DESCRIPTION
We need to filter brief responses by framework as part of this trello story
https://trello.com/c/vntb9Xql/396-allow-suppliers-to-view-their-applications

I've also decided to kept the conftest quite light (not following the more indepth pattern of `fixture_inner`) as keen not to over-engineer. 


Potential things for discussion:
- The second test (test_list_brief_responses_by_multiple_framework_slugs) maybe feels a little fragile due to there only being two DOS frameworks
- General conftest and fixture setup 
