### PR TITLE
Refactor BaseApplicationTest remove unused code

### DIFF
--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -18,16 +18,18 @@ class TestApplication(BaseApplicationTest):
         assert response.status_code == 404
 
     def test_bearer_token_is_required(self):
-        self.do_not_provide_access_token()
+        """Stop the client from sending an auth header and assert response is 401 Unauthorised."""
+        self.app.wsgi_app.kwargs.pop('HTTP_AUTHORIZATION')
         response = self.client.get('/')
         assert response.status_code == 401
         assert 'WWW-Authenticate' in response.headers
 
-    def test_invalid_bearer_token_is_required(self):
-        self.do_not_provide_access_token()
+    def test_invalid_bearer_token_is_not_allowed(self):
+        """Force the client to send an invalid auth header and assert response is 403 Forbidden."""
+        self.app.wsgi_app.kwargs['HTTP_AUTHORIZATION'] = 'Bearer invalid-token'
         response = self.client.get(
             '/',
-            headers={'Authorization': 'Bearer invalid-token'})
+        )
         assert response.status_code == 403
 
     def test_max_age_is_one_day(self):


### PR DESCRIPTION
Some work to remove unused code. 
Will make the factory boy test changes easier to review if I do this refactor separately.

Removed:
* `BaseApplicationTest.lots`
* `BaseApplicationTest.setup_authorization`
* `BaseApplicationTest.teardown_database`
* `BaseApplicationTest.teardown_authorization`
* `BaseApplicationTest.do_not_provide_access_token `

Move `BaseApplicationTest.teardown_database` to `BaseApplicationTest.teardown` there is no other teardown now except tearing down the DB so it can live in the general teardown.

The tests that used `setup_authorization` and `do_not_provide_access_token` were too few and too exrtapolated to warrant their own methods, especially on the general base class.
These now explicitly perform their action within the test methods.