### PR TITLE
New admin-manager user role

### DIFF
--- a/app/models/main.py
+++ b/app/models/main.py
@@ -718,10 +718,10 @@ class User(db.Model):
     ROLES = [
         'buyer',
         'supplier',
-        'admin',               # a general admin user, with permission to do most (but not all)
-                               # admin actions.
+        'admin',               # a general admin user, with permission to do most (but not all) admin actions.
         'admin-ccs-category',  # generally restricted to read-only access to admin views.
         'admin-ccs-sourcing',  # can perform admin actions involving supplier acceptance.
+        'admin-manager',       # can add, edit and disable other types of admin user
     ]
 
     id = db.Column(db.Integer, primary_key=True)

--- a/json_schemas/users.json
+++ b/json_schemas/users.json
@@ -30,7 +30,8 @@
         "supplier",
         "admin",
         "admin-ccs-category",
-        "admin-ccs-sourcing"
+        "admin-ccs-sourcing",
+        "admin-manager"
       ]
     },
     "supplierId": {

--- a/migrations/versions/1050_add_admin_manager_role.py
+++ b/migrations/versions/1050_add_admin_manager_role.py
@@ -1,0 +1,22 @@
+"""Add admin-manager role
+
+Revision ID: 1050
+Revises: 1040
+Create Date: 2017-11-21 11:20:00.000000
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '1050'
+down_revision = '1040'
+
+from alembic import op
+
+
+def upgrade():
+    op.execute("COMMIT")  # See: http://stackoverflow.com/a/30910417/15720
+    op.execute("ALTER TYPE user_roles_enum ADD VALUE 'admin-manager' AFTER 'admin-ccs-sourcing';")
+
+
+def downgrade():
+    raise NotImplemented("Cannot remove user role value")

--- a/tests/main/views/test_users.py
+++ b/tests/main/views/test_users.py
@@ -316,6 +316,21 @@ class TestUsersPost(BaseApplicationTest, JSONTestMixin, FixtureMixin):
         data = json.loads(response.get_data())["users"]
         assert data["emailAddress"] == "joeblogs+sourcing@email.com"
 
+    def test_can_post_an_admin_manager_user(self):
+        response = self.client.post(
+            '/users',
+            data=json.dumps({
+                'users': {
+                    'emailAddress': 'joeblogs+manager@email.com',
+                    'password': '1234567890',
+                    'role': 'admin-manager',
+                    'name': 'joe bloggs'}}),
+            content_type='application/json')
+
+        assert response.status_code == 201
+        data = json.loads(response.get_data())["users"]
+        assert data["emailAddress"] == "joeblogs+manager@email.com"
+
     # The admin-ccs role is no longer in use
     def test_can_not_post_an_admin_ccs_user(self):
         response = self.client.post(


### PR DESCRIPTION
These are the minimal changes necessary to allow creation of users with "admin-manager" role.

I think it's OK to put the migration with model changes here as it's only adding a value to an enum.  But will split it if you, the reviewer, feels strongly it should be split.

There will be more changes to come later when we enforce only certain email domains can have this role, but I think it's worth getting this in on its own now as a starter for ten.