### PR TITLE
Add milliseconds to application log time format

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM digitalmarketplace/base-api:2.0.1
+FROM digitalmarketplace/base-api:2.0.5

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -9,7 +9,7 @@ psycopg2==2.5.4
 SQLAlchemy==1.1.4
 SQLAlchemy-Utils==0.30.5
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@27.1.2#egg=digitalmarketplace-utils==27.1.2
+git+https://github.com/alphagov/digitalmarketplace-utils.git@29.0.0#egg=digitalmarketplace-utils==29.0.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@10.7.0#egg=digitalmarketplace-apiclient==10.7.0
 
 # For schema validation

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ psycopg2==2.5.4
 SQLAlchemy==1.1.4
 SQLAlchemy-Utils==0.30.5
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@27.1.2#egg=digitalmarketplace-utils==27.1.2
+git+https://github.com/alphagov/digitalmarketplace-utils.git@29.0.0#egg=digitalmarketplace-utils==29.0.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@10.7.0#egg=digitalmarketplace-apiclient==10.7.0
 
 # For schema validation
@@ -20,18 +20,18 @@ strict-rfc3339==0.5
 
 ## The following requirements were added by pip freeze:
 alembic==0.9.5
-asn1crypto==0.22.0
+asn1crypto==0.23.0
 backoff==1.0.7
 bcrypt==3.1.3
 boto3==1.4.4
 botocore==1.5.95
-cffi==1.10.0
+cffi==1.11.2
 contextlib2==0.4.0
 cryptography==1.9
 docopt==0.4.0
 docutils==0.14
 Flask-FeatureFlags==0.6
-Flask-Script==2.0.5
+Flask-Script==2.0.6
 Flask-WTF==0.12
 future==0.16.0
 idna==2.6
@@ -45,16 +45,17 @@ mandrill==1.0.57
 MarkupSafe==1.0
 monotonic==0.3
 notifications-python-client==4.1.0
+odfpy==1.3.3
 pycparser==2.18
-PyJWT==1.5.2
+PyJWT==1.5.3
 python-dateutil==2.6.1
 python-editor==1.0.3
 python-json-logger==0.1.4
 pytz==2015.4
 PyYAML==3.11
 requests==2.7.0
-s3transfer==0.1.10
-six==1.10.0
+s3transfer==0.1.11
+six==1.11.0
 unicodecsv==0.14.1
 Werkzeug==0.12.2
 workdays==1.4


### PR DESCRIPTION
Upgrades dmutils and base Docker image to add milliseconds to app logs shipped to CloudWatch.

This allows us to maintain the order of the log messages written by an application instance in Kibana.