### PR TITLE
Add missing URL argument type annotations and fix serivice_id tests

### DIFF
--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -308,7 +308,7 @@ def add_clarification_question(brief_id):
     return jsonify(briefs=brief.serialize(with_clarification_questions=True)), 200
 
 
-@main.route("/briefs/<brief_id>/services", methods=["GET"])
+@main.route("/briefs/<int:brief_id>/services", methods=["GET"])
 def list_brief_services(brief_id):
     brief = Brief.query.filter(
         Brief.id == brief_id

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -78,7 +78,7 @@ def get_framework(framework_slug):
     return jsonify(frameworks=framework.serialize())
 
 
-@main.route('/frameworks/<framework_slug>', methods=['POST'])
+@main.route('/frameworks/<string:framework_slug>', methods=['POST'])
 def update_framework(framework_slug):
     attribute_whitelist = {
         'status': 'status',

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -251,7 +251,7 @@ def update_contact_information(supplier_id, contact_id):
     return jsonify(contactInformation=contact.serialize())
 
 
-@main.route('/suppliers/<supplier_id>/frameworks/<framework_slug>/declaration', methods=['PUT'])
+@main.route('/suppliers/<int:supplier_id>/frameworks/<framework_slug>/declaration', methods=['PUT'])
 def set_a_declaration(supplier_id, framework_slug):
     framework = Framework.query.filter(
         Framework.slug == framework_slug
@@ -297,7 +297,7 @@ def set_a_declaration(supplier_id, framework_slug):
     return jsonify(declaration=supplier_framework.declaration), status_code
 
 
-@main.route('/suppliers/<supplier_id>/frameworks/interest', methods=['GET'])
+@main.route('/suppliers/<int:supplier_id>/frameworks/interest', methods=['GET'])
 def get_registered_frameworks(supplier_id):
     supplier_frameworks = SupplierFramework.query.filter(
         SupplierFramework.supplier_id == supplier_id
@@ -312,7 +312,7 @@ def get_registered_frameworks(supplier_id):
     return jsonify(frameworks=slugs)
 
 
-@main.route('/suppliers/<supplier_id>/frameworks', methods=['GET'])
+@main.route('/suppliers/<int:supplier_id>/frameworks', methods=['GET'])
 def get_supplier_frameworks_info(supplier_id):
     supplier = Supplier.query.filter(
         Supplier.supplier_id == supplier_id
@@ -334,7 +334,7 @@ def get_supplier_frameworks_info(supplier_id):
     )
 
 
-@main.route('/suppliers/<supplier_id>/frameworks/<framework_slug>', methods=['GET'])
+@main.route('/suppliers/<int:supplier_id>/frameworks/<framework_slug>', methods=['GET'])
 def get_supplier_framework_info(supplier_id, framework_slug):
     supplier_framework = SupplierFramework.find_by_supplier_and_framework(
         supplier_id, framework_slug
@@ -345,7 +345,7 @@ def get_supplier_framework_info(supplier_id, framework_slug):
     return jsonify(frameworkInterest=supplier_framework.serialize(with_users=True))
 
 
-@main.route('/suppliers/<supplier_id>/frameworks/<framework_slug>', methods=['PUT'])
+@main.route('/suppliers/<int:supplier_id>/frameworks/<framework_slug>', methods=['PUT'])
 def register_framework_interest(supplier_id, framework_slug):
 
     framework = Framework.query.filter(
@@ -395,7 +395,7 @@ def register_framework_interest(supplier_id, framework_slug):
     return jsonify(frameworkInterest=interest_record.serialize()), 201
 
 
-@main.route('/suppliers/<supplier_id>/frameworks/<framework_slug>', methods=['POST'])
+@main.route('/suppliers/<int:supplier_id>/frameworks/<framework_slug>', methods=['POST'])
 def update_supplier_framework(supplier_id, framework_slug):
     framework = Framework.query.filter(
         Framework.slug == framework_slug

--- a/tests/main/views/test_services.py
+++ b/tests/main/views/test_services.py
@@ -1314,7 +1314,7 @@ class TestPutService(BaseApplicationTest, JSONUpdateTestMixin, FixtureMixin):
         assert response.status_code == 400
         assert b'Invalid service ID supplied' in response.get_data()
 
-    @pytest.mark.parametrize("invalid_service_id", [('tooshort', 'this_one_is_way_too_long')])
+    @pytest.mark.parametrize("invalid_service_id", ['tooshort', 'this_one_is_way_too_long'])
     def test_invalid_service_ids(self, invalid_service_id):
         response = self.client.put(
             '/services/{}'.format(invalid_service_id),


### PR DESCRIPTION
Using single-argument parametrize with a tuple uses that tuple as
a single value.