### PR TITLE
Improve API test coverage (v2)

### DIFF
--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -157,9 +157,9 @@ def create_user():
     except IntegrityError:
         db.session.rollback()
         abort(400, "Invalid supplier id")
-    except DataError:
+    except DataError as e:
         db.session.rollback()
-        abort(400, "Invalid user role")
+        abort(400, "Data Error: {}".format(e))
 
     return jsonify(users=user.serialize()), 201
 

--- a/tests/main/views/test_drafts.py
+++ b/tests/main/views/test_drafts.py
@@ -1012,7 +1012,7 @@ class TestDraftServices(BaseApplicationTest, FixtureMixin):
         ).get_data())['services']
 
         res = self.client.get(
-            '/draft-services/%d' % draft['id'],
+            '/draft-services/{}'.format(draft['id']),
             data=json.dumps(self.create_draft_json),
             content_type='application/json'
         )
@@ -1075,7 +1075,7 @@ class TestCopyDraft(BaseApplicationTest, JSONUpdateTestMixin):
 
     def test_copy_draft(self):
         res = self.client.post(
-            '/draft-services/%s/copy' % self.draft_id,
+            '/draft-services/{}/copy'.format(self.draft_id),
             data=json.dumps({'updated_by': 'joeblogs'}),
             content_type='application/json')
 
@@ -1090,7 +1090,7 @@ class TestCopyDraft(BaseApplicationTest, JSONUpdateTestMixin):
 
     def test_copy_draft_should_create_audit_event(self):
         res = self.client.post(
-            '/draft-services/%s/copy' % self.draft_id,
+            '/draft-services/{}/copy'.format(self.draft_id),
             data=json.dumps({'updated_by': 'joeblogs'}),
             content_type='application/json')
 
@@ -1144,7 +1144,7 @@ class TestCopyDraft(BaseApplicationTest, JSONUpdateTestMixin):
     def test_copy_draft_service_should_catch_db_integrity_error(self, db_commit):
         db_commit.side_effect = IntegrityError("Could not commit", orig=None, params={})
         res = self.client.post(
-            '/draft-services/%s/copy' % self.draft_id,
+            '/draft-services/{}/copy'.format(self.draft_id),
             data=json.dumps({'updated_by': 'joeblogs'}),
             content_type='application/json')
 
@@ -1188,7 +1188,7 @@ class TestCompleteDraft(BaseApplicationTest, JSONUpdateTestMixin):
 
     def test_complete_draft(self):
         res = self.client.post(
-            '/draft-services/%s/complete' % self.draft_id,
+            '/draft-services/{}/complete'.format(self.draft_id),
             data=json.dumps({'updated_by': 'joeblogs'}),
             content_type='application/json')
 
@@ -1198,7 +1198,7 @@ class TestCompleteDraft(BaseApplicationTest, JSONUpdateTestMixin):
 
     def test_complete_draft_should_create_audit_event(self):
         res = self.client.post(
-            '/draft-services/%s/complete' % self.draft_id,
+            '/draft-services/{}/complete'.format(self.draft_id),
             data=json.dumps({'updated_by': 'joeblogs'}),
             content_type='application/json')
 
@@ -1216,7 +1216,7 @@ class TestCompleteDraft(BaseApplicationTest, JSONUpdateTestMixin):
 
     def test_should_not_complete_draft_without_updated_by(self):
         res = self.client.post(
-            '/draft-services/%s/complete' % self.draft_id,
+            '/draft-services/{}/complete'.format(self.draft_id),
             data=json.dumps({}),
             content_type='application/json')
 
@@ -1242,7 +1242,7 @@ class TestCompleteDraft(BaseApplicationTest, JSONUpdateTestMixin):
         draft = json.loads(draft.get_data())['services']
 
         res = self.client.post(
-            '/draft-services/%s/complete' % draft['id'],
+            '/draft-services/{}/complete'.format(draft['id']),
             data=json.dumps({'updated_by': 'joeblogs'}),
             content_type='application/json')
 
@@ -1254,7 +1254,7 @@ class TestCompleteDraft(BaseApplicationTest, JSONUpdateTestMixin):
     def test_complete_draft_catches_db_integrity_errors(self, db_commit):
         db_commit.side_effect = IntegrityError("Could not commit", orig=None, params={})
         res = self.client.post(
-            '/draft-services/%s/complete' % self.draft_id,
+            '/draft-services/{}/complete'.format(self.draft_id),
             data=json.dumps({'updated_by': 'joeblogs'}),
             content_type='application/json')
 
@@ -1556,7 +1556,7 @@ class TestUpdateDraftStatus(BaseApplicationTest, JSONUpdateTestMixin):
 
     def test_update_draft_status(self):
         res = self.client.post(
-            '/draft-services/%s/update-status' % self.draft_id,
+            '/draft-services/{}/update-status'.format(self.draft_id),
             data=json.dumps({'services': {'status': 'failed'}, 'updated_by': 'joeblogs'}),
             content_type='application/json')
 
