### PR TITLE
Add columns to suppliers table

### DIFF
--- a/migrations/versions/940_more_supplier_details.py
+++ b/migrations/versions/940_more_supplier_details.py
@@ -1,0 +1,34 @@
+""" Extend suppliers table with new fields (to be initially populated from declaration data)
+
+Revision ID: 940
+Revises: 930
+Create Date: 2017-08-16 16:39:00.000000
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '940'
+down_revision = '930'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column(u'suppliers', sa.Column('registered_name', sa.String(), nullable=True))
+    op.add_column(u'suppliers', sa.Column('registration_country', sa.String(), nullable=True))
+    op.add_column(u'suppliers', sa.Column('other_company_registration_number', sa.String(), nullable=True))
+    op.add_column(u'suppliers', sa.Column('registration_date', sa.DateTime(), nullable=True))
+    op.add_column(u'suppliers', sa.Column('vat_number', sa.String(), nullable=True))
+    op.add_column(u'suppliers', sa.Column('organisation_size', sa.String(), nullable=True))
+    op.add_column(u'suppliers', sa.Column('trading_status', sa.String(), nullable=True))
+
+
+def downgrade():
+    op.drop_column(u'suppliers', 'registered_name')
+    op.drop_column(u'suppliers', 'registration_country')
+    op.drop_column(u'suppliers', 'other_company_registration_number')
+    op.drop_column(u'suppliers', 'registration_date')
+    op.drop_column(u'suppliers', 'vat_number')
+    op.drop_column(u'suppliers', 'organisation_size')
+    op.drop_column(u'suppliers', 'trading_status')


### PR DESCRIPTION
The following data is moving from framework-level supplier declarations to the
supplier account level:

* Organisation size
* VAT number
* Non-companies-house registration number (for non-UK companies)
* Registered organisation name (as opposed to marketplace supplier account name)
* Registration date
* Trading status
* Registration country

This adds the relevant columns to the supplier table. All are nullable string fields, except
registration date which is a string in the declaration data we have, but we are moving to
a proper DateTime field at the supplier account level.

PR for associated API model changes will come separately, "soon".