### PR TITLE
Add a parameter to allow only returning active searches

### DIFF
--- a/app/main/views/direct_award.py
+++ b/app/main/views/direct_award.py
@@ -110,6 +110,9 @@ def list_project_searches(project_id):
     else:
         searches = searches.order_by(asc(DirectAwardSearch.id))
 
+    if convert_to_boolean(request.args.get('only-active', False)):
+        searches = searches.filter(DirectAwardSearch.active == True)  # noqa
+
     searches = searches.paginate(
         page=page,
         per_page=current_app.config['DM_API_PROJECTS_PAGE_SIZE'],

--- a/app/main/views/direct_award.py
+++ b/app/main/views/direct_award.py
@@ -98,6 +98,9 @@ def get_project(project_id):
 
 @main.route('/direct-award/projects/<int:project_id>/searches', methods=['GET'])
 def list_project_searches(project_id):
+    # If the project doesn't exist, we should 404 early.
+    DirectAwardProject.query.filter(DirectAwardProject.id == project_id).first_or_404()
+
     page = get_valid_page_or_1()
 
     searches = DirectAwardSearch.query.filter(DirectAwardSearch.project_id == project_id)
@@ -137,6 +140,9 @@ def list_project_searches(project_id):
 @main.route('/direct-award/projects/<int:project_id>/searches', methods=['POST'])
 def create_project_search(project_id):
     updater_json = validate_and_return_updater_request()
+
+    # If the project doesn't exist, we should 404 early.
+    DirectAwardProject.query.filter(DirectAwardProject.id == project_id).first_or_404()
 
     json_payload = get_json_from_request()
     json_has_required_keys(json_payload, ['search'])
@@ -182,6 +188,9 @@ def create_project_search(project_id):
 
 @main.route('/direct-award/projects/<int:project_id>/searches/<int:search_id>', methods=['GET'])
 def get_project_search(project_id, search_id):
+    # If the project doesn't exist, we should 404 early.
+    DirectAwardProject.query.filter(DirectAwardProject.id == project_id).first_or_404()
+
     search = DirectAwardSearch.query.filter(
         DirectAwardSearch.id == search_id,
         DirectAwardSearch.project_id == project_id
@@ -199,9 +208,7 @@ def list_project_services(project_id):
 def lock_project(project_id):
     updater_json = validate_and_return_updater_request()
 
-    project = DirectAwardProject.query.filter(
-        DirectAwardProject.id == project_id
-    ).first_or_404()
+    project = DirectAwardProject.query.filter(DirectAwardProject.id == project_id).first_or_404()
 
     if project.locked_at:
         abort(400, 'Project has already been locked: {}'.format(project_id))

--- a/tests/main/views/test_direct_award.py
+++ b/tests/main/views/test_direct_award.py
@@ -2,6 +2,7 @@ import json
 from datetime import datetime
 import math
 import random
+import sys
 
 import pytest
 from tests.helpers import FixtureMixin
@@ -254,6 +255,11 @@ class TestDirectAwardListProjectSearches(DirectAwardSetupAndTeardown):
                                                                                      self.user_id))
         assert res.status_code == 200
 
+    def test_list_searches_404s_with_invalid_project_id(self):
+        res = self.client.get('/direct-award/projects/{}/searches?user-id={}'.format(sys.maxsize,
+                                                                                     self.user_id))
+        assert res.status_code == 404
+
     def test_list_searches_returns_only_for_project_requested(self):
         # Create a project for another user with a search, i.e. one that shouldn't be returned
         self.setup_dummy_user(id=self.user_id + 1, role='buyer')
@@ -459,6 +465,13 @@ class TestDirectAwardCreateProjectSearch(DirectAwardSetupAndTeardown):
                                data=json.dumps(search_data), content_type='application/json')
         assert res.status_code == 400
 
+    def test_create_search_404s_with_invalid_project(self):
+        search_data = self._create_project_search_data()
+
+        res = self.client.post('/direct-award/projects/{}/searches'.format(sys.maxsize),
+                               data=json.dumps(search_data), content_type='application/json')
+        assert res.status_code == 404
+
     def test_create_search_makes_other_searches_inactive(self):
         search_data = self._create_project_search_data()
 
@@ -505,6 +518,12 @@ class TestDirectAwardGetProjectSearch(DirectAwardSetupAndTeardown):
                                                                                         self.user_id))
         assert res.status_code == 200
 
+    def test_get_search_404s_with_invalid_project(self):
+        res = self.client.get('/direct-award/projects/{}/searches/{}?user-id={}'.format(sys.maxsize,
+                                                                                        self.search_id,
+                                                                                        self.user_id))
+        assert res.status_code == 404
+
     def test_get_search_returns_serialized_search(self):
         res = self.client.get('/direct-award/projects/{}/searches/{}?user-id={}'.format(self.project_id,
                                                                                         self.search_id,
@@ -533,17 +552,21 @@ class TestDirectAwardLockProject(DirectAwardSetupAndTeardown):
         }.copy()
 
     @pytest.mark.skip
-    def test_400s_if_project_already_locked(self):
+    def test_lock_project_400s_if_project_already_locked(self):
         pass
 
     @pytest.mark.skip
-    def test_search_and_project_datetimes_are_updated(self):
+    def test_lock_project_404s_if_invalid_project(self):
         pass
 
     @pytest.mark.skip
-    def test_search_result_entries_populated_with_latest_archived_service_for_searched_services(self):
+    def test_lock_project_search_and_project_datetimes_are_updated(self):
         pass
 
     @pytest.mark.skip
-    def test_locking_project_creates_audit_event(self):
+    def test_lock_project_search_result_entries_populated_with_latest_archived_service_for_searched_services(self):
+        pass
+
+    @pytest.mark.skip
+    def test_lock_project_creates_audit_event(self):
         pass


### PR DESCRIPTION
## Summary
In the buyer-frontend we always ask for a list of searches associated to a Direct Award project, but we are currently only ever interested in the active search which leads to a lot of repeated filtering. This adds a query param to the endpoint that will cause only the active search(es) to be returned.

Bonus: Also adds 404s to direct award endpoints if the project doesn't exist, and tests to boot.

## Ticket
https://trello.com/c/igRhA3Bt/711-shortlist-file-download