### PR TITLE
Index briefs on update

### DIFF
--- a/app/brief_utils.py
+++ b/app/brief_utils.py
@@ -40,9 +40,14 @@ def get_supplier_service_eligible_for_brief(supplier, brief):
 
 
 def index_brief(brief):
-    index_object(
-        framework=brief.framework.slug,
-        object_type='briefs',
-        object_id=brief.id,
-        serialized_object=brief.serialize(),
-    )
+    if (
+        brief.framework.framework == 'digital-outcomes-and-specialists' and
+        brief.status != 'draft'
+    ):
+
+        index_object(
+            framework=brief.framework.slug,
+            object_type='briefs',
+            object_id=brief.id,
+            serialized_object=brief.serialize(),
+        )

--- a/app/brief_utils.py
+++ b/app/brief_utils.py
@@ -47,7 +47,7 @@ def index_brief(brief):
 
         index_object(
             framework=brief.framework.slug,
-            object_type='briefs',
+            doc_type='briefs',
             object_id=brief.id,
             serialized_object=brief.serialize(),
         )

--- a/app/brief_utils.py
+++ b/app/brief_utils.py
@@ -3,6 +3,7 @@ from flask import abort
 from .models import Service
 from .validation import get_validation_errors
 from .service_utils import filter_services
+from .utils import index_object
 
 
 def validate_brief_data(brief, enforce_required=True, required_fields=None):
@@ -36,3 +37,12 @@ def get_supplier_service_eligible_for_brief(supplier, brief):
     services = services.filter(Service.supplier_id == supplier.supplier_id)
 
     return services.first()
+
+
+def index_brief(brief):
+    index_object(
+        framework=brief.framework.slug,
+        object_type='briefs',
+        object_id=brief.id,
+        serialized_object=brief.serialize(),
+    )

--- a/app/brief_utils.py
+++ b/app/brief_utils.py
@@ -40,11 +40,7 @@ def get_supplier_service_eligible_for_brief(supplier, brief):
 
 
 def index_brief(brief):
-    if (
-        brief.framework.framework == 'digital-outcomes-and-specialists' and
-        brief.status != 'draft'
-    ):
-
+    if brief.status != 'draft':
         index_object(
             framework=brief.framework.slug,
             doc_type='briefs',

--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -12,7 +12,7 @@ from ...utils import (
     purge_nulls_from_data
 )
 from ...service_utils import validate_and_return_lot, filter_services
-from ...brief_utils import validate_brief_data
+from ...brief_utils import index_brief, validate_brief_data
 from ...validation import get_validation_errors
 
 
@@ -227,6 +227,7 @@ def update_brief_status(brief_id, action):
         db.session.add(brief)
         db.session.add(audit)
         db.session.commit()
+        index_brief(brief)
 
     return jsonify(briefs=brief.serialize()), 200
 
@@ -335,6 +336,7 @@ def award_brief_details(brief_id, brief_response_id):
 
     db.session.add_all([brief_response, audit_event])
     db.session.commit()
+    index_brief(brief)
 
     return jsonify(briefs=brief.serialize()), 200
 

--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -58,8 +58,9 @@ def create_brief():
     )
 
     db.session.add(audit)
-
     db.session.commit()
+    # We are intentionally not indexing briefs here. We don't need drafts in search results, and they are indexed each
+    # night by the batch indexing job run by Jenkins. In future we may index all briefs with a lower level ORM hook.
 
     return jsonify(briefs=brief.serialize()), 201
 
@@ -97,6 +98,8 @@ def update_brief(brief_id):
     db.session.add(brief)
     db.session.add(audit)
     db.session.commit()
+    # We are intentionally not indexing briefs here. We don't need drafts in search results, and they are indexed each
+    # night by the batch indexing job run by Jenkins. In future we may index all briefs with a lower level ORM hook.
 
     return jsonify(briefs=brief.serialize()), 200
 

--- a/app/service_utils.py
+++ b/app/service_utils.py
@@ -136,7 +136,7 @@ def index_service(service):
 
         index_object(
             framework=service.framework.slug,
-            object_type='services',
+            doc_type='services',
             object_id=service.service_id,
             serialized_object=service.serialize(),
         )

--- a/app/service_utils.py
+++ b/app/service_utils.py
@@ -1,8 +1,7 @@
 from flask import current_app, abort
 from sqlalchemy.exc import IntegrityError, DataError
 
-from .utils import get_json_from_request, \
-    json_has_matching_id, json_has_required_keys
+from .utils import get_json_from_request, index_object, json_has_matching_id, json_has_required_keys
 from .validation import get_validation_errors
 from . import search_api_client, dmapiclient
 from . import db
@@ -134,14 +133,13 @@ def index_service(service):
         service.framework.framework == 'g-cloud' and
         service.status == 'published'
     ):
-        try:
-            search_api_client.index(index=service.framework.slug,
-                                    service_id=service.service_id,
-                                    service=service.serialize())
-        except dmapiclient.HTTPError as e:
-            current_app.logger.warning(
-                'Failed to add {} to search index: {}'.format(
-                    service.service_id, e.message))
+
+        index_object(
+            framework=service.framework.slug,
+            object_type='services',
+            object_id=service.service_id,
+            serialized_object=service.serialize(),
+        )
 
 
 def delete_service_from_index(service):

--- a/app/utils.py
+++ b/app/utils.py
@@ -164,21 +164,23 @@ def get_request_page_questions():
     return json_payload.get('page_questions', [])
 
 
-def index_object(framework, object_type, object_id, serialized_object):
+def index_object(framework, doc_type, object_id, serialized_object):
     try:
-        index_name = current_app.config['DM_FRAMEWORK_TO_ES_INDEX_MAPPING'][framework][object_type]
+        index_name = current_app.config['DM_FRAMEWORK_TO_ES_INDEX_MAPPING'][framework][doc_type]
 
         try:
-            search_api_client.index(index_name=index_name,
-                                    object_type=object_type,
-                                    object_id=object_id,
-                                    serialized_object=serialized_object)
+            search_api_client.index(
+                index_name=index_name,
+                object_id=object_id,
+                serialized_object=serialized_object,
+                doc_type=doc_type,
+            )
         except dmapiclient.HTTPError as e:
             current_app.logger.warning(
                 'Failed to add {} object with id {} to {} index: {}'.format(
-                    object_type, object_id, index_name, e.message))
+                    doc_type, object_id, index_name, e.message))
 
     except KeyError as e:
         current_app.logger.warning(
-            "Failed to find index name for framework '{}' with object type '{}'".format(framework, object_type)
+            "Failed to find index name for framework '{}' with object type '{}'".format(framework, doc_type)
         )

--- a/app/utils.py
+++ b/app/utils.py
@@ -181,6 +181,6 @@ def index_object(framework, doc_type, object_id, serialized_object):
                     doc_type, object_id, index_name, e.message))
 
     except KeyError as e:
-        current_app.logger.warning(
+        current_app.logger.error(
             "Failed to find index name for framework '{}' with object type '{}'".format(framework, doc_type)
         )

--- a/app/utils.py
+++ b/app/utils.py
@@ -166,7 +166,7 @@ def get_request_page_questions():
 
 def index_object(framework, doc_type, object_id, serialized_object):
     try:
-        index_name = current_app.config['DM_FRAMEWORK_TO_ES_INDEX_MAPPING'][framework][doc_type]
+        index_name = current_app.config['DM_FRAMEWORK_TO_ES_INDEX'][framework][doc_type]
 
         try:
             search_api_client.index(

--- a/app/utils.py
+++ b/app/utils.py
@@ -165,14 +165,20 @@ def get_request_page_questions():
 
 
 def index_object(framework, object_type, object_id, serialized_object):
-    index_name = current_app.config['DM_FRAMEWORK_TO_ES_INDEX_MAPPING'][framework][object_type]
-
     try:
-        search_api_client.index(index_name=index_name,
-                                object_type=object_type,
-                                object_id=object_id,
-                                serialized_object=serialized_object)
-    except dmapiclient.HTTPError as e:
+        index_name = current_app.config['DM_FRAMEWORK_TO_ES_INDEX_MAPPING'][framework][object_type]
+
+        try:
+            search_api_client.index(index_name=index_name,
+                                    object_type=object_type,
+                                    object_id=object_id,
+                                    serialized_object=serialized_object)
+        except dmapiclient.HTTPError as e:
+            current_app.logger.warning(
+                'Failed to add {} object with id {} to {} index: {}'.format(
+                    object_type, object_id, index_name, e.message))
+
+    except KeyError as e:
         current_app.logger.warning(
-            'Failed to add {} object with id {} to {} index: {}'.format(
-                object_type, object_id, index_name, e.message))
+            "Failed to find index name for framework '{}' with object type '{}'".format(framework, object_type)
+        )

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,9 +1,10 @@
 from flask import url_for as base_url_for
-from flask import abort, request
+from flask import abort, current_app, request
 from six import iteritems, string_types
 from werkzeug.exceptions import BadRequest
 
 from .validation import validate_updater_json_or_400
+from . import search_api_client, dmapiclient
 
 
 def validate_and_return_updater_request():
@@ -161,3 +162,17 @@ def purge_nulls_from_data(data):
 def get_request_page_questions():
     json_payload = get_json_from_request()
     return json_payload.get('page_questions', [])
+
+
+def index_object(framework, object_type, object_id, serialized_object):
+    index_name = current_app.config['DM_FRAMEWORK_TO_ES_INDEX_MAPPING'][framework][object_type]
+
+    try:
+        search_api_client.index(index_name=index_name,
+                                object_type=object_type,
+                                object_id=object_id,
+                                serialized_object=serialized_object)
+    except dmapiclient.HTTPError as e:
+        current_app.logger.warning(
+            'Failed to add {} object with id {} to {} index: {}'.format(
+                object_type, object_id, index_name, e.message))

--- a/config.py
+++ b/config.py
@@ -49,10 +49,10 @@ class Config:
             'services': 'g-cloud-9'
         },
         'digital-outcomes-and-specialists': {
-            'briefs': 'briefs-digital-outcomes-and-specialists-2'
+            'briefs': 'briefs-digital-outcomes-and-specialists'
         },
         'digital-outcomes-and-specialists-2': {
-            'briefs': 'briefs-digital-outcomes-and-specialists-2'
+            'briefs': 'briefs-digital-outcomes-and-specialists'
         },
     }
 

