### PR TITLE
Improve API test coverage

### DIFF
--- a/app/main/views/brief_responses.py
+++ b/app/main/views/brief_responses.py
@@ -214,6 +214,12 @@ def list_brief_responses():
     if brief_id is not None:
         brief_responses = brief_responses.filter(BriefResponse.brief_id == brief_id)
 
+    brief_responses = brief_responses.options(
+        db.defaultload(BriefResponse.brief).defaultload(Brief.framework).lazyload("*"),
+        db.defaultload(BriefResponse.brief).defaultload(Brief.lot).lazyload("*"),
+        db.defaultload(BriefResponse.supplier).lazyload("*"),
+    )
+
     if brief_id or supplier_id:
         return jsonify(
             briefResponses=[brief_response.serialize() for brief_response in brief_responses.all()],

--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -104,7 +104,7 @@ def get_brief(brief_id):
         Brief.id == brief_id
     ).first_or_404()
 
-    return jsonify(briefs=brief.serialize(with_users=True))
+    return jsonify(briefs=brief.serialize(with_users=True, with_clarification_questions=True))
 
 
 @main.route('/briefs', methods=['GET'])
@@ -305,7 +305,7 @@ def add_clarification_question(brief_id):
     db.session.add(audit)
     db.session.commit()
 
-    return jsonify(briefs=brief.serialize()), 200
+    return jsonify(briefs=brief.serialize(with_clarification_questions=True)), 200
 
 
 @main.route("/briefs/<brief_id>/services", methods=["GET"])

--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -308,7 +308,7 @@ def add_clarification_question(brief_id):
     return jsonify(briefs=brief.serialize(with_clarification_questions=True)), 200
 
 
