### PR TITLE
Filtering Briefs by datestamp fields

### DIFF
--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -154,12 +154,13 @@ def list_briefs():
         status = "applications_closed" if status == "closed" else status  # Hack for 'closed' status
         day_value = datetime.strptime(request.args.get(status_date_key), "%Y-%m-%d")
         if temporal_filter == 'on':
-            day_end = datetime(day_value.year, day_value.month, day_value.day, 23, 59, 59)
-            briefs = briefs.has_date_field_between("{}_at".format(status), day_value, day_end, inclusive=True)
+            day_end = datetime(day_value.year, day_value.month, day_value.day, 23, 59, 59, 999999)
+            briefs = briefs.has_datetime_field_between("{}_at".format(status), day_value, day_end, inclusive=True)
         if temporal_filter == 'before':
-            briefs = briefs.has_date_field_before("{}_at".format(status), day_value)
+            briefs = briefs.has_datetime_field_before("{}_at".format(status), day_value)
         if temporal_filter == 'after':
-            briefs = briefs.has_date_field_after("{}_at".format(status), day_value)
+            day_end = datetime(day_value.year, day_value.month, day_value.day, 23, 59, 59, 999999)
+            briefs = briefs.has_datetime_field_after("{}_at".format(status), day_end)
 
     if user_id:
         return jsonify(

--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -143,6 +143,24 @@ def list_briefs():
             *(status.strip() for status in request.args['status'].split(','))
         )
 
