### PR TITLE
User model validates admin email domain

### DIFF
--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -10,7 +10,7 @@ from ...models import User, AuditEvent, Supplier, Framework, SupplierFramework, 
 from ...utils import get_json_from_request, json_has_required_keys, \
     json_has_matching_id, pagination_links, get_valid_page_or_1, validate_and_return_updater_request
 from ...validation import validate_user_json_or_400, validate_user_auth_json_or_400, \
-    buyer_email_address_has_approved_domain
+    buyer_email_address_has_approved_domain, admin_email_address_has_approved_domain
 
 
 @main.route('/users/auth', methods=['POST'])
@@ -304,7 +304,7 @@ def email_is_valid_for_admin_user():
     if not email_address:
         abort(400, "'email_address' is a required parameter")
 
-    valid = email_address.split('@')[-1] in current_app.config.get('DM_ALLOWED_ADMIN_DOMAINS', [])
+    valid = admin_email_address_has_approved_domain(email_address)
     return jsonify(valid=valid)
 
 

--- a/app/models/main.py
+++ b/app/models/main.py
@@ -767,9 +767,11 @@ class User(db.Model):
     @validates('email_address')
     def validate_email_address(self, key, value):
         existing_buyer_domains = BuyerEmailDomain.query.all()
-        if value and self.role == 'buyer' and \
-                not buyer_email_address_has_approved_domain(existing_buyer_domains, value):
-            raise ValidationError("invalid_buyer_domain")
+        if value:
+            if self.role == 'buyer' and not buyer_email_address_has_approved_domain(existing_buyer_domains, value):
+                raise ValidationError("invalid_buyer_domain")
+            if self.role == 'admin' and not admin_email_address_has_approved_domain(value):
+                raise ValidationError("invalid_admin_domain")
         return value
 
     @validates('role')

--- a/app/validation.py
+++ b/app/validation.py
@@ -4,7 +4,7 @@ import os
 import copy
 from decimal import Decimal
 
-from flask import abort
+from flask import abort, current_app
 from jsonschema import ValidationError, FormatChecker
 from jsonschema.validators import validator_for
 from datetime import datetime
