### PR TITLE
Push context in tests

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -177,8 +177,8 @@ def revert_service(service_id):
     if archived_service.service_id != service_id:
         abort(400, "ArchivedService does not correspond to this service id")
 
+    validate_service_data(archived_service)
     service.data = archived_service.data.copy()
-    validate_service_data(service)
 
     commit_and_archive_service(
         service,

--- a/tests/bases.py
+++ b/tests/bases.py
@@ -25,18 +25,20 @@ class BaseApplicationTest(object):
             self.app.wsgi_app,
             HTTP_AUTHORIZATION='Bearer {}'.format(self.app.config['DM_API_AUTH_TOKENS'])
         )
+        self.ctx = self.app.app_context()
+        self.ctx.push()
         self.client = self.app.test_client()
 
     def teardown(self):
-        with self.app.app_context():
-            db.session.remove()
-            for table in reversed(db.metadata.sorted_tables):
-                if table.name not in ["lots", "frameworks", "framework_lots"]:
-                    db.engine.execute(table.delete())
-            FrameworkLot.query.filter(FrameworkLot.framework_id >= 100).delete()
-            Framework.query.filter(Framework.id >= 100).delete()
-            db.session.commit()
-            db.get_engine(self.app).dispose()
+        db.session.remove()
+        for table in reversed(db.metadata.sorted_tables):
+            if table.name not in ["lots", "frameworks", "framework_lots"]:
+                db.engine.execute(table.delete())
+        FrameworkLot.query.filter(FrameworkLot.framework_id >= 100).delete()
+        Framework.query.filter(Framework.id >= 100).delete()
+        db.session.commit()
+        db.get_engine(self.app).dispose()
+        self.ctx.pop()
 
 
 class JSONTestMixin(object):

--- a/tests/main/views/test_brief_response.py
+++ b/tests/main/views/test_brief_response.py
@@ -429,6 +429,7 @@ class TestUpdateBriefResponse(BaseBriefResponseTest):
                     "UPDATE frameworks SET status=:status WHERE slug='digital-outcomes-and-specialists'",
                     {'status': framework_status},
                 )
+                db.session.commit()
 
                 res = self._update_brief_response(
                     self.brief_response_id,

--- a/tests/models/test_main.py
+++ b/tests/models/test_main.py
@@ -728,7 +728,6 @@ class TestCopyBrief(BaseApplicationTest, FixtureMixin):
 
     def setup(self, *args, **kwargs):
         super(TestCopyBrief, self).setup(*args, **kwargs)
-        self.app.app_context().push()
         self.setup_dummy_user(role='buyer')
         self.framework = Framework.query.filter(
             Framework.slug == 'digital-outcomes-and-specialists',


### PR DESCRIPTION
If we add this in the setup we can later remove all the instances of `with self.app.context():` and access objects that are created within tests throughout the entire test instead of needing to enter and exit the context to access the objects we create. This has broad implications for setups, fixtures and factories. Making them accessible as part of a 'test-wide' context.

This will make writing tests cleaner and easier hopefully faster by:
* Making it possible to attach objects to a class in a `setup` method and access them in tests
* Reducing database calls
* Reducing unneeded lines of code and indentation
* Easing the implementation of factory boy factories

See documentation here for naming convention and how this works:
http://flask.pocoo.org/docs/0.12/reqcontext/#diving-into-context-locals