### PR TITLE
Tidying up some tests

### DIFF
--- a/tests/main/views/test_frameworks.py
+++ b/tests/main/views/test_frameworks.py
@@ -36,6 +36,7 @@ class TestListFrameworks(BaseApplicationTest):
 
 
 class TestCreateFramework(BaseApplicationTest):
+
     def framework(self, **kwargs):
         return {
             "frameworks": {
@@ -52,13 +53,12 @@ class TestCreateFramework(BaseApplicationTest):
         }
 
     def teardown(self):
+        framework = Framework.query.filter(Framework.slug == "example").first()
+        if framework:
+            FrameworkLot.query.filter(FrameworkLot.framework_id == framework.id).delete()
+            Framework.query.filter(Framework.id == framework.id).delete()
+            db.session.commit()
         super(TestCreateFramework, self).teardown()
-        with self.app.app_context():
-            framework = Framework.query.filter(Framework.slug == "example").first()
-            if framework:
-                FrameworkLot.query.filter(FrameworkLot.framework_id == framework.id).delete()
-                Framework.query.filter(Framework.id == framework.id).delete()
-                db.session.commit()
 
     def test_create_a_framework(self):
         with self.app.app_context():

--- a/tests/main/views/test_frameworks.py
+++ b/tests/main/views/test_frameworks.py
@@ -36,7 +36,6 @@ class TestListFrameworks(BaseApplicationTest):
 
 
 class TestCreateFramework(BaseApplicationTest):
-
     def framework(self, **kwargs):
         return {
             "frameworks": {

--- a/tests/main/views/test_suppliers.py
+++ b/tests/main/views/test_suppliers.py
@@ -1590,10 +1590,9 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest):
         self,
         open_g8_framework_live_dos_framework_suppliers_on_framework,
     ):
-        with self.app.app_context():
-            supplier_framework = SupplierFramework.query.filter(
-                SupplierFramework.framework.has(Framework.slug == "digital-outcomes-and-specialists")
-            ).order_by(Supplier.id.asc()).first().serialize()
+        supplier_framework = SupplierFramework.query.filter(
+            SupplierFramework.framework.has(Framework.slug == "digital-outcomes-and-specialists")
+        ).order_by(Supplier.id.asc()).first().serialize()
 
         response = self.supplier_framework_interest(
             supplier_framework,
@@ -1608,11 +1607,11 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest):
         assert data['frameworkInterest']['frameworkSlug'] == supplier_framework['frameworkSlug']
         assert data['frameworkInterest']['prefillDeclarationFromFrameworkSlug'] == "g-cloud-8"
 
-        with self.app.app_context():
-            supplier_framework2 = self._refetch_serialized_sf(data['frameworkInterest'])
-            assert data['frameworkInterest'] == supplier_framework2
-            audit = self._assert_and_return_audit_event(supplier_framework)
-            assert audit.data['update']['prefillDeclarationFromFrameworkSlug'] == "g-cloud-8"
+        supplier_framework2 = self._refetch_serialized_sf(data['frameworkInterest'])
+        assert data['frameworkInterest'] == supplier_framework2
+        audit = self._assert_and_return_audit_event(supplier_framework)
+        audit_id = audit.id
+        assert audit.data['update']['prefillDeclarationFromFrameworkSlug'] == "g-cloud-8"
 
         # now we make sure that a single property update failure prevents any db changes
         response2 = self.supplier_framework_interest(
@@ -1624,10 +1623,9 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest):
         )
         assert response2.status_code == 400
 
