### PR TITLE
Repair super: wrong method super'd

### DIFF
--- a/tests/main/views/test_services.py
+++ b/tests/main/views/test_services.py
@@ -1678,7 +1678,7 @@ class TestGetService(BaseApplicationTest):
 
 @mock.patch('app.service_utils.search_api_client', autospec=True)
 class TestRevertService(BaseApplicationTest, FixtureMixin):
-    def setup_method(self, method):
+    def setup(self):
         super(TestRevertService, self).setup()
         with self.app.app_context():
             self.set_framework_status("g-cloud-7", "live")


### PR DESCRIPTION
So this isn't really broken but it does do something weird.
When pytest runs its test classes it looks for a setup_method method and runs it before every test_ method in the class. As backwards compatibility with unittest it also looks for a setup method and runs that.
Our base classes use the old setup method to set up the app, client etc.

So for this test pytest will:
Run setup_method first which is using super to call self.setup()
Then pytest runs setup
Then test_x

The code in the setup for this class needs to be run after the base class setup so it can't go in setup_method so if we change the name to setup pytest will pick it up, we can super the base class setup and then the rest of the code runs after the base class setup. 💯