### PR TITLE
Add option for brief clarification questions to briefs list endpoint

### DIFF
--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -118,6 +118,8 @@ def list_briefs():
 
     with_users = request.args.get('with_users', 'false').lower() == 'true'
 
+    with_clarification_questions = request.args.get('with_clarification_questions', 'false').lower() == 'true'
+
     user_id = get_int_or_400(request.args, 'user_id')
 
     if user_id:
@@ -140,7 +142,7 @@ def list_briefs():
 
     if user_id:
         return jsonify(
-            briefs=[brief.serialize(with_users) for brief in briefs.all()],
+            briefs=[brief.serialize(with_users, with_clarification_questions) for brief in briefs.all()],
             links={},
         )
     else:
@@ -150,7 +152,7 @@ def list_briefs():
         )
 
         return jsonify(
-            briefs=[brief.serialize(with_users) for brief in briefs.items],
+            briefs=[brief.serialize(with_users, with_clarification_questions) for brief in briefs.items],
             meta={
                 "total": briefs.total,
             },


### PR DESCRIPTION
Our models no longer return them by default (a change to improve
memory usage), so now we must request them from the frontend ourselves
if we wish to get them.