### PR TITLE
flake8 config: ignore all venv* directories

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -5,7 +5,7 @@
 # E402: module level import not at top of file
 # C901: too complex
 # W503: line break before binary operator
-exclude = venv,venv3,__pycache__,node_modules,bower_components,migrations
+exclude = venv*,__pycache__,node_modules,bower_components,migrations
 ignore = D203,W503
 max-complexity = 24
 max-line-length = 120


### PR DESCRIPTION
Certainly the nix configuration at least uses `venvx.y` `x.y` being the python version