### PR TITLE
Fix old Briefs missing niceToHaveRequirements field

### DIFF
--- a/migrations/versions/990_add_missing_nice_to_have_requirements_field.py
+++ b/migrations/versions/990_add_missing_nice_to_have_requirements_field.py
@@ -1,0 +1,47 @@
+"""Adds missing 'niceToHaveRequirements' to old published Brief data blobs.
+
+Revision ID: 990
+Revises: 980
+Create Date: 2017-09-05 17:08:57.947569
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '990'
+down_revision = '980'
+
+
+briefs_table = sa.Table(
+    'briefs',
+    sa.MetaData(),
+    sa.Column('id', sa.Integer, primary_key=True),
+    sa.Column('data', sa.JSON, nullable=True),
+    sa.Column('published_at', sa.DateTime, nullable=True)
+)
+
+
+def upgrade():
+    conn = op.get_bind()
+    # SELECT id, data FROM briefs WHERE briefs.published_at IS NOT null
+    query = briefs_table.select(
+        briefs_table.c.published_at != sa.null()
+    ).with_only_columns(
+        (
+            briefs_table.c.id,
+            briefs_table.c.data
+        )
+    )
+    results = conn.execute(query).fetchall()
+    for brief_id, brief_data in results:
+        if 'niceToHaveRequirements' not in brief_data:
+            brief_data['niceToHaveRequirements'] = []
+            # UPDATE briefs SET data = brief_data WHERE id = brief_id;
+            query = briefs_table.update().where(briefs_table.c.id == brief_id).values(data=brief_data)
+            conn.execute(query)
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
Bug Ticket: https://trello.com/c/QhJqiS8z/850-bug-suppliers-unable-to-apply-to-a-copied-brief-on-preview

Some older Briefs were created before the `niceToHaveRequirements` field was mandatory. Although suppliers can't apply to those (long closed!) Briefs, it's possible for the buyer to make a copy of them and publish a new Brief that is missing the field. Applying to these copied Briefs shows a 500 error to the supplier.

Solution: a data migration to add `"niceToHaveRequirements": []` to any older Briefs that are missing this field. I copied the query structure from a recent-ish data migration (880), it's not the most efficient query in the world but hopefully it will only need to be run once.

I haven't included a `downgrade` step as it would be difficult to restore only the erroneous Briefs without a list of IDs, which we don't have for all environments.

**Reviewers**: please double check my queries carefully! I don't want to accidentally wipe requirements that are already there.