### PR TITLE
New cancelled and unsuccessful statuses for Brief

### DIFF
--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -167,7 +167,7 @@ def list_briefs():
         )
 
 
-@main.route('/briefs/<int:brief_id>/<any(publish, withdraw):action>', methods=['POST'])
+@main.route('/briefs/<int:brief_id>/<any(publish, withdraw, cancel, unsuccessful):action>', methods=['POST'])
 def update_brief_status(brief_id, action):
     updater_json = validate_and_return_updater_request()
 
@@ -180,7 +180,9 @@ def update_brief_status(brief_id, action):
 
     action_to_status = {
         'publish': 'live',
-        'withdraw': 'withdrawn'
+        'withdraw': 'withdrawn',
+        'cancel': 'cancelled',
+        'unsuccessful': 'unsuccessful'
     }
     if brief.status != action_to_status[action]:
         previousStatus = brief.status

--- a/app/models/main.py
+++ b/app/models/main.py
@@ -1210,6 +1210,8 @@ class Brief(db.Model):
                            default=datetime.utcnow, onupdate=datetime.utcnow)
     published_at = db.Column(db.DateTime, index=True, nullable=True)
     withdrawn_at = db.Column(db.DateTime, index=True, nullable=True)
+    cancelled_at = db.Column(db.DateTime, index=True, nullable=True)
+    unsuccessful_at = db.Column(db.DateTime, index=True, nullable=True)
 
     __table_args__ = (db.ForeignKeyConstraint([framework_id, _lot_id],
                                               ['framework_lots.framework_id', 'framework_lots.lot_id']),
@@ -1315,6 +1317,10 @@ class Brief(db.Model):
             return 'draft'
         elif self.applications_closed_at > datetime.utcnow():
             return 'live'
+        elif self.cancelled_at:
+            return 'cancelled'
+        elif self.unsuccessful_at:
+            return 'unsuccessful'
         elif self.awarded_brief_response:
             return 'awarded'
         else:
@@ -1329,6 +1335,10 @@ class Brief(db.Model):
             self.published_at = datetime.utcnow()
         elif value == 'withdrawn' and self.status == 'live':
             self.withdrawn_at = datetime.utcnow()
+        elif value == 'cancelled' and self.status == 'closed':
+            self.cancelled_at = datetime.utcnow()
+        elif value == 'unsuccessful' and self.status == 'closed':
+            self.unsuccessful_at = datetime.utcnow()
         else:
             raise ValidationError("Cannot change brief status from '{}' to '{}'".format(self.status, value))
 

--- a/app/models/main.py
+++ b/app/models/main.py
@@ -1349,6 +1349,8 @@ class Brief(db.Model):
         return sql_case([
             (cls.withdrawn_at.isnot(None), 'withdrawn'),
             (cls.published_at.is_(None), 'draft'),
+            (cls.cancelled_at.isnot(None), 'cancelled'),
+            (cls.unsuccessful_at.isnot(None), 'unsuccessful'),
             (
                 exists([BriefResponse.id]).where(
                     sql_and(cls.id == BriefResponse.brief_id, BriefResponse.awarded_at != None)  # noqa
@@ -1361,6 +1363,8 @@ class Brief(db.Model):
         "live": 0,
         "closed": 1,
         "awarded": 1,
+        "cancelled": 1,
+        "unsuccessful": 1,
         "draft": 2,
         "withdrawn": 2
     }
@@ -1374,6 +1378,8 @@ class Brief(db.Model):
         return sql_case([
             (cls.withdrawn_at.isnot(None), cls.search_result_status_ordering['withdrawn']),
             (cls.published_at.is_(None), cls.search_result_status_ordering['draft']),
+            (cls.cancelled_at.isnot(None), cls.search_result_status_ordering['cancelled']),
+            (cls.unsuccessful_at.isnot(None), cls.search_result_status_ordering['unsuccessful']),
             (
                 exists([BriefResponse.id]).where(
                     sql_and(cls.id == BriefResponse.brief_id, BriefResponse.awarded_at != None)  # noqa

--- a/tests/main/views/test_briefs.py
+++ b/tests/main/views/test_briefs.py
@@ -1398,7 +1398,7 @@ class TestAwardPendingBriefResponse(FrameworkSetupAndTeardown):
         error = json.loads(res.get_data(as_text=True))['error']
         assert "'updated_by' is a required property" in error
 
-    @pytest.mark.parametrize('status', ['draft', 'live', 'withdrawn', 'awarded'])
+    @pytest.mark.parametrize('status', ['draft', 'live', 'withdrawn', 'awarded', 'cancelled', 'unsuccessful'])
     def test_400_if_awarding_a_brief_response_to_a_non_closed_brief(self, status):
         self.setup_dummy_briefs(1, status=status)
         res = self._post_to_award_endpoint({'briefResponseId': 1})


### PR DESCRIPTION
Trello ticket: https://trello.com/c/ggDGUY5d/823-2-collect-status-when-a-buyer-is-not-proceeding-with-an-award-no-journey-backend

The migration branch for these fields should be merged first (this branch contains the same commit to make sure tests past): https://github.com/alphagov/digitalmarketplace-api/pull/634

- new fields and status property
- status setting, filtering and ordering
- include the new statuses as actions in the `update_brief_status` route
- reorganise Brief tests
