### PR TITLE
Update api to Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: python
 sudo: false
 python:
-  - "2.7"
-  - "3.4"
+  - "3.6"
 addons:
   postgresql: "9.3"
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "3.6"
 addons:
   postgresql: "9.5"
+dist: "trusty"
 env:
   - SQLALCHEMY_DATABASE_URI=postgresql://postgres:@localhost:5432/digitalmarketplace_test
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 python:
   - "3.6"
 addons:
-  postgresql: "9.3"
+  postgresql: "9.5"
 env:
   - SQLALCHEMY_DATABASE_URI=postgresql://postgres:@localhost:5432/digitalmarketplace_test
 install:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM digitalmarketplace/base-api:1.0.3
+FROM digitalmarketplace/base-api:2.0.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM digitalmarketplace/base-api:2.0.0
+FROM digitalmarketplace/base-api:2.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,8 +7,8 @@ psycopg2==2.5.4
 SQLAlchemy==1.1.4
 SQLAlchemy-Utils==0.30.5
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@25.2.0#egg=digitalmarketplace-utils==25.2.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@7.6.0#egg=digitalmarketplace-apiclient==7.6.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@27.1.1#egg=digitalmarketplace-utils==27.1.1
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@8.10.2#egg=digitalmarketplace-apiclient==8.10.2
 
 # For schema validation
 jsonschema==2.5.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [pep8]
-exclude = ./migrations,./venv,./venv3
+exclude = ./migrations,./venv,./venv3,./venv3.6
 max-line-length = 120
 
 [nosetests]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [pep8]
-exclude = ./migrations,./venv,./venv3,./venv3.6
+exclude = ./migrations,./venv*
 max-line-length = 120
 
 [nosetests]


### PR DESCRIPTION
### Pull in version 2.0.0 of base-api image

The version 2 series of base images are built with python3. See the docker-base repo for more info.

### Pull in version 27.1.1 of utils and 8.10.2 of apiclient

The new utils version has a fix for header's needing to be strings in
python3. The two major changes, 26 and 27 don't affect the api.

The new apiclient version has a fix to only require enum34 if the python
version being used is 3.4 or below. The major version bump, 8, doesn't
affect the api.