+    status_filters = ['created', 'published', 'withdrawn', 'cancelled', 'unsuccessful', 'closed']
+    temporal_filters = ['on', 'before', 'after']
+    status_date_filters = [
+        '{}_{}'.format(status, temporal) for status in status_filters for temporal in temporal_filters
+    ]
+
+    for status_date_key in [arg for arg in request.args.keys() if arg in status_date_filters]:
+        status, temporal_filter = status_date_key.split('_')
+        status = "applications_closed" if status == "closed" else status  # Hack for 'closed' status
+        day_value = datetime.strptime(request.args.get(status_date_key), "%Y-%m-%d")
+        if temporal_filter == 'on':
+            day_end = datetime(day_value.year, day_value.month, day_value.day, 23, 59, 59)
+            briefs = briefs.has_date_field_between("{}_at".format(status), day_value, day_end, inclusive=True)
+        if temporal_filter == 'before':
+            briefs = briefs.has_date_field_before("{}_at".format(status), day_value)
+        if temporal_filter == 'after':
+            briefs = briefs.has_date_field_after("{}_at".format(status), day_value)
+
     if user_id:
         return jsonify(
             briefs=[brief.serialize(with_users, with_clarification_questions) for brief in briefs.all()],

--- a/app/models/main.py
+++ b/app/models/main.py
@@ -1371,9 +1371,6 @@ class Brief(db.Model):
         def has_statuses(self, *statuses):
             return self.filter(Brief.status.in_(statuses))
 
-        def data_key_contains_value(self, k, v):
-            return self.filter(Brief.data[k].astext.contains(u'"{}"'.format(v)))  # Postgres 9.3: use string matching
-
         def has_date_field_after(self, attr, start_date, inclusive=None):
             """Date filter values can be either strings or datetime objects."""
             if inclusive:

--- a/app/models/main.py
+++ b/app/models/main.py
@@ -1371,30 +1371,38 @@ class Brief(db.Model):
         def has_statuses(self, *statuses):
             return self.filter(Brief.status.in_(statuses))
 
-        def has_date_field_after(self, attr, start_date, inclusive=None):
-            """Date filter values can be either strings or datetime objects."""
+        def has_datetime_field_after(self, attr, start_datetime, inclusive=None):
+            """Date filter values should be datetime objects."""
+            if not isinstance(start_datetime, datetime):
+                raise ValueError('Datetime object required')
             if inclusive:
-                return self.filter(getattr(Brief, attr) >= str(start_date))
-            return self.filter(getattr(Brief, attr) > str(start_date))
+                return self.filter(getattr(Brief, attr) >= str(start_datetime))
+            return self.filter(getattr(Brief, attr) > str(start_datetime))
 
-        def has_date_field_before(self, attr, start_date, inclusive=None):
-            """Date filter values can be either strings or datetime objects."""
+        def has_datetime_field_before(self, attr, start_datetime, inclusive=None):
+            """Date filter values should be datetime objects."""
+            if not isinstance(start_datetime, datetime):
+                raise ValueError('Datetime object required')
             if inclusive:
-                return self.filter(getattr(Brief, attr) <= str(start_date))
-            return self.filter(getattr(Brief, attr) < str(start_date))
+                return self.filter(getattr(Brief, attr) <= str(start_datetime))
+            return self.filter(getattr(Brief, attr) < str(start_datetime))
 
-        def has_date_field_between(self, attr, start_date, end_date, inclusive=None):
+        def has_datetime_field_between(self, attr, start_datetime, end_datetime, inclusive=None):
             """
-            Date filter values can be either strings or datetime objects.
-            e.g. Brief.query.has_date_field_between('published_at', '2017-01-01', datetime(2017, 1, 2), inclusive=True)
-            would return briefs published between 2017-01-01T00:00:00.000000Z and 2017-01-02T00:00:00.000000Z.
+            Date filter values should be datetime objects. e.g.
+                Brief.query.has_date_field_between(
+                    'published_at', datetime(2017, 1, 1), datetime(2017, 1, 2, 23, 59, 59, 999999), inclusive=True
+                )
+            would return briefs published between 2017-01-01T00:00:00.000000Z and 2017-01-02T23:59:59.999999Z.
             """
+            if not (isinstance(start_datetime, datetime) and isinstance(end_datetime, datetime)):
+                raise ValueError('Datetime object required')
             if inclusive:
                 return self.filter(
-                    sql_and(getattr(Brief, attr) >= str(start_date), getattr(Brief, attr) <= str(end_date))
+                    sql_and(getattr(Brief, attr) >= str(start_datetime), getattr(Brief, attr) <= str(end_datetime))
                 )
             return self.filter(
-                sql_and(getattr(Brief, attr) > str(start_date), getattr(Brief, attr) < str(end_date))
+                sql_and(getattr(Brief, attr) > str(start_datetime), getattr(Brief, attr) < str(end_datetime))
             )
 
     def add_clarification_question(self, question, answer):

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -90,6 +90,7 @@ class FixtureMixin(object):
 
     def setup_dummy_brief(
         self, id=None, user_id=1, status=None, data=None, published_at=None, withdrawn_at=None,
+        cancelled_at=None, unsuccessful_at=None,
         framework_slug='digital-outcomes-and-specialists', lot_slug='digital-specialists',
         add_clarification_question=False
     ):
@@ -103,6 +104,12 @@ class FixtureMixin(object):
             elif status == 'withdrawn':
                 published_at = datetime.utcnow() - timedelta(days=1000)
                 withdrawn_at = datetime.utcnow()
+            elif status == 'cancelled':
+                published_at = datetime.utcnow() - timedelta(days=1000)
+                cancelled_at = datetime.utcnow()
+            elif status == 'unsuccessful':
+                published_at = datetime.utcnow() - timedelta(days=1000)
+                unsuccessful_at = datetime.utcnow()
             else:
                 published_at = None if status == 'draft' else datetime.utcnow()
         framework = Framework.query.filter(Framework.slug == framework_slug).first()
@@ -116,6 +123,8 @@ class FixtureMixin(object):
             users=[User.query.get(user_id)],
             published_at=published_at,
             withdrawn_at=withdrawn_at,
+            cancelled_at=cancelled_at,
+            unsuccessful_at=unsuccessful_at
         )
 
         db.session.add(brief)

--- a/tests/main/views/test_briefs.py
+++ b/tests/main/views/test_briefs.py
@@ -2,6 +2,7 @@ import json
 from datetime import datetime
 from datetime import timedelta
 