--- a/config.py
+++ b/config.py
@@ -48,9 +48,12 @@ class Config:
         'g-cloud-9': {
             'services': 'g-cloud-9'
         },
+        'digital-outcomes-and-specialists': {
+            'briefs': 'briefs-digital-outcomes-and-specialists-2'
+        },
         'digital-outcomes-and-specialists-2': {
             'briefs': 'briefs-digital-outcomes-and-specialists-2'
-        }
+        },
     }
 
 

--- a/config.py
+++ b/config.py
@@ -44,6 +44,15 @@ class Config:
 
     VCAP_SERVICES = None
 
+    DM_FRAMEWORK_TO_ES_INDEX_MAPPING = {
+        'g-cloud-9': {
+            'services': 'g-cloud-9'
+        },
+        'digital-outcomes-and-specialists-2': {
+            'briefs': 'briefs-digital-outcomes-and-specialists-2'
+        }
+    }
+
 
 class Test(Config):
     SERVER_NAME = '127.0.0.1:5000'

--- a/config.py
+++ b/config.py
@@ -44,7 +44,7 @@ class Config:
 
     VCAP_SERVICES = None
 
-    DM_FRAMEWORK_TO_ES_INDEX_MAPPING = {
+    DM_FRAMEWORK_TO_ES_INDEX = {
         'g-cloud-9': {
             'services': 'g-cloud-9'
         },

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -10,7 +10,7 @@ SQLAlchemy==1.1.4
 SQLAlchemy-Utils==0.30.5
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@29.0.0#egg=digitalmarketplace-utils==29.0.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@11.4.0#egg=digitalmarketplace-apiclient==11.4.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@12.2.0#egg=digitalmarketplace-apiclient==12.2.0
 
 # For schema validation
 jsonschema==2.5.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,6 +9,6 @@ mock==2.0.0
 freezegun==0.3.8
 nose==1.3.6
 coverage==3.7.1
-pytest-cov==2.2.0
+pytest-cov==2.5.1
 python-coveralls==2.5.0
 hypothesis==2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ SQLAlchemy==1.1.4
 SQLAlchemy-Utils==0.30.5
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@29.0.0#egg=digitalmarketplace-utils==29.0.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@11.4.0#egg=digitalmarketplace-apiclient==11.4.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@12.2.0#egg=digitalmarketplace-apiclient==12.2.0
 
 # For schema validation
 jsonschema==2.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,7 @@ future==0.16.0
 idna==2.6
 inflection==0.2.1
 itsdangerous==0.24
-Jinja2==2.9.6
+Jinja2==2.10
 jmespath==0.9.3
 mailchimp3==2.0.11
 Mako==1.0.7

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
-[pytest]
+[tool:pytest]
 norecursedirs = venv* src

--- a/tests/main/views/test_authenticate.py
+++ b/tests/main/views/test_authenticate.py
@@ -4,13 +4,11 @@ from app.authentication import get_token_from_headers, get_allowed_tokens_from_c
 
 
 def test_get_token_from_headers():
-    yield check_token, {'Authorization': 'Bearer foo-bar'}, 'foo-bar'
-    yield check_token, {'Authorization': 'Bearer bar-foo'}, 'bar-foo'
-    yield check_token, {'Authorization': 'Bearer '}, ''
-    yield (check_token, {'Authorisation': 'Bearer foo-bar'}, None,
-           "Authorization header misspelt")
-    yield (check_token, {'Authorization': 'Borrower foo-bar'}, None,
-           "Authorization header prefix invalid")
+    check_token({'Authorization': 'Bearer foo-bar'}, 'foo-bar')
+    check_token({'Authorization': 'Bearer bar-foo'}, 'bar-foo')
+    check_token({'Authorization': 'Bearer '}, '')
+    check_token({'Authorisation': 'Bearer foo-bar'}, None, "Authorization header misspelt")
+    check_token({'Authorization': 'Borrower foo-bar'}, None, "Authorization header prefix invalid")
 
 
 def check_token(headers, expected_token, message=None):

--- a/tests/main/views/test_direct_award.py
+++ b/tests/main/views/test_direct_award.py
@@ -780,34 +780,35 @@ class TestDirectAwardLockProject(DirectAwardSetupAndTeardown, FixtureMixin):
             assert search_result_entry.all()[0].archived_service_id == archived_services[0].id
 
     def _create_service_and_update(self):
-        service = load_example_listing("G6-SaaS")
-        self.setup_dummy_suppliers(2)
-        res1 = self.client.put(
-            '/services/{}'.format(service['id']),
-            data=json.dumps(
-                {
-                    'updated_by': 'joeblogs',
-                    'services': service
-                }
-            ),
-            content_type='application/json')
+        with mock.patch('app.main.views.services.index_service'):
+            service = load_example_listing("G6-SaaS")
+            self.setup_dummy_suppliers(2)
+            res1 = self.client.put(
+                '/services/{}'.format(service['id']),
+                data=json.dumps(
+                    {
+                        'updated_by': 'joeblogs',
+                        'services': service
+                    }
+                ),
+                content_type='application/json')
 
-        assert res1.status_code == 201
+            assert res1.status_code == 201
 
-        service['title'] = "New Service Title"
-        service['createdAt'] = "2017-12-23T14:51:19Z"
+            service['title'] = "New Service Title"
+            service['createdAt'] = "2017-12-23T14:51:19Z"
 
-        res2 = self.client.post(
-            '/services/{}'.format(service['id']),
-            data=json.dumps(
-                {
-                    'updated_by': 'example',
-                    'services': service
-                }
-            ),
-            content_type='application/json')
+            res2 = self.client.post(
+                '/services/{}'.format(service['id']),
+                data=json.dumps(
+                    {
+                        'updated_by': 'example',
+                        'services': service
+                    }
+                ),
+                content_type='application/json')
 
-        assert res2.status_code == 200
+            assert res2.status_code == 200
 
 
 class TestDirectAwardRecordProjectDownload(DirectAwardSetupAndTeardown):

--- a/tests/main/views/test_services.py
+++ b/tests/main/views/test_services.py
@@ -445,6 +445,7 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin, FixtureMixin):
     def setup(self):
         super(TestPostService, self).setup()
         payload = load_example_listing("G6-SaaS")
+        self.payload_g4 = load_example_listing("G4")
         self.service_id = str(payload['id'])
         with self.app.app_context():
             db.session.add(
@@ -462,20 +463,24 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin, FixtureMixin):
                 service_id=self.service_id,
                 **payload
             )
+            self.setup_dummy_service(
+                service_id=self.payload_g4['id'],
+                **self.payload_g4
+            )
 
     def _post_service_update(self, service_data, service_id=None, user_role=None):
-        with mock.patch('app.main.views.services.index_service'):
-            return self.client.post(
-                '/services/{}{}'.format(
-                    service_id or self.service_id, '?user-role={}'.format(user_role) if user_role else ''
-                ),
-                data=json.dumps({
-                    'updated_by': 'joeblogs',
-                    'services': service_data
-                }),
-                content_type='application/json')
+        return self.client.post(
+            '/services/{}{}'.format(
+                service_id or self.service_id, '?user-role={}'.format(user_role) if user_role else ''
+            ),
+            data=json.dumps({
+                'updated_by': 'joeblogs',
+                'services': service_data
+            }),
+            content_type='application/json')
 
-    def test_can_not_post_to_root_services_url(self):
+    @mock.patch('app.main.views.services.index_service', autospec=True)
+    def test_can_not_post_to_root_services_url(self, index_service):
         response = self.client.post(
             "/services",
             data=json.dumps(
@@ -485,8 +490,10 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin, FixtureMixin):
             content_type='application/json')
 
         assert response.status_code == 405
+        assert index_service.called is False
 
-    def test_post_returns_404_if_no_service_to_update(self):
+    @mock.patch('app.main.views.services.index_service', autospec=True)
+    def test_post_returns_404_if_no_service_to_update(self, index_service):
         response = self.client.post(
             "/services/9999999999",
             data=json.dumps(
@@ -496,8 +503,10 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin, FixtureMixin):
             content_type='application/json')
 
         assert response.status_code == 404
+        assert index_service.called is False
 
-    def test_no_content_type_causes_failure(self):
+    @mock.patch('app.main.views.services.index_service', autospec=True)
+    def test_no_content_type_causes_failure(self, index_service):
         with self.app.app_context():
             response = self.client.post(
                 '/services/{}'.format(self.service_id),
@@ -508,8 +517,10 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin, FixtureMixin):
 
             assert response.status_code == 400
             assert b'Unexpected Content-Type' in response.get_data()
+            assert index_service.called is False
 
-    def test_invalid_content_type_causes_failure(self):
+    @mock.patch('app.main.views.services.index_service', autospec=True)
+    def test_invalid_content_type_causes_failure(self, index_service):
         with self.app.app_context():
             response = self.client.post(
                 '/services/{}'.format(self.service_id),
@@ -521,8 +532,10 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin, FixtureMixin):
 
             assert response.status_code == 400
             assert b'Unexpected Content-Type' in response.get_data()
+            assert index_service.called is False
 
-    def test_invalid_json_causes_failure(self):
+    @mock.patch('app.main.views.services.index_service', autospec=True)
+    def test_invalid_json_causes_failure(self, index_service):
         with self.app.app_context():
             response = self.client.post(
                 '/services/{}'.format(self.service_id),
@@ -531,21 +544,30 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin, FixtureMixin):
 
             assert response.status_code == 400
             assert b'Invalid JSON' in response.get_data()
