### PR TITLE
Only retrieve service IDs when locking a project

### DIFF
--- a/app/main/views/direct_award.py
+++ b/app/main/views/direct_award.py
@@ -208,7 +208,9 @@ def lock_project(project_id):
     ).first_or_404()
 
     now = datetime.datetime.utcnow()
-    service_ids = [search['id'] for search in search_api_client.search_services_from_url_iter(search.search_url)]
+
+    service_ids = [service['id'] for service in search_api_client.search_services_from_url_iter(search.search_url,
+                                                                                                id_only=True)]
 
     # We want the most recent ArchivedService for each service_id
     archived_services = ArchivedService.query.\

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -10,7 +10,7 @@ SQLAlchemy==1.1.4
 SQLAlchemy-Utils==0.30.5
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@27.1.2#egg=digitalmarketplace-utils==27.1.2
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@10.4.0#egg=digitalmarketplace-apiclient==10.4.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@10.5.0#egg=digitalmarketplace-apiclient==10.5.0
 
 # For schema validation
 jsonschema==2.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ SQLAlchemy==1.1.4
 SQLAlchemy-Utils==0.30.5
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@27.1.2#egg=digitalmarketplace-utils==27.1.2
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@10.4.0#egg=digitalmarketplace-apiclient==10.4.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@10.5.0#egg=digitalmarketplace-apiclient==10.5.0
 
 # For schema validation
 jsonschema==2.5.1


### PR DESCRIPTION
## Summary
When we lock a Direct Award project/search we need to scrape all the matching services and freeze the result set. We don't care about any of the service data, so let's only ask for the IDs.
Pulls in the apiclient 10.5.0

## Ticket
https://trello.com/c/gs2I3Cj2/676-end-your-search