### PR TITLE
Add an external ID to the Direct Award Project/'saved search' table

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,8 @@ test-requirements:
 	         echo "Run 'make freeze-requirements' to update."; exit 1; } \
 	    || { echo "requirements.txt is up to date"; exit 0; }
 
-.PHONY test-flake8: virtualenv
+.PHONY: test-flake8
+test-flake8: virtualenv
 	${VIRTUALENV_ROOT}/bin/flake8 .
 
 .PHONY: test-migrations

--- a/app/main/views/direct_award.py
+++ b/app/main/views/direct_award.py
@@ -11,8 +11,23 @@ from ... import db
 from ...models import User, AuditEvent, ArchivedService
 from ...models.direct_award import DirectAwardProject, DirectAwardSearch
 from ...utils import (
-    get_json_from_request, get_int_or_400, json_has_required_keys, pagination_links,
-    get_valid_page_or_1, validate_and_return_updater_request, drop_all_other_fields)
+    drop_all_other_fields,
+    get_int_or_400,
+    get_json_from_request,
+    get_valid_page_or_1,
+    json_has_required_keys,
+    pagination_links,
+    validate_and_return_updater_request,
+)
+
+
+def get_project_by_id_or_404(project_id: int):
+    """During the transitional period, project_id may be either the internal or the public ID of the project."""
+    project = DirectAwardProject.query.filter(DirectAwardProject.id == project_id).first()
+    if project:
+        return project
+
+    return DirectAwardProject.query.filter(DirectAwardProject.external_id == project_id).first_or_404()
 
 
 @main.route('/direct-award/projects', methods=['GET'])
@@ -71,20 +86,28 @@ def create_project():
     if user is None:
         abort(400, "User ID not supplied")
 
-    project = DirectAwardProject(name=project_json['name'], users=[user])
-    db.session.add(project)
+    retries = 0
+    while True:
+        project = DirectAwardProject(name=project_json['name'], users=[user])
+        db.session.add(project)
 
-    try:
-        db.session.flush()
-    except IntegrityError as e:
-        db.session.rollback()
-        abort(400, e.orig)
+        try:
+            db.session.flush()
+            break
+
+        except IntegrityError as e:
+            current_app.logger.warning("Project ID collision on {}".format(project.external_id))
+            db.session.rollback()
+
+            retries += 1
+            if retries >= 5:
+                abort(400, str(e.orig))
 
     audit = AuditEvent(
         audit_type=AuditTypes.create_project,
         user=updater_json['updated_by'],
         data={
-            'projectId': project.id,
+            'projectExternalId': project.external_id,
             'projectJson': project_json,
         },
         db_object=project,
@@ -96,21 +119,20 @@ def create_project():
     return jsonify(project=project.serialize()), 201
 
 
-@main.route('/direct-award/projects/<int:project_id>', methods=['GET'])
-def get_project(project_id):
-    project = DirectAwardProject.query.filter(DirectAwardProject.id == project_id).first_or_404()
+@main.route('/direct-award/projects/<int:project_external_id>', methods=['GET'])
+def get_project(project_external_id):
+    project = get_project_by_id_or_404(project_external_id)
 
     return jsonify(project=project.serialize(with_users=True))
 
 
-@main.route('/direct-award/projects/<int:project_id>/searches', methods=['GET'])
-def list_project_searches(project_id):
-    # If the project doesn't exist, we should 404 early.
-    DirectAwardProject.query.filter(DirectAwardProject.id == project_id).first_or_404()
+@main.route('/direct-award/projects/<int:project_external_id>/searches', methods=['GET'])
+def list_project_searches(project_external_id):
+    project = get_project_by_id_or_404(project_external_id)
 
     page = get_valid_page_or_1()
 
-    searches = DirectAwardSearch.query.filter(DirectAwardSearch.project_id == project_id)
+    searches = DirectAwardSearch.query.filter(DirectAwardSearch.project_id == project.id)
 
     if 'latest-first' in request.args:
         if convert_to_boolean(request.args.get('latest-first')):
@@ -129,7 +151,7 @@ def list_project_searches(project_id):
     )
 
     pagination_params = request.args.to_dict()
-    pagination_params['project_id'] = project_id
+    pagination_params['project_external_id'] = project.external_id
 
     return jsonify(
         searches=[search.serialize() for search in searches.items],
@@ -144,12 +166,11 @@ def list_project_searches(project_id):
     )
 
 
-@main.route('/direct-award/projects/<int:project_id>/searches', methods=['POST'])
-def create_project_search(project_id):
+@main.route('/direct-award/projects/<int:project_external_id>/searches', methods=['POST'])
+def create_project_search(project_external_id):
     updater_json = validate_and_return_updater_request()
 
