### PR TITLE
Start using external IDs in responses from the API

### DIFF
--- a/app/main/views/direct_award.py
+++ b/app/main/views/direct_award.py
@@ -151,7 +151,7 @@ def list_project_searches(project_external_id):
     )
 
     pagination_params = request.args.to_dict()
-    pagination_params['project_external_id'] = project.id
+    pagination_params['project_external_id'] = project.external_id
 
     return jsonify(
         searches=[search.serialize() for search in searches.items],
@@ -257,7 +257,7 @@ def list_project_services(project_external_id):
 
     project_archived_services = list(map(lambda service: {
         'id': service.service_id,
-        'projectId': project.id,
+        'projectId': project.external_id,
         'supplier': {
             'name': service.supplier.name,
             'contact': {
@@ -270,7 +270,7 @@ def list_project_services(project_external_id):
     }, paginated_archived_services.items))
 
     pagination_params = request.args.to_dict()
-    pagination_params['project_external_id'] = project.id
+    pagination_params['project_external_id'] = project.external_id
 
     return jsonify(
         services=project_archived_services,

--- a/app/models/direct_award.py
+++ b/app/models/direct_award.py
@@ -27,7 +27,7 @@ class DirectAwardProject(db.Model):
 
     def serialize(self, with_users=False):
         data = {
-            "id": self.id,
+            "id": self.external_id,
             "name": self.name,
             "createdAt": self.created_at.strftime(DATETIME_FORMAT),
             "lockedAt": self.locked_at.strftime(DATETIME_FORMAT) if self.locked_at is not None else None,
@@ -93,7 +93,7 @@ class DirectAwardSearch(db.Model):
         return {
             "id": self.id,
             "createdBy": self.created_by,
-            "projectId": self.project_id,
+            "projectId": self.project.external_id,
             "createdAt": self.created_at.strftime(DATETIME_FORMAT),
             "searchedAt": self.searched_at.strftime(DATETIME_FORMAT) if self.searched_at is not None else None,
             "searchUrl": resolved_search_url,

--- a/tests/main/views/test_direct_award.py
+++ b/tests/main/views/test_direct_award.py
@@ -132,7 +132,7 @@ class TestDirectAwardListProjects(DirectAwardSetupAndTeardown):
 
         assert len(set(projects_seen)) == self.app.config['DM_API_PROJECTS_PAGE_SIZE'] * pages
 
-    def test_list_projects_orders_by_id(self):
+    def test_list_projects_orders_by_internal_id(self):
         self.app.config['DM_API_PROJECTS_PAGE_SIZE'] = 2
 
         i = 1
@@ -148,7 +148,7 @@ class TestDirectAwardListProjects(DirectAwardSetupAndTeardown):
 
             with self.app.app_context():
                 for project in data['projects']:
-                    project = DirectAwardProject.query.filter(DirectAwardProject.id == project['id']).first()
+                    project = DirectAwardProject.query.filter(DirectAwardProject.external_id == project['id']).first()
                     assert last_seen < project.id
                     last_seen = project.id
 
@@ -331,11 +331,11 @@ class TestDirectAwardGetProject(DirectAwardSetupAndTeardown):
             user_id=self.user_id, project_name=self.direct_award_project_name
         )
 
-        res = self.client.get('/direct-award/projects/{}?user-id={}'.format(self.project_id, self.user_id))
+        res = self.client.get('/direct-award/projects/{}?user-id={}'.format(self.project_external_id, self.user_id))
         assert res.status_code == 200
 
     def test_get_project_returns_serialized_project(self):
-        res = self.client.get('/direct-award/projects/{}?user-id={}'.format(self.project_id, self.user_id))
+        res = self.client.get('/direct-award/projects/{}?user-id={}'.format(self.project_external_id, self.user_id))
         data = json.loads(res.get_data(as_text=True))
 
         with self.app.app_context():
@@ -351,7 +351,7 @@ class TestDirectAwardListProjectSearches(DirectAwardSetupAndTeardown):
         self.search_id = self.create_direct_award_project_search(created_by=self.user_id, project_id=self.project_id)
 
     def test_list_searches_200s_with_user_id(self):
-        res = self.client.get('/direct-award/projects/{}/searches?user-id={}'.format(self.project_id,
+        res = self.client.get('/direct-award/projects/{}/searches?user-id={}'.format(self.project_external_id,
                                                                                      self.user_id))
         assert res.status_code == 200
 
@@ -361,12 +361,12 @@ class TestDirectAwardListProjectSearches(DirectAwardSetupAndTeardown):
         assert res.status_code == 404
 
     def test_list_searches_links_use_external_id(self):
-        res = self.client.get('/direct-award/projects/{}/searches'.format(self.project_id))
+        res = self.client.get('/direct-award/projects/{}/searches'.format(self.project_external_id))
         data = json.loads(res.get_data(as_text=True))
 
         with self.app.app_context():
             assert data['links']['self'] == 'http://127.0.0.1:5000/direct-award/projects/{}/searches'.format(
-                self.project_id
+                self.project_external_id
             )
 
     def test_list_searches_returns_only_for_project_requested(self):
@@ -375,18 +375,19 @@ class TestDirectAwardListProjectSearches(DirectAwardSetupAndTeardown):
         self.create_direct_award_project(user_id=self.user_id + 1, project_id=self.project_id + 1)
         self.create_direct_award_project_search(created_by=self.user_id, project_id=self.project_id + 1)
 
-        res = self.client.get('/direct-award/projects/{}/searches'.format(self.project_id))
+        res = self.client.get('/direct-award/projects/{}/searches'.format(self.project_external_id))
         data = json.loads(res.get_data(as_text=True))
 
         with self.app.app_context():
-            assert all([search['projectId'] == self.project_id for search in data['searches']])
+            assert all([search['projectId'] == self.project_external_id for search in data['searches']])
             assert data['meta']['total'] < len(DirectAwardSearch.query.all())
 
     def test_list_searches_returns_all_searches_for_project(self):
         self.search_id = self.create_direct_award_project_search(created_by=self.user_id, project_id=self.project_id,
                                                                  active=False)
 
-        res = self.client.get('/direct-award/projects/{}/searches?user-id={}'.format(self.project_id, self.user_id))
+        res = self.client.get('/direct-award/projects/{}/searches?user-id={}'.format(self.project_external_id,
+                                                                                     self.user_id))
         data = json.loads(res.get_data(as_text=True))
 
         assert res.status_code == 200
@@ -410,7 +411,8 @@ class TestDirectAwardListProjectSearches(DirectAwardSetupAndTeardown):
         for i in range(extra_searches):
             self.create_direct_award_project_search(created_by=self.user_id, project_id=self.project_id, active=False)
 
-        res = self.client.get('/direct-award/projects/{}/searches?user-id={}'.format(self.project_id, self.user_id))
+        res = self.client.get('/direct-award/projects/{}/searches?user-id={}'.format(self.project_external_id,
+                                                                                     self.user_id))
         data = json.loads(res.get_data(as_text=True))
 
         num_pages = math.ceil((extra_searches + 1) / page_size)
@@ -432,9 +434,9 @@ class TestDirectAwardListProjectSearches(DirectAwardSetupAndTeardown):
         searches_seen = []
         pages = 0
         while pages == 0 or data['links']['next'] != data['links']['last']:
-            res = self.client.get('/direct-award/projects/{}/searches?user-id={}&page={}'.format(self.project_id,
-                                                                                                 self.user_id,
-                                                                                                 pages + 1))
+            res = self.client.get('/direct-award/projects/{}/searches?user-id={}&page={}'.format(
+                self.project_external_id, self.user_id, pages + 1)
+            )
             data = json.loads(res.get_data(as_text=True))
 
             for search in data['searches']:
@@ -453,9 +455,9 @@ class TestDirectAwardListProjectSearches(DirectAwardSetupAndTeardown):
 
         last_seen = 0
         for i in range(5):
-            res = self.client.get('/direct-award/projects/{}/searches?user-id={}&page={}'.format(self.project_id,
-                                                                                                 self.user_id,
-                                                                                                 i + 1))
+            res = self.client.get('/direct-award/projects/{}/searches?user-id={}&page={}'.format(
+                self.project_external_id, self.user_id, i + 1)
+            )
             data = json.loads(res.get_data(as_text=True))
 
             # Check that each project has a created_at date older than the last, i.e. reverse chronological order.
@@ -473,9 +475,9 @@ class TestDirectAwardListProjectSearches(DirectAwardSetupAndTeardown):
         self.create_direct_award_project_search(created_by=self.user_id, project_id=self.project_id, active=False,
                                                 created_at=datetime(2017, 1, 1, 0, 0, 0))
 
-        res = self.client.get('/direct-award/projects/{}/searches?user-id={}&only-active={}'.format(self.project_id,
-                                                                                                    self.user_id,
-                                                                                                    only_active))
+        res = self.client.get('/direct-award/projects/{}/searches?user-id={}&only-active={}'.format(
+            self.project_external_id, self.user_id, only_active)
+        )
         data = json.loads(res.get_data(as_text=True))
         assert len(data['searches']) == expected_count
         assert list(map(lambda search: search['active'], data['searches'])) == expected_states
@@ -494,7 +496,7 @@ class TestDirectAwardListProjectSearches(DirectAwardSetupAndTeardown):
         last_seen_datetime = None
         for i in range(5):
             res = self.client.get('/direct-award/projects/{}/searches?user-id={}&page={}'
-                                  '&latest-first=true'.format(self.project_id, self.user_id, i + 1))
+                                  '&latest-first=true'.format(self.project_external_id, self.user_id, i + 1))
             data = json.loads(res.get_data(as_text=True))
 
             # Check that each project has a created_at date older than the last, i.e. reverse chronological order.
@@ -507,7 +509,7 @@ class TestDirectAwardListProjectSearches(DirectAwardSetupAndTeardown):
                 last_seen_datetime = next_datetime
 
     def test_list_searches_returns_serialized_searches_with_metadata(self):
-        res = self.client.get('/direct-award/projects/{}/searches?user-id={}'.format(self.project_id,
+        res = self.client.get('/direct-award/projects/{}/searches?user-id={}'.format(self.project_external_id,
                                                                                      self.user_id))
         data = json.loads(res.get_data(as_text=True))
 
@@ -545,7 +547,7 @@ class TestDirectAwardCreateProjectSearch(DirectAwardSetupAndTeardown):
         for key in drop_search_keys:
             del search_data[key]
 
-        res = self.client.post('/direct-award/projects/{}/searches'.format(self.project_id),
+        res = self.client.post('/direct-award/projects/{}/searches'.format(self.project_external_id),
                                data=json.dumps(search_data),
                                content_type='application/json')
         assert res.status_code == expected_status
@@ -562,7 +564,7 @@ class TestDirectAwardCreateProjectSearch(DirectAwardSetupAndTeardown):
         for key in drop_search_keys:
             del search_data['search'][key]
 
-        res = self.client.post('/direct-award/projects/{}/searches'.format(self.project_id),
+        res = self.client.post('/direct-award/projects/{}/searches'.format(self.project_external_id),
                                data=json.dumps(search_data),
                                content_type='application/json')
         assert res.status_code == expected_status
@@ -571,7 +573,7 @@ class TestDirectAwardCreateProjectSearch(DirectAwardSetupAndTeardown):
         search_data = self._create_project_search_data()
         search_data['search']['userId'] = 9999999
 
-        res = self.client.post('/direct-award/projects/{}/searches'.format(self.project_id),
+        res = self.client.post('/direct-award/projects/{}/searches'.format(self.project_external_id),
                                data=json.dumps(search_data), content_type='application/json')
         assert res.status_code == 400
 
@@ -585,20 +587,20 @@ class TestDirectAwardCreateProjectSearch(DirectAwardSetupAndTeardown):
     def test_create_search_makes_other_searches_inactive(self):
         search_data = self._create_project_search_data()
 
-        res = self.client.post('/direct-award/projects/{}/searches'.format(self.project_id),
+        res = self.client.post('/direct-award/projects/{}/searches'.format(self.project_external_id),
                                data=json.dumps(search_data), content_type='application/json')
         data = json.loads(res.get_data(as_text=True))
         first_search_id = data['search']['id']
 
         assert data['search']['active'] is True
 
-        res = self.client.post('/direct-award/projects/{}/searches'.format(self.project_id),
+        res = self.client.post('/direct-award/projects/{}/searches'.format(self.project_external_id),
                                data=json.dumps(search_data), content_type='application/json')
         data = json.loads(res.get_data(as_text=True))
 
         assert data['search']['active'] is True
 
-        res = self.client.get('/direct-award/projects/{}/searches/{}?user-id={}'.format(self.project_id,
+        res = self.client.get('/direct-award/projects/{}/searches/{}?user-id={}'.format(self.project_external_id,
                                                                                         first_search_id,
                                                                                         self.user_id))
         data = json.loads(res.get_data(as_text=True))
@@ -606,7 +608,7 @@ class TestDirectAwardCreateProjectSearch(DirectAwardSetupAndTeardown):
         assert data['search']['active'] is False
 
     def test_create_project_search_creates_audit_event(self):
-        res = self.client.post('/direct-award/projects/{}/searches'.format(self.project_id),
+        res = self.client.post('/direct-award/projects/{}/searches'.format(self.project_external_id),
                                data=json.dumps(self._create_project_search_data()),
                                content_type='application/json')
         assert res.status_code == 201
@@ -623,7 +625,7 @@ class TestDirectAwardGetProjectSearch(DirectAwardSetupAndTeardown):
         )
         self.search_id = self.create_direct_award_project_search(created_by=self.user_id, project_id=self.project_id)
 
-        res = self.client.get('/direct-award/projects/{}/searches/{}?user-id={}'.format(self.project_id,
+        res = self.client.get('/direct-award/projects/{}/searches/{}?user-id={}'.format(self.project_external_id,
                                                                                         self.search_id,
                                                                                         self.user_id))
         assert res.status_code == 200
@@ -635,7 +637,7 @@ class TestDirectAwardGetProjectSearch(DirectAwardSetupAndTeardown):
         assert res.status_code == 404
 
     def test_get_search_returns_serialized_search(self):
-        res = self.client.get('/direct-award/projects/{}/searches/{}?user-id={}'.format(self.project_id,
+        res = self.client.get('/direct-award/projects/{}/searches/{}?user-id={}'.format(self.project_external_id,
                                                                                         self.search_id,
                                                                                         self.user_id))
         data = json.loads(res.get_data(as_text=True))
@@ -673,7 +675,7 @@ class TestDirectAwardListProjectServices(DirectAwardSetupAndTeardown):
             db.session.add(project)
             db.session.commit()
 
-        res = self.client.get('/direct-award/projects/{}/services'.format(self.project_id))
+        res = self.client.get('/direct-award/projects/{}/services'.format(self.project_external_id))
         assert res.status_code == 400
 
     def test_list_project_services_400s_if_no_saved_search(self):
@@ -683,7 +685,7 @@ class TestDirectAwardListProjectServices(DirectAwardSetupAndTeardown):
             db.session.delete(search)
             db.session.commit()
 
-        res = self.client.get('/direct-award/projects/{}/services'.format(self.project_id))
+        res = self.client.get('/direct-award/projects/{}/services'.format(self.project_external_id))
 
         assert res.status_code == 400
 
@@ -699,7 +701,7 @@ class TestDirectAwardListProjectServices(DirectAwardSetupAndTeardown):
                                                             search_id=self.search_id))
             db.session.commit()
 
-            res = self.client.get('/direct-award/projects/{}/services'.format(self.project_id))
+            res = self.client.get('/direct-award/projects/{}/services'.format(self.project_external_id))
             assert res.status_code == 200
 
             data = json.loads(res.get_data(as_text=True))
@@ -707,12 +709,12 @@ class TestDirectAwardListProjectServices(DirectAwardSetupAndTeardown):
             assert set(data.keys()) == {'meta', 'links', 'services'}
             assert data['meta'] == {'total': 5}
             assert data['links'] == {'self': 'http://127.0.0.1:5000/direct-award/projects/{}/services'.format(
-                self.project_id
+                self.project_external_id
             )}
             for service in data['services']:
                 assert service in [{
                     'id': service.service_id,
-                    'projectId': self.project_id,
+                    'projectId': self.project_external_id,
                     'supplier': {
                         'name': service.supplier.name,
                         'contact': {
@@ -736,14 +738,16 @@ class TestDirectAwardListProjectServices(DirectAwardSetupAndTeardown):
                                                             search_id=self.search_id))
             db.session.commit()
 
-            res = self.client.get('/direct-award/projects/{}/services?fields=serviceName'.format(self.project_id))
+            res = self.client.get('/direct-award/projects/{}/services?fields=serviceName'.format(
+                self.project_external_id)
+            )
             assert res.status_code == 200
 
             data = json.loads(res.get_data(as_text=True))
             assert data['services'][0]['data'] == {'serviceName': archived_services[0].data['serviceName']}
             assert data['links'] == {
                 'self': 'http://127.0.0.1:5000/direct-award/projects/{}/services?fields=serviceName'.format(
-                    self.project_id
+                    self.project_external_id
                 )
             }
 
@@ -761,7 +765,7 @@ class TestDirectAwardListProjectServices(DirectAwardSetupAndTeardown):
                                                             search_id=self.search_id))
             db.session.commit()
 
-        res = self.client.get('/direct-award/projects/{}/services?user-id={}'.format(self.project_id,
+        res = self.client.get('/direct-award/projects/{}/services?user-id={}'.format(self.project_external_id,
                                                                                      self.user_id))
         data = json.loads(res.get_data(as_text=True))
 
@@ -771,10 +775,10 @@ class TestDirectAwardListProjectServices(DirectAwardSetupAndTeardown):
         assert data['meta']['total'] == project_services_count
 
         next_url = 'http://127.0.0.1:5000/direct-award/projects/{}/services?user-id={}&page=2'.format(
-            self.project_id, self.user_id
+            self.project_external_id, self.user_id
         )
         last_url = 'http://127.0.0.1:5000/direct-award/projects/{}/services?user-id={}&page=20'.format(
-            self.project_id, self.user_id
+            self.project_external_id, self.user_id
         )
         assert data['links']['next'] == next_url
         assert data['links']['last'] == last_url
@@ -788,7 +792,7 @@ class TestDirectAwardLockProject(DirectAwardSetupAndTeardown, FixtureMixin):
         )
         self.search_id = self.create_direct_award_project_search(created_by=self.user_id, project_id=self.project_id)
 
-        res = self.client.get('/direct-award/projects/{}/searches/{}?user-id={}'.format(self.project_id,
+        res = self.client.get('/direct-award/projects/{}/searches/{}?user-id={}'.format(self.project_external_id,
                                                                                         self.search_id,
                                                                                         self.user_id))
         assert res.status_code == 200
@@ -807,7 +811,7 @@ class TestDirectAwardLockProject(DirectAwardSetupAndTeardown, FixtureMixin):
             db.session.commit()
 
         res = self.client.post(
-            '/direct-award/projects/{}/lock'.format(self.project_id),
+            '/direct-award/projects/{}/lock'.format(self.project_external_id),
             data=json.dumps({
                 'updated_by': 'example',
             }),
@@ -832,7 +836,7 @@ class TestDirectAwardLockProject(DirectAwardSetupAndTeardown, FixtureMixin):
         search_api_client.search_services_from_url_iter.return_value = [{"id": service_id}]
 
         res = self.client.post(
-            '/direct-award/projects/{}/lock'.format(self.project_id),
+            '/direct-award/projects/{}/lock'.format(self.project_external_id),
             data=json.dumps({
                 'updated_by': 'example',
             }),
@@ -840,7 +844,7 @@ class TestDirectAwardLockProject(DirectAwardSetupAndTeardown, FixtureMixin):
         data = json.loads(res.get_data(as_text=True))
 
         assert res.status_code == 200
-        assert data['project']['id'] == self.project_id
+        assert data['project']['id'] == self.project_external_id
         assert data['project']['lockedAt'] is not None
 
         with self.app.app_context():
@@ -908,7 +912,7 @@ class TestDirectAwardRecordProjectDownload(DirectAwardSetupAndTeardown):
         for key in drop_project_keys:
             del project_data[key]
 
-        res = self.client.post('/direct-award/projects/{}/record-download'.format(self.project_id),
+        res = self.client.post('/direct-award/projects/{}/record-download'.format(self.project_external_id),
                                data=json.dumps(project_data),
                                content_type='application/json')
         assert res.status_code == expected_status
@@ -920,9 +924,9 @@ class TestDirectAwardRecordProjectDownload(DirectAwardSetupAndTeardown):
                              ))
     def test_record_project_download_404s_if_invalid_project(self, override_project_id, expected_status):
         if override_project_id:
-            self.project_id = override_project_id
+            self.project_external_id = override_project_id
 
-        res = self.client.post('/direct-award/projects/{}/record-download'.format(self.project_id),
+        res = self.client.post('/direct-award/projects/{}/record-download'.format(self.project_external_id),
                                data=json.dumps(self._updated_by_data()),
                                content_type='application/json')
         assert res.status_code == expected_status
@@ -940,7 +944,7 @@ class TestDirectAwardRecordProjectDownload(DirectAwardSetupAndTeardown):
             db.session.add(project)
             db.session.commit()
 
-        self.client.post('/direct-award/projects/{}/record-download'.format(self.project_id),
+        self.client.post('/direct-award/projects/{}/record-download'.format(self.project_external_id),
                          data=json.dumps(self._updated_by_data()),
                          content_type='application/json')
 
@@ -949,10 +953,31 @@ class TestDirectAwardRecordProjectDownload(DirectAwardSetupAndTeardown):
             assert project.downloaded_at == datetime.strptime(expected_timestamp, DATETIME_FORMAT)
 
     def test_record_project_download_creates_audit_event(self):
-        res = self.client.post('/direct-award/projects/{}/record-download'.format(self.project_id),
+        res = self.client.post('/direct-award/projects/{}/record-download'.format(self.project_external_id),
                                data=json.dumps(self._updated_by_data()),
                                content_type='application/json')
         assert res.status_code == 200
 
         with self.app.app_context():
             self._assert_one_audit_event_created_for_only_project(AuditTypes.downloaded_project.value)
+
+
+class TestDirectAwardRoutesAcceptInternalAndExternalIdentifiers(DirectAwardSetupAndTeardown):
+    def setup(self):
+        super(TestDirectAwardRoutesAcceptInternalAndExternalIdentifiers, self).setup()
+        self.project_id, self.project_external_id = self.create_direct_award_project(
+            user_id=self.user_id, project_name=self.direct_award_project_name
+        )
+        self.search_id = self.create_direct_award_project_search(created_by=self.user_id, project_id=self.project_id)
+
+    @pytest.mark.parametrize('route', ['/direct-award/projects/{project_id}',
+                                       '/direct-award/projects/{project_id}/searches',
+                                       '/direct-award/projects/{project_id}/searches/{search_id}'])
+    def test_routes_return_same_result(self, route):
+        internal_id_response = self.client.get(route.format(project_id=self.project_id,
+                                                            search_id=self.search_id))
+        external_id_response = self.client.get(route.format(project_id=self.project_external_id,
+                                                            search_id=self.search_id))
+
+        assert internal_id_response.status_code == external_id_response.status_code == 200
+        assert internal_id_response.get_data(as_text=True) == external_id_response.get_data(as_text=True)

--- a/tests/models/test_direct_award.py
+++ b/tests/models/test_direct_award.py
@@ -38,7 +38,7 @@ class TestProjects(BaseApplicationTest, FixtureMixin):
             serialized_project = project.serialize()
             project_keys_set = set(serialized_project.keys())
             assert {'id', 'name', 'createdAt', 'lockedAt', 'active'} <= project_keys_set
-            assert serialized_project['id'] == project.id
+            assert serialized_project['id'] == project.external_id
 
             # We aren't serializing with_users=True, so we better not get them.
             assert 'users' not in project_keys_set
@@ -55,7 +55,7 @@ class TestProjects(BaseApplicationTest, FixtureMixin):
             project_keys_set = set(serialized_project.keys())
             # Must send at least these keys.
             assert {'id', 'name', 'createdAt', 'lockedAt', 'active', 'users'} <= project_keys_set
-            assert serialized_project['id'] == project.id
+            assert serialized_project['id'] == project.external_id
 
             # Must send these keys exactly - don't want to unknowingly expose more info.
             for user in serialized_project['users']:


### PR DESCRIPTION
## Summary
Now that we've got a database properly populated with external IDs, we can start replying with them from the API. Adds a test to ensure both internal and external IDs are accepted.