### PR TITLE
Create buyer email domains via the API

### DIFF
--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -14,5 +14,5 @@ def add_cache_control(response):
 
 
 from .views import suppliers, services, users, drafts, audits, frameworks, briefs, brief_responses, agreements,\
-    direct_award
+    direct_award, buyer_domains
 from . import errors

--- a/app/main/views/buyer_domains.py
+++ b/app/main/views/buyer_domains.py
@@ -5,7 +5,7 @@ from flask import jsonify, abort
 from .. import main
 from ... import db
 from ...models import BuyerEmailDomain, AuditEvent
-from ...validation import validate_buyer_email_domain_json_or_400, buyer_email_already_approved
+from ...validation import validate_buyer_email_domain_json_or_400, buyer_email_domain_approved
 from ...utils import get_json_from_request, json_has_required_keys, validate_and_return_updater_request
 
 
@@ -19,7 +19,7 @@ def create_buyer_email_domain():
 
     new_domain = json_payload["buyerEmailDomains"]['domainName'].lower()
 
-    if buyer_email_already_approved(BuyerEmailDomain.query.all(), new_domain):
+    if buyer_email_domain_approved(BuyerEmailDomain.query.all(), new_domain):
         abort(409, "Domain name {} has already been approved".format(new_domain))
 
     buyer_email_domain = BuyerEmailDomain(domain_name=new_domain)

--- a/app/main/views/buyer_domains.py
+++ b/app/main/views/buyer_domains.py
@@ -1,12 +1,15 @@
 from dmapiclient.audit import AuditTypes
 from sqlalchemy.exc import IntegrityError
-from flask import jsonify, abort
+from flask import jsonify, abort, request
 
 from .. import main
 from ... import db
 from ...models import BuyerEmailDomain, AuditEvent
 from ...validation import validate_buyer_email_domain_json_or_400, buyer_email_domain_approved
-from ...utils import get_json_from_request, json_has_required_keys, validate_and_return_updater_request
+from ...utils import (
+    get_json_from_request, json_has_required_keys, validate_and_return_updater_request,
+    get_valid_page_or_1, pagination_links
+)
 
 
 @main.route('/buyer-email-domain', methods=['POST'])
@@ -44,3 +47,25 @@ def create_buyer_email_domain():
     db.session.commit()
 
     return jsonify(buyerEmailDomains=buyer_email_domain.serialize()), 201
+
+
+@main.route('/buyer-email-domain', methods=['GET'])
+def list_buyer_email_domains():
+    page = get_valid_page_or_1()
+
+    buyer_email_domains = BuyerEmailDomain.query.order_by(BuyerEmailDomain.domain_name).paginate(
+        page=page,
+        per_page=100,
+    )
+
+    return jsonify(
+        buyerEmailDomains=[domain.serialize() for domain in buyer_email_domains.items],
+        meta={
+            "total": buyer_email_domains.total,
+        },
+        links=pagination_links(
+            buyer_email_domains,
+            '.list_buyer_email_domains',
+            request.args
+        ),
+    )

--- a/app/main/views/buyer_domains.py
+++ b/app/main/views/buyer_domains.py
@@ -12,7 +12,7 @@ from ...utils import (
 )
 
 
-@main.route('/buyer-email-domain', methods=['POST'])
+@main.route('/buyer-email-domains', methods=['POST'])
 def create_buyer_email_domain():
     updater_json = validate_and_return_updater_request()
 
@@ -49,7 +49,7 @@ def create_buyer_email_domain():
     return jsonify(buyerEmailDomains=buyer_email_domain.serialize()), 201
 
 
-@main.route('/buyer-email-domain', methods=['GET'])
+@main.route('/buyer-email-domains', methods=['GET'])
 def list_buyer_email_domains():
     page = get_valid_page_or_1()
 

