### PR TITLE
Revert "Add an external ID to our direct award projects/saved searches"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,8 +49,7 @@ test-requirements:
 	         echo "Run 'make freeze-requirements' to update."; exit 1; } \
 	    || { echo "requirements.txt is up to date"; exit 0; }
 
-.PHONY: test-flake8
-test-flake8: virtualenv
+.PHONY test-flake8: virtualenv
 	${VIRTUALENV_ROOT}/bin/flake8 .
 
 .PHONY: test-migrations

--- a/app/main/views/direct_award.py
+++ b/app/main/views/direct_award.py
@@ -11,23 +11,8 @@ from ... import db
 from ...models import User, AuditEvent, ArchivedService
 from ...models.direct_award import DirectAwardProject, DirectAwardSearch
 from ...utils import (
-    drop_all_other_fields,
-    get_int_or_400,
-    get_json_from_request,
-    get_valid_page_or_1,
-    json_has_required_keys,
-    pagination_links,
-    validate_and_return_updater_request,
-)
-
-
-def get_project_by_id_or_404(project_id: int):
-    """During the transitional period, project_id may be either the internal or the public ID of the project."""
-    project = DirectAwardProject.query.filter(DirectAwardProject.id == project_id).first()
-    if project:
-        return project
-
-    return DirectAwardProject.query.filter(DirectAwardProject.external_id == project_id).first_or_404()
+    get_json_from_request, get_int_or_400, json_has_required_keys, pagination_links,
+    get_valid_page_or_1, validate_and_return_updater_request, drop_all_other_fields)
 
 
 @main.route('/direct-award/projects', methods=['GET'])
@@ -86,28 +71,20 @@ def create_project():
     if user is None:
         abort(400, "User ID not supplied")
 
-    retries = 0
-    while True:
-        project = DirectAwardProject(name=project_json['name'], users=[user])
-        db.session.add(project)
+    project = DirectAwardProject(name=project_json['name'], users=[user])
+    db.session.add(project)
 
-        try:
-            db.session.flush()
-            break
-
-        except IntegrityError as e:
-            current_app.logger.warning("Project ID collision on {}".format(project.external_id))
-            db.session.rollback()
-
-            retries += 1
-            if retries >= 5:
-                abort(400, str(e.orig))
+    try:
+        db.session.flush()
+    except IntegrityError as e:
+        db.session.rollback()
+        abort(400, e.orig)
 
     audit = AuditEvent(
         audit_type=AuditTypes.create_project,
         user=updater_json['updated_by'],
         data={
-            'projectExternalId': project.external_id,
+            'projectId': project.id,
             'projectJson': project_json,
         },
         db_object=project,
@@ -119,20 +96,21 @@ def create_project():
     return jsonify(project=project.serialize()), 201
 
 
-@main.route('/direct-award/projects/<int:project_external_id>', methods=['GET'])
-def get_project(project_external_id):
-    project = get_project_by_id_or_404(project_external_id)
+@main.route('/direct-award/projects/<int:project_id>', methods=['GET'])
+def get_project(project_id):
+    project = DirectAwardProject.query.filter(DirectAwardProject.id == project_id).first_or_404()
 
     return jsonify(project=project.serialize(with_users=True))
 
 
-@main.route('/direct-award/projects/<int:project_external_id>/searches', methods=['GET'])
-def list_project_searches(project_external_id):
-    project = get_project_by_id_or_404(project_external_id)
+@main.route('/direct-award/projects/<int:project_id>/searches', methods=['GET'])
+def list_project_searches(project_id):
+    # If the project doesn't exist, we should 404 early.
+    DirectAwardProject.query.filter(DirectAwardProject.id == project_id).first_or_404()
 
     page = get_valid_page_or_1()
 
-    searches = DirectAwardSearch.query.filter(DirectAwardSearch.project_id == project.id)
+    searches = DirectAwardSearch.query.filter(DirectAwardSearch.project_id == project_id)
 
     if 'latest-first' in request.args:
         if convert_to_boolean(request.args.get('latest-first')):
@@ -151,7 +129,7 @@ def list_project_searches(project_external_id):
     )
 
     pagination_params = request.args.to_dict()
-    pagination_params['project_external_id'] = project.external_id
+    pagination_params['project_id'] = project_id
 
     return jsonify(
         searches=[search.serialize() for search in searches.items],
@@ -166,11 +144,12 @@ def list_project_searches(project_external_id):
     )
 
 
