### PR TITLE
Add new buyer email domains

### DIFF
--- a/data/buyer-email-domains.txt
+++ b/data/buyer-email-domains.txt
@@ -33,6 +33,7 @@ childcomwales.org.uk
 circle.org.uk
 citb.co.uk
 citizensadvice.org.uk
+clarionhg.com
 commercialservices.org.uk
 communitygateway.co.uk
 co-ownership.org
@@ -52,6 +53,7 @@ essexcares.org
 ewc.wales
 fasst.org.uk
 fca.org.uk
+fgould.com
 financial-ombudsman.org.uk
 fscs.org.uk
 fundraisingregulator.org.uk
@@ -162,6 +164,7 @@ sportengland.org
 spt.co.uk
 sqa.org.uk
 stockporthomes.org
+swan.org.uk
 sypte.co.uk
 tate.org.uk
 tetrust.org


### PR DESCRIPTION
### domains added:
- clarionhg.com
- fgould.com
- swan.org.uk

**Trello ticket:** https://trello.com/c/7h733mRR/807-add-additional-buyer-email-domains-for-buyer-accounts