--- a/app/main/views/buyer_domains.py
+++ b/app/main/views/buyer_domains.py
@@ -1,0 +1,43 @@
+from dmapiclient.audit import AuditTypes
+from sqlalchemy.exc import IntegrityError
+from flask import jsonify, abort
+
+from .. import main
+from ... import db
+from ...models import BuyerEmailDomain, AuditEvent
+from ...utils import get_json_from_request, json_has_required_keys, validate_and_return_updater_request
+
+
+@main.route('/buyer-email-domain', methods=['POST'])
+def create_buyer_email_domain():
+    updater_json = validate_and_return_updater_request()
+    json_payload = get_json_from_request()
+    json_has_required_keys(json_payload, ["domainName"])
+
+    # TODO: check if domain name already exists before creating
+    existing_domain_name = None
+    if existing_domain_name:
+        abort(409, "Domain name already exists")
+
+    buyer_email_domain = BuyerEmailDomain(domain_name=json_payload['domainName'])
+    db.session.add(buyer_email_domain)
+    try:
+        db.session.flush()
+    except IntegrityError as e:
+        db.session.rollback()
+        abort(400, e.orig)
+
+    audit = AuditEvent(
+        audit_type=AuditTypes.create_buyer_email_domain,
+        user=updater_json['updated_by'],
+        data={
+            'buyerEmailDomainId': buyer_email_domain.id,
+            'buyerEmailDomainJson': {'domainName': json_payload['domainName']}
+        },
+        db_object=buyer_email_domain,
+    )
+
+    db.session.add(audit)
+    db.session.commit()
+
+    return jsonify(buyer_email_domains=buyer_email_domain.serialize()), 201

--- a/app/main/views/buyer_domains.py
+++ b/app/main/views/buyer_domains.py
@@ -5,21 +5,24 @@ from flask import jsonify, abort
 from .. import main
 from ... import db
 from ...models import BuyerEmailDomain, AuditEvent
+from ...validation import validate_buyer_email_domain_json_or_400, buyer_email_already_approved
 from ...utils import get_json_from_request, json_has_required_keys, validate_and_return_updater_request
 
 
 @main.route('/buyer-email-domain', methods=['POST'])
 def create_buyer_email_domain():
     updater_json = validate_and_return_updater_request()
+
     json_payload = get_json_from_request()
-    json_has_required_keys(json_payload, ["domainName"])
+    json_has_required_keys(json_payload, ["buyerEmailDomains"])
+    validate_buyer_email_domain_json_or_400(json_payload["buyerEmailDomains"])
 
-    # TODO: check if domain name already exists before creating
-    existing_domain_name = None
-    if existing_domain_name:
-        abort(409, "Domain name already exists")
+    new_domain = json_payload["buyerEmailDomains"]['domainName'].lower()
 
-    buyer_email_domain = BuyerEmailDomain(domain_name=json_payload['domainName'])
+    if buyer_email_already_approved(BuyerEmailDomain.query.all(), new_domain):
+        abort(409, "Domain name {} has already been approved".format(new_domain))
+
+    buyer_email_domain = BuyerEmailDomain(domain_name=new_domain)
     db.session.add(buyer_email_domain)
     try:
         db.session.flush()
@@ -32,7 +35,7 @@ def create_buyer_email_domain():
         user=updater_json['updated_by'],
         data={
             'buyerEmailDomainId': buyer_email_domain.id,
-            'buyerEmailDomainJson': {'domainName': json_payload['domainName']}
+            'buyerEmailDomainJson': {'domainName': new_domain}
         },
         db_object=buyer_email_domain,
     )
@@ -40,4 +43,4 @@ def create_buyer_email_domain():
     db.session.add(audit)
     db.session.commit()
 
-    return jsonify(buyer_email_domains=buyer_email_domain.serialize()), 201
+    return jsonify(buyerEmailDomains=buyer_email_domain.serialize()), 201

--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -6,10 +6,11 @@ from flask import jsonify, abort, request, current_app
 
 from .. import main
 from ... import db, encryption