-    # If the project doesn't exist, we should 404 early.
-    DirectAwardProject.query.filter(DirectAwardProject.id == project_id).first_or_404()
+    project = get_project_by_id_or_404(project_external_id)
 
     json_payload = get_json_from_request()
     json_has_required_keys(json_payload, ['search'])
@@ -163,9 +184,9 @@ def create_project_search(project_id):
 
     # TODO: Validate user has authorisation to access resource.
 
-    db.session.query(DirectAwardSearch).filter(DirectAwardSearch.project_id == project_id).\
+    db.session.query(DirectAwardSearch).filter(DirectAwardSearch.project_id == project.id).\
         update({DirectAwardSearch.active: False})
-    search = DirectAwardSearch(created_by=user.id, project_id=project_id,
+    search = DirectAwardSearch(created_by=user.id, project_id=project.id,
                                search_url=search_json['searchUrl'], active=True)
 
     db.session.add(search)
@@ -181,7 +202,8 @@ def create_project_search(project_id):
         audit_type=AuditTypes.create_project_search,
         user=updater_json['updated_by'],
         data={
-            'projectId': project_id,
+            'projectId': project.id,
+            'projectExternalId': project.external_id,
             'searchJson': search_json,
         },
         db_object=search,
@@ -193,21 +215,20 @@ def create_project_search(project_id):
     return jsonify(search=search.serialize()), 201
 
 
-@main.route('/direct-award/projects/<int:project_id>/searches/<int:search_id>', methods=['GET'])
-def get_project_search(project_id, search_id):
-    # If the project doesn't exist, we should 404 early.
-    DirectAwardProject.query.filter(DirectAwardProject.id == project_id).first_or_404()
+@main.route('/direct-award/projects/<int:project_external_id>/searches/<int:search_id>', methods=['GET'])
+def get_project_search(project_external_id, search_id):
+    project = get_project_by_id_or_404(project_external_id)
 
     search = DirectAwardSearch.query.filter(
         DirectAwardSearch.id == search_id,
-        DirectAwardSearch.project_id == project_id
+        DirectAwardSearch.project_id == project.id
     ).first_or_404()
 
     return jsonify(search=search.serialize())
 
 
-@main.route('/direct-award/projects/<int:project_id>/services', methods=['GET'])
-def list_project_services(project_id):
+@main.route('/direct-award/projects/<int:project_external_id>/services', methods=['GET'])
+def list_project_services(project_external_id):
     """This endpoint returns all the services associated with a particular (locked) Direct Award Project. It returns
     some fairly arbitrary data which is obviously not ideal, but as we don't have a task runner that we can utilise to
     manage jobs like this and we need it to be responsive on-click, we're having to jerryrig in some data extraction and
@@ -215,19 +236,19 @@ def list_project_services(project_id):
     the service data JSON keys as specified in the request (which will be loaded via a framework-specific manifest)."""
     page = get_valid_page_or_1()
     requested_fields = request.args.get('fields', '').split(',')
-    project = DirectAwardProject.query.filter(DirectAwardProject.id == project_id).first_or_404()
+    project = get_project_by_id_or_404(project_external_id)
 
     if not project.locked_at:
-        abort(400, 'Project has not been locked: {}'.format(project_id))
+        abort(400, 'Project has not been locked: {}'.format(project.id))
 
     # TODO: This should work for _all_ active searches, not just the first (although we currently enforce only one
     # TODO: active search) - SW 21/09/2017
     search = DirectAwardSearch.query.filter(
-        DirectAwardSearch.project_id == project_id,
+        DirectAwardSearch.project_id == project.id,
         DirectAwardSearch.active == True  # noqa
     ).first()
     if not search:
-        abort(400, 'Project does not have a saved search: {}'.format(project_id))
+        abort(400, 'Project does not have a saved search: {}'.format(project.id))
 
     paginated_archived_services = search.archived_services.paginate(
         page=page,
@@ -236,7 +257,7 @@ def list_project_services(project_id):
 
     project_archived_services = list(map(lambda service: {
         'id': service.service_id,
-        'projectId': project_id,
+        'projectId': project.external_id,
         'supplier': {
             'name': service.supplier.name,
             'contact': {
@@ -249,7 +270,7 @@ def list_project_services(project_id):
     }, paginated_archived_services.items))
 
     pagination_params = request.args.to_dict()
-    pagination_params['project_id'] = project_id
+    pagination_params['project_external_id'] = project.external_id
 
     return jsonify(
         services=project_archived_services,
@@ -264,17 +285,17 @@ def list_project_services(project_id):
     )
 
 
-@main.route('/direct-award/projects/<int:project_id>/lock', methods=['POST'])
-def lock_project(project_id):
+@main.route('/direct-award/projects/<int:project_external_id>/lock', methods=['POST'])
+def lock_project(project_external_id):
     updater_json = validate_and_return_updater_request()
 
-    project = DirectAwardProject.query.filter(DirectAwardProject.id == project_id).first_or_404()
+    project = get_project_by_id_or_404(project_external_id)
 
     if project.locked_at:
-        abort(400, 'Project has already been locked: {}'.format(project_id))
+        abort(400, 'Project has already been locked: {}'.format(project.id))
 
     search = DirectAwardSearch.query.filter(
-        DirectAwardSearch.project_id == project_id,
+        DirectAwardSearch.project_id == project.id,
         DirectAwardSearch.active == True,  # noqa
     ).first_or_404()
 
@@ -303,7 +324,8 @@ def lock_project(project_id):
         audit_type=AuditTypes.lock_project,
         user=updater_json['updated_by'],
         data={
-            'projectId': project.id
+            'projectId': project.id,
+            'projectExternalId': project.external_id,
         },
         db_object=search,
     )
@@ -314,11 +336,11 @@ def lock_project(project_id):
     return jsonify(project=project.serialize())
 
 
-@main.route('/direct-award/projects/<int:project_id>/record-download', methods=['POST'])
-def record_project_download(project_id):
+@main.route('/direct-award/projects/<int:project_external_id>/record-download', methods=['POST'])
+def record_project_download(project_external_id):
     updater_json = validate_and_return_updater_request()
 
-    project = DirectAwardProject.query.filter(DirectAwardProject.id == project_id).first_or_404()
+    project = get_project_by_id_or_404(project_external_id)
 
     # We want to track the latest datetime the results were downloaded, overriding previous (although they're audited).
     project.downloaded_at = datetime.datetime.utcnow()
@@ -329,7 +351,7 @@ def record_project_download(project_id):
         audit_type=AuditTypes.downloaded_project,
         user=updater_json['updated_by'],
         data={
-            'projectId': project.id
+            'projectExternalId': project.external_id,
         },
         db_object=project,
     )

--- a/app/models/direct_award.py
+++ b/app/models/direct_award.py
@@ -5,8 +5,10 @@ from sqlalchemy.orm import validates
 from flask import current_app
 
 from app import db
+from app.utils import random_positive_external_id
 from app.url_utils import force_relative_url
 from app.models import User, ValidationError, ArchivedService
+
 from dmutils.formats import DATETIME_FORMAT
 
 
@@ -14,6 +16,7 @@ class DirectAwardProject(db.Model):
     __tablename__ = 'direct_award_projects'
 
     id = db.Column(db.Integer, primary_key=True)
+    external_id = db.Column(db.BigInteger, default=random_positive_external_id, nullable=False, index=True, unique=True)
     name = db.Column(db.String(255), nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
     locked_at = db.Column(db.DateTime, nullable=True)  # When the project's active search/es are final and cannot change
@@ -24,7 +27,7 @@ class DirectAwardProject(db.Model):
 
     def serialize(self, with_users=False):
         data = {
-            "id": self.id,
+            "id": self.external_id,
             "name": self.name,
             "createdAt": self.created_at.strftime(DATETIME_FORMAT),
             "lockedAt": self.locked_at.strftime(DATETIME_FORMAT) if self.locked_at is not None else None,

--- a/app/models/main.py
+++ b/app/models/main.py
@@ -1,6 +1,5 @@
 # TODO split this file into per-functional-area modules
 
-import random
 from datetime import datetime
 
 import re
@@ -31,7 +30,14 @@ from dmutils.dates import get_publishing_dates
 from dmutils.formats import DATETIME_FORMAT, DATE_FORMAT
 from .. import db
 from ..models.buyer_domains import BuyerEmailDomain
-from ..utils import link, url_for, strip_whitespace_from_data, drop_foreign_fields, purge_nulls_from_data
+from app.utils import (
+    drop_foreign_fields,
+    link,
+    purge_nulls_from_data,
+    random_positive_external_id,
+    strip_whitespace_from_data,
+    url_for,
+)
 from ..validation import (
     is_valid_service_id, get_validation_errors, buyer_email_address_has_approved_domain,
     admin_email_address_has_approved_domain
@@ -839,7 +845,7 @@ class ServiceTableMixin(object):
     id = db.Column(db.Integer, primary_key=True)
 
     # used as externally-visible "pk" for Services and allows services identity to be tracked
-    # across a service's lifetime. assigned randomly (see generate_new_service_id) at DraftService ->
+    # across a service's lifetime. assigned randomly (see random_positive_external_id) at DraftService ->
     # Service publishing time.
     service_id = db.Column(db.String, index=True, unique=True, nullable=False)
 
@@ -963,7 +969,7 @@ class Service(db.Model, ServiceTableMixin):
         return Service(
             framework=draft.framework,
             lot=draft.lot,
-            service_id=generate_new_service_id(draft.framework.slug),
+            service_id=str(random_positive_external_id()),
             supplier=draft.supplier,
             data=draft.data,
             status=status
@@ -1827,8 +1833,3 @@ def filter_null_value_fields(obj):
     return dict(
         filter(lambda x: x[1] is not None, obj.items())
     )
-
-
-def generate_new_service_id(framework_slug):
-    # FIXME framework_slug parameter ignored??
-    return str(random.randint(10 ** 14, 10 ** 15 - 1))

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,10 +1,18 @@
 from flask import url_for as base_url_for
 from flask import abort, current_app, request
 from six import iteritems, string_types
+import random
 from werkzeug.exceptions import BadRequest
 
 from .validation import validate_updater_json_or_400
 from . import search_api_client, dmapiclient
+
+
+def random_positive_external_id() -> int:
+    """
+    Generate a random integer ID that's 15-digits long.
+    """
+    return random.SystemRandom().randint(10 ** 14, (10 ** 15) - 1)
 
 
 def validate_and_return_updater_request():

--- a/migrations/versions/1070_add_external_id_column.py
+++ b/migrations/versions/1070_add_external_id_column.py
@@ -1,0 +1,77 @@
+"""Add external ID column
+
+Revision ID: 1070
+Revises: 1060
+Create Date: 2017-11-23 16:46:00.569239
+
+"""
+from alembic import op
+import json
+import random
+import sqlalchemy as sa
+from sqlalchemy.sql import text
+
+# revision identifiers, used by Alembic.
+revision = '1070'
+down_revision = '1060'
+
+DIRECT_AWARD_AUDIT_TYPES = ('create_project', 'create_project_search', 'lock_project', 'downloaded_project')
+
+
+def random_positive_external_id():
+    return random.SystemRandom().randint(10 ** 14, (10 ** 15) - 1)
+
+
+def upgrade():
+    op.add_column('direct_award_projects', sa.Column('external_id', sa.BigInteger()))
+    op.create_index(op.f('ix_direct_award_projects_external_id'), 'direct_award_projects', ['external_id'], unique=True)
+
+    # Manually generate random IDs for all existing saved searches
+    project_connection = op.get_bind()
+    project_id_internal_to_external = {}
+    for row_id, *_ in project_connection.execute('select id from direct_award_projects'):
+        # Some logic to ensure all IDs generated are unique; keep track so we can update AuditEvents.
+        random_id = random_positive_external_id()
+        while random_id in project_id_internal_to_external.values():
+            random_id = random_positive_external_id()
+        project_id_internal_to_external[row_id] = random_id
+
+        project_connection.execute(text('UPDATE direct_award_projects SET external_id = :external_id WHERE id = :id'),
+                                   {'external_id': random_id, 'id': row_id})
+
+    # Now that all rows have an external ID, generate the unique constraint for them.
+    op.create_unique_constraint('uq_direct_award_projects_external_id', 'direct_award_projects', ['external_id'])
+
+    # Inject external IDs into existing Audit Events to allow them to be searched by the reference that we are likely
+    # to be given e.g. by support enquiries.
+    audit_connection = op.get_bind()
+    for audit_id, audit_data, project_id in audit_connection.execute(
+            text('SELECT id, data, object_id FROM audit_events WHERE type IN :audit_types'),
+            {'audit_types': DIRECT_AWARD_AUDIT_TYPES}
+    ):
+        # If for some hellish reason we are re-running this after external IDs already exist, our audit events should
+        # keep the original external ID (ie not be overwritten).
+        new_audit_data = json.dumps({'projectExternalId': project_id_internal_to_external[project_id], **audit_data})
+        audit_connection.execute(text('UPDATE audit_events SET data = (:new_audit_data)::json WHERE id = :audit_id'),
+                                 {'new_audit_data': new_audit_data, 'audit_id': audit_id})
+
+
+def downgrade():
+    op.drop_index(op.f('ix_direct_award_projects_external_id'), table_name='direct_award_projects')
+    op.drop_column('direct_award_projects', 'external_id')
+
+    # I don't think we ought to delete the external ID from the Audit Event on a downgrade... But if we do, here's
+    # the code.
+    """
+    audit_connection = op.get_bind()
+    for audit_id, audit_data, project_id in audit_connection.execute(
+            text('SELECT id, data, object_id FROM audit_events WHERE type IN :audit_types'),
+            {'audit_types': DIRECT_AWARD_AUDIT_TYPES}
+    ):
+        if 'projectExternalId' in audit_data:
+            del audit_data['projectExternalId']
+
+        new_audit_data = json.dumps(audit_data)
+        audit_connection.execute(text('UPDATE audit_events SET data = (:new_audit_data)::json WHERE id = :audit_id'),
+                                 {'new_audit_data': new_audit_data, 'audit_id': audit_id})
+     """

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -293,23 +293,17 @@ class FixtureMixin(object):
     def create_direct_award_project(self, user_id, project_id=1, project_name=DIRECT_AWARD_PROJECT_NAME,
                                     created_at=DIRECT_AWARD_FROZEN_TIME):
         with self.app.app_context():
-            if DirectAwardProject.query.get(project_id):
-                return project_id
+            project = DirectAwardProject.query.get(project_id)
+            if not project:
+                project = DirectAwardProject(id=project_id, name=project_name, created_at=created_at)
+                db.session.add(project)
+                db.session.flush()
 
-            db.session.add(DirectAwardProject(
-                id=project_id,
-                name=project_name,
-                created_at=created_at
-            ))
-            db.session.flush()
+                project_user = DirectAwardProjectUser(user_id=user_id, project_id=project_id)
+                db.session.add(project_user)
+                db.session.commit()
 
-            db.session.add(DirectAwardProjectUser(
-                user_id=user_id,
-                project_id=project_id
-            ))
-            db.session.commit()
-
-            return project_id
+            return project_id, project.external_id
 
     def create_direct_award_project_search(self, created_by, project_id, search_url=DIRECT_AWARD_SEARCH_URL,
                                            active=True, created_at=DIRECT_AWARD_FROZEN_TIME):

--- a/tests/main/views/test_direct_award.py
+++ b/tests/main/views/test_direct_award.py
@@ -11,7 +11,7 @@ from app import db
 import pytest
 from tests.bases import BaseApplicationTest
 
-from sqlalchemy import desc
+from sqlalchemy import desc, Integer, BigInteger
 from dmapiclient.audit import AuditTypes
 
 from app.models import DATETIME_FORMAT, AuditEvent, User, ArchivedService
@@ -48,12 +48,24 @@ class DirectAwardSetupAndTeardown(BaseApplicationTest, FixtureMixin):
     def _updated_by_data(self):
         return {'updated_by': str(self.user_id)}
 
+    @staticmethod
+    def _assert_one_audit_event_created_for_only_project(audit_type):
+        projects = DirectAwardProject.query.all()
+        assert len(projects) == 1
+
+        audit_events = AuditEvent.query.filter(AuditEvent.type == audit_type
+                                               and AuditEvent.data['projectId'].astext.cast(Integer) == projects[0].id
+                                               and AuditEvent.data['projectExternalId'].astext.cast(BigInteger)
+                                               == projects[0].external_id).all()
+        assert len(audit_events) == 1
+
 
 class TestDirectAwardListProjects(DirectAwardSetupAndTeardown):
     def setup(self):
         super(TestDirectAwardListProjects, self).setup()
-        self.project_id = self.create_direct_award_project(user_id=self.user_id,
-                                                           project_name=self.direct_award_project_name)
+        self.project_id, self.project_external_id = self.create_direct_award_project(
+            user_id=self.user_id, project_name=self.direct_award_project_name
+        )
 
     def test_list_projects_200s_with_user_id(self):
         res = self.client.get('/direct-award/projects?user-id={}'.format(self.user_id))
@@ -134,9 +146,11 @@ class TestDirectAwardListProjects(DirectAwardSetupAndTeardown):
             res = self.client.get('/direct-award/projects?user-id={}&page={}'.format(self.user_id, i + 1))
             data = json.loads(res.get_data(as_text=True))
 
-            # Check that each project has a created_at date older than the last, i.e. reverse chronological order.
-            for project in data['projects']:
-                assert last_seen < project['id']
+            with self.app.app_context():
+                for project in data['projects']:
+                    project = DirectAwardProject.query.filter(DirectAwardProject.external_id == project['id']).first()
+                    assert last_seen < project.id
+                    last_seen = project.id
 
     def test_list_projects_orders_by_created_at_descending(self):
         self.app.config['DM_API_PROJECTS_PAGE_SIZE'] = 2
@@ -247,6 +261,53 @@ class TestDirectAwardCreateProject(DirectAwardSetupAndTeardown):
         with self.app.app_context():
             assert len(DirectAwardProjectUser.query.all()) == 1
 
+    def test_create_project_retries_on_external_id_collision(self):
+        project_data = self._create_project_data()
+
+        with self.app.app_context():
+            assert len(DirectAwardProjectUser.query.all()) == 0
+
+        with mock.patch('app.models.direct_award.DirectAwardProject.external_id.default.arg') as external_id_default:
+            external_id_default.side_effect = (
+                123456789012345,
+                123456789012345,
+                123456789012345,
+                222222222222222,
+            )
+
+            res = self.client.post('/direct-award/projects', data=json.dumps(project_data),
+                                   content_type='application/json')
+            assert res.status_code == 201
+
+            with self.app.app_context():
+                assert len(DirectAwardProjectUser.query.all()) == 1
+
+    def test_create_project_fails_after_5_retries_on_external_id_collision(self):
+        project_data = self._create_project_data()
+
+        with self.app.app_context():
+            assert len(DirectAwardProjectUser.query.all()) == 0
+
+        with mock.patch('app.models.direct_award.DirectAwardProject.external_id.default.arg') as external_id_default:
+            external_id_default.side_effect = (
+                123456789012345,
+                123456789012345,
+                123456789012345,
+                123456789012345,
+                123456789012345,
+                123456789012345,
+                123456789012345,
+                222222222222222,
+            )
+
+            res = self.client.post('/direct-award/projects', data=json.dumps(project_data),
+                                   content_type='application/json')
+            assert res.status_code == 201
+
+            res = self.client.post('/direct-award/projects', data=json.dumps(project_data),
+                                   content_type='application/json')
+            assert res.status_code == 400
+
     def test_create_project_400s_with_invalid_user(self):
         project_data = self._create_project_data()
         project_data['project']['userId'] = 9999999
@@ -260,15 +321,15 @@ class TestDirectAwardCreateProject(DirectAwardSetupAndTeardown):
         assert res.status_code == 201
 
         with self.app.app_context():
-            assert len(AuditEvent.query.all()) == 1
-            assert AuditEvent.query.all()[0].type == AuditTypes.create_project.value
+            self._assert_one_audit_event_created_for_only_project(AuditTypes.create_project.value)
 
 
 class TestDirectAwardGetProject(DirectAwardSetupAndTeardown):
     def setup(self):
         super(TestDirectAwardGetProject, self).setup()
-        self.project_id = self.create_direct_award_project(user_id=self.user_id,
-                                                           project_name=self.direct_award_project_name)
+        self.project_id, self.project_external_id = self.create_direct_award_project(
+            user_id=self.user_id, project_name=self.direct_award_project_name
+        )
 
         res = self.client.get('/direct-award/projects/{}?user-id={}'.format(self.project_id, self.user_id))
         assert res.status_code == 200
@@ -284,8 +345,9 @@ class TestDirectAwardGetProject(DirectAwardSetupAndTeardown):
 class TestDirectAwardListProjectSearches(DirectAwardSetupAndTeardown):
     def setup(self):
         super(TestDirectAwardListProjectSearches, self).setup()
-        self.project_id = self.create_direct_award_project(user_id=self.user_id,
-                                                           project_name=self.direct_award_project_name)
+        self.project_id, self.project_external_id = self.create_direct_award_project(
+            user_id=self.user_id, project_name=self.direct_award_project_name
+        )
         self.search_id = self.create_direct_award_project_search(created_by=self.user_id, project_id=self.project_id)
 
     def test_list_searches_200s_with_user_id(self):
@@ -297,6 +359,15 @@ class TestDirectAwardListProjectSearches(DirectAwardSetupAndTeardown):
         res = self.client.get('/direct-award/projects/{}/searches?user-id={}'.format(sys.maxsize,
                                                                                      self.user_id))
         assert res.status_code == 404
+
+    def test_list_searches_links_use_external_id(self):
+        res = self.client.get('/direct-award/projects/{}/searches'.format(self.project_id))
+        data = json.loads(res.get_data(as_text=True))
+
+        with self.app.app_context():
+            assert data['links']['self'] == 'http://127.0.0.1:5000/direct-award/projects/{}/searches'.format(
+                self.project_external_id
+            )
 
     def test_list_searches_returns_only_for_project_requested(self):
         # Create a project for another user with a search, i.e. one that shouldn't be returned
@@ -460,8 +531,9 @@ class TestDirectAwardCreateProjectSearch(DirectAwardSetupAndTeardown):
 
     def setup(self):
         super(TestDirectAwardCreateProjectSearch, self).setup()
-        self.project_id = self.create_direct_award_project(user_id=self.user_id,
-                                                           project_name=self.direct_award_project_name)
+        self.project_id, self.project_external_id = self.create_direct_award_project(
+            user_id=self.user_id, project_name=self.direct_award_project_name
+        )
 
     @pytest.mark.parametrize('drop_search_keys, expected_status',
                              (
@@ -533,22 +605,22 @@ class TestDirectAwardCreateProjectSearch(DirectAwardSetupAndTeardown):
 
         assert data['search']['active'] is False
 
-    def test_create_project_creates_audit_event(self):
+    def test_create_project_search_creates_audit_event(self):
         res = self.client.post('/direct-award/projects/{}/searches'.format(self.project_id),
                                data=json.dumps(self._create_project_search_data()),
                                content_type='application/json')
         assert res.status_code == 201
 
         with self.app.app_context():
-            assert len(AuditEvent.query.all()) == 1
-            assert AuditEvent.query.all()[0].type == AuditTypes.create_project_search.value
+            self._assert_one_audit_event_created_for_only_project(AuditTypes.create_project_search.value)
 
 
 class TestDirectAwardGetProjectSearch(DirectAwardSetupAndTeardown):
     def setup(self):
         super(TestDirectAwardGetProjectSearch, self).setup()
-        self.project_id = self.create_direct_award_project(user_id=self.user_id,
-                                                           project_name=self.direct_award_project_name)
+        self.project_id, self.project_external_id = self.create_direct_award_project(
+            user_id=self.user_id, project_name=self.direct_award_project_name
+        )
         self.search_id = self.create_direct_award_project_search(created_by=self.user_id, project_id=self.project_id)
 
         res = self.client.get('/direct-award/projects/{}/searches/{}?user-id={}'.format(self.project_id,
@@ -576,8 +648,9 @@ class TestDirectAwardListProjectServices(DirectAwardSetupAndTeardown):
     def setup(self):
         super(TestDirectAwardListProjectServices, self).setup()
 
-        self.project_id = self.create_direct_award_project(user_id=self.user_id,
-                                                           project_name=self.direct_award_project_name)
+        self.project_id, self.project_external_id = self.create_direct_award_project(
+            user_id=self.user_id, project_name=self.direct_award_project_name
+        )
         self.search_id = self.create_direct_award_project_search(created_by=self.user_id, project_id=self.project_id)
 
         with self.app.app_context():
@@ -633,11 +706,13 @@ class TestDirectAwardListProjectServices(DirectAwardSetupAndTeardown):
 
             assert set(data.keys()) == {'meta', 'links', 'services'}
             assert data['meta'] == {'total': 5}
-            assert data['links'] == {'self': 'http://127.0.0.1:5000/direct-award/projects/1/services'}
+            assert data['links'] == {'self': 'http://127.0.0.1:5000/direct-award/projects/{}/services'.format(
+                self.project_external_id
+            )}
             for service in data['services']:
                 assert service in [{
                     'id': service.service_id,
-                    'projectId': self.project_id,
+                    'projectId': self.project_external_id,
                     'supplier': {
                         'name': service.supplier.name,
                         'contact': {
@@ -666,8 +741,11 @@ class TestDirectAwardListProjectServices(DirectAwardSetupAndTeardown):
 
             data = json.loads(res.get_data(as_text=True))
             assert data['services'][0]['data'] == {'serviceName': archived_services[0].data['serviceName']}
-            assert data['links'] == \
-                {'self': 'http://127.0.0.1:5000/direct-award/projects/1/services?fields=serviceName'}
+            assert data['links'] == {
+                'self': 'http://127.0.0.1:5000/direct-award/projects/{}/services?fields=serviceName'.format(
+                    self.project_external_id
+                )
+            }
 
     def test_list_project_services_accepts_page_offset(self):
         project_services_count = 100
@@ -693,10 +771,10 @@ class TestDirectAwardListProjectServices(DirectAwardSetupAndTeardown):
         assert data['meta']['total'] == project_services_count
 
         next_url = 'http://127.0.0.1:5000/direct-award/projects/{}/services?user-id={}&page=2'.format(
-            self.project_id, self.user_id
+            self.project_external_id, self.user_id
         )
         last_url = 'http://127.0.0.1:5000/direct-award/projects/{}/services?user-id={}&page=20'.format(
-            self.project_id, self.user_id
+            self.project_external_id, self.user_id
         )
         assert data['links']['next'] == next_url
         assert data['links']['last'] == last_url
@@ -705,8 +783,9 @@ class TestDirectAwardListProjectServices(DirectAwardSetupAndTeardown):
 class TestDirectAwardLockProject(DirectAwardSetupAndTeardown, FixtureMixin):
     def setup(self):
         super(TestDirectAwardLockProject, self).setup()
-        self.project_id = self.create_direct_award_project(user_id=self.user_id,
-                                                           project_name=self.direct_award_project_name)
+        self.project_id, self.project_external_id = self.create_direct_award_project(
+            user_id=self.user_id, project_name=self.direct_award_project_name
+        )
         self.search_id = self.create_direct_award_project_search(created_by=self.user_id, project_id=self.project_id)
 
         res = self.client.get('/direct-award/projects/{}/searches/{}?user-id={}'.format(self.project_id,
@@ -761,7 +840,7 @@ class TestDirectAwardLockProject(DirectAwardSetupAndTeardown, FixtureMixin):
         data = json.loads(res.get_data(as_text=True))
 
         assert res.status_code == 200
-        assert data['project']['id'] == self.project_id
+        assert data['project']['id'] == self.project_external_id
         assert data['project']['lockedAt'] is not None
 
         with self.app.app_context():
@@ -814,8 +893,9 @@ class TestDirectAwardLockProject(DirectAwardSetupAndTeardown, FixtureMixin):
 class TestDirectAwardRecordProjectDownload(DirectAwardSetupAndTeardown):
     def setup(self):
         super(TestDirectAwardRecordProjectDownload, self).setup()
-        self.project_id = self.create_direct_award_project(user_id=self.user_id,
-                                                           project_name=self.direct_award_project_name)
+        self.project_id, self.project_external_id = self.create_direct_award_project(
+            user_id=self.user_id, project_name=self.direct_award_project_name
+        )
         self.search_id = self.create_direct_award_project_search(created_by=self.user_id, project_id=self.project_id)
 
     @pytest.mark.parametrize('drop_project_keys, expected_status',
@@ -875,5 +955,4 @@ class TestDirectAwardRecordProjectDownload(DirectAwardSetupAndTeardown):
         assert res.status_code == 200
 
         with self.app.app_context():
-            assert len(AuditEvent.query.all()) == 1
-            assert AuditEvent.query.all()[0].type == AuditTypes.downloaded_project.value
+            self._assert_one_audit_event_created_for_only_project(AuditTypes.downloaded_project.value)

--- a/tests/main/views/test_drafts.py
+++ b/tests/main/views/test_drafts.py
@@ -995,14 +995,14 @@ class TestDraftServices(BaseApplicationTest, FixtureMixin):
         assert self.service_count() == 1
         assert self.draft_service_count() == 0
 
-    @mock.patch('app.models.main.generate_new_service_id')
-    def test_service_id_collisions_should_be_handled(self, generate_new_service_id):
+    @mock.patch('app.models.main.random_positive_external_id')
+    def test_service_id_collisions_should_be_handled(self, random_positive_external_id):
         # Return the same ID a few times (cause collisions) and then return a different one.
-        generate_new_service_id.side_effect = (
-            '1234567890123457',
-            '1234567890123457',
-            '1234567890123457',
-            '2222222222222222',
+        random_positive_external_id.side_effect = (
+            '123456789012345',
+            '123456789012345',
+            '123456789012345',
+            '222222222222222',
         )
 
         res = self.publish_new_draft_service()
@@ -1014,8 +1014,8 @@ class TestDraftServices(BaseApplicationTest, FixtureMixin):
         assert self.service_count() == 3
         res = self.client.get('/services?framework=g-cloud-7')
         services = json.loads(res.get_data())['services']
-        assert services[0]['id'] == '1234567890123457'
-        assert services[1]['id'] == '2222222222222222'
+        assert services[0]['id'] == '123456789012345'
+        assert services[1]['id'] == '222222222222222'
         assert self.draft_service_count() == 2
 
     def test_get_draft_returns_last_audit_event(self):


### PR DESCRIPTION
## Summary
We will generate random external integer IDs for our Direct Award saved searches in line with best practice to mitigate risks around flawed implementation of authorization. For a transitional period, we will allow URLs on the frontend using a saved search's internal ID to go ahead (although we will redirect to the external ID).

The randomly generated IDs are consistently 15 digits in length, fitting into a PostgreSQL BigInteger and (hopefully) below the threshold for scientific notation in spreadsheet programs. For the sake of preserving our existing analytics setup, these won't be (eg base32) encoded when they leave the API - they will remain as raw integers. I don't envision this causing a problem or looking too awful, although they are 15 characters, which could be considered long.

There is no collision detection/avoidance; on the slim chance that a randomly generated ID has already been submitted, a unique constraint on the external ID will cause the API to error if a duplicate entry is committed. After speaking to @galund and @risicle it seems we are happy to accept this.

Existing AuditEvents will be updated to inject the new external ID of existing direct award projects so that we retain the ability to filter AuditEvents on the ID we are likely to be given (e.g. by the support team).

## Ticket
https://trello.com/c/GEziXqcE/34-security-change-direct-award-projects-to-use-randomly-generated-ids-rather-than-sequential