### PR TITLE
supplier json schema: allow null companiesHouseNumber

### DIFF
--- a/json_schemas/suppliers.json
+++ b/json_schemas/suppliers.json
@@ -11,9 +11,16 @@
       "type": "array"
     },
     "companiesHouseNumber": {
-      "maxLength": 8,
-      "minLength": 8,
-      "type": "string"
+      "oneOf": [
+        {
+          "maxLength": 8,
+          "minLength": 8,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "contactInformation": {
       "items": {

--- a/tests/main/views/test_suppliers.py
+++ b/tests/main/views/test_suppliers.py
@@ -609,6 +609,17 @@ class TestUpdateSupplier(BaseApplicationTest, JSONUpdateTestMixin):
 
         assert response.status_code == 400
 
+    def test_update_chid_with_none(self):
+        response = self.update_request({"companiesHouseNumber": None})
+        assert response.status_code == 200
+
+        with self.app.app_context():
+            supplier = Supplier.query.filter(
+                Supplier.supplier_id == self.supplier_id
+            ).first()
+
+            assert supplier.companies_house_number is None
+
     def test_update_with_bad_company_number(self):
         response = self.update_request({"companiesHouseNumber": "ABCDEFGH"})
         assert response.status_code == 400


### PR DESCRIPTION
Broadly related to https://trello.com/c/v0ouuEMF/61-migrate-the-data-from-the-g9-dos2-declaration-to-account-level-2

We're supposed to be allowing a null `companiesHouseNumber` for suppliers but it would appear to be impossible to *set* it as such - clearly we were relying on the initial state of suppliers for those without CHIDs.

Also adds a test for this.