### PR TITLE
Restrict email domains for admin category/sourcing/managers

### DIFF
--- a/app/models/main.py
+++ b/app/models/main.py
@@ -724,14 +724,17 @@ SupplierFramework.current_framework_agreement = db.relationship(
 class User(db.Model):
     __tablename__ = 'users'
 
-    ROLES = [
-        'buyer',
-        'supplier',
-        'admin',               # a general admin user, with permission to do most (but not all) admin actions.
+    ADMIN_ROLES = [
+        'admin',  # a general admin user, with permission to do most (but not all) admin actions.
         'admin-ccs-category',  # generally restricted to read-only access to admin views.
         'admin-ccs-sourcing',  # can perform admin actions involving supplier acceptance.
-        'admin-manager',       # can add, edit and disable other types of admin user
+        'admin-manager',  # can add, edit and disable other types of admin user
         'admin-framework-manager',  # can perform admin actions involving framework applications
+    ]
+
+    ROLES = ADMIN_ROLES + [
+        'buyer',
+        'supplier',
     ]
 
     id = db.Column(db.Integer, primary_key=True)
@@ -776,7 +779,7 @@ class User(db.Model):
         if value:
             if self.role == 'buyer' and not buyer_email_address_has_approved_domain(existing_buyer_domains, value):
                 raise ValidationError("invalid_buyer_domain")
-            if self.role == 'admin' and not admin_email_address_has_approved_domain(value):
+            if self.role in self.ADMIN_ROLES and not admin_email_address_has_approved_domain(value):
                 raise ValidationError("invalid_admin_domain")
         return value
 
@@ -787,7 +790,7 @@ class User(db.Model):
             if value == 'buyer' and \
                     not buyer_email_address_has_approved_domain(existing_buyer_domains, self.email_address):
                 raise ValidationError("invalid_buyer_domain")
-            if value == 'admin' and \
+            if value in self.ADMIN_ROLES and \
                     not admin_email_address_has_approved_domain(self.email_address):
                 raise ValidationError("invalid_admin_domain")
         return value

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -61,7 +61,12 @@ class FixtureMixin(object):
             # The user should have a valid email domain
             self.setup_default_buyer_domain()
 
-            domain = 'digital.cabinet-office.gov.uk' if role == 'admin' else 'digital.gov.uk'
+            if role == 'admin':
+                domain = 'digital.cabinet-office.gov.uk'
+            elif role == 'admin-ccs-sourcing':
+                domain = 'crowncommercial.gov.uk'
+            else:
+                domain = 'digital.gov.uk'
 
             if User.query.get(id):
                 return id

--- a/tests/main/views/test_agreements.py
+++ b/tests/main/views/test_agreements.py
@@ -1114,7 +1114,7 @@ class TestApproveFrameworkAgreement(BaseFrameworkAgreementTest):
             user = User(
                 id=1234,
                 name='Chris',
-                email_address='chris@example.com',
+                email_address='chris@crowncommercial.gov.uk',
                 password='password',
                 active=True,
                 created_at=datetime.now(),
@@ -1141,7 +1141,7 @@ class TestApproveFrameworkAgreement(BaseFrameworkAgreementTest):
             supplier_framework = agreement.supplier_framework.serialize(with_users=True)
 
         assert supplier_framework['countersignedDetails']['approvedByUserName'] == 'Chris'
-        assert supplier_framework['countersignedDetails']['approvedByUserEmail'] == 'chris@example.com'
+        assert supplier_framework['countersignedDetails']['approvedByUserEmail'] == 'chris@crowncommercial.gov.uk'
 
     def test_can_unapprove_approved_agreement(self, supplier_framework):
         agreement_id = self.create_agreement(

--- a/tests/models/test_main.py
+++ b/tests/models/test_main.py
@@ -57,12 +57,13 @@ class TestUser(BaseApplicationTest, FixtureMixin):
 
         assert str(exc.value) == 'invalid_buyer_domain'
 
-    def test_admin_user_requires_whitelisted_email_domain(self):
+    @pytest.mark.parametrize('role', User.ADMIN_ROLES)
+    def test_admin_user_requires_whitelisted_email_domain(self, role):
         with self.app.app_context(), pytest.raises(ValidationError) as exc:
             valid_admin_user = User(
                 email_address='email@digital.cabinet-office.gov.uk',
                 name='name',
-                role='admin',
+                role=role,
                 password='password',
                 active=True,
             )
@@ -85,7 +86,8 @@ class TestUser(BaseApplicationTest, FixtureMixin):
 
         assert str(exc.value) == 'invalid_buyer_domain'
 
-    def test_user_with_invalid_email_domain_cannot_be_changed_to_admin_role(self):
+    @pytest.mark.parametrize('role', User.ADMIN_ROLES)
+    def test_user_with_invalid_email_domain_cannot_be_changed_to_admin_role(self, role):
         with self.app.app_context(), pytest.raises(ValidationError) as exc:
             self.setup_default_buyer_domain()
             valid_buyer_user = User(
@@ -96,7 +98,7 @@ class TestUser(BaseApplicationTest, FixtureMixin):
                 active=True,
             )
             # Changing role to admin raises an error
-            valid_buyer_user.role = 'admin'
+            valid_buyer_user.role = role
         assert str(exc.value) == 'invalid_admin_domain'
 
 


### PR DESCRIPTION
Trello: https://trello.com/c/D2QFAPod/158-api-should-only-allow-creation-of-admin-accounts-with-allowed-email-domains

Follow up PR to https://github.com/alphagov/digitalmarketplace-api/pull/701. Email restrictions are now applied at API level for `admin-ccs-sourcing`, `admin-ccs-category`, `admin-manager` and `admin-framework-manager` users.