+            assert index_service.called is False
 
-    def test_can_post_a_valid_service_update(self):
+    @mock.patch('app.main.views.services.index_service', autospec=True)
+    def test_can_post_a_valid_service_update(self, index_service):
         with self.app.app_context():
             response = self._post_service_update({'serviceName': 'new service name'})
             assert response.status_code == 200
+
+            service = Service.query.filter(
+                Service.service_id == self.service_id
+            ).one()
+            index_service.assert_called_once_with(service)
 
             response = self.client.get('/services/{}'.format(self.service_id))
             data = json.loads(response.get_data())
             assert data['services']['serviceName'] == 'new service name'
             assert response.status_code == 200
 
-    def test_valid_service_update_creates_audit_event(self):
+    @mock.patch('app.main.views.services.index_service', autospec=True)
+    def test_valid_service_update_creates_audit_event(self, index_service):
         with self.app.app_context():
             response = self._post_service_update({'serviceName': 'new service name'})
             assert response.status_code == 200
+            assert index_service.called is True
 
             audit_response = self.client.get('/audit-events')
             assert audit_response.status_code == 200
@@ -558,10 +580,12 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin, FixtureMixin):
             assert update_event['user'] == 'joeblogs'
             assert update_event['data']['serviceId'] == self.service_id
 
-    def test_valid_service_update_by_admin_creates_audit_event_with_correct_audit_type(self):
+    @mock.patch('app.main.views.services.index_service', autospec=True)
+    def test_valid_service_update_by_admin_creates_audit_event_with_correct_audit_type(self, index_service):
         with self.app.app_context():
             response = self._post_service_update({'serviceName': 'new service name'}, user_role='admin')
             assert response.status_code == 200
+            assert index_service.called is True
 
             audit_response = self.client.get('/audit-events')
             assert audit_response.status_code == 200
@@ -574,11 +598,14 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin, FixtureMixin):
             assert update_event['user'] == 'joeblogs'
             assert update_event['data']['serviceId'] == self.service_id
 
-    def test_service_update_audit_event_links_to_both_archived_services(self):
+    @mock.patch('app.main.views.services.index_service', autospec=True)
+    def test_service_update_audit_event_links_to_both_archived_services(self, index_service):
         with self.app.app_context():
             for name in ['new service name', 'new new service name']:
+                index_service.reset_mock()
                 response = self._post_service_update({'serviceName': name})
                 assert response.status_code == 200
+                assert index_service.called is True
 
             audit_response = self.client.get('/audit-events')
             assert audit_response.status_code == 200
@@ -596,7 +623,8 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin, FixtureMixin):
             assert data['auditEvents'][0]['data']['supplierName'] == 'Supplier 1'
             assert data['auditEvents'][0]['data']['supplierId'] == 1
 
-    def test_can_post_a_valid_service_update_on_several_fields(self):
+    @mock.patch('app.main.views.services.index_service', autospec=True)
+    def test_can_post_a_valid_service_update_on_several_fields(self, index_service):
         with self.app.app_context():
             response = self._post_service_update({
                 'serviceName': 'new service name',
@@ -604,6 +632,7 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin, FixtureMixin):
                 'serviceTypes': ['Software development tools']}
             )
             assert response.status_code == 200
+            assert index_service.called is True
 
             response = self.client.get('/services/{}'.format(self.service_id))
             data = json.loads(response.get_data())
@@ -612,11 +641,13 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin, FixtureMixin):
             assert data['services']['serviceTypes'][0] == 'Software development tools'
             assert response.status_code == 200
 
-    def test_can_post_a_valid_service_update_with_list(self):
+    @mock.patch('app.main.views.services.index_service', autospec=True)
+    def test_can_post_a_valid_service_update_with_list(self, index_service):
         with self.app.app_context():
             support_types = ['Service desk', 'Email', 'Phone', 'Live chat', 'Onsite']
             response = self._post_service_update({'supportTypes': support_types})
             assert response.status_code == 200
+            assert index_service.called is True
 
             response = self.client.get('/services/{}'.format(self.service_id))
             data = json.loads(response.get_data())
@@ -624,7 +655,8 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin, FixtureMixin):
             assert all(i in support_types for i in data['services']['supportTypes']) is True
             assert response.status_code == 200
 
-    def test_can_post_a_valid_service_update_with_object(self):
+    @mock.patch('app.main.views.services.index_service', autospec=True)
+    def test_can_post_a_valid_service_update_with_object(self, index_service):
         with self.app.app_context():
             identity_authentication_controls = {
                 "value": ["Authentication federation"],
@@ -632,6 +664,7 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin, FixtureMixin):
             }
             response = self._post_service_update({'identityAuthenticationControls': identity_authentication_controls})
             assert response.status_code == 200
+            assert index_service.called is True
 
             response = self.client.get('/services/{}'.format(self.service_id))
             data = json.loads(response.get_data())
@@ -643,7 +676,8 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin, FixtureMixin):
             assert len(updated_auth_controls['value']) == 1
             assert ('Authentication federation' in updated_auth_controls['value']) is True
 
-    def test_invalid_field_not_accepted_on_update(self):
+    @mock.patch('app.main.views.services.index_service', autospec=True)
+    def test_invalid_field_not_accepted_on_update(self, index_service):
         with self.app.app_context():
             response = self._post_service_update({'thisIsInvalid': 'so I should never see this'})
 
@@ -651,18 +685,23 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin, FixtureMixin):
             assert 'Additional properties are not allowed' in "{}".format(
                 json.loads(response.get_data())['error']['_form']
             )
+            assert index_service.called is False
 
-    def test_invalid_field_value_not_accepted_on_update(self):
+    @mock.patch('app.main.views.services.index_service', autospec=True)
+    def test_invalid_field_value_not_accepted_on_update(self, index_service):
         with self.app.app_context():
             response = self._post_service_update({'priceUnit': 'per Truth'})
 
             assert response.status_code == 400
             assert "no_unit_specified" in json.loads(response.get_data())['error']['priceUnit']
+            assert index_service.called is False
 
-    def test_updated_service_is_archived_right_away(self):
+    @mock.patch('app.main.views.services.index_service', autospec=True)
+    def test_updated_service_is_archived_right_away(self, index_service):
         with self.app.app_context():
             response = self._post_service_update({'serviceName': 'new service name'})
             assert response.status_code == 200
+            assert index_service.called is True
 
             archived_state = self.client.get(
                 '/archived-services?service-id=' + self.service_id).get_data()
@@ -670,11 +709,13 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin, FixtureMixin):
 
             assert archived_service_json['serviceName'] == 'new service name'
 
-    def test_updated_service_archive_is_listed_in_chronological_order(self):
+    @mock.patch('app.main.views.services.index_service', autospec=True)
+    def test_updated_service_archive_is_listed_in_chronological_order(self, index_service):
         with self.app.app_context():
             for name in ['new service name', 'new new service name']:
                 response = self._post_service_update({'serviceName': name})
                 assert response.status_code == 200
+                assert index_service.called is True
 
             archived_state = self.client.get(
                 '/archived-services?service-id=' +
@@ -685,34 +726,42 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin, FixtureMixin):
             # only the two updates done at the beginning of this test will be archived
             assert [s['serviceName'] for s in archived_service_json] == ['new service name', 'new new service name']
 
-    def test_updated_service_should_be_archived_on_each_update(self):
+    @mock.patch('app.main.views.services.index_service', autospec=True)
+    def test_updated_service_should_be_archived_on_each_update(self, index_service):
         with self.app.app_context():
             for i in range(5):
+                index_service.reset_mock()
                 response = self._post_service_update({'serviceName': 'new service name' + str(i)})
                 assert response.status_code == 200
+                assert index_service.called is True
 
             archived_state = self.client.get(
                 '/archived-services?service-id=' + self.service_id).get_data()
             assert len(json.loads(archived_state)['services']) == 5
 
-    def test_writing_full_service_back(self):
+    @mock.patch('app.main.views.services.index_service', autospec=True)
+    def test_writing_full_service_back(self, index_service):
         with self.app.app_context():
             response = self.client.get('/services/{}'.format(self.service_id))
             data = json.loads(response.get_data())
             response = self._post_service_update(data['services'])
 
             assert response.status_code == 200
+            assert index_service.called is True
 
-    def test_should_404_if_no_archived_service_found_by_pk(self):
+    @mock.patch('app.main.views.services.index_service', autospec=True)
+    def test_should_404_if_no_archived_service_found_by_pk(self, index_service):
         response = self.client.get('/archived-services/5')
         assert response.status_code == 404
 
-    def test_return_404_if_no_archived_service_by_service_id(self):
+    @mock.patch('app.main.views.services.index_service', autospec=True)
+    def test_return_404_if_no_archived_service_by_service_id(self, index_service):
         response = self.client.get(
             '/archived-services?service-id=12345678901234')
         assert response.status_code == 404
 
-    def test_should_400_if_invalid_service_id(self):
+    @mock.patch('app.main.views.services.index_service', autospec=True)
+    def test_should_400_if_invalid_service_id(self, index_service):
         response = self.client.get('/archived-services?service-id=not-valid')
         assert response.status_code == 400
         assert b'Invalid service ID supplied' in response.get_data()
@@ -727,7 +776,8 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin, FixtureMixin):
         assert response.status_code == 400
         assert b'Invalid service ID supplied' in response.get_data()
 
