### PR TITLE
list_audits view: allow filtering of events by user

### DIFF
--- a/app/main/views/audits.py
+++ b/app/main/views/audits.py
@@ -68,6 +68,12 @@ def list_audits():
         else:
             abort(400, "Invalid audit type")
 
+    user = request.args.get('user')
+    if user:
+        audits = audits.filter(
+            AuditEvent.user == user
+        )
+
     acknowledged = request.args.get('acknowledged', None)
     if acknowledged and acknowledged != 'all':
         if is_valid_acknowledged_state(acknowledged):


### PR DESCRIPTION
*least exciting feature ever*

for now, this only performs exact matching and doesn't use an index. initially
this feature is intended for manual occasional use. if we find a more regular
use for it, we can analyze & improve the performance at that time.