### PR TITLE
New buyer domains added: clanmil.org.uk and tvha.co.uk

### DIFF
--- a/data/buyer-email-domains.txt
+++ b/data/buyer-email-domains.txt
@@ -32,6 +32,7 @@ childcomwales.org.uk
 circle.org.uk
 citb.co.uk
 citizensadvice.org.uk
+clanmil.org.uk
 clarionhg.com
 commercialservices.org.uk
 communitygateway.co.uk
@@ -173,6 +174,7 @@ thls.org
 tourismireland.com
 traffordhousingtrust.co.uk
 translink.co.uk
+tvha.co.uk
 ukces.org.uk
 uksbs.co.uk
 ukti-invest.com


### PR DESCRIPTION
Trello ticket: https://trello.com/c/PucBhF4v/817-add-additional-buyer-email-domains-for-buyer-accounts