### PR TITLE
Standardise serialized json responses

### DIFF
--- a/app/main/views/agreements.py
+++ b/app/main/views/agreements.py
@@ -1,20 +1,23 @@
 from datetime import datetime
+
 from flask import jsonify, abort
-from .. import main
 from sqlalchemy.exc import IntegrityError
 from dmapiclient.audit import AuditTypes
+
+from .. import main
 from ...models import (
     AuditEvent, db, Framework, FrameworkAgreement, SupplierFramework, User
 )
-
 from ...utils import (
     get_json_from_request,
     json_has_required_keys,
     json_has_keys,
+    single_result_response,
     validate_and_return_updater_request,
 )
-
 from ...supplier_utils import validate_agreement_details_data
+
+RESOURCE_NAME = "agreement"
 
 
 @main.route('/agreements', methods=['POST'])
@@ -66,14 +69,13 @@ def create_framework_agreement():
     db.session.add(audit_event)
     db.session.commit()
 
-    return jsonify(agreement=framework_agreement.serialize()), 201
+    return single_result_response(RESOURCE_NAME, framework_agreement), 201
 
 
 @main.route('/agreements/<int:agreement_id>', methods=['GET'])
 def get_framework_agreement(agreement_id):
     framework_agreement = FrameworkAgreement.query.filter(FrameworkAgreement.id == agreement_id).first_or_404()
-
-    return jsonify(agreement=framework_agreement.serialize())
+    return single_result_response(RESOURCE_NAME, framework_agreement), 200
 
 
 @main.route('/agreements/<int:agreement_id>', methods=['POST'])
@@ -137,7 +139,7 @@ def update_framework_agreement(agreement_id):
         db.session.rollback()
         return jsonify(message="Database Error: {0}".format(e)), 400
 
-    return jsonify(agreement=framework_agreement.serialize())
+    return single_result_response(RESOURCE_NAME, framework_agreement), 200
 
 
 @main.route('/agreements/<int:agreement_id>/sign', methods=['POST'])
@@ -187,7 +189,7 @@ def sign_framework_agreement(agreement_id):
         db.session.rollback()
         return jsonify(message="Database Error: {0}".format(e)), 400
 
-    return jsonify(agreement=framework_agreement.serialize())
+    return single_result_response(RESOURCE_NAME, framework_agreement), 200
 
 
 @main.route('/agreements/<int:agreement_id>/on-hold', methods=['POST'])
@@ -224,7 +226,7 @@ def put_signed_framework_agreement_on_hold(agreement_id):
         db.session.rollback()
         return jsonify(message="Database Error: {0}".format(e)), 400
 
-    return jsonify(agreement=framework_agreement.serialize())
+    return single_result_response(RESOURCE_NAME, framework_agreement), 200
 
 
 @main.route('/agreements/<int:agreement_id>/approve', methods=['POST'])
@@ -288,4 +290,4 @@ def approve_for_countersignature(agreement_id):
         db.session.rollback()
         return jsonify(message="Database Error: {0}".format(e)), 400
 
-    return jsonify(agreement=framework_agreement.serialize())
+    return single_result_response(RESOURCE_NAME, framework_agreement), 200

--- a/config.py
+++ b/config.py
@@ -30,7 +30,7 @@ class Config:
     DM_API_SUPPLIERS_PAGE_SIZE = 100
     DM_API_BRIEFS_PAGE_SIZE = 100
     DM_API_BRIEF_RESPONSES_PAGE_SIZE = 100
-
+    DM_API_BUYER_DOMAINS_PAGE_SIZE = 100
     DM_API_PROJECTS_PAGE_SIZE = 100
 
     DM_ALLOWED_ADMIN_DOMAINS = ['digital.cabinet-office.gov.uk', 'crowncommercial.gov.uk', 'user.marketplace.team']

--- a/tests/main/views/test_brief_response.py
+++ b/tests/main/views/test_brief_response.py
@@ -744,7 +744,6 @@ class TestListBriefResponses(BaseBriefResponseTest):
         assert res.status_code == 200
         assert len(data['briefResponses']) == 8
         assert all(br['supplierId'] == 1 for br in data['briefResponses'])
-        assert 'self' in data['links']
 
     def test_list_brief_responses_for_brief_id(self):
         with self.app.app_context():
@@ -767,7 +766,6 @@ class TestListBriefResponses(BaseBriefResponseTest):
         assert res.status_code == 200
         assert len(data['briefResponses']) == 8
         assert all(br['briefId'] == another_brief_id for br in data['briefResponses'])
