### PR TITLE
Store Search-API-relative URL for all saved searches.

### DIFF
--- a/app/url_utils.py
+++ b/app/url_utils.py
@@ -1,0 +1,24 @@
+from urllib.parse import urlsplit, urlunsplit
+
+
+def force_relative_url(base_url, url):
+    """
+    Forcibly removes the hostname and port from a URL, returning a new URL relative to base_url.
+    :param base_url: the path segment of base_url will be used to shorten the return url if possible
+    :param url: the URL to process into a relative URL
+    :return: sanitised URL relative to base_url
+    """
+    # convert args to str; urllib can accept bytes but our string ops can't
+    base_url, url = str(base_url), str(url)
+
+    # remove the netloc and port from the url...
+    parsed_url = urlsplit(url)
+    sanitised_url = urlunsplit(('', '', parsed_url.path, parsed_url.query, parsed_url.fragment))
+
+    # ...and remove any common path prefix up to and including the final slash
+    base_path = urlsplit(base_url).path or '/'
+    base_path = base_path[:base_path.rfind('/') + 1]
+    if sanitised_url.startswith(base_path):
+        sanitised_url = sanitised_url[len(base_path):]
+
+    return sanitised_url

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -38,7 +38,9 @@ COMPLETE_DIGITAL_SPECIALISTS_BRIEF = {
 
 DIRECT_AWARD_PROJECT_NAME = 'My Direct Award Project'
 DIRECT_AWARD_FROZEN_TIME = '2017-01-01T00:00:00.000000Z'
-DIRECT_AWARD_SEARCH_URL = 'https://search-api.digitalmarketplace.service.gov.uk/g-cloud/services/search?q=hosting'
+DIRECT_AWARD_SEARCH_BASE = 'https://search-api.digitalmarketplace.service.gov.uk/'
+DIRECT_AWARD_SEARCH_RELATIVE_URL = 'g-cloud/services/search?q=hosting'
+DIRECT_AWARD_SEARCH_URL = DIRECT_AWARD_SEARCH_BASE + DIRECT_AWARD_SEARCH_RELATIVE_URL
 
 
 def fixture_params(fixture_name, params):

--- a/tests/models/test_direct_award.py
+++ b/tests/models/test_direct_award.py
@@ -7,7 +7,8 @@ from app import db
 from app.models import User, ValidationError
 from app.models.direct_award import DirectAwardProject, DirectAwardProjectUser, DirectAwardSearch
 from tests.bases import BaseApplicationTest
-from tests.helpers import FixtureMixin, DIRECT_AWARD_PROJECT_NAME, DIRECT_AWARD_SEARCH_URL
+from tests.helpers import (FixtureMixin, DIRECT_AWARD_PROJECT_NAME, DIRECT_AWARD_SEARCH_RELATIVE_URL,
+                           DIRECT_AWARD_SEARCH_URL,)
 
 
 class TestProjects(BaseApplicationTest, FixtureMixin):
@@ -112,7 +113,7 @@ class TestSearches(BaseApplicationTest, FixtureMixin):
             assert search.project_id == project_id
             assert isinstance(search.created_at, datetime)
             assert search.searched_at is None
-            assert search.search_url == DIRECT_AWARD_SEARCH_URL
+            assert search.search_url == DIRECT_AWARD_SEARCH_RELATIVE_URL
             assert search.active is True
 
     def test_only_one_search_active_per_project_is_enforced(self):
@@ -130,8 +131,8 @@ class TestSearches(BaseApplicationTest, FixtureMixin):
 
         with self.app.app_context():
             search = DirectAwardSearch.query.get(search_id)
+            search_keys_set = set(search.serialize().keys())
 
-        search_keys_set = set(search.serialize().keys())
         assert {'id', 'createdAt', 'searchedAt', 'projectId', 'searchUrl', 'active'} <= search_keys_set
 
     @pytest.mark.parametrize('update_kwargs',

--- a/tests/test_url_utils.py
+++ b/tests/test_url_utils.py
@@ -1,0 +1,24 @@
+from app.url_utils import force_relative_url
+
+
+class TestForceRelativeURL(object):
+    def test_hostname_removed(self):
+        result = force_relative_url('http://hostname:port/', 'https://badhostname/plus/path?woo')
+        assert result == "plus/path?woo"
+
+    def test_additional_base_path_removed(self):
+        result = force_relative_url('http://hostname:port/extra/', 'https://badhostname/extra/plus/path?woo')
+        assert result == "plus/path?woo"
+
+    def test_additional_base_path_no_slash(self):
+        # This is a stupid case: the missing slash means that our relative URL *must* include the 'extra' part,
+        # if it is to actually work when eventually re-joined to the base URL. (urljoin will, as expected,
+        # remove the resource at the bottom level when joining a relative URL.)
+        result = force_relative_url('http://hostname:port/extra', 'https://badhostname/extra/plus/path?woo')
+        assert result == "extra/plus/path?woo"
+
+    def test_mismatched_base_paths_ignored(self):
+        result = force_relative_url('http://hostname:port/extra/', 'https://badhostname/mismatch/plus/path?woo')
+        # No way to be sure that removing "mismatch" is correct - so we must not (if this ever happened we
+        # probably did something wrong).
+        assert result == "/mismatch/plus/path?woo"


### PR DESCRIPTION
As well as saving some bytes, and making our saved search data portable between environments, this removes a theoretical attack vector i.e. where a client sends a malicious URL into the API as a 'saved search'.

https://trello.com/c/jjVWnK1e/722-security-fixes-for-save-search-feature