+from freezegun import freeze_time
 import pytest
 import mock
 from tests.helpers import COMPLETE_DIGITAL_SPECIALISTS_BRIEF, FixtureMixin, get_audit_events
@@ -9,7 +10,7 @@ from tests.bases import BaseApplicationTest
 
 from dmapiclient.audit import AuditTypes
 from app import db
-from app.models import Framework, BriefResponse
+from app.models import Framework, BriefResponse, Brief, Lot
 
 
 class FrameworkSetupAndTeardown(BaseApplicationTest, FixtureMixin):
@@ -712,6 +713,88 @@ class TestListBrief(FrameworkSetupAndTeardown):
 
         assert len(data['briefs']) == 7
         assert data['links'] == {}
+
+    @pytest.mark.parametrize('date_arg', ['published_on', 'withdrawn_on', 'cancelled_on', 'unsuccessful_on'])
+    def test_list_briefs_filter_by_single_day(self, date_arg):
+        for i, brief_status in enumerate(["draft", "withdrawn", "published", "cancelled", "unsuccessful"]):
+            with freeze_time('2017-01-01 00:00:00'):
+                self.setup_dummy_briefs(1, lot='digital-outcomes', status=brief_status, brief_start=i + 1)
+            with freeze_time('2017-01-01 23:59:59'):
+                self.setup_dummy_briefs(1, lot='digital-outcomes', status=brief_status, brief_start=i + 6)
+
+            # The following briefs should be outside the time span
+            with freeze_time('2016-12-31 23:59:59'):
+                self.setup_dummy_briefs(1, lot='digital-outcomes', status=brief_status, brief_start=i + 11)
+            with freeze_time('2017-01-02 00:00:00'):
+                self.setup_dummy_briefs(1, lot='digital-outcomes', status=brief_status, brief_start=i + 16)
+
+        res = self.client.get('/briefs?{}=2017-01-01'.format(date_arg))
+        data = json.loads(res.get_data(as_text=True))
+
+        assert res.status_code == 200
+        assert len(data['briefs']) == 2
+
+    @pytest.mark.parametrize(
+        'date_arg,expected_count',
+        [('published_before', 5), ('withdrawn_before', 1), ('cancelled_before', 1), ('unsuccessful_before', 1)]
+    )
+    def test_list_briefs_filter_before_date(self, date_arg, expected_count):
+        for i, brief_status in enumerate(["draft", "withdrawn", "published", "cancelled", "unsuccessful"]):
+            with freeze_time('2016-12-31 23:59:59'):
+                self.setup_dummy_briefs(1, lot='digital-outcomes', status=brief_status, brief_start=i + 1)
+            # The following briefs should be filtered out ('before' is not inclusive)
+            with freeze_time('2017-01-01 00:00:00'):
+                self.setup_dummy_briefs(1, lot='digital-outcomes', status=brief_status, brief_start=i + 6)
+
+        res = self.client.get('/briefs?{}=2017-01-01'.format(date_arg))
+        data = json.loads(res.get_data(as_text=True))
+
+        assert res.status_code == 200
+        # When setting statuses on our dummy Briefs, we also set an 'old' published_at date,
+        #  so there will be more results for the `published_before` query than the others.
+        assert len(data['briefs']) == expected_count
+
+    @pytest.mark.parametrize(
+        'date_arg', ['published_after', 'withdrawn_after', 'cancelled_after', 'unsuccessful_after']
+    )
+    def test_list_briefs_filter_after_date(self, date_arg):
+        for i, brief_status in enumerate(["draft", "withdrawn", "published", "cancelled", "unsuccessful"]):
+            with freeze_time('2017-01-01 00:00:01'):
+                self.setup_dummy_briefs(1, lot='digital-outcomes', status=brief_status, brief_start=i + 1)
+            # The following briefs should be filtered out ('after' is not inclusive)
+            with freeze_time('2017-01-01 00:00:00'):
+                self.setup_dummy_briefs(1, lot='digital-outcomes', status=brief_status, brief_start=i + 6)
+
+        res = self.client.get('/briefs?{}=2017-01-01'.format(date_arg))
+        data = json.loads(res.get_data(as_text=True))
+
+        assert res.status_code == 200
+        assert len(data['briefs']) == 1
+
+    @pytest.mark.parametrize('temporal_arg, expected_count', [('before', 1), ('on', 2), ('after', 3)])
+    def test_list_briefs_filter_closed_briefs_by_date(self, temporal_arg, expected_count):
+        # Closed briefs need to be set up differently, so this test covers all 3 before/after/on cases
+        with self.app.app_context():
+            framework = Framework.query.filter(Framework.slug == 'digital-outcomes-and-specialists').first()
+            lot = Lot.query.filter(Lot.slug == 'digital-specialists').first()
+
+            with freeze_time('2017-01-01 23:59:59'):
+                brief1 = Brief(data={}, framework=framework, lot=lot, published_at=datetime.utcnow())
+            with freeze_time('2017-01-02 00:00:00'):
+                brief2 = Brief(data={}, framework=framework, lot=lot, published_at=datetime.utcnow())
+            with freeze_time('2017-01-02 23:59:59'):
+                brief3 = Brief(data={}, framework=framework, lot=lot, published_at=datetime.utcnow())
+            with freeze_time('2017-01-03 00:00:00'):
+                brief4 = Brief(data={}, framework=framework, lot=lot, published_at=datetime.utcnow())
+
+            db.session.add_all([brief1, brief2, brief3, brief4])
+            db.session.commit()
+
+        res = self.client.get('/briefs?closed_{}=2017-01-16'.format(temporal_arg))
+        data = json.loads(res.get_data(as_text=True))
+
+        assert res.status_code == 200
+        assert len(data['briefs']) == expected_count
 
 
 class TestUpdateBriefStatus(FrameworkSetupAndTeardown):