@@ -1566,7 +1566,7 @@ class TestUpdateDraftStatus(BaseApplicationTest, JSONUpdateTestMixin):
 
     def test_update_draft_status_should_create_audit_event(self):
         res = self.client.post(
-            '/draft-services/%s/update-status' % self.draft_id,
+            '/draft-services/{}/update-status'.format(self.draft_id),
             data=json.dumps({'services': {'status': 'failed'}, 'updated_by': 'joeblogs'}),
             content_type='application/json')
 
@@ -1584,7 +1584,7 @@ class TestUpdateDraftStatus(BaseApplicationTest, JSONUpdateTestMixin):
 
     def test_should_not_update_draft_status_to_invalid_status(self):
         res = self.client.post(
-            '/draft-services/%s/update-status' % self.draft_id,
+            '/draft-services/{}/update-status'.format(self.draft_id),
             data=json.dumps({'services': {'status': 'INVALID-STATUS'}, 'updated_by': 'joeblogs'}),
             content_type='application/json')
 
@@ -1592,10 +1592,10 @@ class TestUpdateDraftStatus(BaseApplicationTest, JSONUpdateTestMixin):
         assert json.loads(res.get_data()) == {"error": "'INVALID-STATUS' is not a valid status"}
 
     @mock.patch('app.db.session.commit')
-    def test_update_draft_catches_db_integrity_errors(self, db_commit):
+    def test_update_draft_status_catches_db_integrity_errors(self, db_commit):
         db_commit.side_effect = IntegrityError("Could not commit", orig=None, params={})
         res = self.client.post(
-            '/draft-services/%s/update-status' % self.draft_id,
+            '/draft-services/{}/update-status'.format(self.draft_id),
             data=json.dumps({'services': {'status': 'failed'}, 'updated_by': 'joeblogs'}),
             content_type='application/json')
 

--- a/tests/main/views/test_frameworks.py
+++ b/tests/main/views/test_frameworks.py
@@ -396,6 +396,7 @@ class TestUpdateFramework(BaseApplicationTest, JSONUpdateTestMixin):
                 })
 
                 assert response.status_code == 400
+                assert "Could not commit" in json.loads(response.get_data())["error"]
 
 
 class TestFrameworkStats(BaseApplicationTest, FixtureMixin):

--- a/tests/main/views/test_services.py
+++ b/tests/main/views/test_services.py
@@ -362,7 +362,7 @@ class TestListServices(BaseApplicationTest, FixtureMixin):
         self.setup_dummy_services_including_unpublished(15)
 
         response = self.client.get(
-            '/services?supplier_id=%d' % TEST_SUPPLIERS_COUNT
+            '/services?supplier_id={}'.format(TEST_SUPPLIERS_COUNT)
         )
         data = json.loads(response.get_data())
 