-    def test_should_400_if_mismatched_service_id(self):
+    @mock.patch('app.main.views.services.index_service', autospec=True)
+    def test_should_400_if_mismatched_service_id(self, index_service):
         response = self.client.post(
             '/services/{}'.format(self.service_id),
             data=json.dumps(
@@ -738,103 +788,21 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin, FixtureMixin):
 
         assert response.status_code == 400
         assert b'id parameter must match id in data' in response.get_data()
+        assert index_service.called is False
 
-    def test_should_not_update_status_through_service_post(self):
+    @mock.patch('app.main.views.services.index_service', autospec=True)
+    def test_should_not_update_status_through_service_post(self, index_service):
         response = self._post_service_update({'status': 'enabled'})
         assert response.status_code == 200
+        assert index_service.called is True
 
         response = self.client.get('/services/{}'.format(self.service_id))
         data = json.loads(response.get_data())
 
         assert data['services']['status'] == 'published'
 
-    @mock.patch('app.main.views.services.index_service')
-    def test_should_update_service_with_valid_statuses(self, index_service):
-        valid_statuses = ServiceTableMixin.STATUSES
-
-        for status in valid_statuses:
-            response = self.client.post(
-                '/services/{0}/status/{1}'.format(
-                    self.service_id,
-                    status
-                ),
-                data=json.dumps(
-                    {'updated_by': 'joeblogs'}),
-                content_type='application/json'
-            )
-
-            assert response.status_code == 200
-            data = json.loads(response.get_data())
-            assert status == data['services']['status']
-
-    def test_update_service_status_creates_audit_event(self):
-        response = self.client.post(
-            '/services/{0}/status/{1}'.format(
-                self.service_id,
-                "disabled"
-            ),
-            data=json.dumps(
-                {'updated_by': 'joeblogs'}),
-            content_type='application/json'
-        )
-
-        assert response.status_code == 200
-
-        audit_response = self.client.get('/audit-events')
-        assert audit_response.status_code == 200
-        data = json.loads(audit_response.get_data())
-
-        assert len(data['auditEvents']) == 1
-        assert data['auditEvents'][0]['type'] == 'update_service_status'
-        assert data['auditEvents'][0]['user'] == 'joeblogs'
-        assert data['auditEvents'][0]['data']['serviceId'] == self.service_id
-        assert data['auditEvents'][0]['data']['new_status'] == 'disabled'
-        assert data['auditEvents'][0]['data']['old_status'] == 'published'
-
-        # initial service creation is done using `setup_dummy_service` in setup(), which skips the archiving process
-        # only the two updates done at the beginning of this test will be archived
-        assert data['auditEvents'][0]['data']['oldArchivedServiceId'] is None
-        assert 'oldArchivedService' not in data['auditEvents'][0]['links']
-
-        assert data['auditEvents'][0]['data']['newArchivedServiceId'] is not None
-        assert '/archived-services/' in data['auditEvents'][0]['links']['newArchivedService']
-
-    def test_should_400_with_invalid_statuses(self):
-        invalid_statuses = [
-            "unpublished",  # not a permissible state
-            "enabeld",  # typo
-        ]
-
-        for status in invalid_statuses:
-            response = self.client.post(
-                '/services/{0}/status/{1}'.format(
-                    self.service_id,
-                    status
-                ),
-                data=json.dumps(
-                    {'updated_by': 'joeblogs'}),
-                content_type='application/json'
-            )
-
-            assert response.status_code == 400
-            assert 'is not a valid status' in json.loads(response.get_data())['error']
-            # assert that valid status names are returned in the response
-            for valid_status in ServiceTableMixin.STATUSES:
-                assert valid_status in json.loads(response.get_data())['error']
-
-    def test_should_404_without_status_parameter(self):
-        response = self.client.post(
-            '/services/{0}/status/'.format(
-                self.service_id,
-            ),
-            data=json.dumps(
-                {'updated_by': 'joeblogs'}),
-            content_type='application/json'
-        )
-
-        assert response.status_code == 404
-
-    def test_json_postgres_field_should_not_include_column_fields(self):
+    @mock.patch('app.main.views.services.index_service', autospec=True)
+    def test_json_postgres_field_should_not_include_column_fields(self, index_service):
         non_json_fields = [
             'supplierName', 'links', 'frameworkSlug', 'updatedAt', 'createdAt', 'frameworkName', 'status', 'id']
         with self.app.app_context():
@@ -843,207 +811,41 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin, FixtureMixin):
 
             response = self._post_service_update(data['services'])
             assert response.status_code == 200
+            assert index_service.called is True
 
             service = Service.query.filter(Service.service_id == self.service_id).first()
 
             for key in non_json_fields:
                 assert key not in service.data
 
-
-@mock.patch('app.utils.search_api_client')
-class TestShouldCallSearchApiOnPutToCreateService(BaseApplicationTest):
-    def setup(self):
-        super(TestShouldCallSearchApiOnPutToCreateService, self).setup()
-        with self.app.app_context():
-            self.app.config['DM_FRAMEWORK_TO_ES_INDEX_MAPPING'] = {
-                'g-cloud-6': {
-                    'services': 'g-cloud-6'
-                }
-            }
-            db.session.add(
-                Supplier(supplier_id=1, name=u"Supplier 1")
-            )
-
-            db.session.commit()
-
-    def test_should_index_on_service_put(self, search_api_client):
-        with self.app.app_context():
-            search_api_client.index.return_value = True
-
-            payload = load_example_listing("G6-IaaS")
-            payload['id'] = "1234567890123456"
-            response = self.client.put(
-                '/services/1234567890123456',
-                data=json.dumps(
-                    {
-                        'updated_by': 'joeblogs',
-                        'services': payload}
-                ),
-                content_type='application/json')
-
-            search_api_client.index.assert_called_with(
-                index_name='g-cloud-6',
-                object_type='services',
-                object_id="1234567890123456",
-                serialized_object=json.loads(response.get_data())['services']
-            )
-
-    def test_should_not_index_on_service_on_expired_frameworks(
-            self, search_api_client
-    ):
-        with self.app.app_context():
-            search_api_client.index.return_value = True
-
-            payload = load_example_listing("G4")
-            res = self.client.put(
-                '/services/' + payload["id"],
-                data=json.dumps(
-                    {
-                        'updated_by': 'joeblogs',
-                        'services': payload}
-                ),
-                content_type='application/json')
-
-            assert res.status_code == 201
-            assert Service.query.filter(Service.service_id == payload["id"]).first() is not None
-            assert search_api_client.index.called is False
-
-    def test_should_ignore_index_error_on_service_put(self, search_api_client):
-        with self.app.app_context():
-            search_api_client.index.side_effect = HTTPError()
-
-            payload = load_example_listing("G6-IaaS")
-            payload['id'] = "1234567890123456"
-            response = self.client.put(
-                '/services/1234567890123456',
-                data=json.dumps(
-                    {
-                        'updated_by': 'joeblogs',
-                        'services': payload}
-                ),
-                content_type='application/json')
-
-            assert response.status_code == 201
-
-
-@mock.patch('app.utils.search_api_client')
-class TestShouldCallSearchApiOnPost(BaseApplicationTest, FixtureMixin):
-
-    payload = None
-    payload_g4 = None
-
-    def setup(self):
-        super(TestShouldCallSearchApiOnPost, self).setup()
-        self.payload = load_example_listing("G6-SaaS")
-        self.payload_g4 = load_example_listing("G4")
-        with self.app.app_context():
-            db.session.add(
-                Supplier(supplier_id=1, name=u"Supplier 1")
-            )
-            self.setup_dummy_service(
-                service_id=self.payload['id'],
-                **self.payload
-            )
-
-            self.setup_dummy_service(
-                service_id=self.payload_g4['id'],
-                **self.payload_g4
-            )
-            self.app.config['DM_FRAMEWORK_TO_ES_INDEX_MAPPING'] = {
-                'g-cloud-6': {
-                    'services': 'g-cloud-6'
-                }
-            }
-
-    def test_should_index_on_service_post(self, search_api_client):
-        with self.app.app_context():
-            search_api_client.index.return_value = True
-
-            self.client.post(
-                '/services/{}'.format(self.payload['id']),
-                data=json.dumps(
-                    {
-                        'updated_by': 'joeblogs',
-                        'services': self.payload}
-                ),
-                content_type='application/json')
-
-            search_api_client.index.assert_called_with(
-                index_name='g-cloud-6',
-                object_type='services',
-                object_id=self.payload['id'],
-                serialized_object=mock.ANY
-            )
-
     @mock.patch('app.service_utils.db.session.commit')
-    def test_should_not_index_on_service_post_if_db_exception(
-            self, search_api_client, db_session_commit
-    ):
+    @mock.patch('app.main.views.services.index_service', autospec=True)
+    def test_should_not_index_on_service_post_if_db_exception(self, index_service, db_session_commit):
         with self.app.app_context():
-            search_api_client.index.return_value = True
             db_session_commit.side_effect = IntegrityError(
                 'message', 'statement', 'params', 'orig')
 
-            payload = load_example_listing("G6-SaaS")
-            self.client.post(
-                '/services/{}'.format(self.payload['id']),
-                data=json.dumps(
-                    {
-                        'updated_by': 'joeblogs',
-                        'services': payload}
-                ),
-                content_type='application/json')
-            assert search_api_client.index.called is False
+            self.client.get('/services/{}'.format(self.service_id))
+            assert index_service.called is False
 
-    def test_should_not_index_on_service_on_expired_frameworks(
-            self, search_api_client
-    ):
-        with self.app.app_context():
-            search_api_client.index.return_value = True
-
-            payload = load_example_listing("G4")
-            res = self.client.post(
-                '/services/{}'.format(self.payload_g4['id']),
-                data=json.dumps(
-                    {
-                        'updated_by': 'joeblogs',
-                        'services': payload}
-                ),
-                content_type='application/json')
-
-            assert res.status_code == 200
-            assert not search_api_client.index.called
-
+    @mock.patch('app.utils.search_api_client')
     def test_should_ignore_index_error(self, search_api_client):
         with self.app.app_context():
             search_api_client.index.side_effect = HTTPError()
 