-from ...models import User, AuditEvent, Supplier, Framework, SupplierFramework
+from ...models import User, AuditEvent, Supplier, Framework, SupplierFramework, BuyerEmailDomain
 from ...utils import get_json_from_request, json_has_required_keys, \
     json_has_matching_id, pagination_links, get_valid_page_or_1, validate_and_return_updater_request
-from ...validation import validate_user_json_or_400, validate_user_auth_json_or_400, is_valid_buyer_email
+from ...validation import validate_user_json_or_400, validate_user_auth_json_or_400, is_valid_buyer_email, \
+    buyer_email_domain_approved
 
 
 @main.route('/users/auth', methods=['POST'])
@@ -293,7 +294,12 @@ def email_has_valid_buyer_domain():
     if not email_address:
         abort(400, "'email_address' is a required parameter")
 
-    return jsonify(valid=is_valid_buyer_email(email_address))
+    domain_ok = buyer_email_domain_approved(BuyerEmailDomain.query.all(), email_address.split('@')[-1])
+    if not domain_ok:
+        # If the data migration hasn't happened yet, check the .txt file
+        domain_ok = is_valid_buyer_email(email_address)
+
+    return jsonify(valid=domain_ok)
 
 
 def check_supplier_role(role, supplier_id):

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,2 +1,3 @@
 from .main import *  # noqa
 from .direct_award import *  # noqa
+from .buyer_domains import *  # noqa

--- a/app/models/buyer_domains.py
+++ b/app/models/buyer_domains.py
@@ -1,0 +1,14 @@
+from app import db
+
+
+class BuyerEmailDomain(db.Model):
+    __tablename__ = 'buyer_email_domains'
+
+    id = db.Column(db.Integer, primary_key=True)
+    domain_name = db.Column(db.String(), nullable=False)
+
+    def serialize(self):
+        return {
+            "id": self.id,
+            "domain_name": self.domain_name,
+        }

--- a/app/models/buyer_domains.py
+++ b/app/models/buyer_domains.py
@@ -10,5 +10,5 @@ class BuyerEmailDomain(db.Model):
     def serialize(self):
         return {
             "id": self.id,
-            "domain_name": self.domain_name,
+            "domainName": self.domain_name,
         }

--- a/app/validation.py
+++ b/app/validation.py
@@ -399,5 +399,5 @@ def validate_buyer_email_domain_json_or_400(submitted_json):
         abort(400, "JSON was not a valid format: {}".format(e1.message))
 
 
-def buyer_email_already_approved(existing_buyer_domains, new_domain):
+def buyer_email_domain_approved(existing_buyer_domains, new_domain):
     return any(new_domain == d.domain_name or new_domain.endswith('.' + d.domain_name) for d in existing_buyer_domains)

--- a/app/validation.py
+++ b/app/validation.py
@@ -67,6 +67,7 @@ SCHEMA_NAMES = [
     'suppliers',
     'new-supplier',
     'contact-information',
+    'buyer-email-domains',
 ]
 FORMAT_CHECKER = FormatChecker()
 
