### PR TITLE
services: add new revert_service endpoint

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -157,8 +157,6 @@ def revert_service(service_id):
         Revert a service's `data` to that of a previous, supplied archivedServiceId
     """
 
-    is_valid_service_id_or_400(service_id)
-
     service = Service.query.filter(
         Service.service_id == service_id
     ).first_or_404()

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -170,6 +170,7 @@ def revert_service(service_id):
             ArchivedService.id == int(payload_json["archivedServiceId"])
         ).first()
     except ValueError:
+        # presumably failed to interpret `archivedServiceId` as an integer
         archived_service = None
     if not archived_service:
         abort(400, "No such ArchivedService")

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -191,9 +191,11 @@ class FixtureMixin(object):
             'updated_at': kwargs.pop('updatedAt', now),
             'data': data or kwargs or {'serviceName': 'Service {}'.format(service_id)}
         }
+        service = model(**service_kwargs)
 
-        db.session.add(model(**service_kwargs))
+        db.session.add(service)
         db.session.commit()
+        return service.id
 
     def setup_dummy_services(self, n, supplier_id=None, framework_id=1,
                              start_id=0, lot_id=1, model=Service):


### PR DESCRIPTION
This allows us to easily revert a service's `data` section back to the version present in a previous `ArchivedService`. There was no particularly convenient way of doing so beforehand.

Services are re-validated before re-saving, which could in some situations cause a reversion to fail if a framework's validation has been tightened up while the framework is `live`. I think we agreed we could revisit this behaviour with something more complex if it becomes common.