### PR TITLE
Add framework manager user role

### DIFF
--- a/app/models/main.py
+++ b/app/models/main.py
@@ -722,6 +722,7 @@ class User(db.Model):
         'admin-ccs-category',  # generally restricted to read-only access to admin views.
         'admin-ccs-sourcing',  # can perform admin actions involving supplier acceptance.
         'admin-manager',       # can add, edit and disable other types of admin user
+        'admin-framework-manager',  # can perform admin actions involving framework applications
     ]
 
     id = db.Column(db.Integer, primary_key=True)

--- a/json_schemas/users.json
+++ b/json_schemas/users.json
@@ -31,7 +31,8 @@
         "admin",
         "admin-ccs-category",
         "admin-ccs-sourcing",
-        "admin-manager"
+        "admin-manager",
+        "admin-framework-manager"
       ]
     },
     "supplierId": {

--- a/migrations/versions/1050_add_admin_manager_role.py
+++ b/migrations/versions/1050_add_admin_manager_role.py
@@ -15,7 +15,7 @@ from alembic import op
 
 def upgrade():
     op.execute("COMMIT")  # See: http://stackoverflow.com/a/30910417/15720
-    op.execute("ALTER TYPE user_roles_enum ADD VALUE 'admin-manager' AFTER 'admin-ccs-sourcing';")
+    op.execute("ALTER TYPE user_roles_enum ADD VALUE IF NOT EXISTS 'admin-manager' AFTER 'admin-ccs-sourcing';")
 
 
 def downgrade():

--- a/migrations/versions/1050_add_admin_manager_role.py
+++ b/migrations/versions/1050_add_admin_manager_role.py
@@ -19,4 +19,5 @@ def upgrade():
 
 
 def downgrade():
-    raise NotImplemented("Cannot remove user role value")
+    # Cannot remove user role value
+    pass

--- a/migrations/versions/1060_add_framework_manager_role.py
+++ b/migrations/versions/1060_add_framework_manager_role.py
@@ -19,4 +19,5 @@ def upgrade():
 
 
 def downgrade():
-    raise NotImplemented("Cannot remove user role value")
+    # Cannot remove user role value
+    pass

--- a/migrations/versions/1060_add_framework_manager_role.py
+++ b/migrations/versions/1060_add_framework_manager_role.py
@@ -1,0 +1,22 @@
+"""Add admin-framework-manager role
+
+Revision ID: 1060
+Revises: 1050
+Create Date: 2017-11-29 15:20:00.000000
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '1060'
+down_revision = '1050'
+
+from alembic import op
+
+
+def upgrade():
+    op.execute("COMMIT")  # See: http://stackoverflow.com/a/30910417/15720
+    op.execute("ALTER TYPE user_roles_enum ADD VALUE 'admin-framework-manager' AFTER 'admin-manager';")
+
+
+def downgrade():
+    raise NotImplemented("Cannot remove user role value")

--- a/migrations/versions/1060_add_framework_manager_role.py
+++ b/migrations/versions/1060_add_framework_manager_role.py
@@ -15,7 +15,7 @@ from alembic import op
 
 def upgrade():
     op.execute("COMMIT")  # See: http://stackoverflow.com/a/30910417/15720
-    op.execute("ALTER TYPE user_roles_enum ADD VALUE 'admin-framework-manager' AFTER 'admin-manager';")
+    op.execute("ALTER TYPE user_roles_enum ADD VALUE IF NOT EXISTS 'admin-framework-manager' AFTER 'admin-manager';")
 
 
 def downgrade():

--- a/tests/main/views/test_users.py
+++ b/tests/main/views/test_users.py
@@ -331,6 +331,21 @@ class TestUsersPost(BaseApplicationTest, JSONTestMixin, FixtureMixin):
         data = json.loads(response.get_data())["users"]
         assert data["emailAddress"] == "joeblogs+manager@email.com"
 
+    def test_can_post_an_admin_framework_manager_user(self):
+        response = self.client.post(
+            '/users',
+            data=json.dumps({
+                'users': {
+                    'emailAddress': 'joeblogs+framework+manager@digital.cabinet-office.gov.uk',
+                    'password': '1234567890',
+                    'role': 'admin-framework-manager',
+                    'name': 'joe bloggs'}}),
+            content_type='application/json')
+
+        assert response.status_code == 201
+        data = json.loads(response.get_data())["users"]
+        assert data["emailAddress"] == "joeblogs+framework+manager@digital.cabinet-office.gov.uk"
+
     # The admin-ccs role is no longer in use
     def test_can_not_post_an_admin_ccs_user(self):
         response = self.client.post(


### PR DESCRIPTION
Trello: https://trello.com/c/iUS9D0ll/163-add-new-framework-manager-role

Almost entirely copied from the recent branch to add the `admin-manager` role: https://github.com/alphagov/digitalmarketplace-api/pull/695

- DB Migration to allow the new role to be added
- Update JSON schema
- Add new role to User model
- Add a basic test for creating a user with the new role