@@ -492,7 +492,7 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin, FixtureMixin):
     def test_no_content_type_causes_failure(self):
         with self.app.app_context():
             response = self.client.post(
-                '/services/%s' % self.service_id,
+                '/services/{}'.format(self.service_id),
                 data=json.dumps(
                     {'updated_by': 'joeblogs',
                      'services': {
@@ -504,7 +504,7 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin, FixtureMixin):
     def test_invalid_content_type_causes_failure(self):
         with self.app.app_context():
             response = self.client.post(
-                '/services/%s' % self.service_id,
+                '/services/{}'.format(self.service_id),
                 data=json.dumps(
                     {'updated_by': 'joeblogs',
                      'services': {
@@ -517,7 +517,7 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin, FixtureMixin):
     def test_invalid_json_causes_failure(self):
         with self.app.app_context():
             response = self.client.post(
-                '/services/%s' % self.service_id,
+                '/services/{}'.format(self.service_id),
                 data="ouiehdfiouerhfuehr",
                 content_type='application/json')
 
@@ -581,7 +581,7 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin, FixtureMixin):
             )
             assert response.status_code == 200
 
-            response = self.client.get('/services/%s' % self.service_id)
+            response = self.client.get('/services/{}'.format(self.service_id))
             data = json.loads(response.get_data())
             assert data['services']['serviceName'] == 'new service name'
             assert data['services']['incidentEscalation'] is False
@@ -594,7 +594,7 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin, FixtureMixin):
             response = self._post_service_update({'supportTypes': support_types})
             assert response.status_code == 200
 
-            response = self.client.get('/services/%s' % self.service_id)
+            response = self.client.get('/services/{}'.format(self.service_id))
             data = json.loads(response.get_data())
 
             assert all(i in support_types for i in data['services']['supportTypes']) is True
@@ -609,7 +609,7 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin, FixtureMixin):
             response = self._post_service_update({'identityAuthenticationControls': identity_authentication_controls})
             assert response.status_code == 200
 
-            response = self.client.get('/services/%s' % self.service_id)
+            response = self.client.get('/services/{}'.format(self.service_id))
             data = json.loads(response.get_data())
 
             updated_auth_controls = \
@@ -673,7 +673,7 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin, FixtureMixin):
 
     def test_writing_full_service_back(self):
         with self.app.app_context():
-            response = self.client.get('/services/%s' % self.service_id)
+            response = self.client.get('/services/{}'.format(self.service_id))
             data = json.loads(response.get_data())
             response = self._post_service_update(data['services'])
 
@@ -705,7 +705,7 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin, FixtureMixin):
 
     def test_should_400_if_mismatched_service_id(self):
         response = self.client.post(
-            '/services/%s' % self.service_id,
+            '/services/{}'.format(self.service_id),
             data=json.dumps(
                 {'updated_by': 'joeblogs',
                  'services': {
@@ -719,7 +719,7 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin, FixtureMixin):
         response = self._post_service_update({'status': 'enabled'})
         assert response.status_code == 200
 
-        response = self.client.get('/services/%s' % self.service_id)
+        response = self.client.get('/services/{}'.format(self.service_id))
         data = json.loads(response.get_data())
 
         assert data['services']['status'] == 'published'
@@ -1408,7 +1408,7 @@ class TestPutService(BaseApplicationTest, JSONUpdateTestMixin, FixtureMixin):
     def test_cannot_update_existing_service_by_put(self, search_api_client):
         with self.app.app_context():
             search_api_client.return_value = "bar"
-            response = self.client.put(
+            self.client.put(
                 '/services/{}'.format(self.service_id),
                 data=json.dumps({
                     'updated_by': 'joeblogs',

--- a/tests/main/views/test_status.py
+++ b/tests/main/views/test_status.py
@@ -1,4 +1,6 @@
 from tests.bases import BaseApplicationTest
+from sqlalchemy.exc import SQLAlchemyError
+import mock
 
 
 class TestStatus(BaseApplicationTest):
@@ -6,3 +8,9 @@ class TestStatus(BaseApplicationTest):
     def test_should_return_200_from_elb_status_check(self):
         status_response = self.client.get('/_status?ignore-dependencies')
         assert status_response.status_code == 200
+
+    @mock.patch('app.status.utils.get_db_version')
+    def test_catches_db_error_and_return_500(self, get_db_version):
+        get_db_version.side_effect = SQLAlchemyError()
+        status_response = self.client.get('/_status')
+        assert status_response.status_code == 500

--- a/tests/main/views/test_users.py
+++ b/tests/main/views/test_users.py
@@ -3,6 +3,8 @@ from freezegun import freeze_time
 from app import db, encryption
 from app.models import User, Supplier
 from datetime import datetime
+import mock
+from sqlalchemy.exc import DataError
 from tests.bases import BaseApplicationTest, JSONTestMixin, JSONUpdateTestMixin
 from tests.helpers import FixtureMixin, load_example_listing
 
@@ -517,6 +519,22 @@ class TestUsersPost(BaseApplicationTest, JSONTestMixin):
         assert response.status_code == 400
         data = json.loads(response.get_data())["error"]
         assert "JSON was not a valid format" in data
+
+    @mock.patch('app.db.session.commit')
+    def test_create_user_catches_db_errors(self, db_commit):
+        db_commit.side_effect = DataError("Unable to commit", orig=None, params={})
+        response = self.client.post(
+            '/users',
+            data=json.dumps({
+                'users': {
+                    'emailAddress': 'joeblogs@email.gov.uk',
+                    'phoneNumber': '01234 567890',
+                    'password': '1234567890',
+                    'role': 'buyer',
+                    'name': 'joe bloggs'}}),
+            content_type='application/json')
+        assert response.status_code == 400
+        assert json.loads(response.get_data())["error"] == "Invalid user role"
 
 
 class TestUsersUpdate(BaseApplicationTest, JSONUpdateTestMixin):

--- a/tests/main/views/test_users.py
+++ b/tests/main/views/test_users.py
@@ -534,7 +534,7 @@ class TestUsersPost(BaseApplicationTest, JSONTestMixin):
                     'name': 'joe bloggs'}}),
             content_type='application/json')
         assert response.status_code == 400
-        assert json.loads(response.get_data())["error"] == "Invalid user role"
+        assert "Unable to commit" in json.loads(response.get_data())["error"]
 
 
 class TestUsersUpdate(BaseApplicationTest, JSONUpdateTestMixin):


### PR DESCRIPTION
A second go at a branch that descended into a conflict/rebase nightmare. Cherry picked the relevant commits from the old branch (see https://github.com/alphagov/digitalmarketplace-api/pull/603)

In the interests of not having the rebase nightmare happen again, I left out the reorganisation of the large test class for another time. The goal of having better test coverage for the modules involved has still hopefully been achieved!