### PR TITLE
750-Show-size-of-suppliers-on-opportunity-page

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -409,6 +409,14 @@ class SupplierFramework(db.Model):
 
     # vvvv current_framework_agreement defined further down (after FrameworkAgreement) vvvv
 
+    @hybrid_property
+    def supplier_organisation_size(self):
+        return self.declaration.get('organisationSize') if self.declaration else None
+
+    @supplier_organisation_size.expression
+    def supplier_organisation_size(cls):
+        return cls.declaration['organisationSize'].astext
+
     @validates('declaration')
     def validates_declaration(self, key, value):
         value = strip_whitespace_from_data(value)
@@ -1481,6 +1489,7 @@ class BriefResponse(db.Model):
             'briefId': self.brief_id,
             'supplierId': self.supplier_id,
             'supplierName': self.supplier.name,
+            'supplierOrganisationSize': self.supplier_framework.supplier_organisation_size,
             'createdAt': self.created_at.strftime(DATETIME_FORMAT),
             'submittedAt': (
                 self.submitted_at and self.submitted_at.strftime(DATETIME_FORMAT)
@@ -1494,6 +1503,58 @@ class BriefResponse(db.Model):
         })
 
         return purge_nulls_from_data(data)
+
+
+# The following is the code to fetch the supplier_framework of a BriefResponse.
+# A standard relationship would not work in this case because we want to join 3 tables, BriefResponses, Briefs and
+# SupplierFrameworks but use a key from BriefResponses (supplier_id) to denote the record from SupplierFrameworks.
+# See docs below, specifically; 'the A->secondary->B pattern does not support any references between A and B directly'.
+# http://docs.sqlalchemy.org/en/latest/orm/join_conditions.html#relationship-to-non-primary-mapper
+
+# Create a join of 3 tables (like a TEMP TABLE) that, in SQL, would look like:
+# SELECT *
+# FROM brief_responses
+#   JOIN briefs
+#     ON brief_responses.brief_id = briefs.id
+#   JOIN supplier_frameworks AS sf
+#     ON sf.supplier_id = brief_responses.supplier_id AND sf.framework_id = briefs.framework_id
+# ;
+brief_responses_supplier_frameworks_join = brsf = db.join(
+    BriefResponse,
+    Brief,
+    BriefResponse.brief_id == Brief.id
+).join(
+    SupplierFramework,
+    sql_and(
+        SupplierFramework.framework_id == Brief.framework_id,
+        SupplierFramework.supplier_id == BriefResponse.supplier_id
+    )
+)
+
+# Map the join to SupplierFramework to tell the ORM what object we want to get from the join.
+# We also have to disambiguate the duplicate name fields (id, data, created_at etc.) using the properties kwarg.
+brief_responses_supplier_frameworks_to_supplier_frameworks_mapping = mapper(
+    SupplierFramework,
+    brief_responses_supplier_frameworks_join,
+    properties={
+        "brief_id": [brsf.c.briefs_id, brsf.c.brief_responses_brief_id],
+        'briefs_data': brsf.c.briefs_data,
+        'briefs_created_at': brsf.c.briefs_created_at,
+        'supplier_id': [brsf.c.brief_responses_supplier_id, brsf.c.supplier_frameworks_supplier_id],
+        'framework_id': [brsf.c.supplier_frameworks_framework_id, brsf.c.briefs_framework_id],
+    },
+    non_primary=True,
+)
+
+# Join the mapping to the brief_responses table as a relationship:
+# SELECT supplier_framework.* FROM brief_responses JOIN brsf ON brief_responses.id = brsf.brief_responses_id
+BriefResponse.supplier_framework = db.relationship(
+    brief_responses_supplier_frameworks_to_supplier_frameworks_mapping,
+    primaryjoin=db.foreign(BriefResponse.id) == brief_responses_supplier_frameworks_join.c.brief_responses_id,
+    lazy="joined",
+    uselist=False,
+    viewonly=True,
+)
 
 
 class BriefClarificationQuestion(db.Model):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -504,6 +504,13 @@ class TestBriefResponses(BaseApplicationTest, FixtureMixin):
 
             self.setup_dummy_suppliers(1)
             self.supplier = Supplier.query.filter(Supplier.supplier_id == 0).first()
+            supplier_framework = SupplierFramework(
+                supplier=self.supplier,
+                framework=framework,
+                declaration={'organisationSize': 'small'}
+            )
+            db.session.add(supplier_framework)
+            db.session.commit()
 
     def test_create_a_new_brief_response(self):
         with self.app.app_context():
@@ -590,6 +597,7 @@ class TestBriefResponses(BaseApplicationTest, FixtureMixin):
                     'briefId': self.brief.id,
                     'supplierId': 0,
                     'supplierName': 'Supplier 0',
+                    'supplierOrganisationSize': 'small',
                     'createdAt': mock.ANY,
                     'submittedAt': '2016-09-28T00:00:00.000000Z',
                     'status': 'submitted',
@@ -623,6 +631,7 @@ class TestBriefResponses(BaseApplicationTest, FixtureMixin):
                     },
                     'supplierId': 0,
                     'supplierName': 'Supplier 0',
+                    'supplierOrganisationSize': 'small',
                     'createdAt': mock.ANY,
                     'status': 'draft',
                     'foo': 'bar',


### PR DESCRIPTION
### What was needed
https://trello.com/c/MUAKZ7G5/750-2-show-size-of-suppliers-on-opportunity-page
We want to be able to show the organisational size of the suppliers that have applied for an opportunity. This is part of the ongoing data transparency work and was born out of a need for suppliers to be able to find out who is applying for work.

### Basic approach
Make organisation_size available on the SupplierFramework model (because it comes from the declaration)
Make supplier_framework available on the BriefResponse model
When serialising BriefResponse return supplier_framework.supplier_organisation_size

### What was done
1. Hybrid property SupplierFramework.supplier_organisation_size
2. Make supplier_framework available on BriefResponse
3. Add `supplierOrganisationSize` to `BriefResponse` serialization and supply it through BriefResponse.supplier_framework.supplier_organisation_size
4. Update tests

### For more info on how this works  and why a normal relationship  wouldn't see:
The docs:
 http://docs.sqlalchemy.org/en/latest/orm/join_conditions.html#relationship-to-non-primary-mapper
Specifically the bit on why a normal relationship would not work in this case.
> since the A->secondary->B pattern does not support any references between A and B directly.

(ie BriefResponse.supplier_id)

The failed attempts branch:
https://github.com/alphagov/digitalmarketplace-api/compare/WIP-sf-on-br?expand=1
😁 

The comments:
https://github.com/alphagov/digitalmarketplace-api/pull/619/files#diff-413e9aa8961126d20e2d90befa13e0f1R1508


### Benchmarks
Does not increase SQL queries for end points. Adds a join.

Endpoint speed:

| With | Without |
| --------- | --------- |
| 0.65  | 0.59  |
| 0.60  | 0.65  |
| 0.62  | 0.59  |
| 0.60  | 0.64  |
| 0.61  | 0.60  |
