### PR TITLE
Reset failed login count and unlock user on password change

### DIFF
--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -179,6 +179,7 @@ def update_user(user_id):
     if 'password' in user_update:
         user.password = encryption.hashpw(user_update['password'])
         user.password_changed_at = datetime.utcnow()
+        user.failed_login_count = 0
         user_update['password'] = 'updated'
     if 'active' in user_update:
         user.active = user_update['active']


### PR DESCRIPTION
This is an alternative to alphagov/digitalmarketplace-apiclient#93

We don't have a good use case for resetting the password without unlocking the user, so we could combine the two operations and unlock the user each time the password is updated.