@@ -389,3 +390,14 @@ _BUYER_EMAIL_DOMAINS = load_buyer_email_domains('./data/buyer-email-domains.txt'
 def is_valid_buyer_email(email):
     domain = email.split('@')[-1]
     return any(domain == d or domain.endswith('.' + d) for d in _BUYER_EMAIL_DOMAINS)
+
+
+def validate_buyer_email_domain_json_or_400(submitted_json):
+    try:
+        get_validator('buyer-email-domains').validate(submitted_json)
+    except ValidationError as e1:
+        abort(400, "JSON was not a valid format: {}".format(e1.message))
+
+
+def buyer_email_already_approved(existing_buyer_domains, new_domain):
+    return any(new_domain == d.domain_name or new_domain.endswith('.' + d.domain_name) for d in existing_buyer_domains)

--- a/json_schemas/buyer-email-domains.json
+++ b/json_schemas/buyer-email-domains.json
@@ -3,7 +3,7 @@
   "additionalProperties": false,
   "properties": {
     "domainName": {
-      "pattern": "^(?!\\.)([^:\/@!&=\\s])+\\.[a-zA-Z]{2,64}?$",
+      "pattern": "^(?!\\.)[^:\/@!&=\\s]+\\.[a-zA-Z]{2,64}$",
       "type": "string",
       "description": "Must not start with a dot, must not contain :/@!&= or whitespace, must end in a dot followed by an alpha TLD between 2 and 64 chars."
     }

--- a/json_schemas/buyer-email-domains.json
+++ b/json_schemas/buyer-email-domains.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "domainName": {
+      "pattern": "^(?!\\.)([^:\/@!&=\\s])+\\.[a-zA-Z]{2,64}?$",
+      "type": "string",
+      "description": "Must not start with a dot, must not contain :/@!&= or whitespace, must end in a dot followed by an alpha TLD between 2 and 64 chars."
+    }
+  },
+  "required": ["domainName"],
+  "title": "Buyer Email Domain Schema",
+  "type": "object"
+}

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -10,7 +10,7 @@ SQLAlchemy==1.1.4
 SQLAlchemy-Utils==0.30.5
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@29.0.0#egg=digitalmarketplace-utils==29.0.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@10.7.0#egg=digitalmarketplace-apiclient==10.7.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@10.8.0#egg=digitalmarketplace-apiclient==10.8.0
 
 # For schema validation
 jsonschema==2.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ SQLAlchemy==1.1.4
 SQLAlchemy-Utils==0.30.5
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@29.0.0#egg=digitalmarketplace-utils==29.0.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@10.7.0#egg=digitalmarketplace-apiclient==10.7.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@10.8.0#egg=digitalmarketplace-apiclient==10.8.0
 
 # For schema validation
 jsonschema==2.5.1
@@ -22,7 +22,7 @@ strict-rfc3339==0.5
 alembic==0.9.5
 asn1crypto==0.23.0
 backoff==1.0.7
-bcrypt==3.1.3
+bcrypt==3.1.4
 boto3==1.4.4
 botocore==1.5.95
 cffi==1.11.2

--- a/tests/main/views/test_buyer_domains.py
+++ b/tests/main/views/test_buyer_domains.py
@@ -10,7 +10,7 @@ from app.models import BuyerEmailDomain, AuditEvent
 class TestCreateBuyerEmailDomain(BaseApplicationTest):
     def test_create_buyer_email_domain_with_no_data(self):
         res = self.client.post(
-            '/buyer-email-domain',
+            '/buyer-email-domains',
             content_type='application/json'
         )
 