-            payload = load_example_listing("G6-SaaS")
-            response = self.client.post(
-                '/services/{}'.format(self.payload['id']),
-                data=json.dumps(
-                    {
-                        'updated_by': 'joeblogs',
-                        'services': payload}
-                ),
-                content_type='application/json')
+            response = self.client.get('/services/{}'.format(self.service_id))
 
             assert response.status_code == 200, response.get_data()
 
 
-class TestShouldCallSearchApiOnPostStatusUpdate(BaseApplicationTest, FixtureMixin):
+class TestUpdateServiceStatus(BaseApplicationTest, FixtureMixin):
     def setup(self):
-        super(TestShouldCallSearchApiOnPostStatusUpdate, self).setup()
+        super().setup()
         self.services = {}
 
         valid_statuses = ServiceTableMixin.STATUSES
 
         with self.app.app_context():
-            self.app.config['DM_FRAMEWORK_TO_ES_INDEX_MAPPING'] = {
-                'g-cloud-6': {
-                    'services': 'g-cloud-6'
-                }
-            }
             db.session.add(
                 Supplier(supplier_id=1, name=u"Supplier 1")
             )
@@ -1074,50 +876,42 @@ class TestShouldCallSearchApiOnPostStatusUpdate(BaseApplicationTest, FixtureMixi
                             service_is_indexed, service_is_deleted,
                             expected_status_code):
 
-        with mock.patch('app.utils.search_api_client') as utils_search_api_client:
+        with mock.patch('app.service_utils.index_object') as index_object:
             with mock.patch('app.service_utils.search_api_client') as service_utils_search_api_client:
-                utils_search_api_client.index.return_value = True
-                service_utils_search_api_client.delete.return_value = True
-
-                response = self.client.post(
-                    '/services/{0}/status/{1}'.format(
-                        self.services[old_status]['id'],
-                        new_status
-                    ),
-                    data=json.dumps(
-                        {'updated_by': 'joeblogs'}),
-                    content_type='application/json'
-                )
-
-                # Check response after posting an update
-                assert response.status_code == expected_status_code
-
-                # Exit function if update was not successful
-                if expected_status_code != 200:
-                    return
-
-                service = self._get_service_from_database_by_service_id(
-                    self.services[old_status]['id'])
-
-                # Check that service in database has been updated
-                assert new_status == service.status
-
-                # Check that search_api_client is doing the right thing
-                if service_is_indexed:
-                    utils_search_api_client.index.assert_called_with(
-                        index_name=service.framework.slug,
-                        object_type='services',
-                        object_id=service.service_id,
-                        serialized_object=json.loads(response.get_data())['services']
+                with self.app.app_context():
+                    response = self.client.post(
+                        '/services/{0}/status/{1}'.format(
+                            self.services[old_status]['id'],
+                            new_status
+                        ),
+                        data=json.dumps(
+                            {'updated_by': 'joeblogs'}),
+                        content_type='application/json'
                     )
-                else:
-                    assert not utils_search_api_client.index.called
 
-                if service_is_deleted:
-                    service_utils_search_api_client.delete.assert_called_with(index=service.framework.slug,
-                                                                              service_id=service.service_id)
-                else:
-                    assert not service_utils_search_api_client.delete.called
+                    # Check response after posting an update
+                    assert response.status_code == expected_status_code
+
+                    # Exit function if update was not successful
+                    if expected_status_code != 200:
+                        return
+
+                    service = self._get_service_from_database_by_service_id(
+                        self.services[old_status]['id'])
+
+                    # Check that service in database has been updated
+                    assert new_status == service.status
+                    # Check that search_api_client is doing the right thing
+                    if service_is_indexed:
+                        assert index_object.called is True
+                    else:
+                        assert index_object.called is False
+
+                    if service_is_deleted:
+                        service_utils_search_api_client.delete.assert_called_with(index=service.framework.slug,
+                                                                                  service_id=service.service_id)
+                    else:
+                        assert not service_utils_search_api_client.delete.called
 
     def test_should_index_on_service_status_changed_to_published(self):
 
@@ -1205,11 +999,121 @@ class TestPutService(BaseApplicationTest, JSONUpdateTestMixin, FixtureMixin):
             # need a supplier_id of '1' because our service has it hardcoded
             self.setup_dummy_suppliers(2)
             db.session.commit()
-            self.app.config['DM_FRAMEWORK_TO_ES_INDEX_MAPPING'] = {
-                'g-cloud-6': {
-                    'services': 'g-cloud-6'
-                }
-            }
+
+    @mock.patch('app.main.views.services.index_service', autospec=True)
+    def test_should_update_service_with_valid_statuses(self, index_service):
+        valid_statuses = ServiceTableMixin.STATUSES
+
+        with self.app.app_context():
+            self.setup_dummy_service(
+                service_id=self.service_id,
+                **self.service
+            )
+            service = Service.query.filter(
+                Service.service_id == self.service_id
+            ).one()
+            for status in valid_statuses:
+                index_service.reset_mock()
+                response = self.client.post(
+                    '/services/{0}/status/{1}'.format(
+                        self.service_id,
+                        status
+                    ),
+                    data=json.dumps(
+                        {'updated_by': 'joeblogs'}),
+                    content_type='application/json'
+                )
+
+                assert response.status_code == 200
+                data = json.loads(response.get_data())
+                assert status == data['services']['status']
+                if status == 'disabled':
+                    assert index_service.called is False
+                else:
+                    index_service.assert_called_once_with(service)
+
+    @mock.patch('app.main.views.services.index_service', autospec=True)
+    def test_update_service_status_creates_audit_event(self, index_service):
+        with self.app.app_context():
+            self.setup_dummy_service(
+                service_id=self.service_id,
+                **self.service
+            )
+        response = self.client.post(
+            '/services/{0}/status/{1}'.format(
+                self.service_id,
+                "disabled"
+            ),
+            data=json.dumps(
+                {'updated_by': 'joeblogs'}),
+            content_type='application/json'
+        )
+
+        assert response.status_code == 200
+        assert index_service.called is False
+
+        audit_response = self.client.get('/audit-events')
+        assert audit_response.status_code == 200
+        data = json.loads(audit_response.get_data())
+
+        assert len(data['auditEvents']) == 1
+        assert data['auditEvents'][0]['type'] == 'update_service_status'
+        assert data['auditEvents'][0]['user'] == 'joeblogs'
+        assert data['auditEvents'][0]['data']['serviceId'] == self.service_id
+        assert data['auditEvents'][0]['data']['new_status'] == 'disabled'
+        assert data['auditEvents'][0]['data']['old_status'] == 'published'
+
+        # initial service creation is done using `setup_dummy_service` in setup(), which skips the archiving process
+        # only the two updates done at the beginning of this test will be archived
+        assert data['auditEvents'][0]['data']['oldArchivedServiceId'] is None
+        assert 'oldArchivedService' not in data['auditEvents'][0]['links']
+
+        assert data['auditEvents'][0]['data']['newArchivedServiceId'] is not None
+        assert '/archived-services/' in data['auditEvents'][0]['links']['newArchivedService']
+
+    @mock.patch('app.main.views.services.index_service', autospec=True)
+    def test_should_400_with_invalid_statuses(self, index_service):
+        with self.app.app_context():
+            self.setup_dummy_service(
+                service_id=self.service_id,
+                **self.service
+            )
+        invalid_statuses = [
+            "unpublished",  # not a permissible state
+            "enabeld",  # typo
+        ]
+
+        for status in invalid_statuses:
+            response = self.client.post(
+                '/services/{0}/status/{1}'.format(
+                    self.service_id,
+                    status
+                ),
+                data=json.dumps(
+                    {'updated_by': 'joeblogs'}),
+                content_type='application/json'
+            )
+
+            assert response.status_code == 400
+            assert index_service.called is False
+            assert 'is not a valid status' in json.loads(response.get_data())['error']
+            # assert that valid status names are returned in the response
+            for valid_status in ServiceTableMixin.STATUSES:
+                assert valid_status in json.loads(response.get_data())['error']
+
+    @mock.patch('app.main.views.services.index_service', autospec=True)
+    def test_should_404_without_status_parameter(self, index_service):
+        response = self.client.post(
+            '/services/{0}/status/'.format(
+                self.service_id,
+            ),
+            data=json.dumps(
+                {'updated_by': 'joeblogs'}),
+            content_type='application/json'
+        )
+
+        assert response.status_code == 404
+        assert index_service.called is False
 
     def test_json_postgres_data_column_should_not_include_column_fields(self):
         non_json_fields = [
@@ -1479,6 +1383,44 @@ class TestPutService(BaseApplicationTest, JSONUpdateTestMixin, FixtureMixin):
             assert response.status_code == 400
             assert json.loads(response.get_data())["error"] == "Cannot update service by PUT"
 
+    @mock.patch('app.main.views.services.index_service')
+    def test_should_index_on_service_put(self, index_service):
+        with self.app.app_context():
+            payload = load_example_listing("G6-IaaS")
+            payload['id'] = "1234567890123456"
+            self.client.put(
+                '/services/1234567890123456',
+                data=json.dumps(
+                    {
+                        'updated_by': 'joeblogs',
+                        'services': payload}
+                ),
+                content_type='application/json')
+
+            service = Service.query.filter(
+                Service.service_id == '1234567890123456'
+            ).one()
+
+            index_service.assert_called_once_with(service)
+
+    @mock.patch('app.utils.search_api_client')
+    def test_should_ignore_index_error_on_service_put(self, search_api_client):
+        with self.app.app_context():
+            search_api_client.index.side_effect = HTTPError()
+
+            payload = load_example_listing("G6-IaaS")
+            payload['id'] = "1234567890123456"
+            response = self.client.put(
+                '/services/1234567890123456',
+                data=json.dumps(
+                    {
+                        'updated_by': 'joeblogs',
+                        'services': payload}
+                ),
+                content_type='application/json')
+
+            assert response.status_code == 201
+
 
 class TestGetService(BaseApplicationTest):
     def setup(self):
@@ -1718,16 +1660,11 @@ class TestGetService(BaseApplicationTest):
         assert data['serviceMadeUnavailableAuditEvent']['data']['update']['status'] == 'expired'
 
 
-@mock.patch('app.utils.search_api_client', autospec=True)
+@mock.patch('app.main.views.services.index_service', autospec=True)
 class TestRevertService(BaseApplicationTest, FixtureMixin):
     def setup(self):
         super(TestRevertService, self).setup()
         with self.app.app_context():
-            self.app.config['DM_FRAMEWORK_TO_ES_INDEX_MAPPING'] = {
-                'g-cloud-7': {
-                    'services': 'g-cloud-7'
-                }
-            }
             self.set_framework_status("g-cloud-7", "live")
             self.supplier_ids = self.setup_dummy_suppliers(2)
             g7_scs = load_example_listing("G7-SCS")
@@ -1760,7 +1697,7 @@ class TestRevertService(BaseApplicationTest, FixtureMixin):
                 )),
             )
 
