### PR TITLE
implement list services API endpoint

### DIFF
--- a/app/models/direct_award.py
+++ b/app/models/direct_award.py
@@ -17,6 +17,7 @@ class DirectAwardProject(db.Model):
     name = db.Column(db.String(255), nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
     locked_at = db.Column(db.DateTime, nullable=True)  # When the project's active search/es are final and cannot change
+    downloaded_at = db.Column(db.DateTime, nullable=True)  # When the project's shortlist was last downloaded
     active = db.Column(db.Boolean, default=True, nullable=False)
 
     users = db.relationship(User, secondary='direct_award_project_users', order_by=lambda: DirectAwardProjectUser.id)
@@ -27,6 +28,7 @@ class DirectAwardProject(db.Model):
             "name": self.name,
             "createdAt": self.created_at.strftime(DATETIME_FORMAT),
             "lockedAt": self.locked_at.strftime(DATETIME_FORMAT) if self.locked_at is not None else None,
+            "downloadedAt": self.downloaded_at.strftime(DATETIME_FORMAT) if self.downloaded_at is not None else None,
             "active": self.active
         }
 
@@ -74,7 +76,7 @@ class DirectAwardSearch(db.Model):
     # Service, but by storing this we have the flexibility to show either the live state or the state at the time
     # the user ran the search.
     archived_services = db.relationship(ArchivedService, secondary='direct_award_search_result_entries',
-                                        order_by=lambda: DirectAwardSearchResultEntry.id)
+                                        order_by=lambda: DirectAwardSearchResultEntry.id, lazy='dynamic')
 
     project = db.relationship(DirectAwardProject)
     user = db.relationship(User)

--- a/app/utils.py
+++ b/app/utils.py
@@ -93,7 +93,14 @@ def json_only_has_required_keys(data, keys):
 
 
 def drop_foreign_fields(json_object, list_of_keys, recurse=False):
+    """Filter a JSON object down by _removing_ all keys in list_of_keys"""
     json_object = keyfilter_json(json_object, lambda k: k not in list_of_keys, recurse)
+    return json_object
+
+
+def drop_all_other_fields(json_object, list_of_keys, recurse=False):
+    """Filter a JSON object down by _keeping_ only keys in list_of_keys"""
+    json_object = keyfilter_json(json_object, lambda k: k in list_of_keys, recurse)
     return json_object
 
 

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -10,7 +10,7 @@ SQLAlchemy==1.1.4
 SQLAlchemy-Utils==0.30.5
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@27.1.2#egg=digitalmarketplace-utils==27.1.2
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@10.5.0#egg=digitalmarketplace-apiclient==10.5.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@10.7.0#egg=digitalmarketplace-apiclient==10.7.0
 
 # For schema validation
 jsonschema==2.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ SQLAlchemy==1.1.4
 SQLAlchemy-Utils==0.30.5
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@27.1.2#egg=digitalmarketplace-utils==27.1.2
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@10.5.0#egg=digitalmarketplace-apiclient==10.5.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@10.7.0#egg=digitalmarketplace-apiclient==10.7.0
 
 # For schema validation
 jsonschema==2.5.1

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -174,7 +174,7 @@ class FixtureMixin(object):
             db.session.commit()
 
     def setup_dummy_service(self, service_id, supplier_id=1, data=None,
-                            status='published', framework_id=1, lot_id=1, **kwargs):
+                            status='published', framework_id=1, lot_id=1, model=Service, **kwargs):
         now = datetime.utcnow()
 
         # lot and framework ids aren't in json responses, so we'll look for them first
@@ -192,18 +192,19 @@ class FixtureMixin(object):
             'data': data or kwargs or {'serviceName': 'Service {}'.format(service_id)}
         }
 
-        db.session.add(Service(**service_kwargs))
+        db.session.add(model(**service_kwargs))
         db.session.commit()
 
     def setup_dummy_services(self, n, supplier_id=None, framework_id=1,
-                             start_id=0, lot_id=1):
+                             start_id=0, lot_id=1, model=Service):
         with self.app.app_context():
             for i in range(start_id, start_id + n):
                 self.setup_dummy_service(
                     service_id=str(2000000000 + start_id + i),
                     supplier_id=supplier_id or (i % TEST_SUPPLIERS_COUNT),
                     framework_id=framework_id,
-                    lot_id=lot_id
+                    lot_id=lot_id,
+                    model=model,
                 )
 
     def setup_dummy_services_including_unpublished(self, n):


### PR DESCRIPTION
## Summary
Adds the endpoint required for constructing a download file containing services matched by a Direct Award search. This endpoint paginates normally but we are going to limit the number of services that can be saved into a locked project to 100, which will effectively mean no pagination with our current configuration. We've had to limit this to 100 to remain responsive and minimise memory usage; ideally we'd have some kind of Digital Marketplace task runner that manage creating documents, combining lots of disparate data, etc, as opposed to doing it all on the frontends.

The list services endpoint accepts a `fields` parameter that allows the frontend to specify a subset of the Service model's `data` field to be returned, limiting the size of the response further. Ideally we would have a way of creating jobs for long-running tasks.

Tests for the list services endpoint requires archived services in the database, so I've slightly generalised the `setup_dummy_service` method to accept a model to use when setting up services. For Direct Award, this model is `ArchivedService`, as all locked searches store archived service instances which are (theoretically) immutable.

Also fixes a bug with the `lock_project` endpoint that wasn't checking for the currently `active` search. This could have been nasty. ☹️  Also stubbed out a test for this.

A second endpoint has also been added to record the downloading of a shortlist so that the tasklist page can correctly update to unlock the final steps. I have implemented this so that an AuditEvent is created every time the tasklist is downloaded, but the timestamp is only recorded for the first call.

## Depends upon
~~https://github.com/alphagov/digitalmarketplace-apiclient/pull/98~~

## Required by
https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/615
https://github.com/alphagov/digitalmarketplace-briefs-frontend/pull/32

## Other associated PRs
https://github.com/alphagov/digitalmarketplace-utils/pull/332
~~https://github.com/alphagov/digitalmarketplace-frameworks/pull/473~~

## Ticket
https://trello.com/c/igRhA3Bt/711-shortlist-file-download