### PR TITLE
Allow cancelled and unsuccessful updates to brief status from expired or closed framework.

### DIFF
--- a/tests/main/views/test_briefs.py
+++ b/tests/main/views/test_briefs.py
@@ -744,8 +744,14 @@ class TestUpdateBriefStatus(FrameworkSetupAndTeardown):
         assert data['briefs']['status'] == 'withdrawn'
         assert data['briefs']['withdrawnAt'] is not None
 
-    def test_cancel_a_brief(self):
+    @pytest.mark.parametrize('framework_status', ('pending', 'expired'))
+    def test_cancel_a_brief(self, framework_status):
         self.setup_dummy_briefs(1, title='The Title', status='closed')
+        with self.app.app_context():
+            framework = Framework.query.filter(Framework.slug == 'digital-outcomes-and-specialists').first()
+            framework.status = framework_status
+            db.session.add(framework)
+            db.session.commit()
 
         res = self.client.post(
             '/briefs/1/cancel',


### PR DESCRIPTION
https://trello.com/c/Umt24W6d/816-3-collect-status-when-buyer-has-cancelled-procurement-no-journey-frontend

Briefs: https://github.com/alphagov/digitalmarketplace-briefs-frontend/pull/26

As a brief can never be published without the framework being in a live or expired state we don't need to perform checks here when changing the brief status to either `unsuccessful` or `cancelled`