### PR TITLE
Model update add supplier details columns

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -255,7 +255,7 @@ class ContactInformation(db.Model):
         return c
 
     def get_link(self):
-        return url_for(".update_contact_information",
+        return url_for("main.update_contact_information",
                        supplier_id=self.supplier_id,
                        contact_id=self.id)
 
@@ -338,7 +338,7 @@ class Supplier(db.Model):
         return dict(services)
 
     def get_link(self):
-        return url_for(".get_supplier", supplier_id=self.supplier_id)
+        return url_for("main.get_supplier", supplier_id=self.supplier_id)
 
     def serialize(self, data=None):
         links = link(
@@ -803,7 +803,7 @@ class User(db.Model):
         ).first()
 
     def get_link(self):
-        return url_for('.get_user_by_id', user_id=self.id)
+        return url_for('main.get_user_by_id', user_id=self.id)
 
     def serialize(self):
         user = {
@@ -1003,7 +1003,7 @@ class Service(db.Model, ServiceTableMixin):
             return self.filter(Service.data[k].astext.contains(u'"{}"'.format(v)))  # Postgres 9.3: use string matching
 
     def get_link(self):
-        return url_for(".get_service", service_id=self.service_id)
+        return url_for("main.get_service", service_id=self.service_id)
 
 
 class ArchivedService(db.Model, ServiceTableMixin):
@@ -1032,7 +1032,7 @@ class ArchivedService(db.Model, ServiceTableMixin):
     def link_object(service_id):
         if service_id is None:
             return None
-        return url_for(".get_archived_service",
+        return url_for("main.get_archived_service",
                        archived_service_id=service_id)
 
     def get_link(self):
@@ -1092,14 +1092,14 @@ class DraftService(db.Model, ServiceTableMixin):
         if self.service_id:
             data['serviceId'] = self.service_id
 
-        data['links']['publish'] = url_for('.publish_draft_service', draft_id=self.id)
-        data['links']['complete'] = url_for('.complete_draft_service', draft_id=self.id)
-        data['links']['copy'] = url_for('.copy_draft_service', draft_id=self.id)
+        data['links']['publish'] = url_for('main.publish_draft_service', draft_id=self.id)
+        data['links']['complete'] = url_for('main.complete_draft_service', draft_id=self.id)
+        data['links']['copy'] = url_for('main.copy_draft_service', draft_id=self.id)
 
         return data
 
     def get_link(self):
-        return url_for(".fetch_draft_service", draft_id=self.id)
+        return url_for("main.fetch_draft_service", draft_id=self.id)
 
 
 class AuditEvent(db.Model):
@@ -1157,7 +1157,7 @@ class AuditEvent(db.Model):
             'data': self.data,
             'createdAt': self.created_at.strftime(DATETIME_FORMAT),
             'links': filter_null_value_fields({
-                "self": url_for(".list_audits"),
+                "self": url_for("main.list_audits"),
                 "oldArchivedService": ArchivedService.link_object(
                     self.data.get('oldArchivedServiceId')
                 ),
@@ -1418,8 +1418,8 @@ class Brief(db.Model):
             })
 
         data['links'] = {
-            'self': url_for('.get_brief', brief_id=self.id),
-            'framework': url_for('.get_framework', framework_slug=self.framework.slug),
+            'self': url_for('main.get_brief', brief_id=self.id),
+            'framework': url_for('main.get_framework', framework_slug=self.framework.slug),
         }
 
         if with_users:
@@ -1535,9 +1535,9 @@ class BriefResponse(db.Model):
             ),
             'status': self.status,
             'links': {
-                'self': url_for('.get_brief_response', brief_response_id=self.id),
-                'brief': url_for('.get_brief', brief_id=self.brief_id),
-                'supplier': url_for(".get_supplier", supplier_id=self.supplier_id),
+                'self': url_for('main.get_brief_response', brief_response_id=self.id),
+                'brief': url_for('main.get_brief', brief_id=self.brief_id),
+                'supplier': url_for("main.get_supplier", supplier_id=self.supplier_id),
             }
         })
 

--- a/app/models.py
+++ b/app/models.py
@@ -320,7 +320,7 @@ class Supplier(db.Model):
 
     @validates('companies_house_number')
     def validates_companies_house_number(self, key, value):