--- a/tests/main/views/test_briefs.py
+++ b/tests/main/views/test_briefs.py
@@ -719,11 +719,11 @@ class TestListBrief(FrameworkSetupAndTeardown):
         for i, brief_status in enumerate(["draft", "withdrawn", "published", "cancelled", "unsuccessful"]):
             with freeze_time('2017-01-01 00:00:00'):
                 self.setup_dummy_briefs(1, lot='digital-outcomes', status=brief_status, brief_start=i + 1)
-            with freeze_time('2017-01-01 23:59:59'):
+            with freeze_time('2017-01-01 23:59:59.999999'):
                 self.setup_dummy_briefs(1, lot='digital-outcomes', status=brief_status, brief_start=i + 6)
 
             # The following briefs should be outside the time span
-            with freeze_time('2016-12-31 23:59:59'):
+            with freeze_time('2016-12-31 23:59:59.999999'):
                 self.setup_dummy_briefs(1, lot='digital-outcomes', status=brief_status, brief_start=i + 11)
             with freeze_time('2017-01-02 00:00:00'):
                 self.setup_dummy_briefs(1, lot='digital-outcomes', status=brief_status, brief_start=i + 16)
@@ -740,7 +740,7 @@ class TestListBrief(FrameworkSetupAndTeardown):
     )
     def test_list_briefs_filter_before_date(self, date_arg, expected_count):
         for i, brief_status in enumerate(["draft", "withdrawn", "published", "cancelled", "unsuccessful"]):
-            with freeze_time('2016-12-31 23:59:59'):
+            with freeze_time('2016-12-31 23:59:59.999999'):
                 self.setup_dummy_briefs(1, lot='digital-outcomes', status=brief_status, brief_start=i + 1)
             # The following briefs should be filtered out ('before' is not inclusive)
             with freeze_time('2017-01-01 00:00:00'):
