### PR TITLE
[#138095135]acknowledge multiple audit events atomically

### DIFF
--- a/app/main/views/audits.py
+++ b/app/main/views/audits.py
@@ -223,30 +223,44 @@ def acknowledge_audit(audit_id):
     return jsonify(auditEvents=audit_event.serialize()), 200
 
 
-@main.route('/audit-events/<int:audit_id>/acknowledge-including-previous', methods=['POST'])
-def acknowledge_including_previous(audit_id):
+# this is a "view without a route" for at the moment - it is used as an "inner" view implementation for the service
+# updates acknowledgement view
+def acknowledge_including_previous(
+        audit_id,
+        restrict_object_id=None,
+        restrict_object_type=None,
+        restrict_audit_type=None,
+        ):
     updater_json = validate_and_return_updater_request()
 
-    audit_event = AuditEvent.query.get(audit_id)
+    audit_event_query = db.session.query(AuditEvent)
+    if restrict_object_id is not None:
+        audit_event_query = audit_event_query.filter(AuditEvent.object_id == restrict_object_id)
+    if restrict_object_type is not None:
+        audit_event_query = audit_event_query.filter(AuditEvent.object.is_type(restrict_object_type))
+    if restrict_audit_type is not None:
+        audit_event_query = audit_event_query.filter(AuditEvent.type == restrict_audit_type)
+
+    audit_event = audit_event_query.filter(AuditEvent.id == audit_id).one_or_none()
     if audit_event is None:
-        abort(404, "No audit event with this id")
+        abort(404, "No suitable audit event with this id")
 
     result = db.session.execute(AuditEvent.__table__.update().returning(
-        AuditEvent.__table__.c.id
+        AuditEvent.id
     ).where(db.and_(
-        AuditEvent.__table__.c.object_id == audit_event.object_id,
-        AuditEvent.__table__.c.object_type == audit_event.object_type,
-        AuditEvent.__table__.c.type == audit_event.type,
-        AuditEvent.__table__.c.acknowledged == db.false(),
+        AuditEvent.object_id == audit_event.object_id,
+        AuditEvent.object.is_type(type(audit_event.object)),
+        AuditEvent.type == audit_event.type,
+        AuditEvent.acknowledged == db.false(),
         # ugly, but this just implements the same "id tie breaker" behaviour for created_at-equal events as the
         # ordering we use in list_audits. this way there is some consistency between the two views as to what events
         # are considered "previous" in such cases. we could use postgres composite types to express this far more
         # neatly, but i can't get sqlalchemy to work with anonymous composite types.
         db.or_(
-            AuditEvent.__table__.c.created_at < audit_event.created_at,
+            AuditEvent.created_at < audit_event.created_at,
             db.and_(
-                AuditEvent.__table__.c.created_at == audit_event.created_at,
-                AuditEvent.__table__.c.id <= audit_event.id,
+                AuditEvent.created_at == audit_event.created_at,
+                AuditEvent.id <= audit_event.id,
             ),
         ),
     )).values(

--- a/tests/main/views/test_audits.py
+++ b/tests/main/views/test_audits.py
@@ -84,6 +84,260 @@ class BaseTestAuditEvents(BaseApplicationTest, FixtureMixin):
             return audit_event_id_lookup
 
 
+# these actually test a view whose @route is declared in services.py, but the bulk of the implementation is in audits.py
+# and it heavily uses BaseTestAuditEvents above
+class TestSupplierUpdateAcknowledgement(BaseTestAuditEvents):
+    @pytest.mark.parametrize(
+        "service_audit_event_params,supplier_audit_event_params,target_audit_event_id,expected_resp_events",
+        # where we refer to "id"s in the expected_response_params, because we can't be too sure about the *actual* ids
+        # given to objects, we're using 0-based notional "ids" mased on the order the audit events were inserted into
+        # the db. service_audit_event_params events are inserted in the order given, followed by the
+        # supplier_audit_event_params events. so if we had 5 service_audit_event_params and 2
+        # supplier_audit_event_params, "5" would refer to the audit event created by the first-listed
+        # supplier_audit_event_params.
+        # similarly, where supplier and service "id"s are referred to, the "id"s we're referring to are normalized
+        # pseudo-ids from 0-4 inclusive
+        chain.from_iterable(
+            ((serv_aeps, supp_aeps, tgt_ae_id, expected_resp_events) for tgt_ae_id, expected_resp_events in req_cases)
+            for serv_aeps, supp_aeps, req_cases in (
+                (
+                    (   # service_audit_event_params, as consumed by add_audit_events_by_param_tuples
+                        # service pseudo-id, audit type, created_at, acknowledged_at
+                        (0, AuditTypes.update_service, datetime(2010, 6, 6), None,),
+                        (0, AuditTypes.update_service, datetime(2010, 6, 7), None,),
+                        (4, AuditTypes.update_service, datetime(2010, 6, 2), None,),
+                    ),
+                    (   # supplier_audit_event_params, as consumed by add_audit_events_by_param_tuples
+                        # supplier pseudo-id, audit type, created_at, acknowledged_at
+                        (0, AuditTypes.supplier_update, datetime(2010, 6, 6), None,),
+                    ),
+                    (   # and now a series of req_cases - pairs of (tgt_ae_id, expected_resp_events) to test against
+                        # the above db scenario. these get flattened out into concrete test scenarios by
+                        # chain.from_iterable above before they reach pytest's parametrization
+                        (
+                            1,
+                            frozenset((0, 1,)),
+                        ),
+                        (
+                            2,
+                            frozenset((2,)),
+                        ),
+                        # (
+                        #     3,
+                        #     frozenset((3,)),
+                        # ),
+                    ),
+                ),
+                (
+                    (
+                        (2, AuditTypes.update_service, datetime(2010, 6, 9), None,),
+                        (3, AuditTypes.update_service, datetime(2010, 6, 2), None,),
+                        (2, AuditTypes.update_service, datetime(2010, 6, 7), None,),
+                        (2, AuditTypes.update_service, datetime(2010, 6, 1), datetime(2010, 6, 1, 1),),
+                        (4, AuditTypes.update_service, datetime(2010, 6, 5), None,),
+                        (2, AuditTypes.update_service_status, datetime(2010, 6, 2), None,),
+                    ),
+                    (
+                        (0, AuditTypes.supplier_update, datetime(2010, 7, 1), None,),
+                        (1, AuditTypes.supplier_update, datetime(2010, 7, 9), None,),
+                        (1, AuditTypes.supplier_update, datetime(2010, 7, 8), None,),
+                        (1, AuditTypes.supplier_update, datetime(2010, 7, 5), datetime(2010, 8, 1),),
+                        (0, AuditTypes.supplier_update, datetime(2010, 7, 9), None,),
+                        (1, AuditTypes.supplier_update, datetime(2010, 7, 1), datetime(2010, 8, 1),),
+                        (1, AuditTypes.supplier_update, datetime(2010, 7, 2), datetime(2010, 8, 1),),
+                        (0, AuditTypes.supplier_update, datetime(2010, 7, 6), None,),
+                        (0, AuditTypes.supplier_update, datetime(2010, 7, 5), None,),
+                    ),
+                    (
+                        (
+                            0,
+                            frozenset((0, 2,)),
+                        ),
+                        (
+                            2,
+                            frozenset((2,)),
+                        ),
+                        (
+                            4,
+                            frozenset((4,)),
+                        ),
+                        # (
+                        #     6,
+                        #     frozenset((6,)),
+                        # ),
+                        # (
+                        #     7,
+                        #     frozenset((7, 8,)),
+                        # ),
+                        # (
+                        #     10,
+                        #     frozenset((6, 10, 13, 14,)),
+                        # ),
+                        # (
+                        #     12,
+                        #     frozenset(),  # already acknowledged - should have no effect
+                        # ),
+                    ),
+                ),
+                (
+                    (
+                        (3, AuditTypes.update_service, datetime(2011, 6, 5), None,),
+                        (4, AuditTypes.update_service, datetime(2011, 6, 8), None,),
+                        (2, AuditTypes.update_service, datetime(2011, 6, 1), None,),
+                        # note here deliberate collision of created_at and object_id to verify the secondary-ordering
+                        (4, AuditTypes.update_service, datetime(2011, 6, 8), None,),
+                        (4, AuditTypes.update_service_status, datetime(2011, 6, 7), datetime(2011, 6, 7, 1),),
+                        (4, AuditTypes.update_service, datetime(2011, 6, 6), None,),
+                        (4, AuditTypes.update_service, datetime(2011, 6, 2), datetime(2011, 8, 1),),
+                    ),
+                    (
+                        (4, AuditTypes.supplier_update, datetime(2011, 6, 1), None,),
+                        (1, AuditTypes.supplier_update, datetime(2011, 6, 9), None,),
+                        (1, AuditTypes.supplier_update, datetime(2011, 6, 6), datetime(2011, 8, 1),),
+                        # again here
+                        (1, AuditTypes.supplier_update, datetime(2011, 6, 9), None,),
+                        (3, AuditTypes.supplier_update, datetime(2011, 6, 5), None,),
+                        (1, AuditTypes.supplier_update, datetime(2011, 6, 8), None,),
+                    ),
+                    (
+                        (
+                            0,
+                            frozenset((0,)),
+                        ),
+                        (
+                            1,
+                            frozenset((1, 5,)),
+                        ),
+                        (
+                            3,
+                            frozenset((1, 3, 5,)),
+                        ),
+                        # (
+                        #     4,
+                        #     frozenset(),  # already acknowledged - should have no effect
+                        # ),
+                        (
+                            5,
+                            frozenset((5,)),
+                        ),
+                        (
+                            6,
+                            frozenset(),  # already acknowledged - should have no effect
+                        ),
+                        # (
+                        #     8,
+                        #     frozenset((8, 12,)),
+                        # ),
+                        # (
+                        #     10,
+                        #     frozenset((8, 10, 12,)),
+                        # ),
+                        # (
+                        #     11,
+                        #     frozenset((11,)),
+                        # ),
+                        # (
+                        #     12,
+                        #     frozenset((12,)),
+                        # ),
+                    ),
+                ),
+            )
+        ),
+    )
+    def test_acknowledge_including_previous_happy_path(
+            self,
+            service_audit_event_params,
+            supplier_audit_event_params,
+            target_audit_event_id,
+            expected_resp_events,
+            ):
+        self.setup_dummy_suppliers(5)
+        self.setup_dummy_services(5, supplier_id=1)
+        audit_event_id_lookup = self.add_audit_events_by_param_tuples(
+            service_audit_event_params,
+            supplier_audit_event_params,
+        )
+        audit_event_id_rlookup = {v: k for k, v in audit_event_id_lookup.items()}
+        with self.app.app_context():
+            # because we're doing a fun include-the-servide-id thing on the api endpoint we've got to look it up here,
+            # this being the *public* service id
+            service_id = db.session.query(Service.service_id).join(
+                AuditEvent,
+                AuditEvent.object_id == Service.id,
+            ).filter(AuditEvent.id == audit_event_id_rlookup[target_audit_event_id]).scalar()
+
+        frozen_time = datetime(2016, 6, 6, 15, 32, 44, 1234)
+        with freeze_time(frozen_time):
+            response = self.client.post(
+                "/services/{}/updates/acknowledge".format(service_id),
+                data=json.dumps({
+                    'updated_by': "martha.clifford@example.com",
+                    "latestAuditEventId": audit_event_id_rlookup[target_audit_event_id],
+                }),
+                content_type='application/json',
+            )
+
+        assert response.status_code == 200
+        data = json.loads(response.get_data())
+
+        assert frozenset(audit_event_id_lookup[ae["id"]] for ae in data["auditEvents"]) == expected_resp_events
+
+        with self.app.app_context():
+            assert sorted((
+                audit_event_id_lookup[id_],
+                acknowledged,
+                acknowledged_at,
+                acknowledged_by,
+            ) for id_, acknowledged, acknowledged_at, acknowledged_by in db.session.query(
+                AuditEvent.id,
+                AuditEvent.acknowledged,
+                AuditEvent.acknowledged_at,
+                AuditEvent.acknowledged_by,
+            ).all()) == [
+                (
+                    id_,
+                    (id_ in expected_resp_events) or bool(acknowledged_at),
+                    (frozen_time if id_ in expected_resp_events else acknowledged_at),
+                    (
+                        "martha.clifford@example.com"
+                        if id_ in expected_resp_events else
+                        (acknowledged_at and "c.p.mccoy@example.com")
+                    )
+                ) for id_, (
+                    obj_id,
+                    audit_type,
+                    created_at,
+                    acknowledged_at,
+                ) in enumerate(chain(service_audit_event_params, supplier_audit_event_params))
+            ]
+
+    def test_acknowledge_including_previous_nonexistent_event(self):
+        # would be unfair to not give them any events to start with
+        self.setup_dummy_suppliers(3)
+        self.setup_dummy_services(3, supplier_id=1)
+        audit_event_id_lookup = self.add_audit_events_by_param_tuples(
+            ((0, AuditTypes.update_service, datetime(2010, 6, 7), None,),),
+            ((2, AuditTypes.supplier_update, datetime(2011, 6, 9), None,),),
+        )
+
+        response = self.client.post(
+            "/audit-events/314159/acknowledge-including-previous",
+            data=json.dumps({'updated_by': "martha.clifford@example.com"}),
+            content_type='application/json',
+        )
+
+        assert response.status_code == 404
+
+        with self.app.app_context():
+            # check nothing happened to the data
+            assert not db.session.query(AuditEvent).filter(db.or_(
+                AuditEvent.acknowledged_by.isnot(None),
+                AuditEvent.acknowledged_at.isnot(None),
+                AuditEvent.acknowledged == db.true(),
+            )).all()
+
+
 class TestAuditEvents(BaseTestAuditEvents):
     @pytest.mark.parametrize(
         "service_audit_event_params,supplier_audit_event_params,req_params,expected_resp_events",
@@ -267,256 +521,6 @@ class TestAuditEvents(BaseTestAuditEvents):
         data = json.loads(response.get_data())
 
         assert tuple(audit_event_id_lookup[ae["id"]] for ae in data["auditEvents"]) == expected_resp_events
-
-    @pytest.mark.parametrize(
-        "service_audit_event_params,supplier_audit_event_params,target_audit_event_id,expected_resp_events",
-        # where we refer to "id"s in the expected_response_params, because we can't be too sure about the *actual* ids
-        # given to objects, we're using 0-based notional "ids" mased on the order the audit events were inserted into
-        # the db. service_audit_event_params events are inserted in the order given, followed by the
-        # supplier_audit_event_params events. so if we had 5 service_audit_event_params and 2
-        # supplier_audit_event_params, "5" would refer to the audit event created by the first-listed
-        # supplier_audit_event_params.
-        # similarly, where supplier and service "id"s are referred to, the "id"s we're referring to are normalized
-        # pseudo-ids from 0-4 inclusive
-        chain.from_iterable(
-            ((serv_aeps, supp_aeps, tgt_ae_id, expected_resp_events) for tgt_ae_id, expected_resp_events in req_cases)
-            for serv_aeps, supp_aeps, req_cases in (
-                (
-                    (   # service_audit_event_params, as consumed by add_audit_events_by_param_tuples
-                        # service pseudo-id, audit type, created_at, acknowledged_at
-                        (0, AuditTypes.update_service, datetime(2010, 6, 6), None,),
-                        (0, AuditTypes.update_service, datetime(2010, 6, 7), None,),
-                        (4, AuditTypes.update_service, datetime(2010, 6, 2), None,),
-                    ),
-                    (   # supplier_audit_event_params, as consumed by add_audit_events_by_param_tuples
-                        # supplier pseudo-id, audit type, created_at, acknowledged_at
-                        (0, AuditTypes.supplier_update, datetime(2010, 6, 6), None,),
-                    ),
-                    (   # and now a series of req_cases - pairs of (tgt_ae_id, expected_resp_events) to test against
-                        # the above db scenario. these get flattened out into concrete test scenarios by
-                        # chain.from_iterable above before they reach pytest's parametrization
-                        (
-                            1,
-                            frozenset((0, 1,)),
-                        ),
-                        (
-                            2,
-                            frozenset((2,)),
-                        ),
-                        #(
-                            #3,
-                            #frozenset((3,)),
-                        #),
-                    ),
-                ),
-                (
-                    (
-                        (2, AuditTypes.update_service, datetime(2010, 6, 9), None,),
-                        (3, AuditTypes.update_service, datetime(2010, 6, 2), None,),
-                        (2, AuditTypes.update_service, datetime(2010, 6, 7), None,),
-                        (2, AuditTypes.update_service, datetime(2010, 6, 1), datetime(2010, 6, 1, 1),),
-                        (4, AuditTypes.update_service, datetime(2010, 6, 5), None,),
-                        (2, AuditTypes.update_service_status, datetime(2010, 6, 2), None,),
-                    ),
-                    (
-                        (0, AuditTypes.supplier_update, datetime(2010, 7, 1), None,),
-                        (1, AuditTypes.supplier_update, datetime(2010, 7, 9), None,),
-                        (1, AuditTypes.supplier_update, datetime(2010, 7, 8), None,),
-                        (1, AuditTypes.supplier_update, datetime(2010, 7, 5), datetime(2010, 8, 1),),
-                        (0, AuditTypes.supplier_update, datetime(2010, 7, 9), None,),
-                        (1, AuditTypes.supplier_update, datetime(2010, 7, 1), datetime(2010, 8, 1),),
-                        (1, AuditTypes.supplier_update, datetime(2010, 7, 2), datetime(2010, 8, 1),),
-                        (0, AuditTypes.supplier_update, datetime(2010, 7, 6), None,),
-                        (0, AuditTypes.supplier_update, datetime(2010, 7, 5), None,),
-                    ),
-                    (
-                        (
-                            0,
-                            frozenset((0, 2,)),
-                        ),
-                        (
-                            2,
-                            frozenset((2,)),
-                        ),
-                        (
-                            4,
-                            frozenset((4,)),
-                        ),
-                        #(
-                            #6,
-                            #frozenset((6,)),
-                        #),
-                        #(
-                            #7,
-                            #frozenset((7, 8,)),
-                        #),
-                        #(
-                            #10,
-                            #frozenset((6, 10, 13, 14,)),
-                        #),
-                        #(
-                            #12,
-                            #frozenset(),  # already acknowledged - should have no effect
-                        #),
-                    ),
-                ),
-                (
-                    (
-                        (3, AuditTypes.update_service, datetime(2011, 6, 5), None,),
-                        (4, AuditTypes.update_service, datetime(2011, 6, 8), None,),
-                        (2, AuditTypes.update_service, datetime(2011, 6, 1), None,),
-                        # note here deliberate collision of created_at and object_id to verify the secondary-ordering
-                        (4, AuditTypes.update_service, datetime(2011, 6, 8), None,),
-                        (4, AuditTypes.update_service_status, datetime(2011, 6, 7), datetime(2011, 6, 7, 1),),
-                        (4, AuditTypes.update_service, datetime(2011, 6, 6), None,),
-                        (4, AuditTypes.update_service, datetime(2011, 6, 2), datetime(2011, 8, 1),),
-                    ),
-                    (
-                        (4, AuditTypes.supplier_update, datetime(2011, 6, 1), None,),
-                        (1, AuditTypes.supplier_update, datetime(2011, 6, 9), None,),
-                        (1, AuditTypes.supplier_update, datetime(2011, 6, 6), datetime(2011, 8, 1),),
-                        # again here
-                        (1, AuditTypes.supplier_update, datetime(2011, 6, 9), None,),
-                        (3, AuditTypes.supplier_update, datetime(2011, 6, 5), None,),
-                        (1, AuditTypes.supplier_update, datetime(2011, 6, 8), None,),
-                    ),
-                    (
-                        (
-                            0,
-                            frozenset((0,)),
-                        ),
-                        (
-                            1,
-                            frozenset((1, 5,)),
-                        ),
-                        (
-                            3,
-                            frozenset((1, 3, 5,)),
-                        ),
-                        #(
-                            #4,
-                            #frozenset(),  # already acknowledged - should have no effect
-                        #),
-                        (
-                            5,
-                            frozenset((5,)),
-                        ),
-                        (
-                            6,
-                            frozenset(),  # already acknowledged - should have no effect
-                        ),
-                        #(
-                            #8,
-                            #frozenset((8, 12,)),
-                        #),
-                        #(
-                            #10,
-                            #frozenset((8, 10, 12,)),
-                        #),
-                        #(
-                            #11,
-                            #frozenset((11,)),
-                        #),
-                        #(
-                            #12,
-                            #frozenset((12,)),
-                        #),
-                    ),
-                ),
-            )
-        ),
-    )
-    def test_acknowledge_including_previous_happy_path(
-            self,
-            service_audit_event_params,
-            supplier_audit_event_params,
-            target_audit_event_id,
-            expected_resp_events,
-            ):
-        self.setup_dummy_suppliers(5)
-        self.setup_dummy_services(5, supplier_id=1)
-        audit_event_id_lookup = self.add_audit_events_by_param_tuples(
-            service_audit_event_params,
-            supplier_audit_event_params,
-        )
-        audit_event_id_rlookup = {v: k for k, v in audit_event_id_lookup.items()}
-        with self.app.app_context():
-            # because we're doing a fun include-the-servide-id thing on the api endpoint we've got to look it up here,
-            # this being the *public* service id
-            service_id = db.session.query(Service.service_id).join(
-                AuditEvent,
-                AuditEvent.object_id == Service.id,
-            ).filter(AuditEvent.id == audit_event_id_rlookup[target_audit_event_id]).scalar()
-
-        frozen_time = datetime(2016, 6, 6, 15, 32, 44, 1234)
-        with freeze_time(frozen_time):
-            response = self.client.post(
-                "/services/{}/updates/acknowledge".format(service_id),
-                data=json.dumps({
-                    'updated_by': "martha.clifford@example.com",
-                    "latestAuditEventId": audit_event_id_rlookup[target_audit_event_id],
-                }),
-                content_type='application/json',
-            )
-
-        assert response.status_code == 200
-        data = json.loads(response.get_data())
-
-        assert frozenset(audit_event_id_lookup[ae["id"]] for ae in data["auditEvents"]) == expected_resp_events
-
-        with self.app.app_context():
-            assert sorted((
-                audit_event_id_lookup[id_],
-                acknowledged,
-                acknowledged_at,
-                acknowledged_by,
-            ) for id_, acknowledged, acknowledged_at, acknowledged_by in db.session.query(
-                AuditEvent.id,
-                AuditEvent.acknowledged,
-                AuditEvent.acknowledged_at,
-                AuditEvent.acknowledged_by,
-            ).all()) == [
-                (
-                    id_,
-                    (id_ in expected_resp_events) or bool(acknowledged_at),
-                    (frozen_time if id_ in expected_resp_events else acknowledged_at),
-                    (
-                        "martha.clifford@example.com"
-                        if id_ in expected_resp_events else
-                        (acknowledged_at and "c.p.mccoy@example.com")
-                    )
-                ) for id_, (
-                    obj_id,
-                    audit_type,
-                    created_at,
-                    acknowledged_at,
-                ) in enumerate(chain(service_audit_event_params, supplier_audit_event_params))
-            ]
-
-    def test_acknowledge_including_previous_nonexistent_event(self):
-        # would be unfair to not give them any events to start with
-        self.setup_dummy_suppliers(3)
-        self.setup_dummy_services(3, supplier_id=1)
-        audit_event_id_lookup = self.add_audit_events_by_param_tuples(
-            ((0, AuditTypes.update_service, datetime(2010, 6, 7), None,),),
-            ((2, AuditTypes.supplier_update, datetime(2011, 6, 9), None,),),
-        )
-
-        response = self.client.post(
-            "/audit-events/314159/acknowledge-including-previous",
-            data=json.dumps({'updated_by': "martha.clifford@example.com"}),
-            content_type='application/json',
-        )
-
-        assert response.status_code == 404
-
-        with self.app.app_context():
-            # check nothing happened to the data
-            assert not db.session.query(AuditEvent).filter(db.or_(
-                AuditEvent.acknowledged_by.isnot(None),
-                AuditEvent.acknowledged_at.isnot(None),
-                AuditEvent.acknowledged == db.true(),
-            )).all()
 
     def test_only_one_audit_event_created(self):
         with self.app.app_context():

--- a/tests/main/views/test_audits.py
+++ b/tests/main/views/test_audits.py
@@ -354,6 +354,10 @@ class TestAuditEvents(BaseTestAuditEvents):
                             10,
                             frozenset((6, 10, 13, 14,)),
                         ),
+                        (
+                            12,
+                            frozenset(),  # already acknowledged - should have no effect
+                        ),
                     ),
                 ),
                 (
@@ -390,9 +394,18 @@ class TestAuditEvents(BaseTestAuditEvents):
                             frozenset((1, 3, 5,)),
                         ),
                         (
+                            4,
+                            frozenset(),  # already acknowledged - should have no effect
+                        ),
+                        (
                             5,
                             frozenset((5,)),
                         ),
+                        (
+                            6,
+                            frozenset(),  # already acknowledged - should have no effect
+                        ),
+                        (
                             8,
                             frozenset((8, 12,)),
                         ),

--- a/tests/main/views/test_audits.py
+++ b/tests/main/views/test_audits.py
@@ -356,6 +356,58 @@ class TestAuditEvents(BaseTestAuditEvents):
                         ),
                     ),
                 ),