-        if not self.COMPANIES_HOUSE_NUMBER_REGEX.match(value):
+        if value and not self.COMPANIES_HOUSE_NUMBER_REGEX.match(value):
             raise ValidationError("Invalid companies house number '{}'".format(value))
 
         return value

--- a/app/models.py
+++ b/app/models.py
@@ -286,27 +286,25 @@ class Supplier(db.Model):
 
     # NOTE other tables tend to make foreign key references to `supplier_id` instead of this
     id = db.Column(db.Integer, primary_key=True)
-
     supplier_id = db.Column(db.BigInteger, Sequence('suppliers_supplier_id_seq'), index=True, unique=True,
                             nullable=False)
-
     name = db.Column(db.String(255), nullable=False)
-
-    description = db.Column(db.String, index=False,
-                            unique=False, nullable=True)
-
+    description = db.Column(db.String, index=False, unique=False, nullable=True)
     contact_information = db.relationship(ContactInformation,
                                           backref='supplier',
                                           lazy='joined',
                                           innerjoin=False)
-
     duns_number = db.Column(db.String, index=True, unique=True, nullable=True)
-
     esourcing_id = db.Column(db.String, index=False, unique=False, nullable=True)
-
     companies_house_number = db.Column(db.String, index=False, unique=False, nullable=True)
-
     clients = db.Column(JSON, default=list, nullable=False)
+    registered_name = db.Column(db.String, index=False, unique=False, nullable=True)
+    registration_country = db.Column(db.String, index=False, unique=False, nullable=True)
+    other_company_registration_number = db.Column(db.String, index=False, unique=False, nullable=True)
+    registration_date = db.Column(db.DateTime, index=False, unique=False, nullable=True)
+    vat_number = db.Column(db.String, index=False, unique=False, nullable=True)
+    organisation_size = db.Column(db.String, index=False, unique=False, nullable=True)
+    trading_status = db.Column(db.String, index=False, unique=False, nullable=True)
 
     # Drop this method once the supplier front end is using SupplierFramework counts
     def get_service_counts(self):

--- a/config.py
+++ b/config.py
@@ -40,6 +40,7 @@ class Config:
 
 
 class Test(Config):
+    SERVER_NAME = '127.0.0.1:5000'
     DM_SEARCH_API_AUTH_TOKEN = 'test'
     DM_SEARCH_API_URL = 'http://localhost'
     DEBUG = True

--- a/json_schemas/new-supplier.json
+++ b/json_schemas/new-supplier.json
@@ -42,6 +42,6 @@
     "dunsNumber",
     "name"
   ],
-  "title": "Supplier Schema",
+  "title": "Schema to validate new supplier sign-up",
   "type": "object"
 }

--- a/json_schemas/suppliers.json
+++ b/json_schemas/suppliers.json
@@ -38,12 +38,33 @@
     },
     "name": {
       "type": "string"
+    },
+    "organisationSize": {
+      "type": "string"
+    },
+    "otherCompanyRegistrationNumber": {
+      "type": "string"
+    },
+    "registeredName": {
+      "type": "string"
+    },
+    "registrationCountry": {
+      "type": "string"
+    },
+    "registrationDate": {
+      "type": "string"
+    },
+    "tradingStatus": {
+      "type": "string"
+    },
+    "vatNumber": {
+      "type": "string"
     }
   },
   "required": [
     "id",
     "name"
   ],
-  "title": "G6 Supplier Schema",
+  "title": "Schema to validate updates to supplier data",
   "type": "object"
 }

