### PR TITLE
Optimise queries for brief responses

### DIFF
--- a/app/main/views/brief_responses.py
+++ b/app/main/views/brief_responses.py
@@ -214,6 +214,12 @@ def list_brief_responses():
     if brief_id is not None:
         brief_responses = brief_responses.filter(BriefResponse.brief_id == brief_id)
 
+    brief_responses = brief_responses.options(
+        db.defaultload(BriefResponse.brief).defaultload(Brief.framework).lazyload("*"),
+        db.defaultload(BriefResponse.brief).defaultload(Brief.lot).lazyload("*"),
+        db.defaultload(BriefResponse.supplier).lazyload("*"),
+    )
+
     if brief_id or supplier_id:
         return jsonify(
             briefResponses=[brief_response.serialize() for brief_response in brief_responses.all()],

--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -104,7 +104,7 @@ def get_brief(brief_id):
         Brief.id == brief_id
     ).first_or_404()
 
-    return jsonify(briefs=brief.serialize(with_users=True))
+    return jsonify(briefs=brief.serialize(with_users=True, with_clarification_questions=True))
 
 
 @main.route('/briefs', methods=['GET'])
@@ -305,7 +305,7 @@ def add_clarification_question(brief_id):
     db.session.add(audit)
     db.session.commit()
 
-    return jsonify(briefs=brief.serialize()), 200
+    return jsonify(briefs=brief.serialize(with_clarification_questions=True)), 200
 
 
 @main.route("/briefs/<brief_id>/services", methods=["GET"])

--- a/app/models.py
+++ b/app/models.py
@@ -1168,7 +1168,7 @@ class Brief(db.Model):
     clarification_questions = db.relationship(
         "BriefClarificationQuestion",
         order_by="BriefClarificationQuestion.published_at",
-        lazy='joined'
+        lazy='select',
     )
 
     @validates('users')
@@ -1325,7 +1325,7 @@ class Brief(db.Model):
             'requirementsLength': requirements_length
         }
 
-    def serialize(self, with_users=False):
+    def serialize(self, with_users=False, with_clarification_questions=False):
         data = dict(self.data.items())
 
         data.update({
@@ -1341,10 +1341,12 @@ class Brief(db.Model):
             'lotName': self.lot.name,
             'createdAt': self.created_at.strftime(DATETIME_FORMAT),
             'updatedAt': self.updated_at.strftime(DATETIME_FORMAT),
-            'clarificationQuestions': [
-                question.serialize() for question in self.clarification_questions
-            ],
         })
+
+        if with_clarification_questions:
+            data['clarificationQuestions'] = [
+                question.serialize() for question in self.clarification_questions
+            ]
 
         if self.published_at:
             data.update({


### PR DESCRIPTION
We have been seeing memory issues, in particular on the list brief responses endpoint. Running this on similar data on the PaaS, this has seem good memory reduction.