### PR TITLE
Update awarded contract value schemas to only take 0 or 2 d.p.

### DIFF
--- a/json_schemas/brief-awards-digital-outcomes-and-specialists-2-digital-outcomes.json
+++ b/json_schemas/brief-awards-digital-outcomes-and-specialists-2-digital-outcomes.json
@@ -7,7 +7,7 @@
       "type": "string"
     },
     "awardedContractValue": {
-      "pattern": "^\\d{1,15}(?:\\.\\d{1,5})?$",
+      "pattern": "^[1-9](?:\\d{1,14})?(?:\\.\\d{2})?$|^0\\.(?!00)\\d{2}$",
       "type": "string"
     }
   },

--- a/json_schemas/brief-awards-digital-outcomes-and-specialists-2-digital-specialists.json
+++ b/json_schemas/brief-awards-digital-outcomes-and-specialists-2-digital-specialists.json
@@ -7,7 +7,7 @@
       "type": "string"
     },
     "awardedContractValue": {
-      "pattern": "^\\d{1,15}(?:\\.\\d{1,5})?$",
+      "pattern": "^[1-9](?:\\d{1,14})?(?:\\.\\d{2})?$|^0\\.(?!00)\\d{2}$",
       "type": "string"
     }
   },

--- a/json_schemas/brief-awards-digital-outcomes-and-specialists-2-user-research-participants.json
+++ b/json_schemas/brief-awards-digital-outcomes-and-specialists-2-user-research-participants.json
@@ -7,7 +7,7 @@
       "type": "string"
     },
     "awardedContractValue": {
-      "pattern": "^\\d{1,15}(?:\\.\\d{1,5})?$",
+      "pattern": "^[1-9](?:\\d{1,14})?(?:\\.\\d{2})?$|^0\\.(?!00)\\d{2}$",
       "type": "string"
     }
   },

--- a/json_schemas/brief-awards-digital-outcomes-and-specialists-digital-outcomes.json
+++ b/json_schemas/brief-awards-digital-outcomes-and-specialists-digital-outcomes.json
@@ -7,7 +7,7 @@
       "type": "string"
     },
     "awardedContractValue": {
-      "pattern": "^\\d{1,15}(?:\\.\\d{1,5})?$",
+      "pattern": "^[1-9](?:\\d{1,14})?(?:\\.\\d{2})?$|^0\\.(?!00)\\d{2}$",
       "type": "string"
     }
   },

--- a/json_schemas/brief-awards-digital-outcomes-and-specialists-digital-specialists.json
+++ b/json_schemas/brief-awards-digital-outcomes-and-specialists-digital-specialists.json
@@ -7,7 +7,7 @@
       "type": "string"
     },
     "awardedContractValue": {
-      "pattern": "^\\d{1,15}(?:\\.\\d{1,5})?$",
+      "pattern": "^[1-9](?:\\d{1,14})?(?:\\.\\d{2})?$|^0\\.(?!00)\\d{2}$",
       "type": "string"
     }
   },

--- a/json_schemas/brief-awards-digital-outcomes-and-specialists-user-research-participants.json
+++ b/json_schemas/brief-awards-digital-outcomes-and-specialists-user-research-participants.json
@@ -7,7 +7,7 @@
       "type": "string"
     },
     "awardedContractValue": {
-      "pattern": "^\\d{1,15}(?:\\.\\d{1,5})?$",
+      "pattern": "^[1-9](?:\\d{1,14})?(?:\\.\\d{2})?$|^0\\.(?!00)\\d{2}$",
       "type": "string"
     }
   },


### PR DESCRIPTION
https://trello.com/c/PHnolEgP/16-change-money-format-on-awarding-a-brief-to-be-pounds-and-pence

Users had previously been able to say that a contract was worth £8.105. This should not be allowed. Instead we only allow positive numbers with 0 or 2 decimal places e.g £8 or £8.10. The rest of our pricing fields remain the same and take up to 5dp.

These schemas have been generated by the frameworks repo PR - https://github.com/alphagov/digitalmarketplace-frameworks/pull/477