### PR TITLE
Lock direct award projects

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -10,7 +10,7 @@ SQLAlchemy==1.1.4
 SQLAlchemy-Utils==0.30.5
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@27.1.2#egg=digitalmarketplace-utils==27.1.2
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@9.1.1#egg=digitalmarketplace-apiclient==9.1.1
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@10.3.0#egg=digitalmarketplace-apiclient==10.3.0
 
 # For schema validation
 jsonschema==2.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ SQLAlchemy==1.1.4
 SQLAlchemy-Utils==0.30.5
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@27.1.2#egg=digitalmarketplace-utils==27.1.2
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@9.1.1#egg=digitalmarketplace-apiclient==9.1.1
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@10.3.0#egg=digitalmarketplace-apiclient==10.3.0
 
 # For schema validation
 jsonschema==2.5.1

--- a/tests/main/views/test_direct_award.py
+++ b/tests/main/views/test_direct_award.py
@@ -495,3 +495,37 @@ class TestDirectAwardGetProjectSearch(DirectAwardSetupAndTeardown):
 
         with self.app.app_context():
             assert data['search'] == DirectAwardSearch.query.get(self.search_id).serialize()
+
+
+class TestDirectAwardLockProject(DirectAwardSetupAndTeardown):
+    def setup(self):
+        super(TestDirectAwardLockProject, self).setup()
+        self.project_id = self.create_direct_award_project(user_id=self.user_id,
+                                                           project_name=self.direct_award_project_name)
+        self.search_id = self.create_direct_award_project_search(created_by=self.user_id, project_id=self.project_id)
+
+        res = self.client.get('/direct-award/projects/{}/searches/{}?user-id={}'.format(self.project_id,
+                                                                                        self.search_id,
+                                                                                        self.user_id))
+        assert res.status_code == 200
+
+    def _lock_project_data(self):
+        return {
+            'updated_by': str(self.user_id)
+        }.copy()
+
+    @pytest.mark.skip
+    def test_400s_if_project_already_locked(self):
+        pass
+
+    @pytest.mark.skip
+    def test_search_and_project_datetimes_are_updated(self):
+        pass
+
+    @pytest.mark.skip
+    def test_search_result_entries_populated_with_latest_archived_service_for_searched_services(self):
+        pass
+
+    @pytest.mark.skip
+    def test_locking_project_creates_audit_event(self):
+        pass


### PR DESCRIPTION
## Summary
Add `lock` endpoint to lock a project and freeze the associated service resultset. Pulls in apiclient 10.3.0 so depends on https://github.com/alphagov/digitalmarketplace-apiclient/pull/92

Tests will be written in a follow-up PR.

## Ticket
https://trello.com/c/gs2I3Cj2/676-end-your-search