### PR TITLE
Bug fix for external ID in create_project audit

### DIFF
--- a/app/main/views/direct_award.py
+++ b/app/main/views/direct_award.py
@@ -103,7 +103,7 @@ def create_project():
         audit_type=AuditTypes.create_project,
         user=updater_json['updated_by'],
         data={
-            'projectExternalId': project.id,
+            'projectExternalId': project.external_id,
             'projectJson': project_json,
         },
         db_object=project,

--- a/tests/main/views/test_direct_award.py
+++ b/tests/main/views/test_direct_award.py
@@ -11,7 +11,7 @@ from app import db
 import pytest
 from tests.bases import BaseApplicationTest
 
-from sqlalchemy import desc, Integer, BigInteger
+from sqlalchemy import desc, BigInteger
 from dmapiclient.audit import AuditTypes
 
 from app.models import DATETIME_FORMAT, AuditEvent, User, ArchivedService
@@ -53,9 +53,8 @@ class DirectAwardSetupAndTeardown(BaseApplicationTest, FixtureMixin):
         projects = DirectAwardProject.query.all()
         assert len(projects) == 1
 
-        audit_events = AuditEvent.query.filter(AuditEvent.type == audit_type
-                                               and AuditEvent.data['projectId'].astext.cast(Integer) == projects[0].id
-                                               and AuditEvent.data['projectExternalId'].astext.cast(BigInteger)
+        audit_events = AuditEvent.query.filter(AuditEvent.type == audit_type,
+                                               AuditEvent.data['projectExternalId'].astext.cast(BigInteger)
                                                == projects[0].external_id).all()
         assert len(audit_events) == 1
 


### PR DESCRIPTION
## Summary
We were accidentally storing project internal IDs in the create_project
audit events for Direct Award and the test that was supposed to detect
this was broken, using Python `and`s rather than the format expected by
SQLAlchemy's filter. Also our audit events don't consistently store
`projectId`  now, so remove that part of the test.

## Ticket
https://trello.com/c/GEziXqcE/34-security-change-direct-award-projects-to-use-randomly-generated-ids-rather-than-sequential