+                (
+                    (
+                        (3, AuditTypes.update_service, datetime(2011, 6, 5), None,),
+                        (4, AuditTypes.update_service, datetime(2011, 6, 8), None,),
+                        (2, AuditTypes.update_service, datetime(2011, 6, 1), None,),
+                        # note here deliberate collision of created_at and object_id to verify the secondary-ordering
+                        (4, AuditTypes.update_service, datetime(2011, 6, 8), None,),
+                        (4, AuditTypes.update_service_status, datetime(2011, 6, 7), datetime(2011, 6, 7, 1),),
+                        (4, AuditTypes.update_service, datetime(2011, 6, 6), None,),
+                        (4, AuditTypes.update_service, datetime(2011, 6, 2), datetime(2011, 8, 1),),
+                    ),
+                    (
+                        (4, AuditTypes.supplier_update, datetime(2011, 6, 1), None,),
+                        (1, AuditTypes.supplier_update, datetime(2011, 6, 9), None,),
+                        (1, AuditTypes.supplier_update, datetime(2011, 6, 6), datetime(2011, 8, 1),),
+                        # again here
+                        (1, AuditTypes.supplier_update, datetime(2011, 6, 9), None,),
+                        (3, AuditTypes.supplier_update, datetime(2011, 6, 5), None,),
+                        (1, AuditTypes.supplier_update, datetime(2011, 6, 8), None,),
+                    ),
+                    (
+                        (
+                            0,
+                            frozenset((0,)),
+                        ),
+                        (
+                            1,
+                            frozenset((1, 5,)),
+                        ),
+                        (
+                            3,
+                            frozenset((1, 3, 5,)),
+                        ),
+                        (
+                            5,
+                            frozenset((5,)),
+                        ),
+                            8,
+                            frozenset((8, 12,)),
+                        ),
+                        (
+                            10,
+                            frozenset((8, 10, 12,)),
+                        ),
+                        (
+                            11,
+                            frozenset((11,)),
+                        ),
+                        (
+                            12,
+                            frozenset((12,)),
+                        ),
                     ),
                 ),
             )


