### PR TITLE
Update project award endpoints for data tracking

### DIFF
--- a/app/main/views/direct_award.py
+++ b/app/main/views/direct_award.py
@@ -21,11 +21,8 @@ def list_projects():
 
     projects = DirectAwardProject.query
 
-    with_users = convert_to_boolean(request.args.get('with-users', False))
-    if not isinstance(with_users, bool):
-        abort(400, "with-users param must be True of False")
-
-    if with_users:
+    includes = request.args.get('include', '').split(',')
+    if 'users' in includes:
         projects = projects.options(db.joinedload('users').lazyload('supplier'))
 
     user_id = get_int_or_400(request.args, 'user-id')
@@ -46,7 +43,7 @@ def list_projects():
     )
 
     return jsonify(
-        projects=[project.serialize(with_users=with_users) for project in projects.items],
+        projects=[project.serialize(with_users='users' in includes) for project in projects.items],
         meta={
             "total": projects.total,
         },

--- a/app/main/views/direct_award.py
+++ b/app/main/views/direct_award.py
@@ -20,6 +20,11 @@ def list_projects():
     page = get_valid_page_or_1()
 
     projects = DirectAwardProject.query
+
+    with_users = convert_to_boolean(request.args.get('with-users', False))
+    if not isinstance(with_users, bool):
+        abort(400, "with-users param must be True of False")
+
     user_id = get_int_or_400(request.args, 'user-id')
     if user_id:
         projects = projects.filter(DirectAwardProject.users.any(id=user_id))
@@ -38,7 +43,7 @@ def list_projects():
     )
 
     return jsonify(
-        projects=[project.serialize() for project in projects.items],
+        projects=[project.serialize(with_users=with_users) for project in projects.items],
         meta={
             "total": projects.total,
         },

--- a/app/main/views/direct_award.py
+++ b/app/main/views/direct_award.py
@@ -22,7 +22,9 @@ def list_projects():
     projects = DirectAwardProject.query
 
     includes = request.args.get('include', '').split(',')
-    if 'users' in includes:
+
+    with_users = 'users' in includes
+    if with_users:
         projects = projects.options(db.joinedload('users').lazyload('supplier'))
 
     user_id = get_int_or_400(request.args, 'user-id')
@@ -43,7 +45,7 @@ def list_projects():
     )
 
     return jsonify(
-        projects=[project.serialize(with_users='users' in includes) for project in projects.items],
+        projects=[project.serialize(with_users=with_users) for project in projects.items],
         meta={
             "total": projects.total,
         },

--- a/app/main/views/direct_award.py
+++ b/app/main/views/direct_award.py
@@ -234,6 +234,7 @@ def list_project_services(project_id):
 
     project_archived_services = list(map(lambda service: {
         'id': service.service_id,
+        'projectId': project_id,
         'supplier': {
             'name': service.supplier.name,
             'contact': {

--- a/app/main/views/direct_award.py
+++ b/app/main/views/direct_award.py
@@ -25,6 +25,9 @@ def list_projects():
     if not isinstance(with_users, bool):
         abort(400, "with-users param must be True of False")
 
+    if with_users:
+        projects = projects.options(db.joinedload('users').lazyload('supplier'))
+
     user_id = get_int_or_400(request.args, 'user-id')
     if user_id:
         projects = projects.filter(DirectAwardProject.users.any(id=user_id))

--- a/tests/main/views/test_direct_award.py
+++ b/tests/main/views/test_direct_award.py
@@ -178,7 +178,7 @@ class TestDirectAwardListProjects(DirectAwardSetupAndTeardown):
             assert data['projects'][0] == DirectAwardProject.query.get(self.project_id).serialize()
 
     def test_returns_serialized_project_with_users_if_requested(self):
-        res = self.client.get('/direct-award/projects?with-users=true')
+        res = self.client.get('/direct-award/projects?include=users')
         data = json.loads(res.get_data(as_text=True))
 
         assert 'projects' in data
@@ -190,8 +190,8 @@ class TestDirectAwardListProjects(DirectAwardSetupAndTeardown):
             assert data['projects'][0]['users'][0]['id'] == \
                 DirectAwardProject.query.get(self.project_id).users[0].serialize()['id']
 
-    @pytest.mark.parametrize('param', ('?with-users=false', ''))
-    def test_returns_serialized_project_without_users_if_not_requested(self, param):
+    @pytest.mark.parametrize('param', ('?include=no-users', ''))
+    def test_returns_serialized_project_without_users_if_not_requested_correctly(self, param):
         res = self.client.get('/direct-award/projects{}'.format(param))
         data = json.loads(res.get_data(as_text=True))
 
@@ -199,13 +199,6 @@ class TestDirectAwardListProjects(DirectAwardSetupAndTeardown):
         assert data['meta']['total'] == 1
         assert len(data['projects']) == 1
         assert not data['projects'][0].get('users')
-
-    def test_returns_400_if_with_users_incorrectly_requested(self):
-        res = self.client.get('/direct-award/projects?with-users=some-rubbish')
-        data = json.loads(res.get_data(as_text=True))
-
-        assert res.status_code == 400
-        assert data == {'error': 'with-users param must be True of False'}
 
 
 class TestDirectAwardCreateProject(DirectAwardSetupAndTeardown):

--- a/tests/main/views/test_direct_award.py
+++ b/tests/main/views/test_direct_award.py
@@ -595,9 +595,8 @@ class TestDirectAwardListProjectServices(DirectAwardSetupAndTeardown):
             db.session.commit()
 
     def test_list_project_services_404s_on_invalid_project(self):
-        res = self.client.get('/direct-award/projects/{}/services?user-id={}'.format(sys.maxsize,
-                                                                                     self.search_id,
-                                                                                     self.user_id))
+        res = self.client.get('/direct-award/projects/{}/services'.format(sys.maxsize))
+
         assert res.status_code == 404
 
     def test_list_project_services_400s_on_unlocked_project(self):
@@ -608,9 +607,7 @@ class TestDirectAwardListProjectServices(DirectAwardSetupAndTeardown):
             db.session.add(project)
             db.session.commit()
 
-        res = self.client.get('/direct-award/projects/{}/services?user-id={}'.format(self.project_id,
-                                                                                     self.search_id,
-                                                                                     self.user_id))
+        res = self.client.get('/direct-award/projects/{}/services'.format(self.project_id))
         assert res.status_code == 400
 
     def test_list_project_services_400s_if_no_saved_search(self):


### PR DESCRIPTION
Part of this ticket: https://trello.com/c/eo8gJE4C

### Allow list projects with `with_users`
The `DirectAwardProject` model's serialize method has a `with_users`
parameter to include a projects users.

There was no way for this to be used on the `list_projects` view.

### Return projectId in list_project_services services
The services being returned by the `list_project_services` endpoint did
not include the project id associated with the request.

This made dealing with the data returned difficult, especially if making
multiple calls for different projects, such as when extracting data to
analyse.

This also updates the test of the response to assert that the data is
correct, and not just that the keys are in place.

### Test list_project_services returns requested fields
There was no test to ensure that the data specified in the fields param
was being returned in the service data.

### Remove unnecessary string params
The string formatting wasn't using one of the params, and the other was
requesting data that doesn't exist.