-@main.route('/direct-award/projects/<int:project_external_id>/searches', methods=['POST'])
-def create_project_search(project_external_id):
+@main.route('/direct-award/projects/<int:project_id>/searches', methods=['POST'])
+def create_project_search(project_id):
     updater_json = validate_and_return_updater_request()
 
-    project = get_project_by_id_or_404(project_external_id)
+    # If the project doesn't exist, we should 404 early.
+    DirectAwardProject.query.filter(DirectAwardProject.id == project_id).first_or_404()
 
     json_payload = get_json_from_request()
     json_has_required_keys(json_payload, ['search'])
@@ -184,9 +163,9 @@ def create_project_search(project_external_id):
 
     # TODO: Validate user has authorisation to access resource.
 
-    db.session.query(DirectAwardSearch).filter(DirectAwardSearch.project_id == project.id).\
+    db.session.query(DirectAwardSearch).filter(DirectAwardSearch.project_id == project_id).\
         update({DirectAwardSearch.active: False})
-    search = DirectAwardSearch(created_by=user.id, project_id=project.id,
+    search = DirectAwardSearch(created_by=user.id, project_id=project_id,
                                search_url=search_json['searchUrl'], active=True)
 
     db.session.add(search)
@@ -202,8 +181,7 @@ def create_project_search(project_external_id):
         audit_type=AuditTypes.create_project_search,
         user=updater_json['updated_by'],
         data={
-            'projectId': project.id,
-            'projectExternalId': project.external_id,
+            'projectId': project_id,
             'searchJson': search_json,
         },
         db_object=search,
@@ -215,20 +193,21 @@ def create_project_search(project_external_id):
     return jsonify(search=search.serialize()), 201
 
 
-@main.route('/direct-award/projects/<int:project_external_id>/searches/<int:search_id>', methods=['GET'])
-def get_project_search(project_external_id, search_id):
-    project = get_project_by_id_or_404(project_external_id)
+@main.route('/direct-award/projects/<int:project_id>/searches/<int:search_id>', methods=['GET'])
+def get_project_search(project_id, search_id):
+    # If the project doesn't exist, we should 404 early.
+    DirectAwardProject.query.filter(DirectAwardProject.id == project_id).first_or_404()
 
     search = DirectAwardSearch.query.filter(
         DirectAwardSearch.id == search_id,
-        DirectAwardSearch.project_id == project.id
+        DirectAwardSearch.project_id == project_id
     ).first_or_404()
 
     return jsonify(search=search.serialize())
 
 
-@main.route('/direct-award/projects/<int:project_external_id>/services', methods=['GET'])
-def list_project_services(project_external_id):
+@main.route('/direct-award/projects/<int:project_id>/services', methods=['GET'])
+def list_project_services(project_id):
     """This endpoint returns all the services associated with a particular (locked) Direct Award Project. It returns
     some fairly arbitrary data which is obviously not ideal, but as we don't have a task runner that we can utilise to
     manage jobs like this and we need it to be responsive on-click, we're having to jerryrig in some data extraction and
@@ -236,19 +215,19 @@ def list_project_services(project_external_id):
     the service data JSON keys as specified in the request (which will be loaded via a framework-specific manifest)."""
     page = get_valid_page_or_1()
     requested_fields = request.args.get('fields', '').split(',')
-    project = get_project_by_id_or_404(project_external_id)
+    project = DirectAwardProject.query.filter(DirectAwardProject.id == project_id).first_or_404()
 
     if not project.locked_at:
-        abort(400, 'Project has not been locked: {}'.format(project.id))
+        abort(400, 'Project has not been locked: {}'.format(project_id))
 
     # TODO: This should work for _all_ active searches, not just the first (although we currently enforce only one
     # TODO: active search) - SW 21/09/2017
     search = DirectAwardSearch.query.filter(
-        DirectAwardSearch.project_id == project.id,
+        DirectAwardSearch.project_id == project_id,
         DirectAwardSearch.active == True  # noqa
     ).first()
     if not search:
-        abort(400, 'Project does not have a saved search: {}'.format(project.id))
+        abort(400, 'Project does not have a saved search: {}'.format(project_id))
 
     paginated_archived_services = search.archived_services.paginate(
         page=page,
@@ -257,7 +236,7 @@ def list_project_services(project_external_id):
 
     project_archived_services = list(map(lambda service: {
         'id': service.service_id,
-        'projectId': project.external_id,
+        'projectId': project_id,
         'supplier': {
             'name': service.supplier.name,
             'contact': {
@@ -270,7 +249,7 @@ def list_project_services(project_external_id):
     }, paginated_archived_services.items))
 
     pagination_params = request.args.to_dict()
-    pagination_params['project_external_id'] = project.external_id
+    pagination_params['project_id'] = project_id
 
     return jsonify(
         services=project_archived_services,
@@ -285,17 +264,17 @@ def list_project_services(project_external_id):
     )
 
 
-@main.route('/direct-award/projects/<int:project_external_id>/lock', methods=['POST'])
-def lock_project(project_external_id):
+@main.route('/direct-award/projects/<int:project_id>/lock', methods=['POST'])
+def lock_project(project_id):
     updater_json = validate_and_return_updater_request()
 
-    project = get_project_by_id_or_404(project_external_id)
+    project = DirectAwardProject.query.filter(DirectAwardProject.id == project_id).first_or_404()
 
     if project.locked_at:
-        abort(400, 'Project has already been locked: {}'.format(project.id))
+        abort(400, 'Project has already been locked: {}'.format(project_id))
 
     search = DirectAwardSearch.query.filter(
-        DirectAwardSearch.project_id == project.id,
+        DirectAwardSearch.project_id == project_id,
         DirectAwardSearch.active == True,  # noqa
     ).first_or_404()
 
@@ -324,8 +303,7 @@ def lock_project(project_external_id):
         audit_type=AuditTypes.lock_project,
         user=updater_json['updated_by'],
         data={
-            'projectId': project.id,
-            'projectExternalId': project.external_id,
+            'projectId': project.id
         },
         db_object=search,
     )
@@ -336,11 +314,11 @@ def lock_project(project_external_id):
     return jsonify(project=project.serialize())
 
 
-@main.route('/direct-award/projects/<int:project_external_id>/record-download', methods=['POST'])
-def record_project_download(project_external_id):
+@main.route('/direct-award/projects/<int:project_id>/record-download', methods=['POST'])
+def record_project_download(project_id):
     updater_json = validate_and_return_updater_request()
 
-    project = get_project_by_id_or_404(project_external_id)
+    project = DirectAwardProject.query.filter(DirectAwardProject.id == project_id).first_or_404()
 
     # We want to track the latest datetime the results were downloaded, overriding previous (although they're audited).
     project.downloaded_at = datetime.datetime.utcnow()
@@ -351,7 +329,7 @@ def record_project_download(project_external_id):
         audit_type=AuditTypes.downloaded_project,
         user=updater_json['updated_by'],
         data={
-            'projectExternalId': project.external_id,
+            'projectId': project.id
         },
         db_object=project,
     )

--- a/app/models/direct_award.py
+++ b/app/models/direct_award.py
@@ -5,10 +5,8 @@ from sqlalchemy.orm import validates
 from flask import current_app
 
 from app import db
-from app.utils import random_positive_external_id
 from app.url_utils import force_relative_url
 from app.models import User, ValidationError, ArchivedService
-
 from dmutils.formats import DATETIME_FORMAT
 
 
@@ -16,7 +14,6 @@ class DirectAwardProject(db.Model):
     __tablename__ = 'direct_award_projects'
 
     id = db.Column(db.Integer, primary_key=True)
-    external_id = db.Column(db.BigInteger, default=random_positive_external_id, nullable=False, index=True, unique=True)
     name = db.Column(db.String(255), nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
     locked_at = db.Column(db.DateTime, nullable=True)  # When the project's active search/es are final and cannot change
@@ -27,7 +24,7 @@ class DirectAwardProject(db.Model):
 
     def serialize(self, with_users=False):
         data = {
-            "id": self.external_id,
+            "id": self.id,
             "name": self.name,
             "createdAt": self.created_at.strftime(DATETIME_FORMAT),
             "lockedAt": self.locked_at.strftime(DATETIME_FORMAT) if self.locked_at is not None else None,

--- a/app/models/main.py
+++ b/app/models/main.py
@@ -1,5 +1,6 @@
 # TODO split this file into per-functional-area modules
 
+import random
 from datetime import datetime
 
 import re
@@ -30,14 +31,7 @@ from dmutils.dates import get_publishing_dates
 from dmutils.formats import DATETIME_FORMAT, DATE_FORMAT
 from .. import db
 from ..models.buyer_domains import BuyerEmailDomain
-from app.utils import (
-    drop_foreign_fields,
-    link,
-    purge_nulls_from_data,
-    random_positive_external_id,
-    strip_whitespace_from_data,
-    url_for,
-)
+from ..utils import link, url_for, strip_whitespace_from_data, drop_foreign_fields, purge_nulls_from_data
 from ..validation import (
     is_valid_service_id, get_validation_errors, buyer_email_address_has_approved_domain,
     admin_email_address_has_approved_domain
@@ -848,7 +842,7 @@ class ServiceTableMixin(object):
     id = db.Column(db.Integer, primary_key=True)
 
     # used as externally-visible "pk" for Services and allows services identity to be tracked
-    # across a service's lifetime. assigned randomly (see random_positive_external_id) at DraftService ->
+    # across a service's lifetime. assigned randomly (see generate_new_service_id) at DraftService ->
     # Service publishing time.
     service_id = db.Column(db.String, index=True, unique=True, nullable=False)
 
@@ -972,7 +966,7 @@ class Service(db.Model, ServiceTableMixin):
         return Service(
             framework=draft.framework,
             lot=draft.lot,
-            service_id=str(random_positive_external_id()),
+            service_id=generate_new_service_id(draft.framework.slug),
             supplier=draft.supplier,
             data=draft.data,
             status=status
@@ -1836,3 +1830,8 @@ def filter_null_value_fields(obj):
     return dict(
         filter(lambda x: x[1] is not None, obj.items())
     )
+
+
+def generate_new_service_id(framework_slug):
+    # FIXME framework_slug parameter ignored??
+    return str(random.randint(10 ** 14, 10 ** 15 - 1))

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,18 +1,10 @@
 from flask import url_for as base_url_for
 from flask import abort, current_app, request
 from six import iteritems, string_types
-import random
 from werkzeug.exceptions import BadRequest
 
 from .validation import validate_updater_json_or_400
 from . import search_api_client, dmapiclient
-
-
-def random_positive_external_id() -> int:
-    """
-    Generate a random integer ID that's 15-digits long.
-    """
-    return random.SystemRandom().randint(10 ** 14, (10 ** 15) - 1)
 
 
 def validate_and_return_updater_request():

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -298,17 +298,23 @@ class FixtureMixin(object):
     def create_direct_award_project(self, user_id, project_id=1, project_name=DIRECT_AWARD_PROJECT_NAME,
                                     created_at=DIRECT_AWARD_FROZEN_TIME):
         with self.app.app_context():
-            project = DirectAwardProject.query.get(project_id)
-            if not project:
-                project = DirectAwardProject(id=project_id, name=project_name, created_at=created_at)
-                db.session.add(project)
-                db.session.flush()
+            if DirectAwardProject.query.get(project_id):
+                return project_id
 
-                project_user = DirectAwardProjectUser(user_id=user_id, project_id=project_id)
-                db.session.add(project_user)
-                db.session.commit()
+            db.session.add(DirectAwardProject(
+                id=project_id,
+                name=project_name,
+                created_at=created_at
+            ))
+            db.session.flush()
 
-            return project_id, project.external_id
+            db.session.add(DirectAwardProjectUser(
+                user_id=user_id,
+                project_id=project_id
+            ))
+            db.session.commit()
+
+            return project_id
 
     def create_direct_award_project_search(self, created_by, project_id, search_url=DIRECT_AWARD_SEARCH_URL,
                                            active=True, created_at=DIRECT_AWARD_FROZEN_TIME):

--- a/tests/main/views/test_drafts.py
+++ b/tests/main/views/test_drafts.py
@@ -995,14 +995,14 @@ class TestDraftServices(BaseApplicationTest, FixtureMixin):
         assert self.service_count() == 1
         assert self.draft_service_count() == 0
 
-    @mock.patch('app.models.main.random_positive_external_id')
-    def test_service_id_collisions_should_be_handled(self, random_positive_external_id):
+    @mock.patch('app.models.main.generate_new_service_id')
+    def test_service_id_collisions_should_be_handled(self, generate_new_service_id):
         # Return the same ID a few times (cause collisions) and then return a different one.
-        random_positive_external_id.side_effect = (
-            '123456789012345',
-            '123456789012345',
-            '123456789012345',
-            '222222222222222',
+        generate_new_service_id.side_effect = (
+            '1234567890123457',
+            '1234567890123457',
+            '1234567890123457',
+            '2222222222222222',
         )
 
         res = self.publish_new_draft_service()
@@ -1014,8 +1014,8 @@ class TestDraftServices(BaseApplicationTest, FixtureMixin):
         assert self.service_count() == 3
         res = self.client.get('/services?framework=g-cloud-7')
         services = json.loads(res.get_data())['services']
-        assert services[0]['id'] == '123456789012345'
-        assert services[1]['id'] == '222222222222222'
+        assert services[0]['id'] == '1234567890123457'
+        assert services[1]['id'] == '2222222222222222'
         assert self.draft_service_count() == 2
 
     def test_get_draft_returns_last_audit_event(self):

--- a/tests/models/test_direct_award.py
+++ b/tests/models/test_direct_award.py
@@ -21,7 +21,6 @@ class TestProjects(BaseApplicationTest, FixtureMixin):
             db.session.commit()
 
             assert project.id is not None
-            assert project.external_id is not None
             assert project.name == DIRECT_AWARD_PROJECT_NAME
             assert isinstance(project.created_at, datetime)
             assert project.locked_at is None
@@ -35,10 +34,8 @@ class TestProjects(BaseApplicationTest, FixtureMixin):
             db.session.add(project)
             db.session.commit()
 
-            serialized_project = project.serialize()
-            project_keys_set = set(serialized_project.keys())
+            project_keys_set = set(project.serialize().keys())
             assert {'id', 'name', 'createdAt', 'lockedAt', 'active'} <= project_keys_set
-            assert serialized_project['id'] == project.external_id
 
             # We aren't serializing with_users=True, so we better not get them.
             assert 'users' not in project_keys_set
@@ -55,7 +52,6 @@ class TestProjects(BaseApplicationTest, FixtureMixin):
             project_keys_set = set(serialized_project.keys())
             # Must send at least these keys.
             assert {'id', 'name', 'createdAt', 'lockedAt', 'active', 'users'} <= project_keys_set
-            assert serialized_project['id'] == project.external_id
 
             # Must send these keys exactly - don't want to unknowingly expose more info.
             for user in serialized_project['users']:
@@ -108,7 +104,7 @@ class TestProjectUsers(BaseApplicationTest, FixtureMixin):
 class TestSearches(BaseApplicationTest, FixtureMixin):
     def test_create_new_search(self):
         user_id = self.setup_dummy_user(role='buyer')
-        project_id, project_external_id = self.create_direct_award_project(user_id=user_id)
+        project_id = self.create_direct_award_project(user_id=user_id)
         search_id = self.create_direct_award_project_search(created_by=user_id, project_id=project_id)
 
         with self.app.app_context():
@@ -122,7 +118,7 @@ class TestSearches(BaseApplicationTest, FixtureMixin):
 
     def test_only_one_search_active_per_project_is_enforced(self):
         user_id = self.setup_dummy_user(role='buyer')
-        project_id, project_external_id = self.create_direct_award_project(user_id=user_id)
+        project_id = self.create_direct_award_project(user_id=user_id)
         self.create_direct_award_project_search(created_by=user_id, project_id=project_id)
 
         with pytest.raises(IntegrityError):
@@ -130,7 +126,7 @@ class TestSearches(BaseApplicationTest, FixtureMixin):
 
     def test_serialize_search_contains_required_keys(self):
         user_id = self.setup_dummy_user(role='buyer')
-        project_id, project_external_id = self.create_direct_award_project(user_id=user_id)
+        project_id = self.create_direct_award_project(user_id=user_id)
         search_id = self.create_direct_award_project_search(created_by=user_id, project_id=project_id)
 
         with self.app.app_context():
@@ -146,7 +142,7 @@ class TestSearches(BaseApplicationTest, FixtureMixin):
                              ))
     def test_required_fields_raise_if_missing(self, update_kwargs):
         user_id = self.setup_dummy_user(role='buyer')
-        project_id, project_external_id = self.create_direct_award_project(user_id=user_id)
+        project_id = self.create_direct_award_project(user_id=user_id)
 
         search_kwargs = {'created_by': user_id, 'project_id': project_id, 'search_url': DIRECT_AWARD_SEARCH_URL}
         search_kwargs.update(update_kwargs)
@@ -156,7 +152,7 @@ class TestSearches(BaseApplicationTest, FixtureMixin):
 
     def test_search_in_locked_project_cannot_be_edited(self):
         user_id = self.setup_dummy_user(role='buyer')
-        project_id, project_external_id = self.create_direct_award_project(user_id=user_id)
+        project_id = self.create_direct_award_project(user_id=user_id)
         search_id = self.create_direct_award_project_search(created_by=user_id, project_id=project_id)
 
         with self.app.app_context():


### PR DESCRIPTION
This reverts commit a57958fc7675596391a7d0958ea15fb8567b132e.

## Summary
Revert external ID code - leave migration intact (currently in on Preview).