### PR TITLE
155 allow admin manager invite new admin users

### DIFF
--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -298,6 +298,16 @@ def email_has_valid_buyer_domain():
     return jsonify(valid=domain_ok)
 
 
+@main.route("/users/valid-admin-email", methods=["GET"])
+def email_is_valid_for_admin_user():
+    email_address = request.args.get('email_address')
+    if not email_address:
+        abort(400, "'email_address' is a required parameter")
+
+    valid = email_address.split('@')[-1] in current_app.config.get('DM_ALLOWED_ADMIN_DOMAINS', [])
+    return jsonify(valid=valid)
+
+
 def check_supplier_role(role, supplier_id):
     if role == 'supplier' and not supplier_id:
         abort(400, "'supplierId' is required for users with 'supplier' role")


### PR DESCRIPTION
https://trello.com/c/2Uc2WMl2/155-allow-super-admin-invite-new-admin-users
https://docs.google.com/document/d/1MjvYx9aQWgcbryiaGrRLOPt_lVm8gIbqOH3vmkKx_fo/edit#

For this new page we agreed to restrict email addresses that can be invited to become an admin by domains listed in the app config.

* New view digitalmarketplace-api/app/main/views/users.py::email_is_valid_for_admin_user
  * If no valid param `400`
  * Otherwise check if email domain is listed in new config value `DM_ALLOWED_ADMIN_DOMAINS`
  * Return valid `True` or valid `False` depending
* Tests