-@main.route("/briefs/<brief_id>/services", methods=["GET"])
+@main.route("/briefs/<int:brief_id>/services", methods=["GET"])
 def list_brief_services(brief_id):
     brief = Brief.query.filter(
         Brief.id == brief_id

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -78,7 +78,7 @@ def get_framework(framework_slug):
     return jsonify(frameworks=framework.serialize())
 
 
-@main.route('/frameworks/<framework_slug>', methods=['POST'])
+@main.route('/frameworks/<string:framework_slug>', methods=['POST'])
 def update_framework(framework_slug):
     attribute_whitelist = {
         'status': 'status',

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -251,7 +251,7 @@ def update_contact_information(supplier_id, contact_id):
     return jsonify(contactInformation=contact.serialize())
 
 
-@main.route('/suppliers/<supplier_id>/frameworks/<framework_slug>/declaration', methods=['PUT'])
+@main.route('/suppliers/<int:supplier_id>/frameworks/<framework_slug>/declaration', methods=['PUT'])
 def set_a_declaration(supplier_id, framework_slug):
     framework = Framework.query.filter(
         Framework.slug == framework_slug
@@ -297,7 +297,7 @@ def set_a_declaration(supplier_id, framework_slug):
     return jsonify(declaration=supplier_framework.declaration), status_code
 
 
-@main.route('/suppliers/<supplier_id>/frameworks/interest', methods=['GET'])
+@main.route('/suppliers/<int:supplier_id>/frameworks/interest', methods=['GET'])
 def get_registered_frameworks(supplier_id):
     supplier_frameworks = SupplierFramework.query.filter(
         SupplierFramework.supplier_id == supplier_id
@@ -312,7 +312,7 @@ def get_registered_frameworks(supplier_id):
     return jsonify(frameworks=slugs)
 
 
-@main.route('/suppliers/<supplier_id>/frameworks', methods=['GET'])
+@main.route('/suppliers/<int:supplier_id>/frameworks', methods=['GET'])
 def get_supplier_frameworks_info(supplier_id):
     supplier = Supplier.query.filter(
         Supplier.supplier_id == supplier_id
@@ -334,7 +334,7 @@ def get_supplier_frameworks_info(supplier_id):
     )
 
 
-@main.route('/suppliers/<supplier_id>/frameworks/<framework_slug>', methods=['GET'])
+@main.route('/suppliers/<int:supplier_id>/frameworks/<framework_slug>', methods=['GET'])
 def get_supplier_framework_info(supplier_id, framework_slug):
     supplier_framework = SupplierFramework.find_by_supplier_and_framework(
         supplier_id, framework_slug
@@ -345,7 +345,7 @@ def get_supplier_framework_info(supplier_id, framework_slug):
     return jsonify(frameworkInterest=supplier_framework.serialize(with_users=True))
 
 
-@main.route('/suppliers/<supplier_id>/frameworks/<framework_slug>', methods=['PUT'])
+@main.route('/suppliers/<int:supplier_id>/frameworks/<framework_slug>', methods=['PUT'])
 def register_framework_interest(supplier_id, framework_slug):
 
     framework = Framework.query.filter(
@@ -395,7 +395,7 @@ def register_framework_interest(supplier_id, framework_slug):
     return jsonify(frameworkInterest=interest_record.serialize()), 201
 
 
-@main.route('/suppliers/<supplier_id>/frameworks/<framework_slug>', methods=['POST'])
+@main.route('/suppliers/<int:supplier_id>/frameworks/<framework_slug>', methods=['POST'])
 def update_supplier_framework(supplier_id, framework_slug):
     framework = Framework.query.filter(
         Framework.slug == framework_slug

--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -157,9 +157,9 @@ def create_user():
     except IntegrityError:
         db.session.rollback()
         abort(400, "Invalid supplier id")
-    except DataError:
+    except DataError as e:
         db.session.rollback()
-        abort(400, "Invalid user role")
+        abort(400, "Data Error: {}".format(e))
 
     return jsonify(users=user.serialize()), 201
 

--- a/app/models.py
+++ b/app/models.py
@@ -1168,7 +1168,7 @@ class Brief(db.Model):
     clarification_questions = db.relationship(
         "BriefClarificationQuestion",
         order_by="BriefClarificationQuestion.published_at",
-        lazy='joined'
+        lazy='select',
     )
 
     @validates('users')
@@ -1325,7 +1325,7 @@ class Brief(db.Model):
             'requirementsLength': requirements_length
         }
 
-    def serialize(self, with_users=False):
+    def serialize(self, with_users=False, with_clarification_questions=False):
         data = dict(self.data.items())
 
         data.update({
@@ -1341,10 +1341,12 @@ class Brief(db.Model):
             'lotName': self.lot.name,
             'createdAt': self.created_at.strftime(DATETIME_FORMAT),
             'updatedAt': self.updated_at.strftime(DATETIME_FORMAT),
-            'clarificationQuestions': [
-                question.serialize() for question in self.clarification_questions
-            ],
         })
+
+        if with_clarification_questions:
+            data['clarificationQuestions'] = [
+                question.serialize() for question in self.clarification_questions
+            ]
 
         if self.published_at:
             data.update({

--- a/data/buyer-email-domains.txt
+++ b/data/buyer-email-domains.txt
@@ -13,11 +13,13 @@ bbc.co.uk
 bfi.org.uk
 biglotteryfund.org.uk
 blackwoodgroup.org.uk
+bridgend.gov.uk
 britishcouncil.org
 britishmuseum.org
 caa.co.uk
 calmac.co.uk
 careerswales.com
+careinspectorate.com
 ccea.org.uk
 cceservices.org.uk
 ccwales.org.uk
@@ -125,6 +127,7 @@ npl.co.uk
 ofcom.org.uk
 originhousing.org.uk
 os.uk
+oscr.org.uk
 paradigmhousing.co.uk
 parliament.uk
 pbat.co.uk
@@ -157,6 +160,7 @@ tate.org.uk
 tetrust.org
 tfgm.com
 theipsa.org.uk
+thls.org
 tourismireland.com
 traffordhousingtrust.co.uk
 translink.co.uk

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,9 +19,3 @@ strict-rfc3339==0.5
 requests==2.9.1
 docopt==0.6.2
 six==1.10.0
-
-# For Cloud Foundry
-cffi==1.5.2
-gunicorn==19.4.5
-awscli>=1.11,<1.12
-awscli-cwlogs>=1.4,<1.5

--- a/tests/main/views/test_drafts.py
+++ b/tests/main/views/test_drafts.py
@@ -361,7 +361,6 @@ class TestFetchAndListDraftServices(DraftServicesTestBase):
         assert res.status_code == 201
 
         data = json.loads(res.get_data())
-
         res = self.client.get('/draft-services/{}'.format(data['services']['id']))
         assert res.status_code == 200
         data = json.loads(res.get_data())

--- a/tests/main/views/test_drafts.py
+++ b/tests/main/views/test_drafts.py
@@ -1336,7 +1336,7 @@ class TestCompleteDraft(BaseApplicationTest, JSONUpdateTestMixin):
 
     def test_complete_draft(self):
         res = self.client.post(
-            '/draft-services/%s/complete' % self.draft_id,
+            '/draft-services/{}/complete'.format(self.draft_id),
             data=json.dumps({'updated_by': 'joeblogs'}),
             content_type='application/json')
 
@@ -1346,7 +1346,7 @@ class TestCompleteDraft(BaseApplicationTest, JSONUpdateTestMixin):
 
     def test_complete_draft_should_create_audit_event(self):
         res = self.client.post(
-            '/draft-services/%s/complete' % self.draft_id,
+            '/draft-services/{}/complete'.format(self.draft_id),
             data=json.dumps({'updated_by': 'joeblogs'}),
             content_type='application/json')
 
@@ -1364,7 +1364,7 @@ class TestCompleteDraft(BaseApplicationTest, JSONUpdateTestMixin):
 
     def test_should_not_complete_draft_without_updated_by(self):
         res = self.client.post(
-            '/draft-services/%s/complete' % self.draft_id,
+            '/draft-services/{}/complete'.format(self.draft_id),
             data=json.dumps({}),
             content_type='application/json')
 
@@ -1390,7 +1390,7 @@ class TestCompleteDraft(BaseApplicationTest, JSONUpdateTestMixin):
         draft = json.loads(draft.get_data())['services']
 
         res = self.client.post(
-            '/draft-services/%s/complete' % draft['id'],
+            '/draft-services/{}/complete'.format(draft['id']),
             data=json.dumps({'updated_by': 'joeblogs'}),
             content_type='application/json')
 
@@ -1402,7 +1402,7 @@ class TestCompleteDraft(BaseApplicationTest, JSONUpdateTestMixin):
     def test_complete_draft_catches_db_integrity_errors(self, db_commit):
         db_commit.side_effect = IntegrityError("Could not commit", orig=None, params={})
         res = self.client.post(
-            '/draft-services/%s/complete' % self.draft_id,
+            '/draft-services/{}/complete'.format(self.draft_id),
             data=json.dumps({'updated_by': 'joeblogs'}),
             content_type='application/json')
 
@@ -1446,7 +1446,7 @@ class TestUpdateDraftStatus(BaseApplicationTest, JSONUpdateTestMixin):
 
     def test_update_draft_status(self):
         res = self.client.post(
-            '/draft-services/%s/update-status' % self.draft_id,
+            '/draft-services/{}/update-status'.format(self.draft_id),
             data=json.dumps({'services': {'status': 'failed'}, 'updated_by': 'joeblogs'}),
             content_type='application/json')
 
@@ -1456,7 +1456,7 @@ class TestUpdateDraftStatus(BaseApplicationTest, JSONUpdateTestMixin):
 
     def test_update_draft_status_should_create_audit_event(self):
         res = self.client.post(
-            '/draft-services/%s/update-status' % self.draft_id,
+            '/draft-services/{}/update-status'.format(self.draft_id),
             data=json.dumps({'services': {'status': 'failed'}, 'updated_by': 'joeblogs'}),
             content_type='application/json')
 
@@ -1474,7 +1474,7 @@ class TestUpdateDraftStatus(BaseApplicationTest, JSONUpdateTestMixin):
 
     def test_should_not_update_draft_status_to_invalid_status(self):
         res = self.client.post(
-            '/draft-services/%s/update-status' % self.draft_id,
+            '/draft-services/{}/update-status'.format(self.draft_id),
             data=json.dumps({'services': {'status': 'INVALID-STATUS'}, 'updated_by': 'joeblogs'}),
             content_type='application/json')
 
@@ -1482,10 +1482,10 @@ class TestUpdateDraftStatus(BaseApplicationTest, JSONUpdateTestMixin):
         assert json.loads(res.get_data()) == {"error": "'INVALID-STATUS' is not a valid status"}
 
     @mock.patch('app.db.session.commit')
-    def test_update_draft_catches_db_integrity_errors(self, db_commit):
+    def test_update_draft_status_catches_db_integrity_errors(self, db_commit):
         db_commit.side_effect = IntegrityError("Could not commit", orig=None, params={})
         res = self.client.post(
-            '/draft-services/%s/update-status' % self.draft_id,
+            '/draft-services/{}/update-status'.format(self.draft_id),
             data=json.dumps({'services': {'status': 'failed'}, 'updated_by': 'joeblogs'}),
             content_type='application/json')
 
@@ -1559,7 +1559,7 @@ class TestCopyDraft(BaseApplicationTest, JSONUpdateTestMixin):
 
     def test_copy_draft_should_create_audit_event(self):
         res = self.client.post(
-            '/draft-services/%s/copy' % self.draft_id,
+            '/draft-services/{}/copy'.format(self.draft_id),
             data=json.dumps({'updated_by': 'joeblogs'}),
             content_type='application/json')
 
@@ -1613,7 +1613,7 @@ class TestCopyDraft(BaseApplicationTest, JSONUpdateTestMixin):
     def test_copy_draft_service_should_catch_db_integrity_error(self, db_commit):
         db_commit.side_effect = IntegrityError("Could not commit", orig=None, params={})
         res = self.client.post(
-            '/draft-services/%s/copy' % self.draft_id,
+            '/draft-services/{}/copy'.format(self.draft_id),
             data=json.dumps({'updated_by': 'joeblogs'}),
             content_type='application/json')
 

--- a/tests/main/views/test_drafts.py
+++ b/tests/main/views/test_drafts.py
@@ -8,13 +8,13 @@ from sqlalchemy.exc import IntegrityError
 from tests.helpers import FixtureMixin, load_example_listing
 
 
-class TestDraftServices(BaseApplicationTest, FixtureMixin):
+class DraftServicesTestBase(BaseApplicationTest, FixtureMixin):
     service_id = None
     updater_json = None
     create_draft_json = None
 
     def setup(self):
-        super(TestDraftServices, self).setup()
+        super(DraftServicesTestBase, self).setup()
 
         payload = load_example_listing("G6-SaaS")
 
@@ -59,17 +59,150 @@ class TestDraftServices(BaseApplicationTest, FixtureMixin):
         with self.app.app_context():
             return DraftService.query.count()
 
-    def test_reject_list_drafts_no_supplier_id(self):
-        res = self.client.get('/draft-services')
+    def create_draft_service(self):
+        res = self.client.post(
+            '/draft-services',
+            data=json.dumps(self.create_draft_json),
+            content_type='application/json')
+        assert res.status_code == 201
+        draft = json.loads(res.get_data())['services']
+
+        g7_complete = load_example_listing("G7-SCS").copy()
+        g7_complete.pop('id')
+        draft_update_json = {'services': g7_complete,
+                             'updated_by': 'joeblogs'}
+        res2 = self.client.post(
+            '/draft-services/{}'.format(draft['id']),
+            data=json.dumps(draft_update_json),
+            content_type='application/json')
+        assert res2.status_code == 200
+        draft = json.loads(res2.get_data())['services']
+
+        return draft
+
+    def complete_draft_service(self, draft_id):
+        return self.client.post(
+            '/draft-services/{}/complete'.format(draft_id),
+            data=json.dumps({'updated_by': 'joeblogs'}),
+            content_type='application/json')
+
+    def publish_draft_service(self, draft_id):
+        return self.client.post(
+            '/draft-services/{}/publish'.format(draft_id),
+            data=json.dumps({
+                'updated_by': 'joeblogs'
+            }),
+            content_type='application/json')
+
+    def publish_new_draft_service(self):
+        draft = self.create_draft_service()
+        res = self.complete_draft_service(draft['id'])
+        assert res.status_code == 200
+
+        res = self.publish_draft_service(draft['id'])
+        assert res.status_code == 200
+
+        return res
+
+
+class TestCopyDraftServiceFromExisting(DraftServicesTestBase):
+
+    def test_should_create_draft_from_existing_service(self):
+        res = self.client.put(
+            '/draft-services/copy-from/{}'.format(self.service_id),
+            data=json.dumps(self.updater_json),
+            content_type='application/json')
+
+        data = json.loads(res.get_data())
+        assert res.status_code == 201
+        assert data['services']['serviceId'] == self.service_id
+
+    def test_create_draft_from_existing_should_create_audit_event(self):
+        res = self.client.put(
+            '/draft-services/copy-from/{}'.format(self.service_id),
+            data=json.dumps(self.updater_json),
+            content_type='application/json')
+        assert res.status_code == 201
+
+        audit_response = self.client.get('/audit-events')
+        assert audit_response.status_code == 200
+
+        data = json.loads(audit_response.get_data())
+        assert len(data['auditEvents']) == 1
+        assert data['auditEvents'][0]['user'] == 'joeblogs'
+        assert data['auditEvents'][0]['type'] == 'create_draft_service'
+        assert data['auditEvents'][0]['data']['serviceId'] == self.service_id
+
+    def test_should_not_create_two_drafts_from_existing_service(self):
+        self.client.put(
+            '/draft-services/copy-from/{}'.format(self.service_id),
+            data=json.dumps(self.updater_json),
+            content_type='application/json')
+
+        res = self.client.put(
+            '/draft-services/copy-from/{}'.format(self.service_id),
+            data=json.dumps(self.updater_json),
+            content_type='application/json')
+        data = json.loads(res.get_data())
+
+        assert res.status_code == 400
+        assert 'Draft already exists for service {}'.format(self.service_id) in data['error']
+
+    def test_submission_draft_should_not_prevent_draft_being_created_from_existing_service(self):
+        res = self.publish_new_draft_service()
+
+        service = json.loads(res.get_data())['services']
+
+        res = self.client.put(
+            '/draft-services/copy-from/{}'.format(service['id']),
+            data=json.dumps(self.updater_json),
+            content_type='application/json')
+
+        assert res.status_code == 201
+
+    def test_reject_copy_with_no_updated_by(self):
+        res = self.client.put('/draft-services/copy-from/0000000000')
         assert res.status_code == 400
 
-    def test_reject_list_drafts_invalid_supplier_id(self):
-        res = self.client.get('/draft-services?supplier_id=invalid')
+    def test_reject_invalid_service_id_on_copy(self):
+        res = self.client.put(
+            '/draft-services/copy-from/invalid-id!',
+            data=json.dumps(self.updater_json),
+            content_type='application/json')
         assert res.status_code == 400
 
-    def test_reject_list_drafts_if_no_supplier_for_id(self):
-        res = self.client.get('/draft-services?supplier_id=12345667')
+    def test_should_404_if_service_does_not_exist_on_copy(self):
+        res = self.client.put(
+            '/draft-services/copy-from/0000000000',
+            data=json.dumps(self.updater_json),
+            content_type='application/json')
         assert res.status_code == 404
+
+    @mock.patch('app.db.session.commit')
+    def test_copy_from_existing_service_catches_db_integrity_error(self, db_commit):
+        db_commit.side_effect = IntegrityError("Could not commit", orig=None, params={})
+        res = self.client.put(
+            '/draft-services/copy-from/{}'.format(self.service_id),
+            data=json.dumps(self.updater_json),
+            content_type='application/json')
+
+        assert res.status_code == 400
+        assert "Could not commit" in json.loads(res.get_data())['error']
+
+
+class TestFetchAndListDraftServices(DraftServicesTestBase):
+
+    def test_should_fetch_a_draft(self):
+        res = self.client.put(
+            '/draft-services/copy-from/{}'.format(self.service_id),
+            data=json.dumps(self.updater_json),
+            content_type='application/json')
+        assert res.status_code == 201
+        draft_id = json.loads(res.get_data())['services']['id']
+        fetch = self.client.get('/draft-services/{}'.format(draft_id))
+        assert fetch.status_code == 200
+        data = json.loads(res.get_data())
+        assert data['services']['serviceId'] == self.service_id
 
     def test_returns_empty_list_if_no_drafts(self):
         res = self.client.get('/draft-services?supplier_id=1')
@@ -98,29 +231,6 @@ class TestDraftServices(BaseApplicationTest, FixtureMixin):
         assert res.status_code == 200
         drafts = json.loads(res.get_data())
         assert len(drafts['services']) == 1
-
-    def test_does_not_return_drafts_for_framework_with_no_drafts(self):
-        self.client.put(
-            '/draft-services/copy-from/{}'.format(self.service_id),
-            data=json.dumps(self.updater_json),
-            content_type='application/json')
-        res = self.client.get(
-            '/draft-services?supplier_id=1&framework=g-cloud-7'
-        )
-        assert res.status_code == 200
-        drafts = json.loads(res.get_data())
-        assert len(drafts['services']) == 0
-
-    def test_does_not_return_drafts_from_non_existant_framework(self):
-        self.client.put(
-            '/draft-services/copy-from/{}'.format(self.service_id),
-            data=json.dumps(self.updater_json),
-            content_type='application/json')
-        res = self.client.get(
-            '/draft-services?supplier_id=1&framework=this-is-not-valid'
-        )
-        assert res.status_code == 404
-        assert json.loads(res.get_data(as_text=True))["error"] == "framework 'this-is-not-valid' not found"
 
     def test_returns_all_drafts_for_supplier_on_single_page(self):
         with self.app.app_context():
@@ -173,157 +283,92 @@ class TestDraftServices(BaseApplicationTest, FixtureMixin):
         drafts = json.loads(res.get_data())
         assert len(drafts['links']) == 0
 
-    def test_reject_update_with_no_updater_details(self):
-        res = self.client.post('/draft-services/0000000000')
+    def test_get_draft_returns_last_audit_event(self):
+        draft = json.loads(self.client.post(
+            '/draft-services',
+            data=json.dumps(self.create_draft_json),
+            content_type='application/json'
+        ).get_data())['services']
+
+        res = self.client.get(
+            '/draft-services/%d' % draft['id'],
+            data=json.dumps(self.create_draft_json),
+            content_type='application/json'
+        )
+
+        assert res.status_code == 200
+        data = json.loads(res.get_data())
+        draft, audit_event = data['services'], data['auditEvents']
+
+        assert audit_event['type'] == 'create_draft_service'
+
+    def test_reject_list_drafts_no_supplier_id(self):
+        res = self.client.get('/draft-services')
         assert res.status_code == 400
 
-    def test_reject_copy_with_no_updated_by(self):
-        res = self.client.put('/draft-services/copy-from/0000000000')
+    def test_reject_list_drafts_invalid_supplier_id(self):
+        res = self.client.get('/draft-services?supplier_id=invalid')
         assert res.status_code == 400
 
-    def test_reject_create_with_no_updated_by(self):
-        res = self.client.post('/draft-services')
-        assert res.status_code == 400
-
-    def test_reject_invalid_service_id_on_copy(self):
-        res = self.client.put(
-            '/draft-services/copy-from/invalid-id!',
-            data=json.dumps(self.updater_json),
-            content_type='application/json')
-        assert res.status_code == 400
-
-    def test_should_404_if_service_does_not_exist_on_copy(self):
-        res = self.client.put(
-            '/draft-services/copy-from/0000000000',
-            data=json.dumps(self.updater_json),
-            content_type='application/json')
+    def test_reject_list_drafts_if_no_supplier_for_id(self):
+        res = self.client.get('/draft-services?supplier_id=12345667')
         assert res.status_code == 404
-
-    @mock.patch('app.db.session.commit')
-    def test_copy_from_existing_service_catches_db_integrity_error(self, db_commit):
-        db_commit.side_effect = IntegrityError("Could not commit", orig=None, params={})
-        res = self.client.put(
-            '/draft-services/copy-from/{}'.format(self.service_id),
-            data=json.dumps(self.updater_json),
-            content_type='application/json')
-
-        assert res.status_code == 400
-        assert "Could not commit" in json.loads(res.get_data())['error']
 
     def test_reject_invalid_service_id_on_get(self):
         res = self.client.get('/draft-services?service_id=invalid-id!')
         assert res.status_code == 400
 
-    def test_reject_delete_with_no_updated_by(self):
-        res = self.client.delete('/draft-services/0000000000',
-                                 data=json.dumps({}),
-                                 content_type='application/json')
-        assert res.status_code == 400
-
-    def test_reject_publish_with_no_updated_by(self):
-        res = self.client.post('/draft-services/0000000000/publish',
-                               data=json.dumps({}),
-                               content_type='application/json')
-        assert res.status_code == 400
-
-    def test_should_create_draft_with_minimal_data(self):
-        res = self.client.post(
-            '/draft-services',
-            data=json.dumps(self.create_draft_json),
+    def test_does_not_return_drafts_for_framework_with_no_drafts(self):
+        self.client.put(
+            '/draft-services/copy-from/{}'.format(self.service_id),
+            data=json.dumps(self.updater_json),
             content_type='application/json')
+        res = self.client.get(
+            '/draft-services?supplier_id=1&framework=g-cloud-7'
+        )
+        assert res.status_code == 200
+        drafts = json.loads(res.get_data())
+        assert len(drafts['services']) == 0
 
-        data = json.loads(res.get_data())
-        assert res.status_code == 201
-        assert data['services']['frameworkSlug'] == 'g-cloud-7'
-        assert data['services']['frameworkName'] == 'G-Cloud 7'
-        assert data['services']['status'] == 'not-submitted'
-        assert data['services']['supplierId'] == 1
-        assert data['services']['lot'] == 'scs'
-
-    def test_create_draft_checks_page_questions(self):
-        self.create_draft_json['page_questions'] = ['serviceName']
-        res = self.client.post(
-            '/draft-services',
-            data=json.dumps(self.create_draft_json),
+    def test_does_not_return_drafts_from_non_existant_framework(self):
+        self.client.put(
+            '/draft-services/copy-from/{}'.format(self.service_id),
+            data=json.dumps(self.updater_json),
             content_type='application/json')
+        res = self.client.get(
+            '/draft-services?supplier_id=1&framework=this-is-not-valid'
+        )
+        assert res.status_code == 404
+        assert json.loads(res.get_data(as_text=True))["error"] == "framework 'this-is-not-valid' not found"
 
+    def test_should_404_on_fetch_a_draft_that_doesnt_exist(self):
+        fetch = self.client.get('/draft-services/0000000000')
+        assert fetch.status_code == 404
+
+    def test_valid_draft_should_have_no_validation_errors(self):
+        draft = self.create_draft_service()
+
+        res = self.client.get('/draft-services/{}'.format(draft['id']))
+        assert res.status_code == 200
         data = json.loads(res.get_data())
-        assert res.status_code == 400
-        assert data['error'] == {'serviceName': 'answer_required'}
+        assert not data['validationErrors']
 
-    def test_create_draft_only_checks_valid_page_questions(self):
-        self.create_draft_json['page_questions'] = ['tea_and_cakes']
+    def test_invalid_draft_should_have_validation_errors(self):
         res = self.client.post(
             '/draft-services',
             data=json.dumps(self.create_draft_json),
             content_type='application/json')
         assert res.status_code == 201
 
-    def test_create_draft_should_create_audit_event(self):
-        res = self.client.post(
-            '/draft-services',
-            data=json.dumps(self.create_draft_json),
-            content_type='application/json')
-
-        assert res.status_code == 201
         data = json.loads(res.get_data())
-        draft_id = data['services']['id']
 
-        audit_response = self.client.get('/audit-events')
-        assert audit_response.status_code == 200
-        data = json.loads(audit_response.get_data())
-        assert len(data['auditEvents']) == 1
-        assert data['auditEvents'][0]['user'] == 'joeblogs'
-        assert data['auditEvents'][0]['type'] == 'create_draft_service'
-        assert data['auditEvents'][0]['data']['draftId'] == draft_id
-        assert data['auditEvents'][0]['data']['draftJson'] == self.create_draft_json['services']
-
-    @mock.patch('app.db.session.commit')
-    def test_create_draft_catches_db_integrity_error(self, db_commit):
-        db_commit.side_effect = IntegrityError("Could not commit", orig=None, params={})
-        res = self.client.post(
-            '/draft-services',
-            data=json.dumps(self.create_draft_json),
-            content_type='application/json')
-
-        assert res.status_code == 400
-        assert "Could not commit" in json.loads(res.get_data())['error']
-
-    def test_should_not_create_draft_with_invalid_data(self):
-        invalid_create_json = self.create_draft_json.copy()
-        invalid_create_json['services']['supplierId'] = "ShouldBeInt"
-        res = self.client.post(
-            '/draft-services',
-            data=json.dumps(invalid_create_json),
-            content_type='application/json')
-
+        res = self.client.get('/draft-services/{}'.format(data['services']['id']))
+        assert res.status_code == 200
         data = json.loads(res.get_data())
-        assert res.status_code == 400
-        assert "Invalid supplier ID 'ShouldBeInt'" in data['error']
+        assert data['validationErrors']
 
-    def test_should_not_create_draft_on_not_open_framework(self):
-        draft_json = self.create_draft_json.copy()
-        draft_json['services']['frameworkSlug'] = 'g-cloud-5'
-        res = self.client.post(
-            '/draft-services',
-            data=json.dumps(draft_json),
-            content_type='application/json')
 
-        data = json.loads(res.get_data())
-        assert res.status_code == 400
-        assert "'g-cloud-5' is not open for submissions" in data['error']
-
-    def test_should_not_create_draft_with_invalid_lot(self):
-        draft_json = self.create_draft_json.copy()
-        draft_json['services']['lot'] = 'newlot'
-        res = self.client.post(
-            '/draft-services',
-            data=json.dumps(self.create_draft_json),
-            content_type='application/json')
-
-        data = json.loads(res.get_data())
-        assert res.status_code == 400
-        assert "Incorrect lot 'newlot' for framework 'g-cloud-7'" in data['error']
+class TestUpdateDraftServices(DraftServicesTestBase):
 
     def test_can_save_additional_fields_to_draft(self):
         res = self.client.post(
@@ -467,6 +512,10 @@ class TestDraftServices(BaseApplicationTest, FixtureMixin):
         assert 'serviceName' not in updated_draft
         assert 'serviceBenefits' not in updated_draft
 
+    def test_reject_update_with_no_updater_details(self):
+        res = self.client.post('/draft-services/0000000000')
+        assert res.status_code == 400
+
     def test_update_draft_catches_db_integrity_error(self):
         draft_id = self.create_draft_service()['id']
         draft_update_json = self.updater_json.copy()
@@ -525,148 +574,6 @@ class TestDraftServices(BaseApplicationTest, FixtureMixin):
         assert res.status_code == 400
         assert "'badField' was unexpected" in str(data['error']['_form'])
         assert "no_unit_specified" in data['error']['priceUnit']
-
-    def test_should_create_draft_from_existing_service(self):
-        res = self.client.put(
-            '/draft-services/copy-from/{}'.format(self.service_id),
-            data=json.dumps(self.updater_json),
-            content_type='application/json')
-
-        data = json.loads(res.get_data())
-        assert res.status_code == 201
-        assert data['services']['serviceId'] == self.service_id
-
-    def test_create_draft_from_existing_should_create_audit_event(self):
-        res = self.client.put(
-            '/draft-services/copy-from/{}'.format(self.service_id),
-            data=json.dumps(self.updater_json),
-            content_type='application/json')
-        assert res.status_code == 201
-
-        audit_response = self.client.get('/audit-events')
-        assert audit_response.status_code == 200
-
-        data = json.loads(audit_response.get_data())
-        assert len(data['auditEvents']) == 1
-        assert data['auditEvents'][0]['user'] == 'joeblogs'
-        assert data['auditEvents'][0]['type'] == 'create_draft_service'
-        assert data['auditEvents'][0]['data']['serviceId'] == self.service_id
-
-    def test_should_not_create_two_drafts_from_existing_service(self):
-        self.client.put(
-            '/draft-services/copy-from/{}'.format(self.service_id),
-            data=json.dumps(self.updater_json),
-            content_type='application/json')
-
-        res = self.client.put(
-            '/draft-services/copy-from/{}'.format(self.service_id),
-            data=json.dumps(self.updater_json),
-            content_type='application/json')
-        data = json.loads(res.get_data())
-
-        assert res.status_code == 400
-        assert 'Draft already exists for service {}'.format(self.service_id) in data['error']
-
-    def test_submission_draft_should_not_prevent_draft_being_created_from_existing_service(self):
-        res = self.publish_new_draft_service()
-
-        service = json.loads(res.get_data())['services']
-
-        res = self.client.put(
-            '/draft-services/copy-from/{}'.format(service['id']),
-            data=json.dumps(self.updater_json),
-            content_type='application/json')
-
-        assert res.status_code == 201
-
-    def test_should_fetch_a_draft(self):
-        res = self.client.put(
-            '/draft-services/copy-from/{}'.format(self.service_id),
-            data=json.dumps(self.updater_json),
-            content_type='application/json')
-        assert res.status_code == 201
-        draft_id = json.loads(res.get_data())['services']['id']
-        fetch = self.client.get('/draft-services/{}'.format(draft_id))
-        assert fetch.status_code == 200
-        data = json.loads(res.get_data())
-        assert data['services']['serviceId'] == self.service_id
-
-    def test_invalid_draft_should_have_validation_errors(self):
-        res = self.client.post(
-            '/draft-services',
-            data=json.dumps(self.create_draft_json),
-            content_type='application/json')
-        assert res.status_code == 201
-
-        data = json.loads(res.get_data())
-
-        res = self.client.get('/draft-services/{}'.format(data['services']['id']))
-        assert res.status_code == 200
-        data = json.loads(res.get_data())
-        assert data['validationErrors']
-
-    def test_valid_draft_should_have_no_validation_errors(self):
-        draft = self.create_draft_service()
-
-        res = self.client.get('/draft-services/{}'.format(draft['id']))
-        assert res.status_code == 200
-        data = json.loads(res.get_data())
-        assert not data['validationErrors']
-
-    def test_should_404_on_fetch_a_draft_that_doesnt_exist(self):
-        fetch = self.client.get('/draft-services/0000000000')
-        assert fetch.status_code == 404
-
-    def test_should_404_on_delete_a_draft_that_doesnt_exist(self):
-        res = self.client.delete(
-            '/draft-services/0000000000',
-            data=json.dumps(self.updater_json),
-            content_type='application/json')
-        assert res.status_code == 404
-
-    def test_should_delete_a_draft(self):
-        res = self.client.put(
-            '/draft-services/copy-from/{}'.format(self.service_id),
-            data=json.dumps(self.updater_json),
-            content_type='application/json')
-        assert res.status_code == 201
-        draft_id = json.loads(res.get_data())['services']['id']
-        fetch = self.client.get('/draft-services/{}'.format(draft_id))
-        assert fetch.status_code == 200
-        delete = self.client.delete(
-            '/draft-services/{}'.format(draft_id),
-            data=json.dumps(self.updater_json),
-            content_type='application/json')
-        assert delete.status_code == 200
-
-        audit_response = self.client.get('/audit-events')
-        assert audit_response.status_code == 200
-        data = json.loads(audit_response.get_data())
-
-        assert len(data['auditEvents']) == 2
-        assert data['auditEvents'][0]['type'] == 'create_draft_service'
-        assert data['auditEvents'][1]['user'] == 'joeblogs'
-        assert data['auditEvents'][1]['type'] == 'delete_draft_service'
-        assert data['auditEvents'][1]['data']['serviceId'] == self.service_id
-
-        fetch_again = self.client.get('/draft-services/{}'.format(draft_id))
-        assert fetch_again.status_code == 404
-
-    def test_delete_catches_db_integrity_error(self):
-        res = self.client.put(
-            '/draft-services/copy-from/{}'.format(self.service_id),
-            data=json.dumps(self.updater_json),
-            content_type='application/json')
-        draft_id = json.loads(res.get_data())['services']['id']
-        with mock.patch('app.db.session.commit') as db_commit:
-            db_commit.side_effect = IntegrityError("Could not commit", orig=None, params={})
-            res = self.client.delete(
-                '/draft-services/{}'.format(draft_id),
-                data=json.dumps(self.updater_json),
-                content_type='application/json')
-
-            assert res.status_code == 400
-            assert "Could not commit" in json.loads(res.get_data())['error']
 
     def test_should_be_able_to_update_a_draft(self):
         res = self.client.put(
@@ -768,6 +675,69 @@ class TestDraftServices(BaseApplicationTest, FixtureMixin):
             content_type='application/json')
 
         assert update.status_code == 400
+
+
+class TestDeleteDraftService(DraftServicesTestBase):
+
+    def test_reject_delete_with_no_updated_by(self):
+        res = self.client.delete('/draft-services/0000000000',
+                                 data=json.dumps({}),
+                                 content_type='application/json')
+        assert res.status_code == 400
+
+    def test_should_404_on_delete_a_draft_that_doesnt_exist(self):
+        res = self.client.delete(
+            '/draft-services/0000000000',
+            data=json.dumps(self.updater_json),
+            content_type='application/json')
+        assert res.status_code == 404
+
+    def test_should_delete_a_draft(self):
+        res = self.client.put(
+            '/draft-services/copy-from/{}'.format(self.service_id),
+            data=json.dumps(self.updater_json),
+            content_type='application/json')
+        assert res.status_code == 201
+        draft_id = json.loads(res.get_data())['services']['id']
+        fetch = self.client.get('/draft-services/{}'.format(draft_id))
+        assert fetch.status_code == 200
+        delete = self.client.delete(
+            '/draft-services/{}'.format(draft_id),
+            data=json.dumps(self.updater_json),
+            content_type='application/json')
+        assert delete.status_code == 200
+
+        audit_response = self.client.get('/audit-events')
+        assert audit_response.status_code == 200
+        data = json.loads(audit_response.get_data())
+
+        assert len(data['auditEvents']) == 2
+        assert data['auditEvents'][0]['type'] == 'create_draft_service'
+        assert data['auditEvents'][1]['user'] == 'joeblogs'
+        assert data['auditEvents'][1]['type'] == 'delete_draft_service'
+        assert data['auditEvents'][1]['data']['serviceId'] == self.service_id
+
+        fetch_again = self.client.get('/draft-services/{}'.format(draft_id))
+        assert fetch_again.status_code == 404
+
+    def test_delete_catches_db_integrity_error(self):
+        res = self.client.put(
+            '/draft-services/copy-from/{}'.format(self.service_id),
+            data=json.dumps(self.updater_json),
+            content_type='application/json')
+        draft_id = json.loads(res.get_data())['services']['id']
+        with mock.patch('app.db.session.commit') as db_commit:
+            db_commit.side_effect = IntegrityError("Could not commit", orig=None, params={})
+            res = self.client.delete(
+                '/draft-services/{}'.format(draft_id),
+                data=json.dumps(self.updater_json),
+                content_type='application/json')
+
+            assert res.status_code == 400
+            assert "Could not commit" in json.loads(res.get_data())['error']
+
+
+class TestPublishDraftService(DraftServicesTestBase):
 
     def test_should_not_be_able_to_publish_if_no_draft_exists(self):
         res = self.client.post(
@@ -913,51 +883,6 @@ class TestDraftServices(BaseApplicationTest, FixtureMixin):
         # service should not be indexed as G-Cloud 7 is not live
         assert not search_api_client.index.called
 
-    def create_draft_service(self):
-        res = self.client.post(
-            '/draft-services',
-            data=json.dumps(self.create_draft_json),
-            content_type='application/json')
-        assert res.status_code == 201
-        draft = json.loads(res.get_data())['services']
-
-        g7_complete = load_example_listing("G7-SCS").copy()
-        g7_complete.pop('id')
-        draft_update_json = {'services': g7_complete,
-                             'updated_by': 'joeblogs'}
-        res2 = self.client.post(
-            '/draft-services/{}'.format(draft['id']),
-            data=json.dumps(draft_update_json),
-            content_type='application/json')
-        assert res2.status_code == 200
-        draft = json.loads(res2.get_data())['services']
-
-        return draft
-
-    def complete_draft_service(self, draft_id):
-        return self.client.post(
-            '/draft-services/{}/complete'.format(draft_id),
-            data=json.dumps({'updated_by': 'joeblogs'}),
-            content_type='application/json')
-
-    def publish_draft_service(self, draft_id):
-        return self.client.post(
-            '/draft-services/{}/publish'.format(draft_id),
-            data=json.dumps({
-                'updated_by': 'joeblogs'
-            }),
-            content_type='application/json')
-
-    def publish_new_draft_service(self):
-        draft = self.create_draft_service()
-        res = self.complete_draft_service(draft['id'])
-        assert res.status_code == 200
-
-        res = self.publish_draft_service(draft['id'])
-        assert res.status_code == 200
-
-        return res
-
     def test_submitted_drafts_are_not_deleted_when_published(self):
         draft = self.create_draft_service()
         self.complete_draft_service(draft['id'])
@@ -1004,94 +929,52 @@ class TestDraftServices(BaseApplicationTest, FixtureMixin):
         assert services[1]['id'] == '2222222222222222'
         assert self.draft_service_count() == 2
 
-    def test_get_draft_returns_last_audit_event(self):
-        draft = json.loads(self.client.post(
-            '/draft-services',
-            data=json.dumps(self.create_draft_json),
-            content_type='application/json'
-        ).get_data())['services']
-
-        res = self.client.get(
-            '/draft-services/%d' % draft['id'],
-            data=json.dumps(self.create_draft_json),
-            content_type='application/json'
-        )
-
-        assert res.status_code == 200
-        data = json.loads(res.get_data())
-        draft, audit_event = data['services'], data['auditEvents']
-
-        assert audit_event['type'] == 'create_draft_service'
+    def test_reject_publish_with_no_updated_by(self):
+        res = self.client.post('/draft-services/0000000000/publish',
+                               data=json.dumps({}),
+                               content_type='application/json')
+        assert res.status_code == 400
 
 
-class TestCopyDraft(BaseApplicationTest, JSONUpdateTestMixin):
-    endpoint = '/draft-services/{self.draft_id}/copy'
-    method = 'post'
+class TestCreateDraftServices(DraftServicesTestBase):
 
-    def setup(self):
-        super(TestCopyDraft, self).setup()
-
-        with self.app.app_context():
-            db.session.add(
-                Supplier(supplier_id=1, name=u"Supplier 1")
-            )
-            db.session.add(
-                ContactInformation(
-                    supplier_id=1,
-                    contact_name=u"Liz",
-                    email=u"liz@royal.gov.uk",
-                    postcode=u"SW1A 1AA"
-                )
-            )
-            Framework.query.filter_by(slug='g-cloud-5') \
-                .update(dict(status='live'))
-            Framework.query.filter_by(slug='g-cloud-7') \
-                .update(dict(status='open'))
-            db.session.commit()
-
-        create_draft_json = {
-            'updated_by': 'joeblogs',
-            'services': {
-                'frameworkSlug': 'g-cloud-7',
-                'lot': 'scs',
-                'supplierId': 1,
-                'serviceName': "Draft",
-                'status': 'submitted',
-                'serviceSummary': 'This is a summary',
-                "termsAndConditionsDocumentURL": "http://localhost/example.pdf",
-                "pricingDocumentURL": "http://localhost/example.pdf",
-                "serviceDefinitionDocumentURL": "http://localhost/example.pdf",
-                "sfiaRateDocumentURL": "http://localhost/example.pdf",
-            }
-        }
-
-        draft = self.client.post(
-            '/draft-services',
-            data=json.dumps(create_draft_json),
-            content_type='application/json')
-
-        self.draft = json.loads(draft.get_data())['services']
-        self.draft_id = self.draft['id']
-
-    def test_copy_draft(self):
+    def test_should_create_draft_with_minimal_data(self):
         res = self.client.post(
-            '/draft-services/%s/copy' % self.draft_id,
-            data=json.dumps({'updated_by': 'joeblogs'}),
+            '/draft-services',
+            data=json.dumps(self.create_draft_json),
             content_type='application/json')
 
         data = json.loads(res.get_data())
-        assert res.status_code == 201, res.get_data()
-        assert data['services']['lot'] == 'scs'
+        assert res.status_code == 201
+        assert data['services']['frameworkSlug'] == 'g-cloud-7'
+        assert data['services']['frameworkName'] == 'G-Cloud 7'
         assert data['services']['status'] == 'not-submitted'
-        assert data['services']['serviceName'] == 'Draft copy'
         assert data['services']['supplierId'] == 1
-        assert data['services']['frameworkSlug'] == self.draft['frameworkSlug']
-        assert data['services']['frameworkName'] == self.draft['frameworkName']
+        assert data['services']['lot'] == 'scs'
 
-    def test_copy_draft_should_create_audit_event(self):
+    def test_create_draft_checks_page_questions(self):
+        self.create_draft_json['page_questions'] = ['serviceName']
         res = self.client.post(
-            '/draft-services/%s/copy' % self.draft_id,
-            data=json.dumps({'updated_by': 'joeblogs'}),
+            '/draft-services',
+            data=json.dumps(self.create_draft_json),
+            content_type='application/json')
+
+        data = json.loads(res.get_data())
+        assert res.status_code == 400
+        assert data['error'] == {'serviceName': 'answer_required'}
+
+    def test_create_draft_only_checks_valid_page_questions(self):
+        self.create_draft_json['page_questions'] = ['tea_and_cakes']
+        res = self.client.post(
+            '/draft-services',
+            data=json.dumps(self.create_draft_json),
+            content_type='application/json')
+        assert res.status_code == 201
+
+    def test_create_draft_should_create_audit_event(self):
+        res = self.client.post(
+            '/draft-services',
+            data=json.dumps(self.create_draft_json),
             content_type='application/json')
 
         assert res.status_code == 201
@@ -1101,165 +984,62 @@ class TestCopyDraft(BaseApplicationTest, JSONUpdateTestMixin):
         audit_response = self.client.get('/audit-events')
         assert audit_response.status_code == 200
         data = json.loads(audit_response.get_data())
-        assert len(data['auditEvents']) == 2
-        assert data['auditEvents'][1]['user'] == 'joeblogs'
-        assert data['auditEvents'][1]['type'] == 'create_draft_service'
-        assert data['auditEvents'][1]['data'] == {
-            'draftId': draft_id,
-            'originalDraftId': self.draft_id
-        }
+        assert len(data['auditEvents']) == 1
+        assert data['auditEvents'][0]['user'] == 'joeblogs'
+        assert data['auditEvents'][0]['type'] == 'create_draft_service'
+        assert data['auditEvents'][0]['data']['draftId'] == draft_id
+        assert data['auditEvents'][0]['data']['draftJson'] == self.create_draft_json['services']
+
+    @mock.patch('app.db.session.commit')
+    def test_create_draft_catches_db_integrity_error(self, db_commit):
+        db_commit.side_effect = IntegrityError("Could not commit", orig=None, params={})
+        res = self.client.post(
+            '/draft-services',
+            data=json.dumps(self.create_draft_json),
+            content_type='application/json')
+
+        assert res.status_code == 400
+        assert "Could not commit" in json.loads(res.get_data())['error']
+
+    def test_reject_create_with_no_updated_by(self):
+        res = self.client.post('/draft-services')
+        assert res.status_code == 400
 
     def test_should_not_create_draft_with_invalid_data(self):
+        invalid_create_json = self.create_draft_json.copy()
+        invalid_create_json['services']['supplierId'] = "ShouldBeInt"
         res = self.client.post(
-            '/draft-services/1000/copy',
-            data=json.dumps({'updated_by': 'joeblogs'}),
-            content_type='application/json')
-
-        assert res.status_code == 404
-
-    def test_should_not_copy_draft_service_description(self):
-        res = self.client.post(
-            '/draft-services/{}/copy'.format(self.draft_id),
-            data=json.dumps({"updated_by": "me"}),
-            content_type="application/json")
-        data = json.loads(res.get_data())
-
-        assert res.status_code == 201
-        assert "serviceSummary" not in data['services']
-
-    def test_should_not_copy_draft_documents(self):
-        res = self.client.post(
-            '/draft-services/{}/copy'.format(self.draft_id),
-            data=json.dumps({"updated_by": "me"}),
-            content_type="application/json")
-        data = json.loads(res.get_data())
-
-        assert res.status_code == 201
-        assert "termsAndConditionsDocumentURL" not in data['services']
-        assert "pricingDocumentURL" not in data['services']
-        assert "serviceDefinitionDocumentURL" not in data['services']
-        assert "sfiaRateDocumentURL" not in data['services']
-
-    @mock.patch('app.db.session.commit')
-    def test_copy_draft_service_should_catch_db_integrity_error(self, db_commit):
-        db_commit.side_effect = IntegrityError("Could not commit", orig=None, params={})
-        res = self.client.post(
-            '/draft-services/%s/copy' % self.draft_id,
-            data=json.dumps({'updated_by': 'joeblogs'}),
-            content_type='application/json')
-
-        assert res.status_code == 400
-        assert "Could not commit" in json.loads(res.get_data())['error']
-
-
-class TestCompleteDraft(BaseApplicationTest, JSONUpdateTestMixin):
-    endpoint = '/draft-services/{self.draft_id}/complete'
-    method = 'post'
-
-    def setup(self):
-        super(TestCompleteDraft, self).setup()
-
-        with self.app.app_context():
-            db.session.add(Supplier(supplier_id=1, name=u"Supplier 1"))
-            db.session.add(
-                ContactInformation(
-                    supplier_id=1,
-                    contact_name=u"Test",
-                    email=u"supplier@user.dmdev",
-                    postcode=u"SW1A 1AA"
-                )
-            )
-            Framework.query.filter_by(slug='g-cloud-7').update(dict(status='open'))
-            db.session.commit()
-        draft_json = load_example_listing("G7-SCS")
-        draft_json['frameworkSlug'] = 'g-cloud-7'
-        create_draft_json = {
-            'updated_by': 'joeblogs',
-            'services': draft_json
-        }
-
-        draft = self.client.post(
             '/draft-services',
-            data=json.dumps(create_draft_json),
-            content_type='application/json')
-
-        self.draft = json.loads(draft.get_data())['services']
-        self.draft_id = self.draft['id']
-
-    def test_complete_draft(self):
-        res = self.client.post(
-            '/draft-services/%s/complete' % self.draft_id,
-            data=json.dumps({'updated_by': 'joeblogs'}),
+            data=json.dumps(invalid_create_json),
             content_type='application/json')
 
         data = json.loads(res.get_data())
-        assert res.status_code == 200, res.get_data()
-        assert data['services']['status'] == 'submitted'
-
-    def test_complete_draft_should_create_audit_event(self):
-        res = self.client.post(
-            '/draft-services/%s/complete' % self.draft_id,
-            data=json.dumps({'updated_by': 'joeblogs'}),
-            content_type='application/json')
-
-        assert res.status_code == 200
-
-        audit_response = self.client.get('/audit-events')
-        assert audit_response.status_code == 200
-        data = json.loads(audit_response.get_data())
-        assert len(data['auditEvents']) == 2
-        assert data['auditEvents'][1]['user'] == 'joeblogs'
-        assert data['auditEvents'][1]['type'] == 'complete_draft_service'
-        assert data['auditEvents'][1]['data'] == {
-            'draftId': self.draft_id,
-        }
-
-    def test_should_not_complete_draft_without_updated_by(self):
-        res = self.client.post(
-            '/draft-services/%s/complete' % self.draft_id,
-            data=json.dumps({}),
-            content_type='application/json')
-
         assert res.status_code == 400
+        assert "Invalid supplier ID 'ShouldBeInt'" in data['error']
 
-    def test_should_not_complete_invalid_draft(self):
-        create_draft_json = {
-            'updated_by': 'joeblogs',
-            'services': {
-                'frameworkSlug': 'g-cloud-7',
-                'lot': 'scs',
-                'supplierId': 1,
-                'serviceName': 'Name',
-            }
-        }
-
-        draft = self.client.post(
+    def test_should_not_create_draft_on_not_open_framework(self):
+        draft_json = self.create_draft_json.copy()
+        draft_json['services']['frameworkSlug'] = 'g-cloud-5'
+        res = self.client.post(
             '/draft-services',
-            data=json.dumps(create_draft_json),
-            content_type='application/json'
-        )
-
-        draft = json.loads(draft.get_data())['services']
-
-        res = self.client.post(
-            '/draft-services/%s/complete' % draft['id'],
-            data=json.dumps({'updated_by': 'joeblogs'}),
+            data=json.dumps(draft_json),
             content_type='application/json')
 
+        data = json.loads(res.get_data())
         assert res.status_code == 400
-        errors = json.loads(res.get_data())['error']
-        assert 'serviceSummary' in errors
+        assert "'g-cloud-5' is not open for submissions" in data['error']
 
-    @mock.patch('app.db.session.commit')
-    def test_complete_draft_catches_db_integrity_errors(self, db_commit):
-        db_commit.side_effect = IntegrityError("Could not commit", orig=None, params={})
+    def test_should_not_create_draft_with_invalid_lot(self):
+        draft_json = self.create_draft_json.copy()
+        draft_json['services']['lot'] = 'newlot'
         res = self.client.post(
-            '/draft-services/%s/complete' % self.draft_id,
-            data=json.dumps({'updated_by': 'joeblogs'}),
+            '/draft-services',
+            data=json.dumps(self.create_draft_json),
             content_type='application/json')
 
+        data = json.loads(res.get_data())
         assert res.status_code == 400
-        assert "Could not commit" in json.loads(res.get_data())['error']
+        assert "Incorrect lot 'newlot' for framework 'g-cloud-7'" in data['error']
 
 
 class TestDOSServices(BaseApplicationTest, FixtureMixin):
@@ -1520,6 +1300,116 @@ class TestDOSServices(BaseApplicationTest, FixtureMixin):
         assert complete.status_code == 400
 
 
+class TestCompleteDraft(BaseApplicationTest, JSONUpdateTestMixin):
+    endpoint = '/draft-services/{self.draft_id}/complete'
+    method = 'post'
+
+    def setup(self):
+        super(TestCompleteDraft, self).setup()
+
+        with self.app.app_context():
+            db.session.add(Supplier(supplier_id=1, name=u"Supplier 1"))
+            db.session.add(
+                ContactInformation(
+                    supplier_id=1,
+                    contact_name=u"Test",
+                    email=u"supplier@user.dmdev",
+                    postcode=u"SW1A 1AA"
+                )
+            )
+            Framework.query.filter_by(slug='g-cloud-7').update(dict(status='open'))
+            db.session.commit()
+        draft_json = load_example_listing("G7-SCS")
+        draft_json['frameworkSlug'] = 'g-cloud-7'
+        create_draft_json = {
+            'updated_by': 'joeblogs',
+            'services': draft_json
+        }
+
+        draft = self.client.post(
+            '/draft-services',
+            data=json.dumps(create_draft_json),
+            content_type='application/json')
+
+        self.draft = json.loads(draft.get_data())['services']
+        self.draft_id = self.draft['id']
+
+    def test_complete_draft(self):
+        res = self.client.post(
+            '/draft-services/%s/complete' % self.draft_id,
+            data=json.dumps({'updated_by': 'joeblogs'}),
+            content_type='application/json')
+
+        data = json.loads(res.get_data())
+        assert res.status_code == 200, res.get_data()
+        assert data['services']['status'] == 'submitted'
+
+    def test_complete_draft_should_create_audit_event(self):
+        res = self.client.post(
+            '/draft-services/%s/complete' % self.draft_id,
+            data=json.dumps({'updated_by': 'joeblogs'}),
+            content_type='application/json')
+
+        assert res.status_code == 200
+
+        audit_response = self.client.get('/audit-events')
+        assert audit_response.status_code == 200
+        data = json.loads(audit_response.get_data())
+        assert len(data['auditEvents']) == 2
+        assert data['auditEvents'][1]['user'] == 'joeblogs'
+        assert data['auditEvents'][1]['type'] == 'complete_draft_service'
+        assert data['auditEvents'][1]['data'] == {
+            'draftId': self.draft_id,
+        }
+
+    def test_should_not_complete_draft_without_updated_by(self):
+        res = self.client.post(
+            '/draft-services/%s/complete' % self.draft_id,
+            data=json.dumps({}),
+            content_type='application/json')
+
+        assert res.status_code == 400
+
+    def test_should_not_complete_invalid_draft(self):
+        create_draft_json = {
+            'updated_by': 'joeblogs',
+            'services': {
+                'frameworkSlug': 'g-cloud-7',
+                'lot': 'scs',
+                'supplierId': 1,
+                'serviceName': 'Name',
+            }
+        }
+
+        draft = self.client.post(
+            '/draft-services',
+            data=json.dumps(create_draft_json),
+            content_type='application/json'
+        )
+
+        draft = json.loads(draft.get_data())['services']
+
+        res = self.client.post(
+            '/draft-services/%s/complete' % draft['id'],
+            data=json.dumps({'updated_by': 'joeblogs'}),
+            content_type='application/json')
+
+        assert res.status_code == 400
+        errors = json.loads(res.get_data())['error']
+        assert 'serviceSummary' in errors
+
+    @mock.patch('app.db.session.commit')
+    def test_complete_draft_catches_db_integrity_errors(self, db_commit):
+        db_commit.side_effect = IntegrityError("Could not commit", orig=None, params={})
+        res = self.client.post(
+            '/draft-services/%s/complete' % self.draft_id,
+            data=json.dumps({'updated_by': 'joeblogs'}),
+            content_type='application/json')
+
+        assert res.status_code == 400
+        assert "Could not commit" in json.loads(res.get_data())['error']
+
+
 class TestUpdateDraftStatus(BaseApplicationTest, JSONUpdateTestMixin):
     endpoint = '/draft-services/{self.draft_id}/update-status'
     method = 'post'
@@ -1597,6 +1487,134 @@ class TestUpdateDraftStatus(BaseApplicationTest, JSONUpdateTestMixin):
         res = self.client.post(
             '/draft-services/%s/update-status' % self.draft_id,
             data=json.dumps({'services': {'status': 'failed'}, 'updated_by': 'joeblogs'}),
+            content_type='application/json')
+
+        assert res.status_code == 400
+        assert "Could not commit" in json.loads(res.get_data())['error']
+
+
+class TestCopyDraft(BaseApplicationTest, JSONUpdateTestMixin):
+    endpoint = '/draft-services/{self.draft_id}/copy'
+    method = 'post'
+
+    def setup(self):
+        super(TestCopyDraft, self).setup()
+
+        with self.app.app_context():
+            db.session.add(
+                Supplier(supplier_id=1, name=u"Supplier 1")
+            )
+            db.session.add(
+                ContactInformation(
+                    supplier_id=1,
+                    contact_name=u"Liz",
+                    email=u"liz@royal.gov.uk",
+                    postcode=u"SW1A 1AA"
+                )
+            )
+            Framework.query.filter_by(slug='g-cloud-5') \
+                .update(dict(status='live'))
+            Framework.query.filter_by(slug='g-cloud-7') \
+                .update(dict(status='open'))
+            db.session.commit()
+
+        create_draft_json = {
+            'updated_by': 'joeblogs',
+            'services': {
+                'frameworkSlug': 'g-cloud-7',
+                'lot': 'scs',
+                'supplierId': 1,
+                'serviceName': "Draft",
+                'status': 'submitted',
+                'serviceSummary': 'This is a summary',
+                "termsAndConditionsDocumentURL": "http://localhost/example.pdf",
+                "pricingDocumentURL": "http://localhost/example.pdf",
+                "serviceDefinitionDocumentURL": "http://localhost/example.pdf",
+                "sfiaRateDocumentURL": "http://localhost/example.pdf",
+            }
+        }
+
+        draft = self.client.post(
+            '/draft-services',
+            data=json.dumps(create_draft_json),
+            content_type='application/json')
+
+        self.draft = json.loads(draft.get_data())['services']
+        self.draft_id = self.draft['id']
+
+    def test_copy_draft(self):
+        res = self.client.post(
+            '/draft-services/%s/copy' % self.draft_id,
+            data=json.dumps({'updated_by': 'joeblogs'}),
+            content_type='application/json')
+
+        data = json.loads(res.get_data())
+        assert res.status_code == 201, res.get_data()
+        assert data['services']['lot'] == 'scs'
+        assert data['services']['status'] == 'not-submitted'
+        assert data['services']['serviceName'] == 'Draft copy'
+        assert data['services']['supplierId'] == 1
+        assert data['services']['frameworkSlug'] == self.draft['frameworkSlug']
+        assert data['services']['frameworkName'] == self.draft['frameworkName']
+
+    def test_copy_draft_should_create_audit_event(self):
+        res = self.client.post(
+            '/draft-services/%s/copy' % self.draft_id,
+            data=json.dumps({'updated_by': 'joeblogs'}),
+            content_type='application/json')
+
+        assert res.status_code == 201
+        data = json.loads(res.get_data())
+        draft_id = data['services']['id']
+
+        audit_response = self.client.get('/audit-events')
+        assert audit_response.status_code == 200
+        data = json.loads(audit_response.get_data())
+        assert len(data['auditEvents']) == 2
+        assert data['auditEvents'][1]['user'] == 'joeblogs'
+        assert data['auditEvents'][1]['type'] == 'create_draft_service'
+        assert data['auditEvents'][1]['data'] == {
+            'draftId': draft_id,
+            'originalDraftId': self.draft_id
+        }
+
+    def test_should_not_create_draft_with_invalid_data(self):
+        res = self.client.post(
+            '/draft-services/1000/copy',
+            data=json.dumps({'updated_by': 'joeblogs'}),
+            content_type='application/json')
+
+        assert res.status_code == 404
+
+    def test_should_not_copy_draft_service_description(self):
+        res = self.client.post(
+            '/draft-services/{}/copy'.format(self.draft_id),
+            data=json.dumps({"updated_by": "me"}),
+            content_type="application/json")
+        data = json.loads(res.get_data())
+
+        assert res.status_code == 201
+        assert "serviceSummary" not in data['services']
+
+    def test_should_not_copy_draft_documents(self):
+        res = self.client.post(
+            '/draft-services/{}/copy'.format(self.draft_id),
+            data=json.dumps({"updated_by": "me"}),
+            content_type="application/json")
+        data = json.loads(res.get_data())
+
+        assert res.status_code == 201
+        assert "termsAndConditionsDocumentURL" not in data['services']
+        assert "pricingDocumentURL" not in data['services']
+        assert "serviceDefinitionDocumentURL" not in data['services']
+        assert "sfiaRateDocumentURL" not in data['services']
+
+    @mock.patch('app.db.session.commit')
+    def test_copy_draft_service_should_catch_db_integrity_error(self, db_commit):
+        db_commit.side_effect = IntegrityError("Could not commit", orig=None, params={})
+        res = self.client.post(
+            '/draft-services/%s/copy' % self.draft_id,
+            data=json.dumps({'updated_by': 'joeblogs'}),
             content_type='application/json')
 
         assert res.status_code == 400

--- a/tests/main/views/test_drafts.py
+++ b/tests/main/views/test_drafts.py
@@ -767,7 +767,7 @@ class TestPublishDraftService(DraftServicesTestBase):
         assert first_draft.status_code == 200
         assert json.loads(first_draft.get_data())['services']['serviceName'] == 'A SaaS with lots of options'
 
-        self.client.post(
+        delete = self.client.post(
             '/draft-services/{}'.format(draft_id),
             data=json.dumps({
                 'updated_by': 'joeblogs',
@@ -776,42 +776,20 @@ class TestPublishDraftService(DraftServicesTestBase):
                 }
             }),
             content_type='application/json')
-
-        updated_draft = self.client.get(
-            '/draft-services/{}'.format(draft_id))
-        assert updated_draft.status_code == 200
-        assert json.loads(updated_draft.get_data())['services']['serviceName'] == 'chickens'
-
-        res = self.client.post(
-            '/draft-services/{}/publish'.format(draft_id),
-            data=json.dumps({'updated_by': 'joeblogs'}),
-            content_type='application/json')
-        assert res.status_code == 200
+        assert delete.status_code == 200
 
         audit_response = self.client.get('/audit-events')
         assert audit_response.status_code == 200
         data = json.loads(audit_response.get_data())
 
-        assert len(data['auditEvents']) == 3
+        assert len(data['auditEvents']) == 2
         assert data['auditEvents'][0]['type'] == 'create_draft_service'
-        assert data['auditEvents'][1]['type'] == 'update_draft_service'
-        assert data['auditEvents'][2]['type'] == 'publish_draft_service'
+        assert data['auditEvents'][1]['user'] == 'joeblogs'
+        assert data['auditEvents'][1]['type'] == 'delete_draft_service'
+        assert data['auditEvents'][1]['data']['serviceId'] == self.service_id
 
-        # draft should no longer exist
-        fetch = self.client.get('/draft-services/{}'.format(self.service_id))
-        assert fetch.status_code == 404
-
-        # published should be updated
-        updated_draft = self.client.get('/services/{}'.format(self.service_id))
-        assert updated_draft.status_code == 200
-        assert json.loads(updated_draft.get_data())['services']['serviceName'] == 'chickens'
-
-        # archive should be updated
-        archives = self.client.get(
-            '/archived-services?service-id={}'.format(self.service_id))
-        assert archives.status_code == 200
-        assert json.loads(archives.get_data())['services'][0]['serviceName'] == 'chickens'
-        assert search_api_client.index.called
+        fetch_again = self.client.get('/draft-services/{}'.format(draft_id))
+        assert fetch_again.status_code == 404
 
     def test_should_not_be_able_to_publish_submission_if_not_submitted(self):
         draft = self.create_draft_service()

--- a/tests/main/views/test_frameworks.py
+++ b/tests/main/views/test_frameworks.py
@@ -396,6 +396,7 @@ class TestUpdateFramework(BaseApplicationTest, JSONUpdateTestMixin):
                 })
 
                 assert response.status_code == 400
+                assert "Could not commit" in json.loads(response.get_data())["error"]
 
 
 class TestFrameworkStats(BaseApplicationTest, FixtureMixin):

--- a/tests/main/views/test_services.py
+++ b/tests/main/views/test_services.py
@@ -1314,7 +1314,7 @@ class TestPutService(BaseApplicationTest, JSONUpdateTestMixin, FixtureMixin):
         assert response.status_code == 400
         assert b'Invalid service ID supplied' in response.get_data()
 
-    @pytest.mark.parametrize("invalid_service_id", [('tooshort', 'this_one_is_way_too_long')])
+    @pytest.mark.parametrize("invalid_service_id", ['tooshort', 'this_one_is_way_too_long'])
     def test_invalid_service_ids(self, invalid_service_id):
         response = self.client.put(
             '/services/{}'.format(invalid_service_id),

--- a/tests/main/views/test_services.py
+++ b/tests/main/views/test_services.py
@@ -362,7 +362,7 @@ class TestListServices(BaseApplicationTest, FixtureMixin):
         self.setup_dummy_services_including_unpublished(15)
 
         response = self.client.get(
-            '/services?supplier_id=%d' % TEST_SUPPLIERS_COUNT
+            '/services?supplier_id={}'.format(TEST_SUPPLIERS_COUNT)
         )
         data = json.loads(response.get_data())
 
@@ -492,7 +492,7 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin, FixtureMixin):
     def test_no_content_type_causes_failure(self):
         with self.app.app_context():
             response = self.client.post(
-                '/services/%s' % self.service_id,
+                '/services/{}'.format(self.service_id),
                 data=json.dumps(
                     {'updated_by': 'joeblogs',
                      'services': {
@@ -504,7 +504,7 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin, FixtureMixin):
     def test_invalid_content_type_causes_failure(self):
         with self.app.app_context():
             response = self.client.post(
-                '/services/%s' % self.service_id,
+                '/services/{}'.format(self.service_id),
                 data=json.dumps(
                     {'updated_by': 'joeblogs',
                      'services': {
@@ -517,7 +517,7 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin, FixtureMixin):
     def test_invalid_json_causes_failure(self):
         with self.app.app_context():
             response = self.client.post(
-                '/services/%s' % self.service_id,
+                '/services/{}'.format(self.service_id),
                 data="ouiehdfiouerhfuehr",
                 content_type='application/json')
 
@@ -581,7 +581,7 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin, FixtureMixin):
             )
             assert response.status_code == 200
 
-            response = self.client.get('/services/%s' % self.service_id)
+            response = self.client.get('/services/{}'.format(self.service_id))
             data = json.loads(response.get_data())
             assert data['services']['serviceName'] == 'new service name'
             assert data['services']['incidentEscalation'] is False
@@ -594,7 +594,7 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin, FixtureMixin):
             response = self._post_service_update({'supportTypes': support_types})
             assert response.status_code == 200
 
-            response = self.client.get('/services/%s' % self.service_id)
+            response = self.client.get('/services/{}'.format(self.service_id))
             data = json.loads(response.get_data())
 
             assert all(i in support_types for i in data['services']['supportTypes']) is True
@@ -609,7 +609,7 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin, FixtureMixin):
             response = self._post_service_update({'identityAuthenticationControls': identity_authentication_controls})
             assert response.status_code == 200
 
-            response = self.client.get('/services/%s' % self.service_id)
+            response = self.client.get('/services/{}'.format(self.service_id))
             data = json.loads(response.get_data())
 
             updated_auth_controls = \
@@ -673,7 +673,7 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin, FixtureMixin):
 
     def test_writing_full_service_back(self):
         with self.app.app_context():
-            response = self.client.get('/services/%s' % self.service_id)
+            response = self.client.get('/services/{}'.format(self.service_id))
             data = json.loads(response.get_data())
             response = self._post_service_update(data['services'])
 
@@ -705,7 +705,7 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin, FixtureMixin):
 
     def test_should_400_if_mismatched_service_id(self):
         response = self.client.post(
-            '/services/%s' % self.service_id,
+            '/services/{}'.format(self.service_id),
             data=json.dumps(
                 {'updated_by': 'joeblogs',
                  'services': {
@@ -719,7 +719,7 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin, FixtureMixin):
         response = self._post_service_update({'status': 'enabled'})
         assert response.status_code == 200
 
-        response = self.client.get('/services/%s' % self.service_id)
+        response = self.client.get('/services/{}'.format(self.service_id))
         data = json.loads(response.get_data())
 
         assert data['services']['status'] == 'published'
@@ -1408,7 +1408,7 @@ class TestPutService(BaseApplicationTest, JSONUpdateTestMixin, FixtureMixin):
     def test_cannot_update_existing_service_by_put(self, search_api_client):
         with self.app.app_context():
             search_api_client.return_value = "bar"
-            response = self.client.put(
+            self.client.put(
                 '/services/{}'.format(self.service_id),
                 data=json.dumps({
                     'updated_by': 'joeblogs',

--- a/tests/main/views/test_status.py
+++ b/tests/main/views/test_status.py
@@ -1,4 +1,6 @@
 from tests.bases import BaseApplicationTest
+from sqlalchemy.exc import SQLAlchemyError
+import mock
 
 
 class TestStatus(BaseApplicationTest):
@@ -6,3 +8,9 @@ class TestStatus(BaseApplicationTest):
     def test_should_return_200_from_elb_status_check(self):
         status_response = self.client.get('/_status?ignore-dependencies')
         assert status_response.status_code == 200
+
+    @mock.patch('app.status.utils.get_db_version')
+    def test_catches_db_error_and_return_500(self, get_db_version):
+        get_db_version.side_effect = SQLAlchemyError()
+        status_response = self.client.get('/_status')
+        assert status_response.status_code == 500

--- a/tests/main/views/test_users.py
+++ b/tests/main/views/test_users.py
@@ -522,6 +522,22 @@ class TestUsersPost(BaseApplicationTest, JSONTestMixin):
         assert response.status_code == 400
         assert "Unable to commit" in json.loads(response.get_data())["error"]
 
+    @mock.patch('app.db.session.commit')
+    def test_create_user_catches_db_errors(self, db_commit):
+        db_commit.side_effect = DataError("Unable to commit", orig=None, params={})
+        response = self.client.post(
+            '/users',
+            data=json.dumps({
+                'users': {
+                    'emailAddress': 'joeblogs@email.gov.uk',
+                    'phoneNumber': '01234 567890',
+                    'password': '1234567890',
+                    'role': 'buyer',
+                    'name': 'joe bloggs'}}),
+            content_type='application/json')
+        assert response.status_code == 400
+        assert json.loads(response.get_data())["error"] == "Invalid user role"
+
 
 class TestUsersUpdate(BaseApplicationTest, JSONUpdateTestMixin):
     method = "post"

--- a/tests/main/views/test_users.py
+++ b/tests/main/views/test_users.py
@@ -506,6 +506,21 @@ class TestUsersPost(BaseApplicationTest, JSONTestMixin):
         assert "JSON was not a valid format." in data
         assert "'' is too short" in data
 
+    def test_return_400_for_invalid_user_role(self):
+        response = self.client.post(
+            '/users',
+            data=json.dumps({
+                'users': {
+                    'emailAddress': 'joeblogs@email.com',
+                    'password': '0000000000',
+                    'role': 'invalid',
+                    'name': 'joe bloggs'}}),
+            content_type='application/json')
+
+        assert response.status_code == 400
+        data = json.loads(response.get_data())["error"]
+        assert "JSON was not a valid format" in data
+
     @mock.patch('app.db.session.commit')
     def test_create_user_catches_db_errors(self, db_commit):
         db_commit.side_effect = DataError("Unable to commit", orig=None, params={})

--- a/tests/main/views/test_users.py
+++ b/tests/main/views/test_users.py
@@ -536,7 +536,7 @@ class TestUsersPost(BaseApplicationTest, JSONTestMixin):
                     'name': 'joe bloggs'}}),
             content_type='application/json')
         assert response.status_code == 400
-        assert json.loads(response.get_data())["error"] == "Invalid user role"
+        assert "Unable to commit" in json.loads(response.get_data())["error"]
 
 
 class TestUsersUpdate(BaseApplicationTest, JSONUpdateTestMixin):

--- a/tests/main/views/test_users.py
+++ b/tests/main/views/test_users.py
@@ -501,22 +501,7 @@ class TestUsersPost(BaseApplicationTest, JSONTestMixin):
 
         assert response.status_code == 400
         data = json.loads(response.get_data())["error"]
-        assert "JSON was not a valid format" in data
-
-    def test_return_400_for_invalid_user_role(self):
-        response = self.client.post(
-            '/users',
-            data=json.dumps({
-                'users': {
-                    'emailAddress': 'joeblogs@email.com',
-                    'password': '0000000000',
-                    'role': 'invalid',
-                    'name': 'joe bloggs'}}),
-            content_type='application/json')
-
-        assert response.status_code == 400
-        data = json.loads(response.get_data())["error"]
-        assert "JSON was not a valid format" in data
+        assert data == "JSON was not a valid format. u'' is too short"
 
 
 class TestUsersUpdate(BaseApplicationTest, JSONUpdateTestMixin):

--- a/tests/main/views/test_users.py
+++ b/tests/main/views/test_users.py
@@ -522,22 +522,6 @@ class TestUsersPost(BaseApplicationTest, JSONTestMixin):
         assert response.status_code == 400
         assert "Unable to commit" in json.loads(response.get_data())["error"]
 
-    @mock.patch('app.db.session.commit')
-    def test_create_user_catches_db_errors(self, db_commit):
-        db_commit.side_effect = DataError("Unable to commit", orig=None, params={})
-        response = self.client.post(
-            '/users',
-            data=json.dumps({
-                'users': {
-                    'emailAddress': 'joeblogs@email.gov.uk',
-                    'phoneNumber': '01234 567890',
-                    'password': '1234567890',
-                    'role': 'buyer',
-                    'name': 'joe bloggs'}}),
-            content_type='application/json')
-        assert response.status_code == 400
-        assert "Unable to commit" in json.loads(response.get_data())["error"]
-
 
 class TestUsersUpdate(BaseApplicationTest, JSONUpdateTestMixin):
     method = "post"

--- a/tests/main/views/test_users.py
+++ b/tests/main/views/test_users.py
@@ -503,7 +503,8 @@ class TestUsersPost(BaseApplicationTest, JSONTestMixin):
 
         assert response.status_code == 400
         data = json.loads(response.get_data())["error"]
-        assert data == "JSON was not a valid format. u'' is too short"
+        assert "JSON was not a valid format." in data
+        assert "'' is too short" in data
 
     @mock.patch('app.db.session.commit')
     def test_create_user_catches_db_errors(self, db_commit):

--- a/tests/main/views/test_users.py
+++ b/tests/main/views/test_users.py
@@ -519,7 +519,7 @@ class TestUsersPost(BaseApplicationTest, JSONTestMixin):
                     'name': 'joe bloggs'}}),
             content_type='application/json')
         assert response.status_code == 400
-        assert json.loads(response.get_data())["error"] == "Invalid user role"
+        assert "Unable to commit" in json.loads(response.get_data())["error"]
 
 
 class TestUsersUpdate(BaseApplicationTest, JSONUpdateTestMixin):

--- a/tests/main/views/test_users.py
+++ b/tests/main/views/test_users.py
@@ -3,6 +3,8 @@ from freezegun import freeze_time
 from app import db, encryption
 from app.models import User, Supplier
 from datetime import datetime
+import mock
+from sqlalchemy.exc import DataError
 from tests.bases import BaseApplicationTest, JSONTestMixin, JSONUpdateTestMixin
 from tests.helpers import FixtureMixin, load_example_listing
 
@@ -502,6 +504,22 @@ class TestUsersPost(BaseApplicationTest, JSONTestMixin):
         assert response.status_code == 400
         data = json.loads(response.get_data())["error"]
         assert data == "JSON was not a valid format. u'' is too short"
+
+    @mock.patch('app.db.session.commit')
+    def test_create_user_catches_db_errors(self, db_commit):
+        db_commit.side_effect = DataError("Unable to commit", orig=None, params={})
+        response = self.client.post(
+            '/users',
+            data=json.dumps({
+                'users': {
+                    'emailAddress': 'joeblogs@email.gov.uk',
+                    'phoneNumber': '01234 567890',
+                    'password': '1234567890',
+                    'role': 'buyer',
+                    'name': 'joe bloggs'}}),
+            content_type='application/json')
+        assert response.status_code == 400
+        assert json.loads(response.get_data())["error"] == "Invalid user role"
 
 
 class TestUsersUpdate(BaseApplicationTest, JSONUpdateTestMixin):


### PR DESCRIPTION
The coverage stats show some gaps in our test coverage.

This PR covers:
- Adding tests for catching SQLAlchemy integrity/data errors in `app/main/views`
- Reorganising the vast number of tests in `test_drafts` into classes (mostly according to route, though there are some tests that use more than one route)
- Removal of a duplicate test 

Not included:
- Test coverage for areas that would require some refactoring of the code itself first