### PR TITLE
Remove cffi pinned version after pycparser 2.18 release

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,9 +19,3 @@ strict-rfc3339==0.5
 requests==2.9.1
 docopt==0.6.2
 six==1.10.0
-
-# For Cloud Foundry
-cffi==1.5.2
-gunicorn==19.4.5
-awscli>=1.11,<1.12
-awscli-cwlogs>=1.4,<1.5


### PR DESCRIPTION
cryptography install fails with cffi < 1.10 and the new pycparser
release.

Since we don't need the explicit top-lelel dependency for PaaS
anymore we can remove it from requirements.txt, which will install
the latest version of cffi instead.