### PR TITLE
404 if brief and brief response in `contract-details` url are not related

### DIFF
--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -278,10 +278,11 @@ def award_brief_details(brief_id, brief_response_id):
     brief = Brief.query.filter(
         Brief.id == brief_id
     ).first_or_404()
-
     brief_response = BriefResponse.query.filter(
+        BriefResponse.brief_id == brief_id,
         BriefResponse.id == brief_response_id
     ).first_or_404()
+
     if not brief_response.award_details.get('pending'):
         abort(400, "Cannot update award details for a Brief without a winning supplier")
 

--- a/tests/main/views/test_briefs.py
+++ b/tests/main/views/test_briefs.py
@@ -1462,3 +1462,17 @@ class TestBriefAwardDetails(FrameworkSetupAndTeardown):
         assert res.status_code == 400
         error = json.loads(res.get_data(as_text=True))['error']
         assert "'updated_by' is a required property" in error
+
+    def test_404_if_brief_response_not_related_to_brief(self):
+        with self.app.app_context():
+
+            self.setup_dummy_briefs(2, status="closed")
+            self.setup_dummy_suppliers(1)
+            brief_response = BriefResponse(brief_id=2, supplier_id=0, submitted_at=datetime.utcnow(), data={})
+            db.session.add(brief_response)
+            db.session.commit()
+            brief_response_id = brief_response.id
+
+        res = self._post_to_award_details_endpoint(self.valid_payload, brief_response_id)
+
+        assert res.status_code == 404


### PR DESCRIPTION
Fix for bug found in QA
https://trello.com/c/Gfi4hO1M/825-500-error-when-user-manipulates-url-and-attempts-to-submit-brief-award-form