### PR TITLE
Bump pycodestyle to support Python 3 syntax

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -3,13 +3,12 @@
 # D203: 1 blank line required before class docstring
 # F401: 'identifier' imported but unused
 # E402: module level import not at top of file
-# C901: too complex
 # W503: line break before binary operator
 exclude = venv*,__pycache__,node_modules,bower_components,migrations,.git
 ignore = D203,W503
 max-complexity = 24
 max-line-length = 120
-putty-ignore =
-    **/__init__.py : +F401
-    app/__init__.py, app/main/__init__.py, app/status/__init__.py, app/explorer/__init__.py : +E402
-    app/main/views/*.py : +C901
+per-file-ignores =
+    app/main/__init__.py : E402, F401
+    app/status/__init__.py : E402, F401
+    app/explorer/__init__.py : E402

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ version_label
 
 # local environment customizations
 local.nix
+
+.envrc

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,13 +2,14 @@
 
 # For tests
 pytest==3.2.3
-flake8==2.6.2
-flake8-putty==0.4.0
+flake8==3.5.0
+flake8-per-file-ignores==0.4.0
 requests-mock==0.6.0
 mock==2.0.0
 freezegun==0.3.8
 nose==1.3.6
 coverage==3.7.1
+pycodestyle==2.3.0
 pytest-cov==2.5.1
 python-coveralls==2.5.0
 hypothesis==2.0.0

--- a/scripts/generate_declaration_export_for_ccs_sourcing.py
+++ b/scripts/generate_declaration_export_for_ccs_sourcing.py
@@ -263,6 +263,7 @@ def suppliers_on_framework(data_api_url, data_api_token, questions):
             # status = 'error-key-error'
             pass
 
+
 if __name__ == '__main__':
     arguments = docopt(__doc__)
 

--- a/scripts/generate_model_diagram.py
+++ b/scripts/generate_model_diagram.py
@@ -14,6 +14,7 @@ def _build_desc():
         show_indexes=True,
     )
 
+
 if __name__ == "__main__":
     app = create_app("development")
     with app.app_context():

--- a/scripts/oneoff/fix-pricing.py
+++ b/scripts/oneoff/fix-pricing.py
@@ -51,6 +51,7 @@ def main(api_url, api_access_token):
         if count % 1000 == 0:
             print("** {}".format(count))
 
+
 if __name__ == "__main__":
     arguments = docopt(__doc__)
     main(

--- a/scripts/update_service.py
+++ b/scripts/update_service.py
@@ -47,6 +47,7 @@ def update(base_url, access_token, filename, service_id):
         print(response.text)
         return service_id, response
 
+
 if __name__ == "__main__":
     arguments = docopt(__doc__)
     update(


### PR DESCRIPTION
Remove flake8-putty dependency and install flake8-per-file-ignores, which allows us to bump flake8/pycodestyle, which allows us to use Python3 syntax like static typing and f-strings.