### PR TITLE
Bump api client version to 14.0.0

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -10,7 +10,7 @@ SQLAlchemy==1.1.4
 SQLAlchemy-Utils==0.30.5
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@29.0.0#egg=digitalmarketplace-utils==29.0.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@13.1.0#egg=digitalmarketplace-apiclient==13.1.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@14.0.0#egg=digitalmarketplace-apiclient==14.0.0
 
 # For schema validation
 jsonschema==2.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ SQLAlchemy==1.1.4
 SQLAlchemy-Utils==0.30.5
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@29.0.0#egg=digitalmarketplace-utils==29.0.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@13.1.0#egg=digitalmarketplace-apiclient==13.1.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@14.0.0#egg=digitalmarketplace-apiclient==14.0.0
 
 # For schema validation
 jsonschema==2.5.1
@@ -60,6 +60,6 @@ s3transfer==0.1.12
 six==1.11.0
 unicodecsv==0.14.1
 urllib3==1.22
-Werkzeug==0.12.2
+Werkzeug==0.13
 workdays==1.4
 WTForms==2.1


### PR DESCRIPTION
It allows `make_iter_method` accept more than one model name. We need
this so we can upgrade the search-api to return `documents` instead of
just `services`.

The direct award `lock_project` view uses the search-api to fetch
service ids. We need to bump the api-client so this view doesn't break
when the search-api starts returning documents.