@@ -759,10 +759,10 @@ class TestListBrief(FrameworkSetupAndTeardown):
     )
     def test_list_briefs_filter_after_date(self, date_arg):
         for i, brief_status in enumerate(["draft", "withdrawn", "published", "cancelled", "unsuccessful"]):
-            with freeze_time('2017-01-01 00:00:01'):
+            with freeze_time('2017-01-02 00:00:00'):
                 self.setup_dummy_briefs(1, lot='digital-outcomes', status=brief_status, brief_start=i + 1)
             # The following briefs should be filtered out ('after' is not inclusive)
-            with freeze_time('2017-01-01 00:00:00'):
+            with freeze_time('2017-01-01 23:59:59.999999'):
                 self.setup_dummy_briefs(1, lot='digital-outcomes', status=brief_status, brief_start=i + 6)
 
         res = self.client.get('/briefs?{}=2017-01-01'.format(date_arg))
@@ -771,18 +771,18 @@ class TestListBrief(FrameworkSetupAndTeardown):
         assert res.status_code == 200
         assert len(data['briefs']) == 1
 
-    @pytest.mark.parametrize('temporal_arg, expected_count', [('before', 1), ('on', 2), ('after', 3)])
+    @pytest.mark.parametrize('temporal_arg, expected_count', [('before', 1), ('on', 2), ('after', 1)])
     def test_list_briefs_filter_closed_briefs_by_date(self, temporal_arg, expected_count):
         # Closed briefs need to be set up differently, so this test covers all 3 before/after/on cases
         with self.app.app_context():
             framework = Framework.query.filter(Framework.slug == 'digital-outcomes-and-specialists').first()
             lot = Lot.query.filter(Lot.slug == 'digital-specialists').first()
 
-            with freeze_time('2017-01-01 23:59:59'):
+            with freeze_time('2017-01-01 23:59:59.999999'):
                 brief1 = Brief(data={}, framework=framework, lot=lot, published_at=datetime.utcnow())
             with freeze_time('2017-01-02 00:00:00'):
                 brief2 = Brief(data={}, framework=framework, lot=lot, published_at=datetime.utcnow())
-            with freeze_time('2017-01-02 23:59:59'):
+            with freeze_time('2017-01-02 23:59:59.999999'):
                 brief3 = Brief(data={}, framework=framework, lot=lot, published_at=datetime.utcnow())
             with freeze_time('2017-01-03 00:00:00'):
                 brief4 = Brief(data={}, framework=framework, lot=lot, published_at=datetime.utcnow())

--- a/tests/models/test_main.py
+++ b/tests/models/test_main.py
@@ -565,27 +565,6 @@ class TestBriefQueries(BaseApplicationTest, FixtureMixin):
             db.session.commit()
             assert Brief.query.filter(Brief.applications_closed_at == datetime(2016, 3, 17, 23, 59, 59)).count() == 3
 
-    def test_query_brief_by_data_key_contains_value(self):
-        with self.app.app_context():
-            db.session.add_all(
-                [
-                    Brief(data={'key1': ['foo1', 'foo2'], 'key2': ['bar1']}, framework=self.framework, lot=self.lot),
-                    Brief(data={'key1': ['foo1', 'foo3']}, framework=self.framework, lot=self.lot)
-                ]
-            )
-            db.session.commit()
-            briefs = Brief.query.data_key_contains_value('key1', 'foo1')
-            assert briefs.count() == 2
-
-            briefs = Brief.query.data_key_contains_value('key2', 'bar1')
-            assert briefs.count() == 1
-
-            briefs = Brief.query.data_key_contains_value('key1', 'bar1')
-            assert briefs.count() == 0
-
-            briefs = Brief.query.data_key_contains_value('missing_key', 'foo1')
-            assert briefs.count() == 0
-
     # TODO: add cases for querying created_at/updated_at auto timestamps with freeze_time
 
     @pytest.mark.parametrize('inclusive,expected_count', [(True, 2), (False, 1)])

