### PR TITLE
Buyer users should not be able to change role

### DIFF
--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -203,6 +203,8 @@ def update_user(user_id):
         if user.role == 'supplier' and user_update['role'] != user.role:
             user.supplier_id = None
             user_update.pop('supplierId', None)
+        if user.role == 'buyer' and user_update['role'] != user.role:
+            abort(400, "Can not change a 'buyer' user to a different role.")
         user.role = user_update['role']
     if 'supplierId' in user_update:
         user.supplier_id = user_update['supplierId']

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -5,7 +5,7 @@ Flask==0.10.1
 Flask-Bcrypt==0.7.1
 Flask-Migrate==2.0.3
 Flask-SQLAlchemy==2.1
-psycopg2==2.5.4
+psycopg2==2.7.3
 SQLAlchemy==1.1.4
 SQLAlchemy-Utils==0.30.5
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ Flask==0.10.1
 Flask-Bcrypt==0.7.1
 Flask-Migrate==2.0.3
 Flask-SQLAlchemy==2.1
-psycopg2==2.5.4
+psycopg2==2.7.3
 SQLAlchemy==1.1.4
 SQLAlchemy-Utils==0.30.5
 


### PR DESCRIPTION
For this ticket: https://trello.com/c/1Wpcnqrt/53-tech-debt-remove-functionality-to-change-buyer-account-into-supplier-account

If a buyer user with briefs associated with them changed role it would most likely break our apps we shouldn't let roles be changed for buyers.

It's a moot point whether supplier users should be allowed to convert to buyers, but I've left it possible because we have needed to do it a couple of times in the past (when people signed up for the wrong type of account).  In most cases the email domain check would block the conversion anyway, and also supplier users don't have database objects associated with them in the same way as buyer users do, so a change of role supplier->buyer won't break things in the same way as buyer->supplier might.