-        with self.app.app_context():
-            # check nothing has changed on db
-            assert supplier_framework2 == self._refetch_serialized_sf(supplier_framework2)
-            assert self._latest_supplier_update_audit_event(supplier_framework2["supplierId"]).id == audit.id
+        # check nothing has changed on db
+        assert supplier_framework2 == self._refetch_serialized_sf(supplier_framework2)
+        assert self._latest_supplier_update_audit_event(supplier_framework2["supplierId"]).id == audit_id
 
     def test_setting_prefill_declaration_from_framework_supplier_not_on_other_framework(
         self,

--- a/tests/main/views/test_suppliers.py
+++ b/tests/main/views/test_suppliers.py
@@ -763,25 +763,16 @@ class TestSetSupplierDeclarations(BaseApplicationTest, FixtureMixin, JSONUpdateT
 
     def setup(self):
         super(TestSetSupplierDeclarations, self).setup()
-        with self.app.app_context():
-            framework = Framework(
-                slug='test-open',
-                name='Test open',
-                framework='g-cloud',
-                status='open')
-            db.session.add(framework)
-            db.session.commit()
+        # This is automatically removed in BaseApplicationTest.teardown
+        framework = Framework(
+            id=100,
+            slug='test-open',
+            name='Test open',
+            framework='g-cloud',
+            status='open')
+        db.session.add(framework)
+        db.session.commit()
         self.setup_dummy_suppliers(1)
-
-    def teardown(self):
-        super(TestSetSupplierDeclarations, self).teardown()
-        with self.app.app_context():
-            frameworks = Framework.query.filter(
-                Framework.slug.like('test-%')
-            ).all()
-            for framework in frameworks:
-                db.session.delete(framework)
-            db.session.commit()
 
     def test_add_new_declaration(self):
         with self.app.app_context():

--- a/tests/models/test_main.py
+++ b/tests/models/test_main.py
@@ -4,7 +4,7 @@ import mock
 import pytest
 from sqlalchemy.exc import IntegrityError
 
-from app import db, create_app
+from app import db
 from app.models import (
     User, Lot, Framework, Service,
     Supplier, SupplierFramework, FrameworkAgreement,
@@ -102,22 +102,20 @@ class TestUser(BaseApplicationTest, FixtureMixin):
         assert str(exc.value) == 'invalid_admin_domain'
 
 
-def test_framework_should_not_accept_invalid_status():
-    app = create_app('test')
-    with app.app_context(), pytest.raises(ValidationError):
-        f = Framework(
-            name='foo',
-            slug='foo',
-            framework='g-cloud',
-            status='invalid',
-        )
-        db.session.add(f)
-        db.session.commit()
+class TestFrameworks(BaseApplicationTest):
 
+    def test_framework_should_not_accept_invalid_status(self):
+        with pytest.raises(ValidationError):
+            f = Framework(
+                name='foo',
+                slug='foo',
+                framework='g-cloud',
+                status='invalid',
+            )
+            db.session.add(f)
+            db.session.commit()
 
-def test_framework_should_accept_valid_statuses():
-    app = create_app('test')
-    with app.app_context():
+    def test_framework_should_accept_valid_statuses(self):
         for i, status in enumerate(Framework.STATUSES):
             f = Framework(
                 name='foo',


### PR DESCRIPTION
With the addition of the new context in the `setup` of the tests we can tidy up some existing tests to make use of this. 
These tests are the only instances where it not possible to do remove app_context calls without changing functionality.

`tests/main/views/test_suppliers.py::TestSetSupplierDeclarations::setup`
    Alter the test framework data so it will be deleted by BaseApplicationTest.teardown    
    We already have code to remove test frameworks in BaseApplicationTest.teardown.
    Any framework with id >= 100 will be deleted on a teardown. Therefore by setting
    the id of our test framework to 100 we ensure it will be deleted and can delete
    the code that manually removes it.

`tests/main/views/test_suppliers.py::TestSupplierFrameworkUpdates:: test_multiple_simultaneous_property_updates`
    Avoid accessing stale objects after making requests.

`tests/main/views/test_frameworks.py::TestCreateFramework::teardown`
    Use context provided by BaseApplicationTest.app_context in teardown.    
    Inside the teardown method we can make use of the existing app context by
    calling the `super` at the _end_ of the method instead of the start.

`tests/models/test_main.py::TestFrameworks`
    New `TestFrameworks` class inheriting BaseApplicationTest    
    Uses BaseApplicationTest.app_context instead of creating its own manually