### PR TITLE
Migration for cancelled and unsuccessful Brief status columns

### DIFF
--- a/migrations/versions/980_add_brief_unsuccessful_and_closed_statuses.py
+++ b/migrations/versions/980_add_brief_unsuccessful_and_closed_statuses.py
@@ -1,0 +1,28 @@
+"""Add 2 new status columns; one for 'unsuccessful', one for 'cancelled'.
+
+Revision ID: 980
+Revises: 970
+Create Date: 2017-08-25 11:38:57.947569
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '980'
+down_revision = '970'
+
+
+def upgrade():
+    op.add_column('briefs', sa.Column('cancelled_at', sa.DateTime(), nullable=True))
+    op.add_column('briefs', sa.Column('unsuccessful_at', sa.DateTime(), nullable=True))
+    op.create_index(op.f('ix_briefs_cancelled_at'), 'briefs', ['cancelled_at'], unique=False)
+    op.create_index(op.f('ix_briefs_unsuccessful_at'), 'briefs', ['unsuccessful_at'], unique=False)
+
+
+def downgrade():
+    op.drop_index(op.f('ix_briefs_unsuccessful_at'), table_name='briefs')
+    op.drop_index(op.f('ix_briefs_cancelled_at'), table_name='briefs')
+    op.drop_column('briefs', 'unsuccessful_at')
+    op.drop_column('briefs', 'cancelled_at')


### PR DESCRIPTION
https://trello.com/c/ggDGUY5d/823-2-collect-status-when-a-buyer-is-not-proceeding-with-an-award-no-journey-backend

Migration for 2 new status columns (for 'unsuccessful' and 'cancelled') as per spiked decision:
https://trello.com/c/rkSFb0B4/815-spike-how-will-we-store-the-status-when-a-procurement-is-cancelled