### PR TITLE
Add default.nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ venv*
 __pycache__
 version_label
 .cache
+
+# local environment customizations
+local.nix

--- a/default.nix
+++ b/default.nix
@@ -36,7 +36,7 @@ in (with args; {
     LANG="en_GB.UTF-8";
 
     shellHook = ''
-      export PS1="\[\e[0;34m\](nix-shell\[\e[0m\]:\[\e[0;34m\]${shortName})\[\e[0;32m\]\u@\h\[\e[0m\]:\[\e[0m\]\[\e[0;34m\]\w\[\e[0m\]\$ "
+      export PS1="\[\e[0;36m\](nix-shell\[\e[0m\]:\[\e[0;36m\]${shortName})\[\e[0;32m\]\u@\h\[\e[0m\]:\[\e[0m\]\[\e[0;36m\]\w\[\e[0m\]\$ "
 
       if [ ! -e $VIRTUALENV_ROOT ]; then
         ${pythonPackages.virtualenv}/bin/virtualenv $VIRTUALENV_ROOT

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,40 @@
+{
+  pkgs ? import <nixpkgs> {},
+  pythonPackages ? pkgs.python36Packages,
+  forDev ? true
+}:
+{
+  digitalMarketplaceApiEnv = pkgs.stdenv.mkDerivation {
+    name = "digitalmarketplace-api-env";
+    buildInputs = [
+      pythonPackages.virtualenv
+      pkgs.libffi
+      pkgs.libyaml
+      # for `cryptography`
+      pkgs.openssl_1_1_0
+      # we *would* just depend on the pkgs.postgresql.lib output but pip wants to use the `pg_config` binary during the
+      # install process
+      pkgs.postgresql
+    ] ++ pkgs.stdenv.lib.optionals forDev ([
+        # exotic things possibly go here
+      ]
+    );
+
+    hardeningDisable = pkgs.stdenv.lib.optionals pkgs.stdenv.isDarwin [ "format" ];
+
+    VIRTUALENV_ROOT = "venv${pythonPackages.python.pythonVersion}";
+    VIRTUAL_ENV_DISABLE_PROMPT = "1";
+    SOURCE_DATE_EPOCH = "315532800";
+
+    # if we don't have this, we get unicode troubles in a --pure nix-shell
+    LANG="en_GB.UTF-8";
+
+    shellHook = ''
+      if [ ! -e $VIRTUALENV_ROOT ]; then
+        ${pythonPackages.virtualenv}/bin/virtualenv $VIRTUALENV_ROOT
+      fi
+      source $VIRTUALENV_ROOT/bin/activate
+      make requirements${pkgs.stdenv.lib.optionalString forDev "-dev"}
+    '';
+  };
+}

--- a/default.nix
+++ b/default.nix
@@ -8,8 +8,9 @@ let
     localOverridesPath = ./local.nix;
   } // argsOuter;
 in (with args; {
-  digitalMarketplaceApiEnv = (pkgs.stdenv.mkDerivation {
+  digitalMarketplaceApiEnv = (pkgs.stdenv.mkDerivation rec {
     name = "digitalmarketplace-api-env";
+    shortName = "dm-api";
     buildInputs = [
       pythonPackages.virtualenv
       pkgs.libffi
@@ -35,6 +36,8 @@ in (with args; {
     LANG="en_GB.UTF-8";
 
     shellHook = ''
+      export PS1="\[\e[0;34m\](nix-shell\[\e[0m\]:\[\e[0;34m\]${shortName})\[\e[0;32m\]\u@\h\[\e[0m\]:\[\e[0m\]\[\e[0;34m\]\w\[\e[0m\]\$ "
+
       if [ ! -e $VIRTUALENV_ROOT ]; then
         ${pythonPackages.virtualenv}/bin/virtualenv $VIRTUALENV_ROOT
       fi

--- a/default.nix
+++ b/default.nix
@@ -17,10 +17,9 @@
       # we *would* just depend on the pkgs.postgresql.lib output but pip wants to use the `pg_config` binary during the
       # install process
       pkgs.postgresql
-    ] ++ pkgs.stdenv.lib.optionals forDev ([
-        # exotic things possibly go here
-      ]
-    );
+    ] ++ pkgs.stdenv.lib.optionals forDev [
+      # exotic things possibly go here
+    ];
 
     hardeningDisable = pkgs.stdenv.lib.optionals pkgs.stdenv.isDarwin [ "format" ];
 

--- a/default.nix
+++ b/default.nix
@@ -11,7 +11,7 @@
       pkgs.libffi
       pkgs.libyaml
       # for `cryptography`
-      pkgs.openssl_1_1_0
+      pkgs.openssl
       # we *would* just depend on the pkgs.postgresql.lib output but pip wants to use the `pg_config` binary during the
       # install process
       pkgs.postgresql

--- a/default.nix
+++ b/default.nix
@@ -1,10 +1,14 @@
-{
-  pkgs ? import <nixpkgs> {},
-  pythonPackages ? pkgs.python36Packages,
-  forDev ? true
-}:
-{
-  digitalMarketplaceApiEnv = pkgs.stdenv.mkDerivation {
+argsOuter@{...}:
+let
+  # specifying args defaults in this slightly non-standard way to allow us to include the default values in `args`
+  args = rec {
+    pkgs = import <nixpkgs> {};
+    pythonPackages = pkgs.python36Packages;
+    forDev = true;
+    localOverridesPath = ./local.nix;
+  } // argsOuter;
+in (with args; {
+  digitalMarketplaceApiEnv = (pkgs.stdenv.mkDerivation {
     name = "digitalmarketplace-api-env";
     buildInputs = [
       pythonPackages.virtualenv
@@ -37,5 +41,5 @@
       source $VIRTUALENV_ROOT/bin/activate
       make requirements${pkgs.stdenv.lib.optionalString forDev "-dev"}
     '';
-  };
-}
+  }).overrideAttrs (if builtins.pathExists localOverridesPath then (import localOverridesPath args) else (x: x));
+})

--- a/default.nix
+++ b/default.nix
@@ -10,6 +10,8 @@
       pythonPackages.virtualenv
       pkgs.libffi
       pkgs.libyaml
+      # pip requires git to fetch some of its dependencies
+      pkgs.git
       # for `cryptography`
       pkgs.openssl
       # we *would* just depend on the pkgs.postgresql.lib output but pip wants to use the `pg_config` binary during the

--- a/local.example.nix
+++ b/local.example.nix
@@ -1,0 +1,22 @@
+# default.nix calls out to the file local.nix if it exists, expecting a function which it will call, applying first
+# the args passed to the original default.nix and then `oldAttrs`, the attrset originally applied to mkDerivation.
+#
+# the function should return an attrset altered to the local user's desires, as they would wish to be applied to
+# mkDerivation to produce the env
+
+args: oldAttrs: oldAttrs // {
+  # here we add some of our favourite packages to the environment which aren't necessarily to everyone's tastes
+  buildInputs = oldAttrs.buildInputs ++ [
+    args.pkgs.vim
+    args.pythonPackages.ipython
+  ];
+
+  shellHook =  oldAttrs.shellHook + ''
+    # PS1 can't be set as a normal derivation attr as it gets clobbered early on in the upstream shellHook script
+    export PS1="⚡$PS1⚡"
+
+    # inject some whimsy into our session - note here we access a package which we don't actually end up
+    # explicitly exposing to the final environment
+    ${args.pkgs.fortune}/bin/fortune
+  '';
+}

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,4 +8,4 @@ nocapture=1
 with-doctest=1
 
 [pytest]
-norecursedirs = venv venv3 src
+norecursedirs = venv* src


### PR DESCRIPTION
See https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/719

Mostly similar to that PR, the only notable addition here is postgres to provide us with the libs for `psycopg2` to link against. And the `pg_config` binary as noted in comments. *In an ideal world* this should be chosen to match your locally running postgres version (most postgres versions are available in nixpkgs as e.g. `pkgs.postgresql94`, `pkgs.postgresql95`, but *in reality* the postgres protocol tends to be mostly cross-minor-version-compatible. So it's probably fine to leave it.