### PR TITLE
Firebreak give test requests isolated context

### DIFF
--- a/tests/main/views/test_brief_response.py
+++ b/tests/main/views/test_brief_response.py
@@ -605,17 +605,11 @@ class TestSubmitBriefResponse(BaseBriefResponseTest):
                 db.session.delete(existing_brief_response[-1])
                 db.session.commit()
 
-            # Get dos framework.
-            dos_framework = db.session.query(Framework).filter_by(slug='digital-outcomes-and-specialists').first()
-
-            # Make framework live so a brief response can be created.
-            dos_framework.status = 'live'
-            db.session.commit()
-
             # Create a brief response while the framework is live.
             self._setup_existing_brief_response()
 
             # Set framework status to the invalid status currently under test.
+            dos_framework = db.session.query(Framework).filter_by(slug='digital-outcomes-and-specialists').first()
             dos_framework.status = framework_status
             db.session.commit()
 

--- a/tests/main/views/test_suppliers.py
+++ b/tests/main/views/test_suppliers.py
@@ -1291,6 +1291,7 @@ class TestSupplierFrameworkResponse(BaseApplicationTest):
             )
             db.session.add(framework_agreement)
             db.session.commit()
+            framework_agreement_id = framework_agreement.id
 
             # Get back the SupplierFramework record
             response = self.client.get(
@@ -1309,7 +1310,7 @@ class TestSupplierFrameworkResponse(BaseApplicationTest):
                 'frameworkFramework': supplier_framework['frameworkFramework'],
                 'declaration': {'an_answer': 'Yes it is'},
                 'onFramework': True,
-                'agreementId': framework_agreement.id,
+                'agreementId': framework_agreement_id,
                 'agreementReturned': True,
                 'agreementReturnedAt': '2017-01-01T01:01:01.000000Z',
                 'agreementPath': '/agreement.pdf',
@@ -1350,6 +1351,7 @@ class TestSupplierFrameworkResponse(BaseApplicationTest):
             )
             db.session.add(framework_agreement)
             db.session.commit()
+            framework_agreement_id = framework_agreement.id
 
             # Get back the SupplierFramework record
             response = self.client.get(
@@ -1368,7 +1370,7 @@ class TestSupplierFrameworkResponse(BaseApplicationTest):
                 'frameworkFramework': supplier_framework['frameworkFramework'],
                 'declaration': {'an_answer': 'Yes it is'},
                 'onFramework': True,
-                'agreementId': framework_agreement.id,
+                'agreementId': framework_agreement_id,
                 'agreementReturned': True,
                 'agreementReturnedAt': '2017-01-01T01:01:01.000000Z',
                 'agreementDetails': {


### PR DESCRIPTION
This PR gives our test requests their own isolated `app_context` to attach db operations to.

The test changes reflect the fact that it is no longer possible, in a test, to:

Create an object in the DB
POST to a view to change that object
Then check the result of that POST against the original object without reloading it from the db