--- a/tests/models/test_main.py
+++ b/tests/models/test_main.py
@@ -568,40 +568,43 @@ class TestBriefQueries(BaseApplicationTest, FixtureMixin):
     # TODO: add cases for querying created_at/updated_at auto timestamps with freeze_time
 
     @pytest.mark.parametrize('inclusive,expected_count', [(True, 2), (False, 1)])
-    @pytest.mark.parametrize('date_format', ["2017-01-01", datetime(2017, 1, 1, 0, 0, 0)])
     @pytest.mark.parametrize('datestamp_attr', ['published_at', 'withdrawn_at', 'cancelled_at', 'unsuccessful_at'])
-    def test_query_brief_has_date_field_before_and_after(self, datestamp_attr, date_format, inclusive, expected_count):
+    def test_query_brief_has_datetime_field_before_and_after(self, datestamp_attr, inclusive, expected_count):
         with self.app.app_context():
             new_briefs = [Brief(data={}, framework=self.framework, lot=self.lot) for i in range(3)]
-            setattr(new_briefs[0], datestamp_attr, datetime(2016, 12, 31, 23, 59, 59))  # < date
+            setattr(new_briefs[0], datestamp_attr, datetime(2016, 12, 31, 23, 59, 59, 999999))  # < date
             setattr(new_briefs[1], datestamp_attr, datetime(2017, 1, 1, 0, 0, 0))  # <= and >= date
             setattr(new_briefs[2], datestamp_attr, datetime(2017, 1, 1, 0, 0, 1))  # > date
 
             db.session.add_all(new_briefs)
             db.session.commit()
 