@@ -405,3 +405,12 @@ def is_approved_buyer_domain(existing_buyer_domains, new_domain):
     :return: boolean
     """
     return any(new_domain == d.domain_name or new_domain.endswith('.' + d.domain_name) for d in existing_buyer_domains)
+
+
+def admin_email_address_has_approved_domain(email_address):
+    """
+    Check the admin's email address is from a whitelisted domain
+    :param email_address: string
+    :return: boolean
+    """
+    return email_address.split('@')[-1] in current_app.config.get('DM_ALLOWED_ADMIN_DOMAINS', [])

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -61,11 +61,13 @@ class FixtureMixin(object):
             # The user should have a valid email domain
             self.setup_default_buyer_domain()
 
+            domain = 'digital.cabinet-office.gov.uk' if role == 'admin' else 'digital.gov.uk'
+
             if User.query.get(id):
                 return id
             user = User(
                 id=id,
-                email_address='test+{}@digital.gov.uk'.format(id),
+                email_address='test+{}@{}'.format(id, domain),
                 name='my name',
                 password='fake password',
                 active=True,

--- a/tests/main/views/test_users.py
+++ b/tests/main/views/test_users.py
@@ -362,6 +362,20 @@ class TestUsersPost(BaseApplicationTest, JSONTestMixin, FixtureMixin):
         error = json.loads(response.get_data())['error']
         assert "'admin-ccs' is not one of" in error
 
+    def test_creating_admin_user_with_bad_email_domain_fails(self):
+        response = self.client.post(
+            '/users',
+            data=json.dumps({
+                'users': {
+                    'emailAddress': 'joeblogs@example.com',
+                    'password': '1234567890',
+                    'role': 'admin',
+                    'name': 'joe bloggs'}}),
+            content_type='application/json')
+
+        assert response.status_code == 400
+        assert json.loads(response.get_data())['error'] == 'invalid_admin_domain'
+
     def test_can_post_a_supplier_user(self, supplier_basic):
         response = self.client.post(
             '/users',

--- a/tests/main/views/test_users.py
+++ b/tests/main/views/test_users.py
@@ -27,7 +27,7 @@ class BaseUserTest(BaseApplicationTest):
 
     def _return_post_login(self, auth_users=None, status_code=200):
         _auth_users = {
-            'emailAddress': 'joeblogs@email.com',
+            'emailAddress': 'joeblogs@digital.cabinet-office.gov.uk',
             'password': '1234567890'
         }
         if auth_users is not None and isinstance(auth_users, dict):
@@ -45,7 +45,7 @@ class TestUsersAuth(BaseUserTest):
     def create_user(self):
         with self.app.app_context():
             user = {
-                'emailAddress': 'joeblogs@email.com',
+                'emailAddress': 'joeblogs@digital.cabinet-office.gov.uk',
                 'password': '1234567890',
                 'role': 'admin',
                 'name': 'joe bloggs'
@@ -67,7 +67,7 @@ class TestUsersAuth(BaseUserTest):
             response = self.valid_login()
 
             data = json.loads(response.get_data())['users']
-            assert data['emailAddress'] == 'joeblogs@email.com'
+            assert data['emailAddress'] == 'joeblogs@digital.cabinet-office.gov.uk'
 
     def test_should_validate_mixedcase_credentials(self):
         self.create_user()
@@ -76,13 +76,13 @@ class TestUsersAuth(BaseUserTest):
                 '/users/auth',
                 data=json.dumps({
                     'authUsers': {
-                        'emailAddress': 'JOEbloGS@email.com',
+                        'emailAddress': 'JOEbloGS@digital.cabinet-office.gov.uk',
                         'password': '1234567890'}}),
                 content_type='application/json')
 
             assert response.status_code == 200
             data = json.loads(response.get_data())['users']
-            assert data['emailAddress'] == 'joeblogs@email.com'
+            assert data['emailAddress'] == 'joeblogs@digital.cabinet-office.gov.uk'
 
     def test_should_return_404_for_no_user(self):
         with self.app.app_context():
@@ -90,7 +90,7 @@ class TestUsersAuth(BaseUserTest):
                 '/users/auth',
                 data=json.dumps({
                     'authUsers': {
-                        'emailAddress': 'joeblogs@email.com',
+                        'emailAddress': 'joeblogs@digital.cabinet-office.gov.uk',
                         'password': '1234567890'}}),
                 content_type='application/json')
 
@@ -105,7 +105,7 @@ class TestUsersAuth(BaseUserTest):
                 '/users/auth',
                 data=json.dumps({
                     'authUsers': {
-                        'emailAddress': 'joeblogs@email.com',
+                        'emailAddress': 'joeblogs@digital.cabinet-office.gov.uk',
                         'password': 'this is not right'}}),
                 content_type='application/json')
 
@@ -117,7 +117,7 @@ class TestUsersAuth(BaseUserTest):
         self.create_user()
         with self.app.app_context(), freeze_time('2015-06-06'):
             self.valid_login()
-            user = User.get_by_email_address('joeblogs@email.com')
+            user = User.get_by_email_address('joeblogs@digital.cabinet-office.gov.uk')
 
             assert user.logged_in_at == datetime(2015, 6, 6)
 
@@ -125,7 +125,7 @@ class TestUsersAuth(BaseUserTest):
         self.create_user()
         with self.app.app_context(), freeze_time('2015-06-06'):
             self.invalid_password()
-            user = User.get_by_email_address('joeblogs@email.com')
+            user = User.get_by_email_address('joeblogs@digital.cabinet-office.gov.uk')
 
             assert user.logged_in_at is None
 
@@ -133,7 +133,7 @@ class TestUsersAuth(BaseUserTest):
         self.create_user()
         with self.app.app_context():
             self.invalid_password()
-            user = User.get_by_email_address('joeblogs@email.com')
+            user = User.get_by_email_address('joeblogs@digital.cabinet-office.gov.uk')
 
             assert user.failed_login_count == 1
 
@@ -143,7 +143,7 @@ class TestUsersAuth(BaseUserTest):
             self.invalid_password()
             self.valid_login()
 
-            user = User.get_by_email_address('joeblogs@email.com')
+            user = User.get_by_email_address('joeblogs@digital.cabinet-office.gov.uk')
             assert user.failed_login_count == 0
 
     def test_user_is_locked_after_too_many_failed_login_attempts(self):
@@ -153,7 +153,7 @@ class TestUsersAuth(BaseUserTest):
 
         with self.app.app_context():
             self.invalid_password()
-            user = User.get_by_email_address('joeblogs@email.com')
+            user = User.get_by_email_address('joeblogs@digital.cabinet-office.gov.uk')
 
             assert user.locked is True
 
@@ -163,7 +163,7 @@ class TestUsersAuth(BaseUserTest):
         self.app.config['DM_FAILED_LOGIN_LIMIT'] = 1
 
         with self.app.app_context():
-            user = User.get_by_email_address('joeblogs@email.com')
+            user = User.get_by_email_address('joeblogs@digital.cabinet-office.gov.uk')
 
             user.failed_login_count = 1
             db.session.add(user)
@@ -276,7 +276,7 @@ class TestUsersPost(BaseApplicationTest, JSONTestMixin, FixtureMixin):
             '/users',
             data=json.dumps({
                 'users': {
-                    'emailAddress': 'joeblogs@email.com',
+                    'emailAddress': 'joeblogs@digital.cabinet-office.gov.uk',
                     'password': '1234567890',
                     'role': 'admin',
                     'name': 'joe bloggs'}}),
@@ -284,14 +284,14 @@ class TestUsersPost(BaseApplicationTest, JSONTestMixin, FixtureMixin):
 
         assert response.status_code == 201
         data = json.loads(response.get_data())["users"]
-        assert data["emailAddress"] == "joeblogs@email.com"
+        assert data["emailAddress"] == "joeblogs@digital.cabinet-office.gov.uk"
 
     def test_can_post_an_admin_ccs_category_user(self):
         response = self.client.post(
             '/users',
             data=json.dumps({
                 'users': {
-                    'emailAddress': 'joeblogs@email.com',
+                    'emailAddress': 'joeblogs@crowncommercial.gov.uk',
                     'password': '1234567890',
                     'role': 'admin-ccs-category',
                     'name': 'joe bloggs'}}),
@@ -299,14 +299,14 @@ class TestUsersPost(BaseApplicationTest, JSONTestMixin, FixtureMixin):
 
         assert response.status_code == 201
         data = json.loads(response.get_data())["users"]
-        assert data["emailAddress"] == "joeblogs@email.com"
+        assert data["emailAddress"] == "joeblogs@crowncommercial.gov.uk"
 
     def test_can_post_an_admin_ccs_sourcing_user(self):
         response = self.client.post(
             '/users',
             data=json.dumps({
                 'users': {
-                    'emailAddress': 'joeblogs+sourcing@email.com',
+                    'emailAddress': 'joeblogs+sourcing@crowncommercial.gov.uk',
                     'password': '1234567890',
                     'role': 'admin-ccs-sourcing',
                     'name': 'joe bloggs'}}),
@@ -314,14 +314,14 @@ class TestUsersPost(BaseApplicationTest, JSONTestMixin, FixtureMixin):
 
         assert response.status_code == 201
         data = json.loads(response.get_data())["users"]
-        assert data["emailAddress"] == "joeblogs+sourcing@email.com"
+        assert data["emailAddress"] == "joeblogs+sourcing@crowncommercial.gov.uk"
 
     def test_can_post_an_admin_manager_user(self):
         response = self.client.post(
             '/users',
             data=json.dumps({
                 'users': {
-                    'emailAddress': 'joeblogs+manager@email.com',
+                    'emailAddress': 'joeblogs+manager@digital.cabinet-office.gov.uk',
                     'password': '1234567890',
                     'role': 'admin-manager',
                     'name': 'joe bloggs'}}),
@@ -329,7 +329,7 @@ class TestUsersPost(BaseApplicationTest, JSONTestMixin, FixtureMixin):
 
         assert response.status_code == 201
         data = json.loads(response.get_data())["users"]
-        assert data["emailAddress"] == "joeblogs+manager@email.com"
+        assert data["emailAddress"] == "joeblogs+manager@digital.cabinet-office.gov.uk"
 
     def test_can_post_an_admin_framework_manager_user(self):
         response = self.client.post(
@@ -352,7 +352,7 @@ class TestUsersPost(BaseApplicationTest, JSONTestMixin, FixtureMixin):
             '/users',
             data=json.dumps({
                 'users': {
-                    'emailAddress': 'joeblogs+admin@email.com',
+                    'emailAddress': 'joeblogs+admin@crowncommercial.gov.uk',
                     'password': '1234567890',
                     'role': 'admin-ccs',
                     'name': 'joe bloggs'}}),
@@ -437,7 +437,7 @@ class TestUsersPost(BaseApplicationTest, JSONTestMixin, FixtureMixin):
             '/users',
             data=json.dumps({
                 'users': {
-                    'emailAddress': 'joeblogs@email.com',
+                    'emailAddress': 'joeblogs@digital.cabinet-office.gov.uk',
                     'password': '1234567890',
                     'role': 'admin',
                     'supplierId': 1,
@@ -468,7 +468,7 @@ class TestUsersPost(BaseApplicationTest, JSONTestMixin, FixtureMixin):
                 data=json.dumps({
                     'users': {
                         'hashpw': True,
-                        'emailAddress': 'joeblogs@email.com',
+                        'emailAddress': 'joeblogs@digital.cabinet-office.gov.uk',
                         'password': '1234567890',
                         'role': 'admin',
                         'name': 'joe bloggs'}}),
@@ -476,7 +476,7 @@ class TestUsersPost(BaseApplicationTest, JSONTestMixin, FixtureMixin):
 
             assert response.status_code == 201
             user = User.query.filter(
-                User.email_address == 'joeblogs@email.com') \
+                User.email_address == 'joeblogs@digital.cabinet-office.gov.uk') \
                 .first()
             assert user.password != '1234567890'
 
@@ -487,7 +487,7 @@ class TestUsersPost(BaseApplicationTest, JSONTestMixin, FixtureMixin):
                 data=json.dumps({
                     'users': {
                         'hashpw': False,
-                        'emailAddress': 'joeblogs@email.com',
+                        'emailAddress': 'joeblogs@digital.cabinet-office.gov.uk',
                         'password': '1234567890',
                         'role': 'admin',
                         'name': 'joe bloggs'}}),
@@ -495,7 +495,7 @@ class TestUsersPost(BaseApplicationTest, JSONTestMixin, FixtureMixin):
 
             assert response.status_code == 201
             user = User.query.filter(
-                User.email_address == 'joeblogs@email.com') \
+                User.email_address == 'joeblogs@digital.cabinet-office.gov.uk') \
                 .first()
             assert user.password == '1234567890'
 
@@ -504,7 +504,7 @@ class TestUsersPost(BaseApplicationTest, JSONTestMixin, FixtureMixin):
             '/users',
             data=json.dumps({
                 'users': {
-                    'emailAddress': 'joeblogs@example.com',
+                    'emailAddress': 'joeblogs@digital.cabinet-office.gov.uk',
                     'password': '1234567890',
                     'role': 'admin',
                     'name': 'joe bloggs'}}),
@@ -516,7 +516,7 @@ class TestUsersPost(BaseApplicationTest, JSONTestMixin, FixtureMixin):
             '/users',
             data=json.dumps({
                 'users': {
-                    'emailAddress': 'joeblogs@example.com',
+                    'emailAddress': 'joeblogs@digital.cabinet-office.gov.uk',
                     'password': '1234567890',
                     'role': 'admin',
                     'name': 'joe bloggs'}}),
@@ -1148,7 +1148,7 @@ class TestUsersGet(BaseUserTest, FixtureMixin):
 
     def test_list_users_by_admin_role(self):
         self._post_user({
-            "emailAddress": "admin@digital.gov.uk",
+            "emailAddress": "admin@digital.cabinet-office.gov.uk",
             "name": "Admin",
             "role": "admin",
             "password": "minimum10characterpassword"

--- a/tests/models/test_main.py
+++ b/tests/models/test_main.py
@@ -45,24 +45,58 @@ class TestUser(BaseApplicationTest, FixtureMixin):
     def test_buyer_user_requires_valid_email_domain(self):
         with self.app.app_context(), pytest.raises(ValidationError) as exc:
             self.setup_default_buyer_domain()
-            User(
-                email_address='email@nope.org',
+            valid_buyer_user = User(
+                email_address='email@digital.gov.uk',
                 name='name',
                 role='buyer',
                 password='password',
                 active=True,
             )
+            # Changing email to invalid domain raises an error
+            valid_buyer_user.email_address = 'email@nope.org'
+
         assert str(exc.value) == 'invalid_buyer_domain'
 
     def test_admin_user_requires_whitelisted_email_domain(self):
         with self.app.app_context(), pytest.raises(ValidationError) as exc:
-            User(
-                email_address='email@nope.org',
+            valid_admin_user = User(
+                email_address='email@digital.cabinet-office.gov.uk',
                 name='name',
                 role='admin',
                 password='password',
                 active=True,
             )
+            # Changing email to invalid domain raises an error
+            valid_admin_user.email_address = 'email@nope.org'
+        assert str(exc.value) == 'invalid_admin_domain'
+
+    def test_user_with_invalid_email_domain_cannot_be_changed_to_buyer_role(self):
+        with self.app.app_context(), pytest.raises(ValidationError) as exc:
+            self.setup_default_buyer_domain()
+            valid_admin_user = User(
+                email_address='email@crowncommercial.gov.uk',
+                name='name',
+                role='admin',
+                password='password',
+                active=True,
+            )
+            # Changing role to buyer raises an error
+            valid_admin_user.role = 'buyer'
+
+        assert str(exc.value) == 'invalid_buyer_domain'
+
+    def test_user_with_invalid_email_domain_cannot_be_changed_to_admin_role(self):
+        with self.app.app_context(), pytest.raises(ValidationError) as exc:
+            self.setup_default_buyer_domain()
+            valid_buyer_user = User(
+                email_address='email@digital.gov.uk',
+                name='name',
+                role='buyer',
+                password='password',
+                active=True,
+            )
+            # Changing role to admin raises an error
+            valid_buyer_user.role = 'admin'
         assert str(exc.value) == 'invalid_admin_domain'
 
 

--- a/tests/models/test_main.py
+++ b/tests/models/test_main.py
@@ -42,6 +42,29 @@ class TestUser(BaseApplicationTest, FixtureMixin):
             assert user.serialize()['role'] == "buyer"
             assert 'password' not in user.serialize()
 
+    def test_buyer_user_requires_valid_email_domain(self):
+        with self.app.app_context(), pytest.raises(ValidationError) as exc:
+            self.setup_default_buyer_domain()
+            User(
+                email_address='email@nope.org',
+                name='name',
+                role='buyer',
+                password='password',
+                active=True,
+            )
+        assert str(exc.value) == 'invalid_buyer_domain'
+
+    def test_admin_user_requires_whitelisted_email_domain(self):
+        with self.app.app_context(), pytest.raises(ValidationError) as exc:
+            User(
+                email_address='email@nope.org',
+                name='name',
+                role='admin',
+                password='password',
+                active=True,
+            )
+        assert str(exc.value) == 'invalid_admin_domain'
+
 
 def test_framework_should_not_accept_invalid_status():
     app = create_app('test')


### PR DESCRIPTION
Trello: https://trello.com/c/D2QFAPod/158-api-should-only-allow-creation-of-admin-accounts-with-allowed-email-domains

We already have an API route to check that an admin user's email is valid. This PR adds this validation at the User model level.

- For DRYness (and consistency with the buyer email checks), I moved the shared config check to the `validation` helper functions.
- Some test data needed updating too.