### PR TITLE
Add `hlf.org.uk` to the list of acceptable buyer domains

### DIFF
--- a/data/buyer-email-domains.txt
+++ b/data/buyer-email-domains.txt
@@ -79,6 +79,7 @@ hes.scot
 hient.co.uk
 highwaysengland.co.uk
 historicengland.org.uk
+hlf.org.uk
 hmcts.net
 homegroup.org.uk
 housing-ombudsman.org.uk


### PR DESCRIPTION
## Summary
Request from support to add `hlf.org.uk` to the list of buyer domains.

## Ticket
https://trello.com/c/rqLZ4aMC/23-add-additional-buyer-email-domains-for-buyer-accounts