### PR TITLE
Bump postgres version for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 python:
   - "3.6"
 addons:
-  postgresql: "9.5"
+  postgresql: "9.6"
 dist: "trusty"
 env:
   - SQLALCHEMY_DATABASE_URI=postgresql://postgres:@localhost:5432/digitalmarketplace_test


### PR DESCRIPTION
## Summary
We use PostgreSQL 9.6 in production, so let's do the same in Travis.