### PR TITLE
Remove bridgend.gov.uk from buyer domains

### DIFF
--- a/data/buyer-email-domains.txt
+++ b/data/buyer-email-domains.txt
@@ -14,7 +14,6 @@ bbc.co.uk
 bfi.org.uk
 biglotteryfund.org.uk
 blackwoodgroup.org.uk
-bridgend.gov.uk
 britishcouncil.org
 britishmuseum.org
 caa.co.uk


### PR DESCRIPTION
The top-level gov.uk is allowed as a buyer, so no need for subdomains to ever be included in this list.