### PR TITLE
Add `awe.co.uk` to buyer domains list

### DIFF
--- a/data/buyer-email-domains.txt
+++ b/data/buyer-email-domains.txt
@@ -8,6 +8,7 @@ aldwyck.co.uk
 alexandrapalace.com
 arts.wales
 assembly.wales
+awe.co.uk
 bankofengland.co.uk
 barbican.org.uk
 barnardos.org.uk


### PR DESCRIPTION
Trello: https://trello.com/c/FsY2bCle/874-add-additional-buyer-email-domains-for-buyer-accounts