### PR TITLE
Serialize users for projects

### DIFF
--- a/app/main/views/direct_award.py
+++ b/app/main/views/direct_award.py
@@ -91,7 +91,7 @@ def create_project():
 def get_project(project_id):
     project = DirectAwardProject.query.filter(DirectAwardProject.id == project_id).first_or_404()
 
-    return jsonify(project=project.serialize())
+    return jsonify(project=project.serialize(with_users=True))
 
 
 @main.route('/direct-award/projects/<int:project_id>/searches', methods=['GET'])

--- a/app/models/direct_award.py
+++ b/app/models/direct_award.py
@@ -18,14 +18,22 @@ class DirectAwardProject(db.Model):
 
     users = db.relationship(User, secondary='direct_award_project_users', order_by=lambda: DirectAwardProjectUser.id)
 
-    def serialize(self):
-        return {
+    def serialize(self, with_users=False):
+        data = {
             "id": self.id,
             "name": self.name,
             "createdAt": self.created_at.strftime(DATETIME_FORMAT),
             "lockedAt": self.locked_at.strftime(DATETIME_FORMAT) if self.locked_at is not None else None,
             "active": self.active
         }
+
+        if with_users:
+            data['users'] = [
+                {k: v for k, v in user.serialize().items() if k in {'active', 'emailAddress', 'id', 'name', 'role'}}
+                for user in self.users
+            ]
+
+        return data
 
     @validates('name')
     def _assert_active_project(self, key, value):

--- a/tests/main/views/test_direct_award.py
+++ b/tests/main/views/test_direct_award.py
@@ -239,7 +239,7 @@ class TestDirectAwardGetProject(DirectAwardSetupAndTeardown):
         data = json.loads(res.get_data(as_text=True))
 
         with self.app.app_context():
-            assert data['project'] == DirectAwardProject.query.get(self.project_id).serialize()
+            assert data['project'] == DirectAwardProject.query.get(self.project_id).serialize(with_users=True)
 
 
 class TestDirectAwardListProjectSearches(DirectAwardSetupAndTeardown):


### PR DESCRIPTION
## Summary
Serialize users for Direct Award Projects so that the frontend apps can properly check users have auhority to access the project. This follows the style set by Briefs.

## Ticket
https://trello.com/c/Hlq5mzAy/619-save-a-search-and-create-a-project