@@ -25,7 +25,7 @@ class TestCreateBuyerEmailDomain(BaseApplicationTest):
             db.session.commit()
 
         res = self.client.post(
-            '/buyer-email-domain',
+            '/buyer-email-domains',
             data=json.dumps({
                 'buyerEmailDomains': {'domainName': new_domain},
                 'updated_by': 'example'
@@ -45,7 +45,7 @@ class TestCreateBuyerEmailDomain(BaseApplicationTest):
             db.session.commit()
 
         res = self.client.post(
-            '/buyer-email-domain',
+            '/buyer-email-domains',
             data=json.dumps({
                 'buyerEmailDomains': {'domainName': 'gov.uk'},
                 'updated_by': 'example'
@@ -58,7 +58,7 @@ class TestCreateBuyerEmailDomain(BaseApplicationTest):
 
     def test_create_buyer_email_domain_forces_to_lower_case(self):
         res = self.client.post(
-            '/buyer-email-domain',
+            '/buyer-email-domains',
             data=json.dumps({
                 'buyerEmailDomains': {'domainName': 'EXAMPLE.org'},
                 'updated_by': 'example'
@@ -71,7 +71,7 @@ class TestCreateBuyerEmailDomain(BaseApplicationTest):
 
     def test_create_buyer_email_domain_fails_if_required_field_is_not_provided(self):
         res = self.client.post(
-            '/buyer-email-domain',
+            '/buyer-email-domains',
             data=json.dumps({
                 'updated_by': 'example'
             }),
@@ -83,7 +83,7 @@ class TestCreateBuyerEmailDomain(BaseApplicationTest):
 
     def test_create_buyer_email_domain_creates_audit_event(self):
         self.client.post(
-            '/buyer-email-domain',
+            '/buyer-email-domains',
             data=json.dumps({
                 'buyerEmailDomains': {'domainName': "example.com"},
                 'updated_by': 'example user'
@@ -125,7 +125,7 @@ class TestCreateBuyerEmailDomain(BaseApplicationTest):
     )
     def test_create_buyer_email_domain_fails_if_domain_invalid(self, new_domain):
         res = self.client.post(
-            '/buyer-email-domain',
+            '/buyer-email-domains',
             data=json.dumps({
                 'buyerEmailDomains': {'domainName': new_domain},
                 'updated_by': 'example'
@@ -145,7 +145,7 @@ class TestCreateBuyerEmailDomain(BaseApplicationTest):
             db.session.commit()
 
         res = self.client.post(
-            '/buyer-email-domain',
+            '/buyer-email-domains',
             data=json.dumps({
                 'buyerEmailDomains': {'domainName': new_domain},
                 'updated_by': 'example'
@@ -159,7 +159,7 @@ class TestCreateBuyerEmailDomain(BaseApplicationTest):
 
 class TestListBuyerEmailDomains(BaseApplicationTest):
     def test_list_buyer_email_domain_200s_with_empty_list_when_no_domains(self):
-        res = self.client.get('/buyer-email-domain')
+        res = self.client.get('/buyer-email-domains')
 
         data = json.loads(res.get_data(as_text=True))
 
@@ -172,7 +172,7 @@ class TestListBuyerEmailDomains(BaseApplicationTest):
                 db.session.add(BuyerEmailDomain(domain_name=existing_domain))
                 db.session.commit()
 
-        res = self.client.get('/buyer-email-domain')
+        res = self.client.get('/buyer-email-domains')
 
         data = json.loads(res.get_data(as_text=True))
 
@@ -189,8 +189,8 @@ class TestListBuyerEmailDomains(BaseApplicationTest):
                 db.session.add(BuyerEmailDomain(domain_name=existing_domain))
                 db.session.commit()
 
-        page1 = self.client.get('/buyer-email-domain')
-        page2 = self.client.get('/buyer-email-domain?page=2')
+        page1 = self.client.get('/buyer-email-domains')
+        page2 = self.client.get('/buyer-email-domains?page=2')
 
         page_1_data = json.loads(page1.get_data(as_text=True))
         page_2_data = json.loads(page2.get_data(as_text=True))

--- a/tests/main/views/test_buyer_domains.py
+++ b/tests/main/views/test_buyer_domains.py
@@ -1,6 +1,8 @@
 import json
+import pytest
 
 from tests.bases import BaseApplicationTest
+from app import db
 from app.models import BuyerEmailDomain, AuditEvent
 
 
@@ -13,18 +15,58 @@ class TestCreateBuyerEmailDomain(BaseApplicationTest):
 
         assert res.status_code == 400
 
-    def test_create_buyer_email_domain(self):
+    @pytest.mark.parametrize('new_domain', ["fine.org", "also-fine.org", "also.fine.org"])
+    @pytest.mark.parametrize('existing_domain', ["ine.org", ".org", "o-fine.org"])
+    def test_create_buyer_email_domain(self, existing_domain, new_domain):
+        with self.app.app_context():
+            # Create a domain that shouldn't result in 'already been approved'
+            db.session.add(BuyerEmailDomain(domain_name=existing_domain))
+            db.session.commit()
+
         res = self.client.post(
             '/buyer-email-domain',
             data=json.dumps({
-                'domainName': "example.com",
+                'buyerEmailDomains': {'domainName': new_domain},
                 'updated_by': 'example'
             }),
             content_type='application/json')
         data = json.loads(res.get_data(as_text=True))
 
         assert res.status_code == 201
-        assert data['buyer_email_domains']['domainName'] == 'example.com'
+        assert data['buyerEmailDomains']['domainName'] == new_domain
+
+    @pytest.mark.parametrize(
+        'existing_domain', ['approved.gov.uk', 'already.approved.gov.uk', 'definitely-approved.gov.uk']
+    )
+    def test_higher_level_domain_can_be_created_if_more_specific_domain_already_exists(self, existing_domain):
+        with self.app.app_context():
+            db.session.add(BuyerEmailDomain(domain_name=existing_domain))
+            db.session.commit()
+
+        res = self.client.post(
+            '/buyer-email-domain',
+            data=json.dumps({
+                'buyerEmailDomains': {'domainName': 'gov.uk'},
+                'updated_by': 'example'
+            }),
+            content_type='application/json')
+        data = json.loads(res.get_data(as_text=True))
+
+        assert res.status_code == 201
+        assert data['buyerEmailDomains']['domainName'] == "gov.uk"
+
+    def test_create_buyer_email_domain_forces_to_lower_case(self):
+        res = self.client.post(
+            '/buyer-email-domain',
+            data=json.dumps({
+                'buyerEmailDomains': {'domainName': 'EXAMPLE.org'},
+                'updated_by': 'example'
+            }),
+            content_type='application/json')
+        data = json.loads(res.get_data(as_text=True))
+
+        assert res.status_code == 201
+        assert data['buyerEmailDomains']['domainName'] == "example.org"
 
     def test_create_buyer_email_domain_fails_if_required_field_is_not_provided(self):
         res = self.client.post(
@@ -36,16 +78,17 @@ class TestCreateBuyerEmailDomain(BaseApplicationTest):
         data = json.loads(res.get_data(as_text=True))
 
         assert res.status_code == 400
-        assert data['error'] == "Invalid JSON must have 'domainName' keys"
+        assert data['error'] == "Invalid JSON must have 'buyerEmailDomains' keys"
 
     def test_create_buyer_email_domain_creates_audit_event(self):
-        res = self.client.post(
+        self.client.post(
             '/buyer-email-domain',
             data=json.dumps({
-                'domainName': "example.com",
+                'buyerEmailDomains': {'domainName': "example.com"},
                 'updated_by': 'example user'
             }),
-            content_type='application/json')
+            content_type='application/json'
+        )
 
         with self.app.app_context():
             buyer_email_domain = BuyerEmailDomain.query.filter(
@@ -63,5 +106,38 @@ class TestCreateBuyerEmailDomain(BaseApplicationTest):
                 'buyerEmailDomainJson': {'domainName': 'example.com'}
             }
 
-    def test_create_buyer_email_domain_fails_if_domain_already_exists(self):
-        pass
+    @pytest.mark.parametrize(
+        'new_domain', ['no-dots', 'at@symbol.org', 'contains space.org', 'bad!char.org', 'tld-too-short.x']
+    )
+    def test_create_buyer_email_domain_fails_if_domain_invalid(self, new_domain):
+        res = self.client.post(
+            '/buyer-email-domain',
+            data=json.dumps({
+                'buyerEmailDomains': {'domainName': new_domain},
+                'updated_by': 'example'
+            }),
+            content_type='application/json')
+        data = json.loads(res.get_data())["error"]
+
+        assert res.status_code == 400
+        assert "JSON was not a valid format" in data
+
+    @pytest.mark.parametrize(
+        'new_domain', ['gov.uk', 'approved.gov.uk', 'already.approved.gov.uk', 'definitely-approved.gov.uk']
+    )
+    def test_create_buyer_email_domain_fails_if_higher_level_domain_already_approved(self, new_domain):
+        with self.app.app_context():
+            db.session.add(BuyerEmailDomain(domain_name='gov.uk'))
+            db.session.commit()
+
+        res = self.client.post(
+            '/buyer-email-domain',
+            data=json.dumps({
+                'buyerEmailDomains': {'domainName': new_domain},
+                'updated_by': 'example'
+            }),
+            content_type='application/json')
+        data = json.loads(res.get_data(as_text=True))
+
+        assert res.status_code == 409
+        assert data['error'] == "Domain name {} has already been approved".format(new_domain)

--- a/tests/main/views/test_buyer_domains.py
+++ b/tests/main/views/test_buyer_domains.py
@@ -16,8 +16,8 @@ class TestCreateBuyerEmailDomain(BaseApplicationTest):
 
         assert res.status_code == 400
 
-    @pytest.mark.parametrize('new_domain', ["fine.org", "also-fine.org", "also.fine.org"])
-    @pytest.mark.parametrize('existing_domain', ["ine.org", ".org", "o-fine.org"])
+    @pytest.mark.parametrize('new_domain', ["fine.org", "also-fine.org", "also.fine.org", "f.org"])
+    @pytest.mark.parametrize('existing_domain', ["ine.org", "o-fine.org"])
     def test_create_buyer_email_domain(self, existing_domain, new_domain):
         with self.app.app_context():
             # Create a domain that shouldn't result in 'already been approved'
@@ -108,7 +108,20 @@ class TestCreateBuyerEmailDomain(BaseApplicationTest):
             }
 
     @pytest.mark.parametrize(
-        'new_domain', ['no-dots', 'at@symbol.org', 'contains space.org', 'bad!char.org', 'tld-too-short.x']
+        'new_domain',
+        [
+            'no-dots',
+            'at@symbol.org',
+            'contains space.org',
+            'bad!char.org',
+            'ampers&nd.org',
+            'tld-too-short.x',
+            '.tldonly',
+            '.dots.at.start',
+            'http://contains.colon'
+            'contains.forward/slash',
+            'contains.rogue?query=param'
+        ]
     )
     def test_create_buyer_email_domain_fails_if_domain_invalid(self, new_domain):
         res = self.client.post(

--- a/tests/main/views/test_buyer_domains.py
+++ b/tests/main/views/test_buyer_domains.py
@@ -1,0 +1,67 @@
+import json
+
+from tests.bases import BaseApplicationTest
+from app.models import BuyerEmailDomain, AuditEvent
+
+
+class TestCreateBuyerEmailDomain(BaseApplicationTest):
+    def test_create_buyer_email_domain_with_no_data(self):
+        res = self.client.post(
+            '/buyer-email-domain',
+            content_type='application/json'
+        )
+
+        assert res.status_code == 400
+
+    def test_create_buyer_email_domain(self):
+        res = self.client.post(
+            '/buyer-email-domain',
+            data=json.dumps({
+                'domainName': "example.com",
+                'updated_by': 'example'
+            }),
+            content_type='application/json')
+        data = json.loads(res.get_data(as_text=True))
+
+        assert res.status_code == 201
+        assert data['buyer_email_domains']['domainName'] == 'example.com'
+
+    def test_create_buyer_email_domain_fails_if_required_field_is_not_provided(self):
+        res = self.client.post(
+            '/buyer-email-domain',
+            data=json.dumps({
+                'updated_by': 'example'
+            }),
+            content_type='application/json')
+        data = json.loads(res.get_data(as_text=True))
+
+        assert res.status_code == 400
+        assert data['error'] == "Invalid JSON must have 'domainName' keys"
+
+    def test_create_buyer_email_domain_creates_audit_event(self):
+        res = self.client.post(
+            '/buyer-email-domain',
+            data=json.dumps({
+                'domainName': "example.com",
+                'updated_by': 'example user'
+            }),
+            content_type='application/json')
+
+        with self.app.app_context():
+            buyer_email_domain = BuyerEmailDomain.query.filter(
+                BuyerEmailDomain.domain_name == "example.com"
+            ).first()
+
+            audit = AuditEvent.query.filter(
+                AuditEvent.object == buyer_email_domain
+            ).first()
+
+            assert audit.type == "create_buyer_email_domain"
+            assert audit.user == "example user"
+            assert audit.data == {
+                'buyerEmailDomainId': buyer_email_domain.id,
+                'buyerEmailDomainJson': {'domainName': 'example.com'}
+            }
+
+    def test_create_buyer_email_domain_fails_if_domain_already_exists(self):
+        pass

--- a/tests/models/test_buyer_domains.py
+++ b/tests/models/test_buyer_domains.py
@@ -1,0 +1,21 @@
+from app import db
+from app.models.buyer_domains import BuyerEmailDomain
+from tests.bases import BaseApplicationTest
+
+
+class TestBuyerEmailDomains(BaseApplicationTest):
+
+    def test_create_new_buyer_email_domain(self):
+        with self.app.app_context():
+
+            buyer_domain = BuyerEmailDomain(domain_name="superkalifrajilisticexpialidocious.org.uk")
+            db.session.add(buyer_domain)
+            db.session.commit()
+
+            assert buyer_domain.id is not None
+            assert buyer_domain.domain_name == "superkalifrajilisticexpialidocious.org.uk"
+
+    def test_buyer_email_domain_serialization(self):
+        buyer_domain = BuyerEmailDomain(domain_name="superkalifrajilisticexpialidocious.org.uk")
+
+        assert buyer_domain.serialize().keys() == {'id', 'domain_name'}

--- a/tests/models/test_buyer_domains.py
+++ b/tests/models/test_buyer_domains.py
@@ -8,14 +8,14 @@ class TestBuyerEmailDomains(BaseApplicationTest):
     def test_create_new_buyer_email_domain(self):
         with self.app.app_context():
 
-            buyer_domain = BuyerEmailDomain(domain_name="superkalifrajilisticexpialidocious.org.uk")
+            buyer_domain = BuyerEmailDomain(domain_name="superkalifragilisticexpialidocious.org.uk")
             db.session.add(buyer_domain)
             db.session.commit()
 
             assert buyer_domain.id is not None
-            assert buyer_domain.domain_name == "superkalifrajilisticexpialidocious.org.uk"
+            assert buyer_domain.domain_name == "superkalifragilisticexpialidocious.org.uk"
 
     def test_buyer_email_domain_serialization(self):
-        buyer_domain = BuyerEmailDomain(domain_name="superkalifrajilisticexpialidocious.org.uk")
+        buyer_domain = BuyerEmailDomain(domain_name="superkalifragilisticexpialidocious.org.uk")
 
         assert buyer_domain.serialize().keys() == {'id', 'domainName'}

--- a/tests/models/test_buyer_domains.py
+++ b/tests/models/test_buyer_domains.py
@@ -18,4 +18,4 @@ class TestBuyerEmailDomains(BaseApplicationTest):
     def test_buyer_email_domain_serialization(self):
         buyer_domain = BuyerEmailDomain(domain_name="superkalifrajilisticexpialidocious.org.uk")
 
-        assert buyer_domain.serialize().keys() == {'id', 'domain_name'}
+        assert buyer_domain.serialize().keys() == {'id', 'domainName'}


### PR DESCRIPTION
Trello ticket: https://trello.com/c/JxwDhnDh/82-migrate-existing-domain-check-to-use-database

- Add the `BuyerEmailDomain` model (used to generate the schema migration in PR 1) and a `serialize` method
- New route to create new `BuyerEmailDomain` objects
- Validate requests using JSON schema
- Ensure buyers with a domain already approved (either in the DB or the .txt file) can still create an account

NB This branch is based on the schema migration branch in order to make the tests pass, so the migration will be included in the diff until that gets merged. Travis will fail on this PR until the APIClient PR is merged. 

This is PR 3 out of 4.
PR 1: Schema migration alphagov/digitalmarketplace-api#672
PR 2: API Client https://github.com/alphagov/digitalmarketplace-apiclient/pull/102
PR 4: Data migration https://github.com/alphagov/digitalmarketplace-api/pull/675