### PR TITLE
 Change brief_response editing validation to use brief status

### DIFF
--- a/app/main/views/brief_responses.py
+++ b/app/main/views/brief_responses.py
@@ -106,8 +106,8 @@ def update_brief_response(brief_response_id):
     if not brief_service:
         abort(400, "Supplier is not eligible to apply to this brief")
 
-    if brief_response.status != 'draft':
-        abort(400, "Brief response must be a draft")
+    if brief.status is not 'live':
+        abort(400, "Brief must have 'live' status for the brief response to be updated")
 
     if brief.framework.status not in ['live', 'expired']:
         abort(400, "Brief framework must be live or expired")
@@ -155,8 +155,8 @@ def submit_brief_response(brief_response_id):
     if not brief_service:
         abort(400, "Supplier is not eligible to apply to this brief")
 
-    if brief_response.status != 'draft':
-        abort(400, "Brief response must be a draft")
+    if brief.status is not 'live':
+        abort(400, "Brief must have 'live' status for the brief response to be submitted")
 
     if brief.framework.status not in ['live', 'expired']:
         abort(400, "Brief framework must be live or expired")


### PR DESCRIPTION
Earlier the brief response could only be edited if it had draft status. Now we are introducing a new feature that allows suppliers to edit submitted brief responses while the brief is live, so the validation system needed updating.

Trello ticket for the new feature: https://trello.com/c/kQpbazwt/85-allow-suppliers-edit-submitted-application-if-opportunity-is-still-open