-        assert 'self' in data['links']
 
     def test_list_brief_responses_by_one_framework_slug(self, live_dos2_framework):
         with self.app.app_context():

--- a/tests/main/views/test_briefs.py
+++ b/tests/main/views/test_briefs.py
@@ -712,7 +712,6 @@ class TestListBrief(FrameworkSetupAndTeardown):
         assert res.status_code == 200
 
         assert len(data['briefs']) == 7
-        assert data['links'] == {}
 
     @pytest.mark.parametrize('date_arg', ['published_on', 'withdrawn_on', 'cancelled_on', 'unsuccessful_on'])
     def test_list_briefs_filter_by_single_day(self, date_arg):

--- a/tests/main/views/test_drafts.py
+++ b/tests/main/views/test_drafts.py
@@ -163,16 +163,6 @@ class TestDraftServices(BaseApplicationTest, FixtureMixin):
             drafts = json.loads(res.get_data())
             assert len(drafts['services']) == 10
 
-    def test_returns_drafts_for_supplier_has_no_links(self):
-        self.client.put(
-            '/draft-services/copy-from/{}'.format(self.service_id),
-            data=json.dumps(self.updater_json),
-            content_type='application/json')
-        res = self.client.get('/draft-services?supplier_id=1')
-        assert res.status_code == 200
-        drafts = json.loads(res.get_data())
-        assert len(drafts['links']) == 0
-
     def test_reject_update_with_no_updater_details(self):
         res = self.client.post('/draft-services/0000000000')
         assert res.status_code == 400

--- a/tests/main/views/test_frameworks.py
+++ b/tests/main/views/test_frameworks.py
@@ -70,7 +70,7 @@ class TestCreateFramework(BaseApplicationTest):
                                         data=json.dumps(self.framework()),
                                         content_type="application/json")
 
-            assert response.status_code == 200
+            assert response.status_code == 201
 
             framework = Framework.query.filter(Framework.slug == "example").first()
 
@@ -824,7 +824,6 @@ class TestGetFrameworkSuppliers(BaseApplicationTest, FixtureMixin):
         self._subtest_list_suppliers_by_multiple_statuses_2()
         self._subtest_list_suppliers_by_multiple_statuses_and_agreement_returned_true()
         self._subtest_list_suppliers_by_multiple_statuses_and_agreement_returned_false()
-        self._subtest_response_contains_links()
 
     def _subtest_list_suppliers_related_to_a_framework(self):
         # One G7 supplier
@@ -945,12 +944,6 @@ class TestGetFrameworkSuppliers(BaseApplicationTest, FixtureMixin):
         assert response.status_code == 200
         data = json.loads(response.get_data())
         assert len(data['supplierFrameworks']) == 0
-
-    def _subtest_response_contains_links(self):
-        response = self.client.get('/frameworks/g-cloud-8/suppliers')
-        assert response.status_code == 200
-        data = json.loads(response.get_data())
-        assert data['links'] == {}
 
 
 class TestGetFrameworkInterest(BaseApplicationTest, FixtureMixin):

--- a/tests/main/views/test_services.py
+++ b/tests/main/views/test_services.py
@@ -379,7 +379,6 @@ class TestListServices(BaseApplicationTest, FixtureMixin):
 
         response = self.client.get('/services?supplier_id=1')
         data = json.loads(response.get_data())
-        assert 'next' not in data['links']
         assert len(data['services']) == 7
 
     def test_unknown_supplier_id(self):


### PR DESCRIPTION
https://trello.com/c/HzdillME/50-api-response-counts

We very often return JSON responses which are
- single serialized objects from our models
- lists of serialized objects from our models
- paginated lists of serialized objects from our models

However, when doing this in the past we have not had consistency.
For example, some lists of objects may include meta such as the
total number of results. Other responses may include links to
their own resources.

This introduces the wrappers for those common types of responses
so we can introduce consistency. This means all lists of results
will contain meta totals for example. If we want to add links to
all our results then that can easily be done in one change.

To implement this around the codebase there were a few exceptions/
things that needed changing. Some times we are not serializing
objects but instead jsonifying dictionarys of data - this case has
been ignored. A handful of our list responses were including either
an empty links dict or a dict containing a link to the resource it
self. These have been removed for consistency as it was rarely done
and our front end does not use them. We can choose to implement
this for all responses if we so choose at a later point.

Two smaller changes also include fixing an incorrect status code
which should have been 201 rather 200 when creating an object, and
moving the number of paginated results for buyer domains into the
config.