### PR DESCRIPTION
Firstly, this sits on top of https://github.com/alphagov/digitalmarketplace-api/pull/596 so the "files changed" will be full of chaff. Sorry.

Story https://www.pivotaltracker.com/story/show/138095135

The motivation behind this is to add the ability to mark multiple audit events as acknowledged in a single atomic call which will result in all affected events being given the same `acknowledged_at` timestamp. This will allow for an amount of lightweight grouping to be performed when showing acknowledgement history without the requirement for any new concepts such as addressable "acknowledgement sets".

In the end, the sensible approach for this seemed to be to add a new endpoint, as so little of the code is shared with the `acknowledge_audit` endpoint. It was also difficult to conceive of a sensible way to "mode switch" an endpoint which is designed to operate on one audit event and make it operate on (and also return) multiple events.

Allowing the endpoint to acknowledge an arbitrary set of audit events seemed mostly out of the question:
- when it comes to HTTP interface, there isn't a particularly neat or concise way of supplying these ids to the endpoint
- in cases of unexpectedly extreme numbers of events, it would require a client to first fetch all of the unacknowledged ids to be able to specify them to this endpoint
- minor, but it allows for "bubbles" of unacknowledged events to be created. The rest of this system rather relies on the fact that there aren't any acknowledged update events after the most recent unacknowledged update event.

Being able to specify a range of audit event ids using a `/audit-events/123123...321321/acknowledge` path is an appealing idea but it has a couple of problems:
- while it _presents itself_ as a general interface for blanket updating of all audit events between those ids, we would need it to restrict affected events to just those with the same object and event type. Which would be a bit magic & unexpected. The magic could be removed if we wanted by adding all sorts of filtering abilities to the endpoint, but that seems like a lot of unnecessary complexity. It would also introduce the possibility of the first specified event and last specified event not sharing one of those properties - another category of error cases to check for...
- also it implies `id`-order is the thing we care about, whereas what we actually are ordering these by is `created_at`. Which, yes, *should* generally be monotonic, but... corner cases arising from manual intervention...
- it would also allow bubbles to be formed.

So the most sensible conclusion looked like adding a new endpoint whose specific job is to, given a single event id, acknowledge it and all previously-occurring events for that object for that event type. This prevents bubbles being formed, and prevents any of the property-mismatch issues mentioned above.