### PR TITLE
[#138031901]list_audits: add after-event-id filter

### DIFF
--- a/app/main/views/audits.py
+++ b/app/main/views/audits.py
@@ -115,6 +115,27 @@ def list_audits():
     elif object_id:
         abort(400, 'object-id cannot be provided without object-type')
 
+    after_event_id = request.args.get('after-event-id')
+    if after_event_id:
+        ref_audit_event = db.session.query(AuditEvent).get(int(after_event_id))
+        if ref_audit_event is None:
+            abort(400, "No audit event with id {}".format(after_event_id))
+
+        audits = audits.filter(
+            # much like in acknowledge_including_previous, this clause implements the same "id tie breaker" behaviour
+            # ordering we use. this way the filter appears to behave exactly like a regular request truncated. the only
+            # situation where it will behave at all differently is cases where earliest_for_each_object is also used.
+            # again, we could use postgres composite types to express this far more neatly, but i can't get sqlalchemy
+            # to work with anonymous composite types.
+            db.or_(
+                AuditEvent.created_at > ref_audit_event.created_at,
+                db.and_(
+                    AuditEvent.created_at == ref_audit_event.created_at,
+                    AuditEvent.id > ref_audit_event.id,
+                ),
+            ),
+        )
+
     if earliest_for_each_object:
         if not (
                 acknowledged and


### PR DESCRIPTION
More from the land of ugly/crazy API endpoints. 🏝 

This allows the results to be limited to those that occurred notionally "after" the specified one. "after" meaning it has a higher created_at value with id used as the tie-breaker, as is the standard way among these endpoints.

This should allow the supplier update acknowledgement pages to perform the "next" functionality without having to page through an arbitrarily large number of events to find its position. 

Another option would have been to have it as "created-after" and accept a timestamp, but that would fail to do the trick in the case of multiple updates sharing the same timestamp - again it would potentially require paging through an "unbounded" number of results to find itself.

Do what you like with this, but, it's there...