-            briefs_before = Brief.query.has_date_field_before(
-                datestamp_attr, start_date=date_format, inclusive=inclusive
+            briefs_before = Brief.query.has_datetime_field_before(
+                datestamp_attr, start_datetime=datetime(2017, 1, 1, 0, 0, 0), inclusive=inclusive
             )
             assert briefs_before.count() == expected_count
 
-            briefs_after = Brief.query.has_date_field_after(
-                datestamp_attr, start_date=date_format, inclusive=inclusive
+            briefs_after = Brief.query.has_datetime_field_after(
+                datestamp_attr, start_datetime=datetime(2017, 1, 1, 0, 0, 0), inclusive=inclusive
             )
             assert briefs_after.count() == expected_count
 
+    def test_query_brief_has_datetime_field_before_requires_datetime(self):
+        with self.app.app_context(), pytest.raises(ValueError) as e:
+            Brief.query.has_datetime_field_before('published_on', start_datetime='2017-01-01')
+        assert str(e.value) == 'Datetime object required'
+
+    def test_query_brief_has_datetime_field_after_requires_datetime(self):
+        with self.app.app_context(), pytest.raises(ValueError) as e:
+            Brief.query.has_datetime_field_after('published_on', start_datetime='2017-01-01')
+        assert str(e.value) == 'Datetime object required'
+
     @pytest.mark.parametrize('inclusive,expected_count', [(True, 2), (False, 0)])
-    @pytest.mark.parametrize(
-        'start_date,end_date', [
-            ("2017-01-01", "2017-01-03"),
-            (datetime(2017, 1, 1, 0, 0, 0), datetime(2017, 1, 3, 0, 0, 0)),
-        ]
-    )
     @pytest.mark.parametrize('datestamp_attr', ['published_at', 'withdrawn_at', 'cancelled_at', 'unsuccessful_at'])
-    def test_query_brief_has_date_field_between(self, datestamp_attr, start_date, end_date, inclusive, expected_count):
+    def test_query_brief_has_datetime_field_between(self, datestamp_attr, inclusive, expected_count):
         with self.app.app_context():
             new_briefs = [Brief(data={}, framework=self.framework, lot=self.lot) for i in range(4)]
-            setattr(new_briefs[0], datestamp_attr, datetime(2016, 12, 31, 23, 59, 59))  # < date range
+            setattr(new_briefs[0], datestamp_attr, datetime(2016, 12, 31, 23, 59, 59, 999999))  # < date range
             setattr(new_briefs[1], datestamp_attr, datetime(2017, 1, 1, 0, 0, 0))  # <= date range
             setattr(new_briefs[2], datestamp_attr, datetime(2017, 1, 3, 0, 0, 0))  # >= date range
             setattr(new_briefs[3], datestamp_attr, datetime(2017, 1, 3, 0, 0, 1))  # > date range
@@ -609,10 +612,23 @@ class TestBriefQueries(BaseApplicationTest, FixtureMixin):
             db.session.add_all(new_briefs)
             db.session.commit()
 
-            briefs = Brief.query.has_date_field_between(
-                datestamp_attr, start_date=start_date, end_date=end_date, inclusive=inclusive
+            briefs = Brief.query.has_datetime_field_between(
+                datestamp_attr,
+                start_datetime=datetime(2017, 1, 1, 0, 0, 0),
+                end_datetime=datetime(2017, 1, 3, 0, 0, 0),
+                inclusive=inclusive
             )
             assert briefs.count() == expected_count
+
+    @pytest.mark.parametrize(
+        'start_date,end_date', [
+            ('2017-01-01', datetime(2017, 1, 2)), (datetime(2017, 1, 1), '2017-01-02'), ('2017-01-01', '2017-01-03'),
+        ]
+    )
+    def test_query_brief_has_datetime_field_between_requires_datetime(self, start_date, end_date):
+        with self.app.app_context(), pytest.raises(ValueError) as e:
+            Brief.query.has_datetime_field_between('published_at', start_datetime=start_date, end_datetime=end_date)
+        assert str(e.value) == 'Datetime object required'
 
 
 class TestAwardedBriefs(BaseApplicationTest, FixtureMixin):


### PR DESCRIPTION
A lot of our scripts involve getting Briefs that closed on a certain day. This involves querying the API for Briefs by 'closed' status, then applying a date filter to the query result in Python. 

I thought it would be nice to be able to filter Briefs by their date fields with an API call. We rarely need to query for a specific datestamp, it's usually 'Briefs closed/published on day X'.

This PR introduces some new `query_class` methods:
- ~~`data_key_contains_value` to filter by any top level key list in `Brief.data` (copied wholesale from the Service model)~~ we're not using this, let's get rid of it
- `has_date_field_between` which will accept either date strings or datetime objects, and filter the Brief's date attributes (currently `created_at`, `updated_at`, `published_at`, `cancelled_at`, `unsuccessful_at`, `withdrawn_at`). 
- equivalent `has_date_field_before` and `has_date_field_after` which are hopefully self explanatory. 

The date filter methods have an `inclusive` flag (defaults to False).

(NB there is no `awarded_at` attribute on the Brief model - this is on the BriefResponse model.)

The `list_briefs` view makes use of these query class methods by accepting the following GET parameters: 'created_on', 'published_on', 'withdrawn_on', 'cancelled_on', 'unsuccessful_on'. Note the `_on` suffix, to differentiate from `_at` - the value we're supplying is a single day in `YYYY-MM-DD` format, not a datestamp or date range (I am not about to write a new API syntax for that!). 

**UPDATE: ** The view now accepts `foo_after` and `foo_before` args! 🎉 

For example: `GET /briefs?closed_on=2017-01-01` will return all Briefs with an `applications_closed_at` attribute between 2017-01-01 00:00:00 and 2017-01-01 23:59:59.

There are some TODOs:
- ~~We can't filter explicitly by `closed_on` yet, because it could be 1 or 2 weeks after the published date. But we'd know it would be one of two `published_on` dates, either 1 or 2 weeks previously, which might help us avoid making 117 paginated API calls in order to get 1 or 2 briefs.~~ DONE
- Missing test cases for the `created_at` and `updated_at` queries, for some reason `freeze_time` isn't working
- ~~Filtering on non-list types in `Brief.data` is untested (and probably won't work yet)~~ Not going to do this

Thoughts welcome.