--- a/tests/main/views/test_briefs.py
+++ b/tests/main/views/test_briefs.py
@@ -434,8 +434,8 @@ class TestGetBrief(FrameworkSetupAndTeardown):
                 'createdAt': mock.ANY,
                 'updatedAt': mock.ANY,
                 'links': {
-                    'framework': 'http://localhost/frameworks/digital-outcomes-and-specialists',
-                    'self': 'http://localhost/briefs/1',
+                    'framework': 'http://127.0.0.1:5000/frameworks/digital-outcomes-and-specialists',
+                    'self': 'http://127.0.0.1:5000/briefs/1',
                 },
                 'users': [
                     {
@@ -687,8 +687,8 @@ class TestListBrief(FrameworkSetupAndTeardown):
 
         assert len(data['briefs']) == 5
         assert data['meta']['total'] == 7
-        assert data['links']['next'] == 'http://localhost/briefs?page=2'
-        assert data['links']['last'] == 'http://localhost/briefs?page=2'
+        assert data['links']['next'] == 'http://127.0.0.1:5000/briefs?page=2'
+        assert data['links']['last'] == 'http://127.0.0.1:5000/briefs?page=2'
 
     def test_list_briefs_pagination_page_two(self):
         self.setup_dummy_briefs(7)
@@ -700,7 +700,7 @@ class TestListBrief(FrameworkSetupAndTeardown):
 
         assert len(data['briefs']) == 2
         assert data['meta']['total'] == 7
-        assert data['links']['prev'] == 'http://localhost/briefs?page=1'
+        assert data['links']['prev'] == 'http://127.0.0.1:5000/briefs?page=1'
 
     def test_list_briefs_no_pagination_if_user_id_supplied(self):
         self.setup_dummy_briefs(7)

--- a/tests/main/views/test_suppliers.py
+++ b/tests/main/views/test_suppliers.py
@@ -463,7 +463,6 @@ class TestUpdateSupplier(BaseApplicationTest, JSONUpdateTestMixin):
                 '/suppliers',
                 data=json.dumps({'suppliers': self.supplier}),
                 content_type='application/json')
-
             assert response.status_code == 201
             self.supplier_id = json.loads(response.get_data())['suppliers']['id']
 
@@ -527,12 +526,19 @@ class TestUpdateSupplier(BaseApplicationTest, JSONUpdateTestMixin):
 
     def test_update_all_fields(self):
         response = self.update_request({
-            'name': "New Name",
-            'description': "New Description",
-            'companiesHouseNumber': "AA123456",
-            'dunsNumber': "010101",
-            'eSourcingId': "010101",
-            'clients': ["Client1", "Client2"]
+            "name": "New Name",
+            "description": "New Description",
+            "companiesHouseNumber": "AA123456",
+            "dunsNumber": "010101",
+            "eSourcingId": "010101",
+            "clients": ["Client1", "Client2"],
+            "otherCompanyRegistrationNumber": "A11",
+            "registeredName": "New Name Inc.",
+            "registrationCountry": "Guatamala",
+            "registrationDate": "1969-07-20",
+            "vatNumber": "12312312",
+            "organisationSize": "micro",
+            "tradingStatus": "Sole trader",
         })
 
         assert response.status_code == 200
@@ -548,6 +554,13 @@ class TestUpdateSupplier(BaseApplicationTest, JSONUpdateTestMixin):
         assert supplier.companies_house_number == "AA123456"
         assert supplier.esourcing_id == "010101"
         assert supplier.clients == ["Client1", "Client2"]
+        assert supplier.other_company_registration_number == "A11"
+        assert supplier.registered_name == "New Name Inc."
+        assert supplier.registration_country == "Guatamala"
+        assert supplier.registration_date == datetime(1969, 7, 20, 0, 0)
+        assert supplier.vat_number == "12312312"
+        assert supplier.organisation_size == "micro"
+        assert supplier.trading_status == "Sole trader"
 
     def test_supplier_json_id_does_not_match_original_id(self):
         response = self.update_request({
@@ -595,6 +608,16 @@ class TestUpdateSupplier(BaseApplicationTest, JSONUpdateTestMixin):
         })
 
         assert response.status_code == 400
+
+    def test_update_with_bad_company_number(self):
+        response = self.update_request({"companiesHouseNumber": "ABCDEFGH"})
+        assert response.status_code == 400
+        assert "Invalid companies house number" in response.get_data(as_text=True)
+
+    def test_update_with_bad_company_size(self):
+        response = self.update_request({"organisationSize": "tiny"})
+        assert response.status_code == 400
+        assert "Invalid organisation size" in response.get_data(as_text=True)
 
 
 class TestUpdateContactInformation(BaseApplicationTest, JSONUpdateTestMixin):

--- a/tests/main/views/test_suppliers.py
+++ b/tests/main/views/test_suppliers.py
@@ -668,6 +668,23 @@ class TestUpdateContactInformation(BaseApplicationTest, JSONUpdateTestMixin):
 
             assert contact.city == "New City"
 
+    def test_simple_field_update_for_supplier_with_no_companies_house_number(self):
+        with self.app.app_context():
+            supplier_db = Supplier.query.first()  # Only one supplier is set up for these tests
+            supplier_db.companies_house_number = None
+
+        response = self.update_request({
+            'city': "New City"
+        })
+        assert response.status_code == 200
+
+        with self.app.app_context():
+            contact = ContactInformation.query.filter(
+                ContactInformation.id == self.contact_id
+            ).first()
+
+            assert contact.city == "New City"
+
     def test_update_creates_audit_event(self):
         self.update_request({
             'city': "New City"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -826,9 +826,7 @@ class TestSuppliers(BaseApplicationTest, FixtureMixin):
             assert self.supplier.organisation_size == "medium"
             assert self.supplier.trading_status == "Sticky"
 
-    def test_serialization_of_supplier_with_all_details_added(self):
-        with self.app.app_context():
-            self._update_supplier_from_json_with_all_details()
+            # Check that serialization of a supplier with all details added looks as it should
             assert self.supplier.serialize() == {
                 'clients': ['Parcel Wrappers Ltd'],
                 'companiesHouseNumber': '98765432',
@@ -836,8 +834,8 @@ class TestSuppliers(BaseApplicationTest, FixtureMixin):
                     {
                         'contactName': u'Contact for Supplier 0',
                         'email': u'0@contact.com',
-                        'id': 13,
-                        'links': {'self': 'http://127.0.0.1:5000/suppliers/0/contact-information/13'},
+                        'id': 12,
+                        'links': {'self': 'http://127.0.0.1:5000/suppliers/0/contact-information/12'},
                         'postcode': u'SW1A 1AA',
                     }
                 ],

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -755,6 +755,108 @@ class TestBriefClarificationQuestion(BaseApplicationTest):
             question.validate()
 
 
+class TestSuppliers(BaseApplicationTest, FixtureMixin):
+    def setup(self):
+        super(TestSuppliers, self).setup()
+        with self.app.app_context():
+            self.setup_dummy_suppliers(1)
+            self.supplier = Supplier.query.filter(Supplier.supplier_id == 0).first()
+
+    def _update_supplier_from_json_with_all_details(self):
+        update_data = {
+            "id": 90006000,
+            "supplierId": "DO_NOT_UPDATE_ME",
+            "name": "String and Sticky Tape Inc.",
+            "clients": ["Parcel Wrappers Ltd"],
+            "dunsNumber": "01010101",
+            "eSourcingId": "020202",
+            "description": "All your parcel wrapping needs catered for",
+            "companiesHouseNumber": "98765432",
+            "registeredName": "Tape and String Inc.",
+            "registrationCountry": "Wales",
+            "otherCompanyRegistrationNumber": "",
+            "registrationDate": "1973-08-10",
+            "vatNumber": "321321321",
+            "organisationSize": "medium",
+            "tradingStatus": "Sticky",
+        }
+        self.supplier.update_from_json(update_data)
+
+    def test_serialization_of_new_supplier(self):
+        assert self.supplier.serialize() == {
+            'clients': [],
+            'contactInformation': [
+                {
+                    'contactName': u'Contact for Supplier 0',
+                    'email': u'0@contact.com',
+                    'id': 11,
+                    'links': {'self': 'http://127.0.0.1:5000/suppliers/0/contact-information/11'},
+                    'postcode': u'SW1A 1AA',
+                }
+            ],
+            'description': u'',
+            'id': 0,
+            'links': {'self': 'http://127.0.0.1:5000/suppliers/0'},
+            'name': u'Supplier 0',
+        }
+
+    def test_update_from_json(self):
+        with self.app.app_context():
+            initial_id = self.supplier.id
+            initial_sid = self.supplier.supplier_id
+
+            self._update_supplier_from_json_with_all_details()
+
+            # Check IDs can't be updated
+            assert self.supplier.id == initial_id
+            assert self.supplier.supplier_id == initial_sid
+
+            # Check everything else has been updated to the correct value
+            assert self.supplier.name == "String and Sticky Tape Inc."
+            assert self.supplier.clients == ["Parcel Wrappers Ltd"]
+            assert self.supplier.duns_number == "01010101"
+            assert self.supplier.esourcing_id == "020202"
+            assert self.supplier.description == "All your parcel wrapping needs catered for"
+            assert self.supplier.companies_house_number == "98765432"
+            assert self.supplier.registered_name == "Tape and String Inc."
+            assert self.supplier.registration_country == "Wales"
+            assert self.supplier.other_company_registration_number == ""
+            assert self.supplier.registration_date == datetime(1973, 8, 10, 0, 0)
+            assert self.supplier.vat_number == "321321321"
+            assert self.supplier.organisation_size == "medium"
+            assert self.supplier.trading_status == "Sticky"
+
+    def test_serialization_of_supplier_with_all_details_added(self):
+        with self.app.app_context():
+            self._update_supplier_from_json_with_all_details()
+            assert self.supplier.serialize() == {
+                'clients': ['Parcel Wrappers Ltd'],
+                'companiesHouseNumber': '98765432',
+                'contactInformation': [
+                    {
+                        'contactName': u'Contact for Supplier 0',
+                        'email': u'0@contact.com',
+                        'id': 13,
+                        'links': {'self': 'http://127.0.0.1:5000/suppliers/0/contact-information/13'},
+                        'postcode': u'SW1A 1AA',
+                    }
+                ],
+                'description': 'All your parcel wrapping needs catered for',
+                'dunsNumber': '01010101',
+                'eSourcingId': '020202',
+                'id': 0,
+                'links': {'self': 'http://127.0.0.1:5000/suppliers/0'},
+                'name': 'String and Sticky Tape Inc.',
+                'organisationSize': 'medium',
+                'otherCompanyRegistrationNumber': '',
+                'registeredName': 'Tape and String Inc.',
+                'registrationCountry': 'Wales',
+                'registrationDate': '1973-08-10',
+                'tradingStatus': 'Sticky',
+                'vatNumber': '321321321',
+            }
+
+
 class TestServices(BaseApplicationTest, FixtureMixin):
     def test_framework_is_live_only_returns_live_frameworks(self):
         with self.app.app_context():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -603,9 +603,9 @@ class TestBriefResponses(BaseApplicationTest, FixtureMixin):
                     'status': 'submitted',
                     'foo': 'bar',
                     'links': {
-                        'self': (('.get_brief_response',), {'brief_response_id': brief_response.id}),
-                        'brief': (('.get_brief',), {'brief_id': self.brief.id}),
-                        'supplier': (('.get_supplier',), {'supplier_id': 0}),
+                        'self': (('main.get_brief_response',), {'brief_response_id': brief_response.id}),
+                        'brief': (('main.get_brief',), {'brief_id': self.brief.id}),
+                        'supplier': (('main.get_supplier',), {'supplier_id': 0}),
                     }
                 }
 
@@ -636,9 +636,9 @@ class TestBriefResponses(BaseApplicationTest, FixtureMixin):
                     'status': 'draft',
                     'foo': 'bar',
                     'links': {
-                        'self': (('.get_brief_response',), {'brief_response_id': brief_response.id}),
-                        'brief': (('.get_brief',), {'brief_id': self.brief.id}),
-                        'supplier': (('.get_supplier',), {'supplier_id': 0}),
+                        'self': (('main.get_brief_response',), {'brief_response_id': brief_response.id}),
+                        'brief': (('main.get_brief',), {'brief_id': self.brief.id}),
+                        'supplier': (('main.get_supplier',), {'supplier_id': 0}),
                     }
                 }
 


### PR DESCRIPTION
The first commit here (the DB migration file) is from #625, so will disappear from this PR once that is reviewed and merged.

The following commits have the corresponding model changes.  There were no tests of the suppliers model at all so I've added some.  In order to get them to work I had to add a couple of things: the `SERVER_NAME` variable in the test config, which allows `url_for` to work outside of a request context (which we need for directly testing model serialization functions that include links, e.g. to "self").  This also, for some reason, seems to need the `main` blueprint specified for finding the right route methods so I've added that and it lets the tests work while apparently making no difference to the running app :crossed_fingers: 