-    def test_non_existent_service(self, search_api_client):
+    def test_non_existent_service(self, index_service):
         response = self.client.post(
             '/services/9876987698760000/revert',
             content_type='application/json',
@@ -1771,9 +1708,9 @@ class TestRevertService(BaseApplicationTest, FixtureMixin):
         with self.app.app_context():
             assert not AuditEvent.query.filter(AuditEvent.type == AuditTypes.update_service.name).all()
             assert ArchivedService.query.count() == 4
-            assert search_api_client.index.called is False
+            assert index_service.called is False
 
-    def test_archived_service_mismatch(self, search_api_client):
+    def test_archived_service_mismatch(self, index_service):
         response = self.client.post(
             '/services/1234123412340001/revert',
             content_type='application/json',
@@ -1788,9 +1725,9 @@ class TestRevertService(BaseApplicationTest, FixtureMixin):
                 Service.service_id == "1234123412340001"
             ).one().data["serviceSummary"] == "Probably the best cloud service in the world"
             assert ArchivedService.query.count() == 4
-            assert search_api_client.index.called is False
+            assert index_service.called is False
 
-    def test_non_existent_archived_service(self, search_api_client):
+    def test_non_existent_archived_service(self, index_service):
         response = self.client.post(
             '/services/1234123412340001/revert',
             content_type='application/json',
@@ -1805,9 +1742,9 @@ class TestRevertService(BaseApplicationTest, FixtureMixin):
                 Service.service_id == "1234123412340001"
             ).one().data["serviceSummary"] == "Probably the best cloud service in the world"
             assert ArchivedService.query.count() == 4
-            assert search_api_client.index.called is False
+            assert index_service.called is False
 
-    def test_archived_service_doesnt_validate(self, search_api_client):
+    def test_archived_service_doesnt_validate(self, index_service):
         response = self.client.post(
             '/services/1234123412340001/revert',
             content_type='application/json',
@@ -1822,20 +1759,21 @@ class TestRevertService(BaseApplicationTest, FixtureMixin):
                 Service.service_id == "1234123412340001"
             ).one().data["serviceSummary"] == "Probably the best cloud service in the world"
             assert ArchivedService.query.count() == 4
-            assert search_api_client.index.called is False
+            assert index_service.called is False
 
-    def test_happy_path(self, search_api_client):
-        response = self.client.post(
-            '/services/1234123412340001/revert',
-            content_type='application/json',
-            data=json.dumps({"updated_by": "papli@example.com", "archivedServiceId": self.archived_service_ids[1]}),
-        )
-        assert response.status_code == 200
-
+    def test_happy_path(self, index_service):
         with self.app.app_context():
-            assert Service.query.filter(
+            response = self.client.post(
+                '/services/1234123412340001/revert',
+                content_type='application/json',
+                data=json.dumps({"updated_by": "papli@example.com", "archivedServiceId": self.archived_service_ids[1]}),
+            )
+            assert response.status_code == 200
+
+            service = Service.query.filter(
                 Service.service_id == "1234123412340001"
-            ).one().data["serviceSummary"] == "Assuredly the best"
+            ).one()
+            assert service.data["serviceSummary"] == "Assuredly the best"
             assert tuple(
                 (event.user, event.data["fromArchivedServiceId"],)
                 for event in AuditEvent.query.filter(AuditEvent.type == AuditTypes.update_service.name).all()
@@ -1843,11 +1781,4 @@ class TestRevertService(BaseApplicationTest, FixtureMixin):
                 ("papli@example.com", self.archived_service_ids[1],),
             )
             assert ArchivedService.query.count() == 5
-            assert search_api_client.index.call_args_list == [
-                ((), {
-                    "index_name": "g-cloud-7",
-                    "object_type": "services",
-                    "object_id": "1234123412340001",
-                    "serialized_object": mock.ANY,
-                })
-            ]
+            index_service.assert_called_once_with(service)

--- a/tests/test_brief_utils.py
+++ b/tests/test_brief_utils.py
@@ -1,6 +1,7 @@
 import mock
+from app import db
 from app.brief_utils import index_brief
-from app.models import Brief, Framework
+from app.models import Brief, Lot, Framework
 from tests.bases import BaseApplicationTest
 
 
@@ -11,13 +12,16 @@ class TestIndexBriefs(BaseApplicationTest):
             dos2 = Framework.query.filter(Framework.slug == 'digital-outcomes-and-specialists-2').first()
 
             with mock.patch.object(Brief, "serialize", return_value={'serialized': 'object'}):
-                brief = Brief(status='live', framework=dos2, data={'requirementsLength': '1 week'})
+                lot = Lot.query.filter(Lot.slug == 'digital-outcomes').one()
+                brief = Brief(status='live', framework=dos2, data={'requirementsLength': '1 week'}, lot=lot)
+                db.session.add(brief)
+                db.session.commit()
                 index_brief(brief)
 
             index_object.assert_called_once_with(
                 framework='digital-outcomes-and-specialists-2',
                 doc_type='briefs',
-                object_id=None,
+                object_id=1,
                 serialized_object={'serialized': 'object'},
             )
 

--- a/tests/test_brief_utils.py
+++ b/tests/test_brief_utils.py
@@ -1,0 +1,42 @@
+import mock
+from app.brief_utils import index_brief
+from app.models import Brief, Framework
+from tests.bases import BaseApplicationTest
+
+
+@mock.patch('app.brief_utils.index_object', autospec=True)
+class TestIndexBriefs(BaseApplicationTest):
+    def test_live_dos_2_brief_is_indexed(self, index_object, live_dos2_framework):
+        with self.app.app_context():
+            dos2 = Framework.query.filter(Framework.slug == 'digital-outcomes-and-specialists-2').first()
+
+            with mock.patch.object(Brief, "serialize", return_value={'serialized': 'object'}):
+                brief = Brief(status='live', framework=dos2, data={'requirementsLength': '1 week'})
+                index_brief(brief)
+
+            index_object.assert_called_once_with(
+                framework='digital-outcomes-and-specialists-2',
+                object_type='briefs',
+                object_id=None,
+                serialized_object={'serialized': 'object'},
+            )
+
+    def test_draft_dos_2_brief_is_not_indexed(self, index_object, live_dos2_framework):
+        with self.app.app_context():
+            dos2 = Framework.query.filter(Framework.slug == 'digital-outcomes-and-specialists-2').first()
+
+            with mock.patch.object(Brief, "serialize", return_value={'serialized': 'object'}):
+                brief = Brief(status='draft', framework=dos2, data={'requirementsLength': '1 week'})
+                index_brief(brief)
+
+            assert index_object.called is False
+
+    def test_object_not_on_dos_not_indexed(self, index_object, live_g8_framework):
+        with self.app.app_context():
+            g8 = Framework.query.filter(Framework.slug == 'g-cloud-8').first()
+
+            with mock.patch.object(Brief, "serialize", return_value={'serialized': 'object'}):
+                brief = Brief(status='live', framework=g8, data={'requirementsLength': '1 week'})
+                index_brief(brief)
+
+            assert index_object.called is False

--- a/tests/test_brief_utils.py
+++ b/tests/test_brief_utils.py
@@ -16,7 +16,7 @@ class TestIndexBriefs(BaseApplicationTest):
 
             index_object.assert_called_once_with(
                 framework='digital-outcomes-and-specialists-2',
-                object_type='briefs',
+                doc_type='briefs',
                 object_id=None,
                 serialized_object={'serialized': 'object'},
             )

--- a/tests/test_brief_utils.py
+++ b/tests/test_brief_utils.py
@@ -30,13 +30,3 @@ class TestIndexBriefs(BaseApplicationTest):
                 index_brief(brief)
 
             assert index_object.called is False
-
-    def test_object_not_on_dos_not_indexed(self, index_object, live_g8_framework):
-        with self.app.app_context():
-            g8 = Framework.query.filter(Framework.slug == 'g-cloud-8').first()
-
-            with mock.patch.object(Brief, "serialize", return_value={'serialized': 'object'}):
-                brief = Brief(status='live', framework=g8, data={'requirementsLength': '1 week'})
-                index_brief(brief)
-
-            assert index_object.called is False

--- a/tests/test_service_utils.py
+++ b/tests/test_service_utils.py
@@ -5,23 +5,28 @@ from app.service_utils import index_service
 from app.models import Service, Framework
 
 
-@mock.patch('app.service_utils.search_api_client')
+@mock.patch('app.service_utils.index_object', autospec=True)
 class TestIndexServices(BaseApplicationTest):
 
     def test_live_g_cloud_8_published_service_is_indexed(
-            self, search_api_client, live_g8_framework
+            self, index_object, live_g8_framework
     ):
         with self.app.app_context():
             g8 = Framework.query.filter(Framework.slug == 'g-cloud-8').first()
 
-            with mock.patch.object(Service, "serialize"):
+            with mock.patch.object(Service, "serialize", return_value={'serialized': 'object'}):
                 service = Service(status='published', framework=g8)
                 index_service(service)
 
-            assert search_api_client.index.called
+            index_object.assert_called_once_with(
+                framework='g-cloud-8',
+                object_type='services',
+                object_id=None,
+                serialized_object={'serialized': 'object'},
+            )
 
     def test_live_g_cloud_8_enabled_service_is_not_indexed(
-            self, search_api_client, live_g8_framework
+            self, index_object, live_g8_framework
     ):
         with self.app.app_context():
             g8 = Framework.query.filter(Framework.slug == 'g-cloud-8').first()
@@ -30,9 +35,9 @@ class TestIndexServices(BaseApplicationTest):
                 service = Service(status='enabled', framework=g8)
                 index_service(service)
 
-            assert not search_api_client.index.called
+            assert not index_object.called
 
-    def test_live_dos_published_service_is_not_indexed(self, search_api_client, live_dos_framework):
+    def test_live_dos_published_service_is_not_indexed(self, index_object, live_dos_framework):
         with self.app.app_context():
             dos = Framework.query.filter(Framework.slug == 'digital-outcomes-and-specialists').first()
 
@@ -40,9 +45,9 @@ class TestIndexServices(BaseApplicationTest):
                 service = Service(status='published', framework=dos)
                 index_service(service)
 
-            assert not search_api_client.index.called
+            assert not index_object.called
 
-    def test_expired_g_cloud_6_published_service_is_not_indexed(self, search_api_client, expired_g6_framework):
+    def test_expired_g_cloud_6_published_service_is_not_indexed(self, index_object, expired_g6_framework):
         with self.app.app_context():
             g6 = Framework.query.filter(Framework.slug == 'g-cloud-6').first()
 
@@ -50,4 +55,4 @@ class TestIndexServices(BaseApplicationTest):
                 service = Service(status='published', framework=g6)
                 index_service(service)
 
-            assert not search_api_client.index.called
+            assert not index_object.called

--- a/tests/test_service_utils.py
+++ b/tests/test_service_utils.py
@@ -20,7 +20,7 @@ class TestIndexServices(BaseApplicationTest):
 
             index_object.assert_called_once_with(
                 framework='g-cloud-8',
-                object_type='services',
+                doc_type='services',
                 object_id=None,
                 serialized_object={'serialized': 'object'},
             )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -76,16 +76,17 @@ class TestKeyFilterJSON(object):
 class TestIndexObject(BaseApplicationTest):
     def test_calls_the_search_api_index_method_correctly(self, search_api_client):
         with self.app.app_context():
-            for framework, object_to_index_mapping in current_app.config['DM_FRAMEWORK_TO_ES_INDEX_MAPPING'].items():
-                for object_type, index_name in object_to_index_mapping.items():
+            for framework, doc_type_to_index_mapping in current_app.config['DM_FRAMEWORK_TO_ES_INDEX_MAPPING'].items():
+                for doc_type, index_name in doc_type_to_index_mapping.items():
 
-                    index_object(framework, object_type, 123, {'serialized': 'object'})
+                    index_object(framework, doc_type, 123, {'serialized': 'object'})
 
                     search_api_client.index.assert_called_once_with(
                         index_name=index_name,
-                        object_type=object_type,
                         object_id=123,
-                        serialized_object={'serialized': 'object'})
+                        serialized_object={'serialized': 'object'},
+                        doc_type=doc_type,
+                    )
                     search_api_client.reset_mock()
 
     @mock.patch('app.utils.current_app')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,7 @@
 import pytest
