### PR TITLE
Provide app context in setup

### DIFF
--- a/tests/bases.py
+++ b/tests/bases.py
@@ -54,17 +54,19 @@ class BaseApplicationTest(object):
         )
         self.app.test_client_class = TestClient
         self.client = self.app.test_client()
+        self.app_context = self.app.app_context()
+        self.app_context.push()
 
     def teardown(self):
-        with self.app.app_context():
-            db.session.remove()
-            for table in reversed(db.metadata.sorted_tables):
-                if table.name not in ["lots", "frameworks", "framework_lots"]:
-                    db.engine.execute(table.delete())
-            FrameworkLot.query.filter(FrameworkLot.framework_id >= 100).delete()
-            Framework.query.filter(Framework.id >= 100).delete()
-            db.session.commit()
-            db.get_engine(self.app).dispose()
+        db.session.remove()
+        for table in reversed(db.metadata.sorted_tables):
+            if table.name not in ["lots", "frameworks", "framework_lots"]:
+                db.engine.execute(table.delete())
+        FrameworkLot.query.filter(FrameworkLot.framework_id >= 100).delete()
+        Framework.query.filter(Framework.id >= 100).delete()
+        db.session.commit()
+        db.get_engine(self.app).dispose()
+        self.app_context.pop()
 
 
 class JSONTestMixin(object):

--- a/tests/models/test_main.py
+++ b/tests/models/test_main.py
@@ -787,7 +787,6 @@ class TestCopyBrief(BaseApplicationTest, FixtureMixin):
 
     def setup(self, *args, **kwargs):
         super(TestCopyBrief, self).setup(*args, **kwargs)
-        self.app.app_context().push()
         self.setup_dummy_user(role='buyer')
         self.framework = Framework.query.filter(
             Framework.slug == 'digital-outcomes-and-specialists',


### PR DESCRIPTION
Instead of using 
`with self.app.app_context():`
in every test we can provide the app context in the setup now the work to isolate requests from said context is done.

This will have the benefit of making objects created in the setup available in the tests before a request is made.

Requires https://github.com/alphagov/digitalmarketplace-api/pull/719