### PR TITLE
DB migration to add new buyer email domain table

### DIFF
--- a/migrations/versions/1020_add_buyer_email_domain_table.py
+++ b/migrations/versions/1020_add_buyer_email_domain_table.py
@@ -1,0 +1,33 @@
+"""Add buyer email domain table
+
+Revision ID: 1020
+Revises: 1010
+Create Date: 2017-10-10 15:18:22.683693
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '1020'
+down_revision = '1010'
+
+
+def upgrade():
+    op.create_table(
+        'buyer_email_domains',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('domain_name', sa.String(), nullable=False),
+        sa.PrimaryKeyConstraint('id', name=op.f('buyer_email_domains_pkey'))
+    )
+    op.create_unique_constraint(
+        op.f('uq_buyer_email_domains_domain_name'), 'buyer_email_domains', ['domain_name']
+    )
+
+
+def downgrade():
+    op.drop_constraint(
+        op.f('uq_buyer_email_domains_domain_name'), 'buyer_email_domains', type_='unique'
+    )
+    op.drop_table('buyer_email_domains')


### PR DESCRIPTION
Trello ticket: https://trello.com/c/JxwDhnDh/82-migrate-existing-domain-check-to-use-database

PR 1: schema migration to add a simple DB table to store the email domain (currently held in a text file).

Related:
PR 2: Add API client method and AuditType https://github.com/alphagov/digitalmarketplace-apiclient/pull/102
PR 3: API model/add domain view/backwards compatibility for existing domain checks https://github.com/alphagov/digitalmarketplace-api/pull/674
PR 4: data migration to transfer domains from text file to DB https://github.com/alphagov/digitalmarketplace-api/pull/675