+import mock
 
+from flask import current_app
 from nose.tools import assert_equal
 from werkzeug.exceptions import BadRequest, HTTPException
 
@@ -12,7 +14,10 @@ from app.utils import (display_list,
                        json_has_required_keys,
                        link,
                        purge_nulls_from_data,
-                       keyfilter_json)
+                       keyfilter_json,
+                       index_object)
+
+from dmapiclient import HTTPError
 
 
 def test_link():
@@ -65,6 +70,56 @@ class TestKeyFilterJSON(object):
                 }
             ],
         }
+
+
+@mock.patch('app.utils.search_api_client', autospec=True)
+class TestIndexObject(BaseApplicationTest):
+    def test_calls_the_search_api_index_method_correctly(self, search_api_client):
+        with self.app.app_context():
+            for framework, object_to_index_mapping in current_app.config['DM_FRAMEWORK_TO_ES_INDEX_MAPPING'].items():
+                for object_type, index_name in object_to_index_mapping.items():
+
+                    index_object(framework, object_type, 123, {'serialized': 'object'})
+
+                    search_api_client.index.assert_called_once_with(
+                        index_name=index_name,
+                        object_type=object_type,
+                        object_id=123,
+                        serialized_object={'serialized': 'object'})
+                    search_api_client.reset_mock()
+
+    @mock.patch('app.utils.current_app')
+    def test_logs_a_warning_message_if_no_mapping_found(self, current_app, search_api_client):
+        current_app.config = {
+            'DM_FRAMEWORK_TO_ES_INDEX_MAPPING': {
+                'not-a-framework': {
+                    'services': 'g-cloud-9'
+                }
+            }
+        }
+
+        index_object('g-cloud-9', 'services', 123, {'serialized': 'object'})
+
+        current_app.logger.warning.assert_called_once_with(
+            "Failed to find index name for framework 'g-cloud-9' with object type 'services'"
+        )
+
+    @mock.patch('app.utils.current_app')
+    def test_logs_a_warning_if_HTTPError_from_search_api(self, current_app, search_api_client):
+        search_api_client.index.side_effect = HTTPError()
+        current_app.config = {
+            'DM_FRAMEWORK_TO_ES_INDEX_MAPPING': {
+                'g-cloud-9': {
+                    'services': 'g-cloud-9'
+                }
+            }
+        }
+
+        index_object('g-cloud-9', 'services', 123, {'serialized': 'object'})
+
+        current_app.logger.warning.assert_called_once_with(
+            'Failed to add services object with id 123 to g-cloud-9 index: Request failed'
+        )
 
 
 def test_display_list_two_items():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -90,7 +90,7 @@ class TestIndexObject(BaseApplicationTest):
                     search_api_client.reset_mock()
 
     @mock.patch('app.utils.current_app')
-    def test_logs_a_warning_message_if_no_mapping_found(self, current_app, search_api_client):
+    def test_logs_an_error_message_if_no_mapping_found(self, current_app, search_api_client):
         current_app.config = {
             'DM_FRAMEWORK_TO_ES_INDEX_MAPPING': {
                 'not-a-framework': {
@@ -101,7 +101,7 @@ class TestIndexObject(BaseApplicationTest):
 
         index_object('g-cloud-9', 'services', 123, {'serialized': 'object'})
 
-        current_app.logger.warning.assert_called_once_with(
+        current_app.logger.error.assert_called_once_with(
             "Failed to find index name for framework 'g-cloud-9' with object type 'services'"
         )
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -130,4 +130,4 @@ def test_json_has_keys():
         ({'key1': 'value1'}, [], [], False),
         ({'key1': 'value1'}, [], ['key2'], False),
     ]:
-        yield check, data, data_required_keys, data_optional_keys, result
+        check(data, data_required_keys, data_optional_keys, result)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -76,7 +76,7 @@ class TestKeyFilterJSON(object):
 class TestIndexObject(BaseApplicationTest):
     def test_calls_the_search_api_index_method_correctly(self, search_api_client):
         with self.app.app_context():
-            for framework, doc_type_to_index_mapping in current_app.config['DM_FRAMEWORK_TO_ES_INDEX_MAPPING'].items():
+            for framework, doc_type_to_index_mapping in current_app.config['DM_FRAMEWORK_TO_ES_INDEX'].items():
                 for doc_type, index_name in doc_type_to_index_mapping.items():
 
                     index_object(framework, doc_type, 123, {'serialized': 'object'})
@@ -92,7 +92,7 @@ class TestIndexObject(BaseApplicationTest):
     @mock.patch('app.utils.current_app')
     def test_logs_an_error_message_if_no_mapping_found(self, current_app, search_api_client):
         current_app.config = {
-            'DM_FRAMEWORK_TO_ES_INDEX_MAPPING': {
+            'DM_FRAMEWORK_TO_ES_INDEX': {
                 'not-a-framework': {
                     'services': 'g-cloud-9'
                 }
@@ -109,7 +109,7 @@ class TestIndexObject(BaseApplicationTest):
     def test_logs_a_warning_if_HTTPError_from_search_api(self, current_app, search_api_client):
         search_api_client.index.side_effect = HTTPError()
         current_app.config = {
-            'DM_FRAMEWORK_TO_ES_INDEX_MAPPING': {
+            'DM_FRAMEWORK_TO_ES_INDEX': {
                 'g-cloud-9': {
                     'services': 'g-cloud-9'
                 }

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -5,7 +5,7 @@ import json
 
 import pytest
 import mock
-from nose.tools import assert_equal, assert_in, assert_not_in
+from nose.tools import assert_equal
 from jsonschema import validate, SchemaError, ValidationError
 
 from app.utils import drop_foreign_fields
@@ -49,7 +49,7 @@ def test_for_valid_date():
     ]
 
     for example, expected in cases:
-        yield assert_equal, is_valid_date(example), expected, example
+        assert is_valid_date(example) == expected
 
 
 def test_for_valid_acknowledged_state():
@@ -62,7 +62,7 @@ def test_for_valid_acknowledged_state():
     ]
 
     for example, expected in cases:
-        yield assert_equal, is_valid_acknowledged_state(example), expected
+        assert is_valid_acknowledged_state(example) == expected
 
 
 def test_for_valid_service_id():
@@ -81,7 +81,7 @@ def test_for_valid_service_id():
     ]
 
     for example, expected in cases:
-        yield assert_equal, is_valid_service_id(example), expected, example
+        assert is_valid_service_id(example) == expected
 
 
 def test_for_valid_string():
@@ -98,15 +98,14 @@ def test_for_valid_string():
     ]
 
     for example, min, max, expected in cases:
-        yield assert_equal, is_valid_string(
-            example, min, max), expected, example
+        assert is_valid_string(example, min, max) == expected
 
 
 def test_all_schemas_are_valid():
     for file_name in os.listdir('json_schemas'):
         file_path = 'json_schemas/%s' % file_name
         if os.path.isfile(file_path) and file_path.endswith(".json"):
-            yield check_schema_file, file_path
+            check_schema_file(file_path)
 
 
 def test_updater_json_validates_correctly():
@@ -215,7 +214,7 @@ def test_user_creation_validates():
 
     for example, expected, message in case:
         result = validates_against_schema('users', example)
-        yield assert_equal, result, expected, message
+        assert result == expected
 
 
 def test_auth_user_validates():
@@ -244,7 +243,7 @@ def test_auth_user_validates():
 
     for example, expected, message in case:
         result = validates_against_schema('users-auth', example)
-        yield assert_equal, result, expected, message
+        assert result == expected
 
 
 def test_valid_g4_service_has_no_validation_errors():
@@ -393,11 +392,11 @@ def test_price_not_money_format_validation_error():
         assert field in errs
         assert "not_money_format" in errs[field]
 
-    yield check_min_price_error, 'priceMin', ""
+    check_min_price_error('priceMin', "")
 
     for case in cases:
-        yield check_min_price_error, 'priceMin', case
-        yield check_min_price_error, 'priceMax', case
+        check_min_price_error('priceMin', case)
+        check_min_price_error('priceMax', case)
 
 
 def test_price_not_money_format_valid_cases():
@@ -416,11 +415,11 @@ def test_price_not_money_format_valid_cases():
         errs = get_validation_errors("services-g-cloud-7-scs", data)
         assert "not_money_format" not in errs.get(field, "")
 
-    yield check_min_price_valid, 'priceMax', ""
+    check_min_price_valid('priceMax', "")
 
     for case in cases:
-        yield check_min_price_valid, 'priceMin', case
-        yield check_min_price_valid, 'priceMax', case
+        check_min_price_valid('priceMin', case)
+        check_min_price_valid('priceMax', case)
 
 
 def test_min_price_larger_than_max_price_causes_validation_error():
@@ -431,7 +430,7 @@ def test_min_price_larger_than_max_price_causes_validation_error():
         data.update({"priceMax": price_max})
         errs = get_validation_errors("services-g-cloud-7-scs", data)
 
-        yield assert_in, 'max_less_than_min', errs['priceMax']
+        assert 'max_less_than_min' == errs['priceMax']
 
 
 def test_max_price_larger_than_min_price():
@@ -442,7 +441,7 @@ def test_max_price_larger_than_min_price():
         data.update({"priceMax": price_max})
         errs = get_validation_errors("services-g-cloud-7-scs", data)
 
-        yield assert_not_in, 'priceMax', errs
+        assert 'priceMax' not in errs
 
 
 def test_max_price_larger_than_min_price_with_multiple_price_fields():
@@ -606,37 +605,37 @@ def test_g9_followup_questions():
 
         # Valid responses for boolean question with followup
 
-        yield check, schema_name, ["freeVersionTrial"], {
+        check(schema_name, ["freeVersionTrial"], {
             "freeVersionTrialOption": False
-        }, {}
+        }, {})
 
-        yield check, schema_name, ["freeVersionTrialOption"], {
+        check(schema_name, ["freeVersionTrialOption"], {
             "freeVersionTrialOption": True,
             "freeVersionDescription": "description",
             "freeVersionLink": "https://gov.uk",
-        }, {}
+        }, {})
 
         # Missing followup answers
 
-        yield check, schema_name, ["freeVersionTrialOption"], {
+        check(schema_name, ["freeVersionTrialOption"], {
             "freeVersionTrialOption": True,
         }, {
             "freeVersionDescription": "answer_required",
-        }
+        })
 
-        yield check, schema_name, ["freeVersionTrialOption"], {
+        check(schema_name, ["freeVersionTrialOption"], {
             "freeVersionTrialOption": True,
             "freeVersionLink": "https://gov.uk",
         }, {
             "freeVersionDescription": "answer_required",
-        }
+        })
 
         # Missing followup question is not required if it's optional
 
-        yield check, schema_name, ["freeVersionTrialOption"], {
+        check(schema_name, ["freeVersionTrialOption"], {
             "freeVersionTrialOption": True,
             "freeVersionDescription": "description",
-        }, {}
+        }, {})
 
         # Followup answers when none should be present. These return the original
         # schema error since they shouldn't happen when request is coming from the
@@ -646,51 +645,51 @@ def test_g9_followup_questions():
             "freeVersionTrialOption": False,
             "freeVersionLink": "https://gov.uk",
         }
-        yield check, schema_name, ["freeVersionTrialOption"], data, {
+        check(schema_name, ["freeVersionTrialOption"], data, {
             '_form': [u'{} is not valid under any of the given schemas'.format(data)]
-        }
+        })
 
         data = {
             "freeVersionTrialOption": False,
             "freeVersionDescription": "description",
         }
-        yield check, schema_name, ["freeVersionTrialOption"], data, {
+        check(schema_name, ["freeVersionTrialOption"], data, {
             '_form': [u'{} is not valid under any of the given schemas'.format(data)]
-        }
+        })
 
         # Followup answers when the original question answer is missing
 
-        yield check, schema_name, ["freeVersionTrialOption"], {
+        check(schema_name, ["freeVersionTrialOption"], {
             "freeVersionDescription": "description",
             "freeVersionLink": "https://gov.uk",
-        }, {"freeVersionTrialOption": "answer_required"}
+        }, {"freeVersionTrialOption": "answer_required"})
 
         # Valid responses for checkbox question with followups
 
-        yield check, schema_name, ["securityGovernanceStandards"], {
+        check(schema_name, ["securityGovernanceStandards"], {
             "securityGovernanceAccreditation": True,
             "securityGovernanceStandards": ["csa_ccm"]
-        }, {}
+        }, {})
 
-        yield check, schema_name, ["securityGovernanceStandards"], {
+        check(schema_name, ["securityGovernanceStandards"], {
             "securityGovernanceAccreditation": False,
             "securityGovernanceApproach": "some other approach"
-        }, {}
+        }, {})
 
-        yield check, schema_name, ["securityGovernanceStandards"], {
+        check(schema_name, ["securityGovernanceStandards"], {
             "securityGovernanceAccreditation": True,
             "securityGovernanceStandards": ["csa_ccm", "other"],
             "securityGovernanceStandardsOther": "some other standards"
-        }, {}
+        }, {})
 
         # Missing followup answers for checkbox question
 
-        yield check, schema_name, ["securityGovernanceStandards"], {
+        check(schema_name, ["securityGovernanceStandards"], {
             "securityGovernanceAccreditation": True,
             "securityGovernanceStandards": ["csa_ccm", "other"]
         }, {
             "securityGovernanceStandardsOther": "answer_required"
-        }
+        })
 
         # Followup answers when none should be present
 
@@ -699,23 +698,23 @@ def test_g9_followup_questions():
             "securityGovernanceStandards": ["csa_ccm"],
             "securityGovernanceStandardsOther": "some other standards"
         }
-        yield check, schema_name, ["securityGovernanceStandards"], data, {
+        check(schema_name, ["securityGovernanceStandards"], data, {
             "_form": [u'{} is not valid under any of the given schemas'.format(data)]
-        }
+        })
 
         # Followup answers when the original question answer is missing
 
-        yield check, schema_name, ["securityGovernanceAccreditation"], {
+        check(schema_name, ["securityGovernanceAccreditation"], {
             "securityGovernanceStandards": ["csa_ccm"]
         }, {
             "securityGovernanceAccreditation": "answer_required"
-        }
+        })
 
-        yield check, schema_name, ["securityGovernanceStandards"], {
+        check(schema_name, ["securityGovernanceStandards"], {
             "securityGovernanceStandardsOther": "some other standards"
         }, {
             "securityGovernanceStandards": "answer_required"
-        }
+        })
 
 
 def test_api_type_is_optional():


### PR DESCRIPTION
For this card on trello: [https://trello.com/c/JR2Ch0ml](https://trello.com/c/JR2Ch0ml)

There will be a PR on the apiclient too, which will need to be merged and pulled in here. Will update when it's done.

### Create `index_object` and use in `index_services`
We were only ever indexing services, now we want to index briefs too.
This moves the call to the api client to a shareable function which can
be used by different object types.

### Add framework/doc_type/index mapping to config
We've agreed that this isn't the best place for this to live. It would
be better in the frameworks table in th db. However, for now, this will
work and we'll look to moving it out at the end of the mission.

### Index briefs on status update
The only time we'll need to re-index a brief is when it's status is
changed.

When a brief response is marked with an `awarded-at` timestamp, this has
the knock on effect of changing the briefs status, hence why we reindex.

### Remove yield tests to remove deprecation warnings
Yield tests are being removed in pytest 4.0, and as a result we were
getting a lot of annoying warnings every test run.

Also a warning about using [pytest] instead of [tool:pytest] in
setup.cfg has been fixed

### Fix tests to work with new indexing function
The new index_object function takes different arguments, and different
objects needed mocking to ensure that existing tests are kept relevant.

More tests need adding to test the new functionality.

### Handle key errors when getting mapping
If an attempt was made to index an object which there wasn't a mapping
for in the config, we'd get a KeyError which would cause a 500. We
probably don't want to do this and instead log a warning

### Constrain `index_briefs` to non draft DOS
For a brief, the framework family should always be
digital-outcomes-and-specialists at the moment.

We also don't want to be indexing briefs before a buyer has published
them, so no drafts.