### PR TITLE
Remove _all_ extraneous calls to `app.app_context()` within tests

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -51,38 +51,36 @@ def fixture_params(fixture_name, params):
 class FixtureMixin(object):
 
     def setup_default_buyer_domain(self):
-        with self.app.app_context():
-            if BuyerEmailDomain.query.filter(BuyerEmailDomain.domain_name == 'digital.gov.uk').count() == 0:
-                db.session.add(BuyerEmailDomain(domain_name='digital.gov.uk'))
-                db.session.commit()
-
-    def setup_dummy_user(self, id=123, role='buyer'):
-        with self.app.app_context():
-            # The user should have a valid email domain
-            self.setup_default_buyer_domain()
-
-            if role == 'admin':
-                domain = 'digital.cabinet-office.gov.uk'
-            elif role == 'admin-ccs-sourcing':
-                domain = 'crowncommercial.gov.uk'
-            else:
-                domain = 'digital.gov.uk'
-
-            if User.query.get(id):
-                return id
-            user = User(
-                id=id,
-                email_address='test+{}@{}'.format(id, domain),
-                name='my name',
-                password='fake password',
-                active=True,
-                role=role,
-                password_changed_at=datetime.now()
-            )
-            db.session.add(user)
+        if BuyerEmailDomain.query.filter(BuyerEmailDomain.domain_name == 'digital.gov.uk').count() == 0:
+            db.session.add(BuyerEmailDomain(domain_name='digital.gov.uk'))
             db.session.commit()
 
-            return user.id
+    def setup_dummy_user(self, id=123, role='buyer'):
+        # The user should have a valid email domain
+        self.setup_default_buyer_domain()
+
+        if role == 'admin':
+            domain = 'digital.cabinet-office.gov.uk'
+        elif role == 'admin-ccs-sourcing':
+            domain = 'crowncommercial.gov.uk'
+        else:
+            domain = 'digital.gov.uk'
+
+        if User.query.get(id):
+            return id
+        user = User(
+            id=id,
+            email_address='test+{}@{}'.format(id, domain),
+            name='my name',
+            password='fake password',
+            active=True,
+            role=role,
+            password_changed_at=datetime.now()
+        )
+        db.session.add(user)
+        db.session.commit()
+
+        return user.id
 
     def setup_dummy_briefs(
         self, n, title=None, status='draft', user_id=1, data=None, brief_start=1, lot='digital-specialists',
@@ -90,21 +88,20 @@ class FixtureMixin(object):
     ):
         user_id = self.setup_dummy_user(id=user_id)
 
-        with self.app.app_context():
-            lot = Lot.query.filter(Lot.slug == lot).first()
-            data = data or COMPLETE_DIGITAL_SPECIALISTS_BRIEF.copy()
-            data['title'] = title
-            for i in range(brief_start, brief_start + n):
-                self.setup_dummy_brief(
-                    id=i,
-                    user_id=user_id,
-                    data=data,
-                    framework_slug='digital-outcomes-and-specialists',
-                    lot_slug=lot.slug,
-                    status=status,
-                    published_at=published_at,
-                    add_clarification_question=add_clarification_question
-                )
+        lot = Lot.query.filter(Lot.slug == lot).first()
+        data = data or COMPLETE_DIGITAL_SPECIALISTS_BRIEF.copy()
+        data['title'] = title
+        for i in range(brief_start, brief_start + n):
+            self.setup_dummy_brief(
+                id=i,
+                user_id=user_id,
+                data=data,
+                framework_slug='digital-outcomes-and-specialists',
+                lot_slug=lot.slug,
+                status=status,
+                published_at=published_at,
+                add_clarification_question=add_clarification_question
+            )
 
     def setup_dummy_brief(
         self, id=None, user_id=1, status=None, data=None, published_at=None, withdrawn_at=None,
@@ -157,46 +154,44 @@ class FixtureMixin(object):
 
     def setup_dummy_suppliers(self, n):
         supplier_ids = []
-        with self.app.app_context():
-            for i in range(n):
-                db.session.add(
-                    Supplier(
-                        supplier_id=i,
-                        name=u'Supplier {}'.format(i),
-                        description=''
-                    )
+        for i in range(n):
+            db.session.add(
+                Supplier(
+                    supplier_id=i,
+                    name=u'Supplier {}'.format(i),
+                    description=''
                 )
-                db.session.add(
-                    ContactInformation(
-                        supplier_id=i,
-                        contact_name=u'Contact for Supplier {}'.format(i),
-                        email=u'{}@contact.com'.format(i),
-                        postcode=u'SW1A 1AA'
-                    )
+            )
+            db.session.add(
+                ContactInformation(
+                    supplier_id=i,
+                    contact_name=u'Contact for Supplier {}'.format(i),
+                    email=u'{}@contact.com'.format(i),
+                    postcode=u'SW1A 1AA'
                 )
-                supplier_ids.append(i)
-            db.session.commit()
+            )
+            supplier_ids.append(i)
+        db.session.commit()
         return supplier_ids
 
     def setup_additional_dummy_suppliers(self, n, initial):
-        with self.app.app_context():
-            for i in range(1000, n + 1000):
-                db.session.add(
-                    Supplier(
-                        supplier_id=i,
-                        name=u'{} suppliers Ltd {}'.format(initial, i),
-                        description=''
-                    )
+        for i in range(1000, n + 1000):
+            db.session.add(
+                Supplier(
+                    supplier_id=i,
+                    name=u'{} suppliers Ltd {}'.format(initial, i),
+                    description=''
                 )
-                db.session.add(
-                    ContactInformation(
-                        supplier_id=i,
-                        contact_name=u'Contact for Supplier {}'.format(i),
-                        email=u'{}@contact.com'.format(i),
-                        postcode=u'SW1A 1AA'
-                    )
+            )
+            db.session.add(
+                ContactInformation(
+                    supplier_id=i,
+                    contact_name=u'Contact for Supplier {}'.format(i),
+                    email=u'{}@contact.com'.format(i),
+                    postcode=u'SW1A 1AA'
                 )
-            db.session.commit()
+            )
+        db.session.commit()
 
     def setup_dummy_service(self, service_id, supplier_id=1, data=None,
                             status='published', framework_id=1, lot_id=1, model=Service, **kwargs):
@@ -224,63 +219,60 @@ class FixtureMixin(object):
 
     def setup_dummy_services(self, n, supplier_id=None, framework_id=1,
                              start_id=0, lot_id=1, model=Service):
-        with self.app.app_context():
-            for i in range(start_id, start_id + n):
-                self.setup_dummy_service(
-                    service_id=str(2000000000 + start_id + i),
-                    supplier_id=supplier_id or (i % TEST_SUPPLIERS_COUNT),
-                    framework_id=framework_id,
-                    lot_id=lot_id,
-                    model=model,
-                )
+        for i in range(start_id, start_id + n):
+            self.setup_dummy_service(
+                service_id=str(2000000000 + start_id + i),
+                supplier_id=supplier_id or (i % TEST_SUPPLIERS_COUNT),
+                framework_id=framework_id,
+                lot_id=lot_id,
+                model=model,
+            )
 
     def setup_dummy_services_including_unpublished(self, n):
         self.setup_dummy_suppliers(TEST_SUPPLIERS_COUNT)
         self.setup_dummy_services(n)
-        with self.app.app_context():
-            # Add extra 'enabled' and 'disabled' services
-            self.setup_dummy_service(
-                service_id=str(n + 2000000001),
-                supplier_id=n % TEST_SUPPLIERS_COUNT,
-                status='disabled')
-            self.setup_dummy_service(
-                service_id=str(n + 2000000002),
-                supplier_id=n % TEST_SUPPLIERS_COUNT,
-                status='enabled')
-            # Add an extra supplier that will have no services
-            db.session.add(
-                Supplier(supplier_id=TEST_SUPPLIERS_COUNT, name=u'Supplier {}'
-                         .format(TEST_SUPPLIERS_COUNT))
+        # Add extra 'enabled' and 'disabled' services
+        self.setup_dummy_service(
+            service_id=str(n + 2000000001),
+            supplier_id=n % TEST_SUPPLIERS_COUNT,
+            status='disabled')
+        self.setup_dummy_service(
+            service_id=str(n + 2000000002),
+            supplier_id=n % TEST_SUPPLIERS_COUNT,
+            status='enabled')
+        # Add an extra supplier that will have no services
+        db.session.add(
+            Supplier(supplier_id=TEST_SUPPLIERS_COUNT, name=u'Supplier {}'
+                     .format(TEST_SUPPLIERS_COUNT))
+        )
+        db.session.add(
+            ContactInformation(
+                supplier_id=TEST_SUPPLIERS_COUNT,
+                contact_name=u'Contact for Supplier {}'.format(
+                    TEST_SUPPLIERS_COUNT),
+                email=u'{}@contact.com'.format(TEST_SUPPLIERS_COUNT),
+                postcode=u'SW1A 1AA'
             )
-            db.session.add(
-                ContactInformation(
-                    supplier_id=TEST_SUPPLIERS_COUNT,
-                    contact_name=u'Contact for Supplier {}'.format(
-                        TEST_SUPPLIERS_COUNT),
-                    email=u'{}@contact.com'.format(TEST_SUPPLIERS_COUNT),
-                    postcode=u'SW1A 1AA'
-                )
-            )
-            db.session.commit()
+        )
+        db.session.commit()
 
     def setup_dos_2_framework(self, status='open', clarifications=True):
-        with self.app.app_context():
-            db.session.add(
-                Framework(
-                    id=101,
-                    slug=u'digital-outcomes-and-specialists-2',
-                    name=u'Digital Outcomes and Specialists 2',
-                    framework=u'digital-outcomes-and-specialists',
-                    status=status,
-                    clarification_questions_open=clarifications,
-                    lots=[Lot.query.filter(Lot.slug == 'digital-outcomes').first(),
-                          Lot.query.filter(Lot.slug == 'digital-specialists').first(),
-                          Lot.query.filter(Lot.slug == 'user-research-participants').first(),
-                          Lot.query.filter(Lot.slug == 'user-research-studios').first(),
-                          ]
-                )
+        db.session.add(
+            Framework(
+                id=101,
+                slug=u'digital-outcomes-and-specialists-2',
+                name=u'Digital Outcomes and Specialists 2',
+                framework=u'digital-outcomes-and-specialists',
+                status=status,
+                clarification_questions_open=clarifications,
+                lots=[Lot.query.filter(Lot.slug == 'digital-outcomes').first(),
+                      Lot.query.filter(Lot.slug == 'digital-specialists').first(),
+                      Lot.query.filter(Lot.slug == 'user-research-participants').first(),
+                      Lot.query.filter(Lot.slug == 'user-research-studios').first(),
+                      ]
             )
-            db.session.commit()
+        )
+        db.session.commit()
 
     def set_framework_status(self, slug, status):
         Framework.query.filter_by(slug=slug).update({'status': status})
@@ -297,31 +289,29 @@ class FixtureMixin(object):
 
     def create_direct_award_project(self, user_id, project_id=1, project_name=DIRECT_AWARD_PROJECT_NAME,
                                     created_at=DIRECT_AWARD_FROZEN_TIME):
-        with self.app.app_context():
-            project = DirectAwardProject.query.get(project_id)
-            if not project:
-                project = DirectAwardProject(id=project_id, name=project_name, created_at=created_at)
-                db.session.add(project)
-                db.session.flush()
+        project = DirectAwardProject.query.get(project_id)
+        if not project:
+            project = DirectAwardProject(id=project_id, name=project_name, created_at=created_at)
+            db.session.add(project)
+            db.session.flush()
 
-                project_user = DirectAwardProjectUser(user_id=user_id, project_id=project_id)
-                db.session.add(project_user)
-                db.session.commit()
+            project_user = DirectAwardProjectUser(user_id=user_id, project_id=project_id)
+            db.session.add(project_user)
+            db.session.commit()
 
-            return project_id, project.external_id
+        return project_id, project.external_id
 
     def create_direct_award_project_search(self, created_by, project_id, search_url=DIRECT_AWARD_SEARCH_URL,
                                            active=True, created_at=DIRECT_AWARD_FROZEN_TIME):
-        with self.app.app_context():
-            search = DirectAwardSearch(created_by=created_by,
-                                       project_id=project_id,
-                                       created_at=created_at,
-                                       search_url=search_url,
-                                       active=active)
-            db.session.add(search)
-            db.session.commit()
+        search = DirectAwardSearch(created_by=created_by,
+                                   project_id=project_id,
+                                   created_at=created_at,
+                                   search_url=search_url,
+                                   active=active)
+        db.session.add(search)
+        db.session.commit()
 
-            return search.id
+        return search.id
 
 
 def load_example_listing(name):

--- a/tests/main/views/test_agreements.py
+++ b/tests/main/views/test_agreements.py
@@ -8,17 +8,16 @@ from tests.bases import BaseApplicationTest
 
 class BaseFrameworkAgreementTest(BaseApplicationTest):
     def create_agreement(self, supplier_framework, **framework_agreement_kwargs):
-        with self.app.app_context():
-            framework = Framework.query.filter(Framework.slug == supplier_framework['frameworkSlug']).first()
+        framework = Framework.query.filter(Framework.slug == supplier_framework['frameworkSlug']).first()
 
-            agreement = FrameworkAgreement(
-                supplier_id=supplier_framework['supplierId'],
-                framework_id=framework.id,
-                **framework_agreement_kwargs)
-            db.session.add(agreement)
-            db.session.commit()
+        agreement = FrameworkAgreement(
+            supplier_id=supplier_framework['supplierId'],
+            framework_id=framework.id,
+            **framework_agreement_kwargs)
+        db.session.add(agreement)
+        db.session.commit()
 
-            return agreement.id
+        return agreement.id
 
 
 class TestCreateFrameworkAgreement(BaseApplicationTest):
@@ -67,21 +66,20 @@ class TestCreateFrameworkAgreement(BaseApplicationTest):
 
         agreement_id = json.loads(res.get_data(as_text=True))['agreement']['id']
 
-        with self.app.app_context():
-            agreement = FrameworkAgreement.query.filter(
-                FrameworkAgreement.id == agreement_id
-            ).first()
+        agreement = FrameworkAgreement.query.filter(
+            FrameworkAgreement.id == agreement_id
+        ).first()
 
-            audit = AuditEvent.query.filter(
-                AuditEvent.object == agreement
-            ).first()
+        audit = AuditEvent.query.filter(
+            AuditEvent.object == agreement
+        ).first()
 
-            assert audit.type == "create_agreement"
-            assert audit.user == "interested@example.com"
-            assert audit.data == {
-                'supplierId': supplier_framework['supplierId'],
-                'frameworkSlug': supplier_framework['frameworkSlug']
-            }
+        assert audit.type == "create_agreement"
+        assert audit.user == "interested@example.com"
+        assert audit.data == {
+            'supplierId': supplier_framework['supplierId'],
+            'frameworkSlug': supplier_framework['frameworkSlug']
+        }
 
     def test_404_if_creating_framework_agreement_with_no_supplier_framework(self, supplier_framework):
         res = self.post_create_agreement(
@@ -410,28 +408,27 @@ class TestUpdateFrameworkAgreement(BaseFrameworkAgreementTest):
 
         assert res.status_code == 200
 
-        with self.app.app_context():
-            agreement = FrameworkAgreement.query.filter(
-                FrameworkAgreement.id == agreement_id
-            ).first()
+        agreement = FrameworkAgreement.query.filter(
+            FrameworkAgreement.id == agreement_id
+        ).first()
 
-            audit = AuditEvent.query.filter(
-                AuditEvent.object == agreement
-            ).first()
+        audit = AuditEvent.query.filter(
+            AuditEvent.object == agreement
+        ).first()
 
-            assert audit.type == "update_agreement"
-            assert audit.user == "interested@example.com"
-            assert audit.data == {
-                'supplierId': supplier_framework['supplierId'],
-                'frameworkSlug': supplier_framework['frameworkSlug'],
-                'update': {
-                    'signedAgreementDetails': {
-                        'signerName': 'name',
-                        'signerRole': 'role',
-                    },
-                    'signedAgreementPath': '/example.pdf'
-                }
+        assert audit.type == "update_agreement"
+        assert audit.user == "interested@example.com"
+        assert audit.data == {
+            'supplierId': supplier_framework['supplierId'],
+            'frameworkSlug': supplier_framework['frameworkSlug'],
+            'update': {
+                'signedAgreementDetails': {
+                    'signerName': 'name',
+                    'signerRole': 'role',
+                },
+                'signedAgreementPath': '/example.pdf'
             }
+        }
 
     @fixture_params('live_example_framework', {'framework_agreement_details': {'frameworkAgreementVersion': 'v1.0'}})
     def test_can_not_set_framework_agreement_version_directly(self, supplier_framework):
@@ -685,22 +682,21 @@ class TestSignFrameworkAgreementThatHasFrameworkAgreementVersion(BaseFrameworkAg
         res = self.sign_agreement(agreement_id, {'signedAgreementDetails': {'uploaderUserId': user_role_supplier}})
         assert res.status_code == 200
 
-        with self.app.app_context():
-            agreement = FrameworkAgreement.query.filter(
-                FrameworkAgreement.id == agreement_id
-            ).first()
+        agreement = FrameworkAgreement.query.filter(
+            FrameworkAgreement.id == agreement_id
+        ).first()
 
-            audit = AuditEvent.query.filter(
-                AuditEvent.object == agreement
-            ).first()
+        audit = AuditEvent.query.filter(
+            AuditEvent.object == agreement
+        ).first()
 
-            assert audit.type == "sign_agreement"
-            assert audit.user == "interested@example.com"
-            assert audit.data == {
-                'supplierId': supplier_framework['supplierId'],
-                'frameworkSlug': supplier_framework['frameworkSlug'],
-                'update': {'signedAgreementDetails': {'uploaderUserId': user_role_supplier}}
-            }
+        assert audit.type == "sign_agreement"
+        assert audit.user == "interested@example.com"
+        assert audit.data == {
+            'supplierId': supplier_framework['supplierId'],
+            'frameworkSlug': supplier_framework['frameworkSlug'],
+            'update': {'signedAgreementDetails': {'uploaderUserId': user_role_supplier}}
+        }
 
     def test_can_re_sign_framework_agreement(self, user_role_supplier, supplier_framework):
         agreement_id = self.create_agreement(
@@ -803,21 +799,20 @@ class TestSignFrameworkAgreementThatHasNoFrameworkAgreementVersion(BaseFramework
         res = self.sign_agreement(agreement_id)
         assert res.status_code == 200
 
-        with self.app.app_context():
-            agreement = FrameworkAgreement.query.filter(
-                FrameworkAgreement.id == agreement_id
-            ).first()
+        agreement = FrameworkAgreement.query.filter(
+            FrameworkAgreement.id == agreement_id
+        ).first()
 
-            audit = AuditEvent.query.filter(
-                AuditEvent.object == agreement
-            ).first()
+        audit = AuditEvent.query.filter(
+            AuditEvent.object == agreement
+        ).first()
 
-            assert audit.type == "sign_agreement"
-            assert audit.user == "interested@example.com"
-            assert audit.data == {
-                'supplierId': supplier_framework['supplierId'],
-                'frameworkSlug': supplier_framework['frameworkSlug'],
-            }
+        assert audit.type == "sign_agreement"
+        assert audit.user == "interested@example.com"
+        assert audit.data == {
+            'supplierId': supplier_framework['supplierId'],
+            'frameworkSlug': supplier_framework['frameworkSlug'],
+        }
 
     def test_can_re_sign_framework_agreement(self, supplier_framework):
         agreement_id = self.create_agreement(
@@ -871,22 +866,21 @@ class TestPutFrameworkAgreementOnHold(BaseFrameworkAgreementTest):
             'signedAgreementPutOnHoldAt': '2016-12-12T00:00:00.000000Z'
         }
 
-        with self.app.app_context():
-            agreement = FrameworkAgreement.query.filter(
-                FrameworkAgreement.id == agreement_id
-            ).first()
+        agreement = FrameworkAgreement.query.filter(
+            FrameworkAgreement.id == agreement_id
+        ).first()
 
-            audit = AuditEvent.query.filter(
-                AuditEvent.object == agreement
-            ).first()
+        audit = AuditEvent.query.filter(
+            AuditEvent.object == agreement
+        ).first()
 
-            assert audit.type == "update_agreement"
-            assert audit.user == "interested@example.com"
-            assert audit.data == {
-                'supplierId': supplier_framework['supplierId'],
-                'frameworkSlug': supplier_framework['frameworkSlug'],
-                'status': 'on-hold'
-            }
+        assert audit.type == "update_agreement"
+        assert audit.user == "interested@example.com"
+        assert audit.data == {
+            'supplierId': supplier_framework['supplierId'],
+            'frameworkSlug': supplier_framework['frameworkSlug'],
+            'status': 'on-hold'
+        }
 
     @fixture_params('live_example_framework', {'framework_agreement_details': {'frameworkAgreementVersion': 'v1.0'}})
     def test_can_not_put_unsigned_framework_agreement_on_hold(self, supplier_framework):
@@ -979,22 +973,21 @@ class TestApproveFrameworkAgreement(BaseFrameworkAgreementTest):
             }
         }
 
-        with self.app.app_context():
-            agreement = FrameworkAgreement.query.filter(
-                FrameworkAgreement.id == agreement_id
-            ).first()
+        agreement = FrameworkAgreement.query.filter(
+            FrameworkAgreement.id == agreement_id
+        ).first()
 
-            audit = AuditEvent.query.filter(
-                AuditEvent.object == agreement
-            ).first()
+        audit = AuditEvent.query.filter(
+            AuditEvent.object == agreement
+        ).first()
 
-            assert audit.type == "countersign_agreement"
-            assert audit.user == "chris@example.com"
-            assert audit.data == {
-                'supplierId': supplier_framework['supplierId'],
-                'frameworkSlug': supplier_framework['frameworkSlug'],
-                'status': 'approved'
-            }
+        assert audit.type == "countersign_agreement"
+        assert audit.user == "chris@example.com"
+        assert audit.data == {
+            'supplierId': supplier_framework['supplierId'],
+            'frameworkSlug': supplier_framework['frameworkSlug'],
+            'status': 'approved'
+        }
 
     @fixture_params(
         'live_example_framework', {
@@ -1110,19 +1103,18 @@ class TestApproveFrameworkAgreement(BaseFrameworkAgreementTest):
         }
     )
     def test_serialized_supplier_framework_contains_updater_details_after_approval(self, supplier_framework):
-        with self.app.app_context():
-            user = User(
-                id=1234,
-                name='Chris',
-                email_address='chris@crowncommercial.gov.uk',
-                password='password',
-                active=True,
-                created_at=datetime.now(),
-                password_changed_at=datetime.now(),
-                role='admin-ccs-sourcing'
-            )
-            db.session.add(user)
-            db.session.commit()
+        user = User(
+            id=1234,
+            name='Chris',
+            email_address='chris@crowncommercial.gov.uk',
+            password='password',
+            active=True,
+            created_at=datetime.now(),
+            password_changed_at=datetime.now(),
+            role='admin-ccs-sourcing'
+        )
+        db.session.add(user)
+        db.session.commit()
 
         agreement_id = self.create_agreement(
             supplier_framework,
@@ -1136,9 +1128,8 @@ class TestApproveFrameworkAgreement(BaseFrameworkAgreementTest):
             countersigned_agreement_returned_at=datetime.now()
         )
 
-        with self.app.app_context():
-            agreement = FrameworkAgreement.query.filter(FrameworkAgreement.id == agreement_id).first()
-            supplier_framework = agreement.supplier_framework.serialize(with_users=True)
+        agreement = FrameworkAgreement.query.filter(FrameworkAgreement.id == agreement_id).first()
+        supplier_framework = agreement.supplier_framework.serialize(with_users=True)
 
         assert supplier_framework['countersignedDetails']['approvedByUserName'] == 'Chris'
         assert supplier_framework['countersignedDetails']['approvedByUserEmail'] == 'chris@crowncommercial.gov.uk'
@@ -1177,23 +1168,22 @@ class TestApproveFrameworkAgreement(BaseFrameworkAgreementTest):
             'signedAgreementReturnedAt': '2016-10-01T00:00:00.000000Z',
         }
 
-        with self.app.app_context():
-            agreement = FrameworkAgreement.query.filter(
-                FrameworkAgreement.id == agreement_id
-            ).first()
+        agreement = FrameworkAgreement.query.filter(
+            FrameworkAgreement.id == agreement_id
+        ).first()
 
-            # Get the most recent audit event and check it is the "unapprove" event
-            audit = AuditEvent.query.filter(
-                AuditEvent.object == agreement
-            ).order_by(AuditEvent.created_at.desc()).first()
+        # Get the most recent audit event and check it is the "unapprove" event
+        audit = AuditEvent.query.filter(
+            AuditEvent.object == agreement
+        ).order_by(AuditEvent.created_at.desc()).first()
 
-            assert audit.type == "countersign_agreement"
-            assert audit.user == "made-a-whoopsie@example.com"
-            assert audit.data == {
-                'supplierId': supplier_framework['supplierId'],
-                'frameworkSlug': supplier_framework['frameworkSlug'],
-                'status': 'unapproved'
-            }
+        assert audit.type == "countersign_agreement"
+        assert audit.user == "made-a-whoopsie@example.com"
+        assert audit.data == {
+            'supplierId': supplier_framework['supplierId'],
+            'frameworkSlug': supplier_framework['frameworkSlug'],
+            'status': 'unapproved'
+        }
 
     def test_can_not_unapprove_countersigned_agreement(self, supplier_framework):
         agreement_id = self.create_agreement(

--- a/tests/main/views/test_briefs.py
+++ b/tests/main/views/test_briefs.py
@@ -18,21 +18,19 @@ class FrameworkSetupAndTeardown(BaseApplicationTest, FixtureMixin):
         super(FrameworkSetupAndTeardown, self).setup()
         self.user_id = self.setup_dummy_user(role='buyer')
 
-        with self.app.app_context():
-            framework = Framework.query.filter(Framework.slug == 'digital-outcomes-and-specialists').first()
-            self._original_framework_status = framework.status
-            framework.status = 'live'
+        framework = Framework.query.filter(Framework.slug == 'digital-outcomes-and-specialists').first()
+        self._original_framework_status = framework.status
+        framework.status = 'live'
 
-            db.session.add(framework)
-            db.session.commit()
+        db.session.add(framework)
+        db.session.commit()
 
     def teardown(self):
-        with self.app.app_context():
-            framework = Framework.query.filter(Framework.slug == 'digital-outcomes-and-specialists').first()
-            framework.status = self._original_framework_status
+        framework = Framework.query.filter(Framework.slug == 'digital-outcomes-and-specialists').first()
+        framework.status = self._original_framework_status
 
-            db.session.add(framework)
-            db.session.commit()
+        db.session.add(framework)
+        db.session.commit()
         super(FrameworkSetupAndTeardown, self).teardown()
 
 
@@ -182,13 +180,12 @@ class TestCreateBrief(FrameworkSetupAndTeardown):
 
     def test_create_brief_fails_if_framework_not_live(self):
         for framework_status in [status for status in Framework.STATUSES if status != 'live']:
-            with self.app.app_context():
-                framework = Framework.query.filter(Framework.slug == 'digital-outcomes-and-specialists').first()
-                self._original_framework_status = framework.status
-                framework.status = framework_status
+            framework = Framework.query.filter(Framework.slug == 'digital-outcomes-and-specialists').first()
+            self._original_framework_status = framework.status
+            framework.status = framework_status
 
-                db.session.add(framework)
-                db.session.commit()
+            db.session.add(framework)
+            db.session.commit()
 
             res = self.client.post(
                 '/briefs',
@@ -417,8 +414,7 @@ class TestGetBrief(FrameworkSetupAndTeardown):
         assert res.status_code == 200
         expected_data = COMPLETE_DIGITAL_SPECIALISTS_BRIEF.copy()
 
-        with self.app.app_context():
-            framework = Framework.query.filter(Framework.slug == 'digital-outcomes-and-specialists').first()
+        framework = Framework.query.filter(Framework.slug == 'digital-outcomes-and-specialists').first()
 
         expected_data.update(
             {
@@ -773,21 +769,20 @@ class TestListBrief(FrameworkSetupAndTeardown):
     @pytest.mark.parametrize('temporal_arg, expected_count', [('before', 1), ('on', 2), ('after', 1)])
     def test_list_briefs_filter_closed_briefs_by_date(self, temporal_arg, expected_count):
         # Closed briefs need to be set up differently, so this test covers all 3 before/after/on cases
-        with self.app.app_context():
-            framework = Framework.query.filter(Framework.slug == 'digital-outcomes-and-specialists').first()
-            lot = Lot.query.filter(Lot.slug == 'digital-specialists').first()
+        framework = Framework.query.filter(Framework.slug == 'digital-outcomes-and-specialists').first()
+        lot = Lot.query.filter(Lot.slug == 'digital-specialists').first()
 
-            with freeze_time('2017-01-01 23:59:59.999999'):
-                brief1 = Brief(data={}, framework=framework, lot=lot, published_at=datetime.utcnow())
-            with freeze_time('2017-01-02 00:00:00'):
-                brief2 = Brief(data={}, framework=framework, lot=lot, published_at=datetime.utcnow())
-            with freeze_time('2017-01-02 23:59:59.999999'):
-                brief3 = Brief(data={}, framework=framework, lot=lot, published_at=datetime.utcnow())
-            with freeze_time('2017-01-03 00:00:00'):
-                brief4 = Brief(data={}, framework=framework, lot=lot, published_at=datetime.utcnow())
+        with freeze_time('2017-01-01 23:59:59.999999'):
+            brief1 = Brief(data={}, framework=framework, lot=lot, published_at=datetime.utcnow())
+        with freeze_time('2017-01-02 00:00:00'):
+            brief2 = Brief(data={}, framework=framework, lot=lot, published_at=datetime.utcnow())
+        with freeze_time('2017-01-02 23:59:59.999999'):
+            brief3 = Brief(data={}, framework=framework, lot=lot, published_at=datetime.utcnow())
+        with freeze_time('2017-01-03 00:00:00'):
+            brief4 = Brief(data={}, framework=framework, lot=lot, published_at=datetime.utcnow())
 
-            db.session.add_all([brief1, brief2, brief3, brief4])
-            db.session.commit()
+        db.session.add_all([brief1, brief2, brief3, brief4])
+        db.session.commit()
 
         res = self.client.get('/briefs?closed_{}=2017-01-16'.format(temporal_arg))
         data = json.loads(res.get_data(as_text=True))
@@ -832,11 +827,10 @@ class TestUpdateBriefStatus(FrameworkSetupAndTeardown):
     @pytest.mark.parametrize('framework_status', ('pending', 'expired'))
     def test_cancel_a_brief(self, index_brief, framework_status):
         self.setup_dummy_briefs(1, title='The Title', status='closed')
-        with self.app.app_context():
-            framework = Framework.query.filter(Framework.slug == 'digital-outcomes-and-specialists').first()
-            framework.status = framework_status
-            db.session.add(framework)
-            db.session.commit()
+        framework = Framework.query.filter(Framework.slug == 'digital-outcomes-and-specialists').first()
+        framework.status = framework_status
+        db.session.add(framework)
+        db.session.commit()
 
         res = self.client.post(
             '/briefs/1/cancel',
@@ -937,11 +931,10 @@ class TestUpdateBriefStatus(FrameworkSetupAndTeardown):
         self.setup_dummy_briefs(1, title='The title')
 
         for framework_status in [status for status in Framework.STATUSES if status != 'live']:
-            with self.app.app_context():
-                framework = Framework.query.get(5)
-                framework.status = framework_status
-                db.session.add(framework)
-                db.session.commit()
+            framework = Framework.query.get(5)
+            framework.status = framework_status
+            db.session.add(framework)
+            db.session.commit()
 
             res = self.client.post(
                 '/briefs/1/publish',
@@ -1221,32 +1214,31 @@ class TestCopyBrief(FrameworkSetupAndTeardown):
 
 class TestSupplierIsEligibleForBrief(BaseApplicationTest, FixtureMixin):
     def setup_services(self):
-        with self.app.app_context():
-            self.setup_dummy_suppliers(2)
-            self.set_framework_status("digital-outcomes-and-specialists", "live")
-            self.setup_dummy_service(
-                service_id='10000000001',
-                supplier_id=0,
-                framework_id=5,  # Digital Outcomes and Specialists
-                lot_id=5,  # digital-outcomes
-                data={"locations": [
-                    "London", "Offsite", "Scotland", "Wales"
-                ]
-                })
-            self.setup_dummy_service(
-                service_id='10000000002',
-                supplier_id=0,
-                framework_id=5,  # Digital Outcomes and Specialists
-                lot_id=6,  # digital-specialists
-                data={"developerLocations": ["London", "Offsite", "Scotland", "Wales"]}
-            )
-            self.setup_dummy_service(
-                service_id='10000000003',
-                supplier_id=1,
-                framework_id=5,  # Digital Outcomes and Specialists
-                lot_id=6,  # digital-specialists
-                data={"developerLocations": ["Wales"]}
-            )
+        self.setup_dummy_suppliers(2)
+        self.set_framework_status("digital-outcomes-and-specialists", "live")
+        self.setup_dummy_service(
+            service_id='10000000001',
+            supplier_id=0,
+            framework_id=5,  # Digital Outcomes and Specialists
+            lot_id=5,  # digital-outcomes
+            data={"locations": [
+                "London", "Offsite", "Scotland", "Wales"
+            ]
+            })
+        self.setup_dummy_service(
+            service_id='10000000002',
+            supplier_id=0,
+            framework_id=5,  # Digital Outcomes and Specialists
+            lot_id=6,  # digital-specialists
+            data={"developerLocations": ["London", "Offsite", "Scotland", "Wales"]}
+        )
+        self.setup_dummy_service(
+            service_id='10000000003',
+            supplier_id=1,
+            framework_id=5,  # Digital Outcomes and Specialists
+            lot_id=6,  # digital-specialists
+            data={"developerLocations": ["Wales"]}
+        )
 
     def test_supplier_is_eligible_for_specialist(self):
         self.setup_services()
@@ -1260,15 +1252,14 @@ class TestSupplierIsEligibleForBrief(BaseApplicationTest, FixtureMixin):
 
     def test_supplier_is_eligible_for_live_outcome(self):
         self.setup_services()
-        with self.app.app_context():
-            self.setup_dummy_user(id=1)
-            self.setup_dummy_brief(
-                id=1,
-                status="live",
-                user_id=1,
-                data={"location": "London"},
-                lot_slug="digital-outcomes")
-            db.session.commit()
+        self.setup_dummy_user(id=1)
+        self.setup_dummy_brief(
+            id=1,
+            status="live",
+            user_id=1,
+            data={"location": "London"},
+            lot_slug="digital-outcomes")
+        db.session.commit()
 
         response = self.client.get("/briefs/1/services?supplier_id=0")
         data = json.loads(response.get_data(as_text=True))
@@ -1304,15 +1295,14 @@ class TestSupplierIsEligibleForBrief(BaseApplicationTest, FixtureMixin):
 
     def test_supplier_is_eligible_even_if_not_in_specialist_location(self):
         self.setup_services()
-        with self.app.app_context():
-            self.setup_dummy_user(id=1)
-            self.setup_dummy_brief(
-                id=1,
-                status="live",
-                user_id=1,
-                data={"location": "North East England",
-                      "specialistRole": "developer"})
-            db.session.commit()
+        self.setup_dummy_user(id=1)
+        self.setup_dummy_brief(
+            id=1,
+            status="live",
+            user_id=1,
+            data={"location": "North East England",
+                  "specialistRole": "developer"})
+        db.session.commit()
 
         response = self.client.get("/briefs/1/services?supplier_id=0")
         data = json.loads(response.get_data(as_text=True))
@@ -1322,15 +1312,14 @@ class TestSupplierIsEligibleForBrief(BaseApplicationTest, FixtureMixin):
 
     def test_supplier_is_ineligible_if_does_not_supply_the_role(self):
         self.setup_services()
-        with self.app.app_context():
-            self.setup_dummy_user(id=1)
-            self.setup_dummy_brief(
-                id=1,
-                status="live",
-                user_id=1,
-                data={"location": "London",
-                      "specialistRole": "agileCoach"})
-            db.session.commit()
+        self.setup_dummy_user(id=1)
+        self.setup_dummy_brief(
+            id=1,
+            status="live",
+            user_id=1,
+            data={"location": "London",
+                  "specialistRole": "agileCoach"})
+        db.session.commit()
 
         response = self.client.get("/briefs/1/services?supplier_id=0")
         data = json.loads(response.get_data(as_text=True))
@@ -1340,15 +1329,14 @@ class TestSupplierIsEligibleForBrief(BaseApplicationTest, FixtureMixin):
 
     def test_supplier_is_eligible_even_if_does_not_supply_in_outcome_location(self):
         self.setup_services()
-        with self.app.app_context():
-            self.setup_dummy_user(id=1)
-            self.setup_dummy_brief(
-                id=1,
-                status="live",
-                user_id=1,
-                data={"location": "North East England"},
-                lot_slug="digital-outcomes")
-            db.session.commit()
+        self.setup_dummy_user(id=1)
+        self.setup_dummy_brief(
+            id=1,
+            status="live",
+            user_id=1,
+            data={"location": "North East England"},
+            lot_slug="digital-outcomes")
+        db.session.commit()
 
         response = self.client.get("/briefs/1/services?supplier_id=0")
         data = json.loads(response.get_data(as_text=True))
@@ -1370,64 +1358,61 @@ class TestAwardPendingBriefResponse(FrameworkSetupAndTeardown):
         )
 
     def test_can_award_brief_response_to_closed_brief_without_award_details(self):
-        with self.app.app_context():
-            self.setup_dummy_briefs(1, status="closed")
-            self.setup_dummy_suppliers(1)
-            brief_response = BriefResponse(brief_id=1, supplier_id=0, submitted_at=datetime.utcnow(), data={})
-            db.session.add(brief_response)
-            db.session.commit()
-            brief_response_id = brief_response.id
+        self.setup_dummy_briefs(1, status="closed")
+        self.setup_dummy_suppliers(1)
+        brief_response = BriefResponse(brief_id=1, supplier_id=0, submitted_at=datetime.utcnow(), data={})
+        db.session.add(brief_response)
+        db.session.commit()
+        brief_response_id = brief_response.id
 
-            res = self._post_to_award_endpoint({'briefResponseId': brief_response.id})
-            assert res.status_code == 200
+        res = self._post_to_award_endpoint({'briefResponseId': brief_response.id})
+        assert res.status_code == 200
 
-            brief_response_audits = get_audit_events(self.client, AuditTypes.update_brief_response)
-            assert len(brief_response_audits) == 1
-            assert brief_response_audits[0]['data'] == {
-                'briefId': 1,
-                'briefResponseId': brief_response_id,
-                'briefResponseAwardedValue': True
-            }
+        brief_response_audits = get_audit_events(self.client, AuditTypes.update_brief_response)
+        assert len(brief_response_audits) == 1
+        assert brief_response_audits[0]['data'] == {
+            'briefId': 1,
+            'briefResponseId': brief_response_id,
+            'briefResponseAwardedValue': True
+        }
 
     def test_can_change_awarded_brief_response_for_closed_brief_without_awarded_datestamp(self):
-        with self.app.app_context():
-            self.setup_dummy_briefs(1, status="closed")
-            self.setup_dummy_suppliers(1)
-            brief_response1 = BriefResponse(brief_id=1, supplier_id=0, submitted_at=datetime.utcnow(), data={})
-            brief_response2 = BriefResponse(brief_id=1, supplier_id=0, submitted_at=datetime.utcnow(), data={})
-            brief_response1.award_details = {'pending': True}
-            db.session.add_all([brief_response1, brief_response2])
-            db.session.commit()
-            brief_response1_id = brief_response1.id
-            brief_response2_id = brief_response2.id
-            # Update to be awarded to brief response 2 rather than brief response 1
-            res = self._post_to_award_endpoint({'briefResponseId': brief_response2.id})
-            assert res.status_code == 200
+        self.setup_dummy_briefs(1, status="closed")
+        self.setup_dummy_suppliers(1)
+        brief_response1 = BriefResponse(brief_id=1, supplier_id=0, submitted_at=datetime.utcnow(), data={})
+        brief_response2 = BriefResponse(brief_id=1, supplier_id=0, submitted_at=datetime.utcnow(), data={})
+        brief_response1.award_details = {'pending': True}
+        db.session.add_all([brief_response1, brief_response2])
+        db.session.commit()
+        brief_response1_id = brief_response1.id
+        brief_response2_id = brief_response2.id
+        # Update to be awarded to brief response 2 rather than brief response 1
+        res = self._post_to_award_endpoint({'briefResponseId': brief_response2.id})
+        assert res.status_code == 200
 
-            brief_response_audits = get_audit_events(self.client, AuditTypes.update_brief_response)
-            assert len(brief_response_audits) == 2
-            assert brief_response_audits[0]['data'] == {
-                'briefId': 1,
-                'briefResponseId': brief_response1_id,
-                'briefResponseAwardedValue': False
-            }
-            assert brief_response_audits[1]['data'] == {
-                'briefId': 1,
-                'briefResponseId': brief_response2_id,
-                'briefResponseAwardedValue': True
-            }
+        brief_response_audits = get_audit_events(self.client, AuditTypes.update_brief_response)
+        assert len(brief_response_audits) == 2
+        assert brief_response_audits[0]['data'] == {
+            'briefId': 1,
+            'briefResponseId': brief_response1_id,
+            'briefResponseAwardedValue': False
+        }
+        assert brief_response_audits[1]['data'] == {
+            'briefId': 1,
+            'briefResponseId': brief_response2_id,
+            'briefResponseAwardedValue': True
+        }
 
     def test_200_if_trying_to_award_a_brief_response_again_even_though_it_has_already_been_awarded(self):
-        with self.app.app_context():
-            self.setup_dummy_briefs(1, status="closed")
-            self.setup_dummy_suppliers(1)
-            brief_response = BriefResponse(brief_id=1, supplier_id=0, submitted_at=datetime.utcnow(), data={})
-            brief_response.award_details = {'pending': True}
-            db.session.add(brief_response)
-            db.session.commit()
+        self.setup_dummy_briefs(1, status="closed")
+        self.setup_dummy_suppliers(1)
+        brief_response = BriefResponse(brief_id=1, supplier_id=0, submitted_at=datetime.utcnow(), data={})
+        brief_response.award_details = {'pending': True}
+        db.session.add(brief_response)
+        db.session.commit()
 
-            res = self._post_to_award_endpoint({'briefResponseId': brief_response.id})
-            assert res.status_code == 200
+        res = self._post_to_award_endpoint({'briefResponseId': brief_response.id})
+        assert res.status_code == 200
 
     def test_400_if_no_updated_by_in_payload(self):
         res = self.client.post(
@@ -1448,32 +1433,30 @@ class TestAwardPendingBriefResponse(FrameworkSetupAndTeardown):
         assert data['error'] == "Brief is not closed"
 
     def test_400_if_awarding_a_draft_brief_response_to_a_closed_brief(self):
-        with self.app.app_context():
-            self.setup_dummy_briefs(1, status="closed")
-            self.setup_dummy_suppliers(1)
-            brief_response = BriefResponse(brief_id=1, supplier_id=0, data={})
-            db.session.add(brief_response)
-            db.session.commit()
+        self.setup_dummy_briefs(1, status="closed")
+        self.setup_dummy_suppliers(1)
+        brief_response = BriefResponse(brief_id=1, supplier_id=0, data={})
+        db.session.add(brief_response)
+        db.session.commit()
 
-            res = self._post_to_award_endpoint({'briefResponseId': brief_response.id})
-            data = json.loads(res.get_data(as_text=True))
-            assert res.status_code == 400
-            assert data['error'] == "BriefResponse cannot be awarded for this Brief"
+        res = self._post_to_award_endpoint({'briefResponseId': brief_response.id})
+        data = json.loads(res.get_data(as_text=True))
+        assert res.status_code == 400
+        assert data['error'] == "BriefResponse cannot be awarded for this Brief"
 
     def test_400_if_awarding_a_brief_response_that_does_not_relate_to_that_brief(self):
-        with self.app.app_context():
-            self.setup_dummy_briefs(2, status="closed")
-            self.setup_dummy_suppliers(1)
-            brief_response = BriefResponse(brief_id=2, supplier_id=0, submitted_at=datetime.utcnow(), data={})
-            db.session.add(brief_response)
-            db.session.commit()
+        self.setup_dummy_briefs(2, status="closed")
+        self.setup_dummy_suppliers(1)
+        brief_response = BriefResponse(brief_id=2, supplier_id=0, submitted_at=datetime.utcnow(), data={})
+        db.session.add(brief_response)
+        db.session.commit()
 
-            # We've set up brief response for brief ID 2 but attempt to award it for brief 1
-            res = self._post_to_award_endpoint({'briefResponseId': brief_response.id})
+        # We've set up brief response for brief ID 2 but attempt to award it for brief 1
+        res = self._post_to_award_endpoint({'briefResponseId': brief_response.id})
 
-            data = json.loads(res.get_data(as_text=True))
-            assert res.status_code == 400
-            assert data['error'] == "BriefResponse cannot be awarded for this Brief"
+        data = json.loads(res.get_data(as_text=True))
+        assert res.status_code == 400
+        assert data['error'] == "BriefResponse cannot be awarded for this Brief"
 
 
 @mock.patch('app.main.views.briefs.index_brief')
@@ -1496,80 +1479,77 @@ class TestBriefAwardDetails(FrameworkSetupAndTeardown):
         )
 
     def test_can_supply_award_details_for_closed_brief_with_awarded_brief_response(self, index_brief):
-        with self.app.app_context():
-            self.setup_dummy_briefs(1, status="closed")
-            self.setup_dummy_suppliers(1)
-            brief_response = BriefResponse(brief_id=1, supplier_id=0, submitted_at=datetime.utcnow(), data={})
-            db.session.add(brief_response)
-            db.session.commit()
-            brief_response.award_details = {'pending': True}
-            db.session.add(brief_response)
-            db.session.commit()
-            assert brief_response.status == 'pending-awarded'
-            brief_response_id = brief_response.id
+        self.setup_dummy_briefs(1, status="closed")
+        self.setup_dummy_suppliers(1)
+        brief_response = BriefResponse(brief_id=1, supplier_id=0, submitted_at=datetime.utcnow(), data={})
+        db.session.add(brief_response)
+        db.session.commit()
+        brief_response.award_details = {'pending': True}
+        db.session.add(brief_response)
+        db.session.commit()
+        assert brief_response.status == 'pending-awarded'
+        brief_response_id = brief_response.id
 
-            res = self._post_to_award_details_endpoint(self.valid_payload, brief_response_id)
-            assert res.status_code == 200
-            data = json.loads(res.get_data(as_text=True))
-            assert data['briefs']['awardedBriefResponseId'] == brief_response_id
-            assert index_brief.called is True
+        res = self._post_to_award_details_endpoint(self.valid_payload, brief_response_id)
+        assert res.status_code == 200
+        data = json.loads(res.get_data(as_text=True))
+        assert data['briefs']['awardedBriefResponseId'] == brief_response_id
+        assert index_brief.called is True
 
-            brief_response_audits = get_audit_events(self.client, AuditTypes.update_brief_response)
-            assert len(brief_response_audits) == 1
-            assert brief_response_audits[0]['data'] == {
-                'briefId': 1,
-                'briefResponseId': brief_response_id,
-                'briefResponseAwardDetails': {
-                    "awardedContractStartDate": "2020-12-31",
-                    "awardedContractValue": "99.95"
-                }
+        brief_response_audits = get_audit_events(self.client, AuditTypes.update_brief_response)
+        assert len(brief_response_audits) == 1
+        assert brief_response_audits[0]['data'] == {
+            'briefId': 1,
+            'briefResponseId': brief_response_id,
+            'briefResponseAwardDetails': {
+                "awardedContractStartDate": "2020-12-31",
+                "awardedContractValue": "99.95"
             }
+        }
 
     def test_400_if_supplying_details_for_closed_brief_without_awarded_brief_response(self, index_brief):
-        with self.app.app_context():
-            self.setup_dummy_briefs(1, status="closed")
-            self.setup_dummy_suppliers(1)
-            brief_response = BriefResponse(brief_id=1, supplier_id=0, submitted_at=datetime.utcnow(), data={})
-            db.session.add(brief_response)
-            db.session.commit()
-            assert brief_response.status == 'submitted'
+        self.setup_dummy_briefs(1, status="closed")
+        self.setup_dummy_suppliers(1)
+        brief_response = BriefResponse(brief_id=1, supplier_id=0, submitted_at=datetime.utcnow(), data={})
+        db.session.add(brief_response)
+        db.session.commit()
+        assert brief_response.status == 'submitted'
 
-            res = self._post_to_award_details_endpoint(self.valid_payload, brief_response.id)
-            assert res.status_code == 400
-            data = json.loads(res.get_data(as_text=True))
-            assert data['error'] == "Cannot update award details for a Brief without a winning supplier"
-            assert index_brief.called is False
+        res = self._post_to_award_details_endpoint(self.valid_payload, brief_response.id)
+        assert res.status_code == 400
+        data = json.loads(res.get_data(as_text=True))
+        assert data['error'] == "Cannot update award details for a Brief without a winning supplier"
+        assert index_brief.called is False
 
     def test_400_if_award_details_payload_invalid(self, index_brief):
-        with self.app.app_context():
-            self.setup_dummy_briefs(1, status="closed")
-            self.setup_dummy_suppliers(1)
-            brief_response = BriefResponse(brief_id=1, supplier_id=0, submitted_at=datetime.utcnow(), data={})
-            db.session.add(brief_response)
-            db.session.commit()
-            brief_response.award_details = {'pending': True}
-            db.session.add(brief_response)
-            db.session.commit()
+        self.setup_dummy_briefs(1, status="closed")
+        self.setup_dummy_suppliers(1)
+        brief_response = BriefResponse(brief_id=1, supplier_id=0, submitted_at=datetime.utcnow(), data={})
+        db.session.add(brief_response)
+        db.session.commit()
+        brief_response.award_details = {'pending': True}
+        db.session.add(brief_response)
+        db.session.commit()
 
-            res = self._post_to_award_details_endpoint(
-                {
-                    "awardDetails": {
-                        "awardedContractValue": "I am not a number",
-                        "awardedContractStartDate-day": None,
-                        "awardedContractStartDate-month": None,
-                        "awardedContractStartDate-year": None,
-                    },
-                    "updated_by": "user@email.com"
-                }, brief_response.id
-            )
+        res = self._post_to_award_details_endpoint(
+            {
+                "awardDetails": {
+                    "awardedContractValue": "I am not a number",
+                    "awardedContractStartDate-day": None,
+                    "awardedContractStartDate-month": None,
+                    "awardedContractStartDate-year": None,
+                },
+                "updated_by": "user@email.com"
+            }, brief_response.id
+        )
 
-            data = json.loads(res.get_data(as_text=True))
-            assert res.status_code == 400
-            assert data['error'] == {
-                'awardedContractStartDate': 'answer_required',
-                'awardedContractValue': 'not_money_format'
-            }
-            assert index_brief.called is False
+        data = json.loads(res.get_data(as_text=True))
+        assert res.status_code == 400
+        assert data['error'] == {
+            'awardedContractStartDate': 'answer_required',
+            'awardedContractValue': 'not_money_format'
+        }
+        assert index_brief.called is False
 
     def test_400_if_no_updated_by_in_payload(self, index_brief):
         res = self._post_to_award_details_endpoint({
@@ -1585,14 +1565,12 @@ class TestBriefAwardDetails(FrameworkSetupAndTeardown):
         assert index_brief.called is False
 
     def test_404_if_brief_response_not_related_to_brief(self, index_brief):
-        with self.app.app_context():
-
-            self.setup_dummy_briefs(2, status="closed")
-            self.setup_dummy_suppliers(1)
-            brief_response = BriefResponse(brief_id=2, supplier_id=0, submitted_at=datetime.utcnow(), data={})
-            db.session.add(brief_response)
-            db.session.commit()
-            brief_response_id = brief_response.id
+        self.setup_dummy_briefs(2, status="closed")
+        self.setup_dummy_suppliers(1)
+        brief_response = BriefResponse(brief_id=2, supplier_id=0, submitted_at=datetime.utcnow(), data={})
+        db.session.add(brief_response)
+        db.session.commit()
+        brief_response_id = brief_response.id
 
         res = self._post_to_award_details_endpoint(self.valid_payload, brief_response_id)
 

--- a/tests/main/views/test_buyer_domains.py
+++ b/tests/main/views/test_buyer_domains.py
@@ -19,10 +19,9 @@ class TestCreateBuyerEmailDomain(BaseApplicationTest):
     @pytest.mark.parametrize('new_domain', ["fine.org", "also-fine.org", "also.fine.org", "f.org"])
     @pytest.mark.parametrize('existing_domain', ["ine.org", "o-fine.org"])
     def test_create_buyer_email_domain(self, existing_domain, new_domain):
-        with self.app.app_context():
-            # Create a domain that shouldn't result in 'already been approved'
-            db.session.add(BuyerEmailDomain(domain_name=existing_domain))
-            db.session.commit()
+        # Create a domain that shouldn't result in 'already been approved'
+        db.session.add(BuyerEmailDomain(domain_name=existing_domain))
+        db.session.commit()
 
         res = self.client.post(
             '/buyer-email-domains',
@@ -40,9 +39,8 @@ class TestCreateBuyerEmailDomain(BaseApplicationTest):
         'existing_domain', ['approved.gov.uk', 'already.approved.gov.uk', 'definitely-approved.gov.uk']
     )
     def test_higher_level_domain_can_be_created_if_more_specific_domain_already_exists(self, existing_domain):
-        with self.app.app_context():
-            db.session.add(BuyerEmailDomain(domain_name=existing_domain))
-            db.session.commit()
+        db.session.add(BuyerEmailDomain(domain_name=existing_domain))
+        db.session.commit()
 
         res = self.client.post(
             '/buyer-email-domains',
@@ -91,21 +89,20 @@ class TestCreateBuyerEmailDomain(BaseApplicationTest):
             content_type='application/json'
         )
 
-        with self.app.app_context():
-            buyer_email_domain = BuyerEmailDomain.query.filter(
-                BuyerEmailDomain.domain_name == "example.com"
-            ).first()
+        buyer_email_domain = BuyerEmailDomain.query.filter(
+            BuyerEmailDomain.domain_name == "example.com"
+        ).first()
 
-            audit = AuditEvent.query.filter(
-                AuditEvent.object == buyer_email_domain
-            ).first()
+        audit = AuditEvent.query.filter(
+            AuditEvent.object == buyer_email_domain
+        ).first()
 
-            assert audit.type == "create_buyer_email_domain"
-            assert audit.user == "example user"
-            assert audit.data == {
-                'buyerEmailDomainId': buyer_email_domain.id,
-                'buyerEmailDomainJson': {'domainName': 'example.com'}
-            }
+        assert audit.type == "create_buyer_email_domain"
+        assert audit.user == "example user"
+        assert audit.data == {
+            'buyerEmailDomainId': buyer_email_domain.id,
+            'buyerEmailDomainJson': {'domainName': 'example.com'}
+        }
 
     @pytest.mark.parametrize(
         'new_domain',
@@ -140,9 +137,8 @@ class TestCreateBuyerEmailDomain(BaseApplicationTest):
         'new_domain', ['gov.uk', 'approved.gov.uk', 'already.approved.gov.uk', 'definitely-approved.gov.uk']
     )
     def test_create_buyer_email_domain_fails_if_higher_level_domain_already_approved(self, new_domain):
-        with self.app.app_context():
-            db.session.add(BuyerEmailDomain(domain_name='gov.uk'))
-            db.session.commit()
+        db.session.add(BuyerEmailDomain(domain_name='gov.uk'))
+        db.session.commit()
 
         res = self.client.post(
             '/buyer-email-domains',
@@ -160,10 +156,9 @@ class TestCreateBuyerEmailDomain(BaseApplicationTest):
 class TestListBuyerEmailDomains(BaseApplicationTest):
     def setup(self):
         super(TestListBuyerEmailDomains, self).setup()
-        with self.app.app_context():
-            # Remove any default fixtures
-            BuyerEmailDomain.query.delete()
-            db.session.commit()
+        # Remove any default fixtures
+        BuyerEmailDomain.query.delete()
+        db.session.commit()
 
     def test_list_buyer_email_domain_200s_with_empty_list_when_no_domains(self):
         res = self.client.get('/buyer-email-domains')
@@ -174,10 +169,9 @@ class TestListBuyerEmailDomains(BaseApplicationTest):
         assert data['buyerEmailDomains'] == []
 
     def test_list_buyer_email_domain_lists_serialized_domains_in_alphabetical_order(self):
-        with self.app.app_context():
-            for existing_domain in ['abc.gov', 'bcd.gov', 'aaa-bcd.gov']:
-                db.session.add(BuyerEmailDomain(domain_name=existing_domain))
-                db.session.commit()
+        for existing_domain in ['abc.gov', 'bcd.gov', 'aaa-bcd.gov']:
+            db.session.add(BuyerEmailDomain(domain_name=existing_domain))
+            db.session.commit()
 
         res = self.client.get('/buyer-email-domains')
 
@@ -191,10 +185,9 @@ class TestListBuyerEmailDomains(BaseApplicationTest):
         ]
 
     def test_list_buyer_email_domain_paginates(self):
-        with self.app.app_context():
-            for existing_domain in ['{}.gov'.format(i) for i in range(101)]:
-                db.session.add(BuyerEmailDomain(domain_name=existing_domain))
-                db.session.commit()
+        for existing_domain in ['{}.gov'.format(i) for i in range(101)]:
+            db.session.add(BuyerEmailDomain(domain_name=existing_domain))
+            db.session.commit()
 
         page1 = self.client.get('/buyer-email-domains')
         page2 = self.client.get('/buyer-email-domains?page=2')

--- a/tests/main/views/test_drafts.py
+++ b/tests/main/views/test_drafts.py
@@ -29,35 +29,32 @@ class TestDraftServices(BaseApplicationTest, FixtureMixin):
             'supplierId': 1
         }
 
-        with self.app.app_context():
-            db.session.add(
-                Supplier(supplier_id=1, name=u"Supplier 1")
+        db.session.add(
+            Supplier(supplier_id=1, name=u"Supplier 1")
+        )
+        db.session.add(
+            ContactInformation(
+                supplier_id=1,
+                contact_name=u"Liz",
+                email=u"liz@royal.gov.uk",
+                postcode=u"SW1A 1AA"
             )
-            db.session.add(
-                ContactInformation(
-                    supplier_id=1,
-                    contact_name=u"Liz",
-                    email=u"liz@royal.gov.uk",
-                    postcode=u"SW1A 1AA"
-                )
-            )
-            Framework.query.filter_by(slug='g-cloud-5') \
-                .update(dict(status='live'))
-            Framework.query.filter_by(slug='g-cloud-7') \
-                .update(dict(status='open'))
+        )
+        Framework.query.filter_by(slug='g-cloud-5') \
+            .update(dict(status='live'))
+        Framework.query.filter_by(slug='g-cloud-7') \
+            .update(dict(status='open'))
 
-            self.setup_dummy_service(
-                service_id=self.service_id,
-                **payload
-            )
+        self.setup_dummy_service(
+            service_id=self.service_id,
+            **payload
+        )
 
     def service_count(self):
-        with self.app.app_context():
-            return Service.query.count()
+        return Service.query.count()
 
     def draft_service_count(self):
-        with self.app.app_context():
-            return DraftService.query.count()
+        return DraftService.query.count()
 
     def test_reject_list_drafts_no_supplier_id(self):
         res = self.client.get('/draft-services')
@@ -123,45 +120,44 @@ class TestDraftServices(BaseApplicationTest, FixtureMixin):
         assert json.loads(res.get_data(as_text=True))["error"] == "framework 'this-is-not-valid' not found"
 
     def test_returns_all_drafts_for_supplier_on_single_page(self):
-        with self.app.app_context():
 
-            now = datetime.utcnow()
-            service_ids = [
-                1234567890123411,
-                1234567890123412,
-                1234567890123413,
-                1234567890123414,
-                1234567890123415,
-                1234567890123416,
-                1234567890123417,
-                1234567890123418,
-                1234567890123419,
-                1234567890123410
-            ]
+        now = datetime.utcnow()
+        service_ids = [
+            1234567890123411,
+            1234567890123412,
+            1234567890123413,
+            1234567890123414,
+            1234567890123415,
+            1234567890123416,
+            1234567890123417,
+            1234567890123418,
+            1234567890123419,
+            1234567890123410
+        ]
 
-            for service_id in service_ids:
-                db.session.add(
-                    Service(
-                        service_id=str(service_id),
-                        supplier_id=1,
-                        updated_at=now,
-                        status='published',
-                        created_at=now,
-                        data={'foo': 'bar'},
-                        lot_id=1,
-                        framework_id=1)
-                )
+        for service_id in service_ids:
+            db.session.add(
+                Service(
+                    service_id=str(service_id),
+                    supplier_id=1,
+                    updated_at=now,
+                    status='published',
+                    created_at=now,
+                    data={'foo': 'bar'},
+                    lot_id=1,
+                    framework_id=1)
+            )
 
-            for service_id in service_ids:
-                self.client.put(
-                    '/draft-services/copy-from/{}'.format(service_id),
-                    data=json.dumps(self.updater_json),
-                    content_type='application/json')
+        for service_id in service_ids:
+            self.client.put(
+                '/draft-services/copy-from/{}'.format(service_id),
+                data=json.dumps(self.updater_json),
+                content_type='application/json')
 
-            res = self.client.get('/draft-services?supplier_id=1')
-            assert res.status_code == 200
-            drafts = json.loads(res.get_data())
-            assert len(drafts['services']) == 10
+        res = self.client.get('/draft-services?supplier_id=1')
+        assert res.status_code == 200
+        drafts = json.loads(res.get_data())
+        assert len(drafts['services']) == 10
 
     def test_reject_update_with_no_updater_details(self):
         res = self.client.post('/draft-services/0000000000')
@@ -607,9 +603,8 @@ class TestDraftServices(BaseApplicationTest, FixtureMixin):
     def test_get_draft_with_no_audit_history(self):
         draft = self.create_draft_service()
 
-        with self.app.app_context():
-            AuditEvent.query.delete()
-            db.session.commit()
+        AuditEvent.query.delete()
+        db.session.commit()
 
         res = self.client.get('/draft-services/{}'.format(draft['id']))
         assert res.status_code == 200
@@ -868,9 +863,8 @@ class TestDraftServices(BaseApplicationTest, FixtureMixin):
         draft_id = self.create_draft_service()['id']
         self.complete_draft_service(draft_id)
 
-        with self.app.app_context():
-            Framework.query.filter_by(slug='g-cloud-7').update(dict(status='live'))
-            db.session.commit()
+        Framework.query.filter_by(slug='g-cloud-7').update(dict(status='live'))
+        db.session.commit()
 
         res = self.publish_draft_service(draft_id)
 
@@ -1035,23 +1029,22 @@ class TestCopyDraft(BaseApplicationTest, JSONUpdateTestMixin):
     def setup(self):
         super(TestCopyDraft, self).setup()
 
-        with self.app.app_context():
-            db.session.add(
-                Supplier(supplier_id=1, name=u"Supplier 1")
+        db.session.add(
+            Supplier(supplier_id=1, name=u"Supplier 1")
+        )
+        db.session.add(
+            ContactInformation(
+                supplier_id=1,
+                contact_name=u"Liz",
+                email=u"liz@royal.gov.uk",
+                postcode=u"SW1A 1AA"
             )
-            db.session.add(
-                ContactInformation(
-                    supplier_id=1,
-                    contact_name=u"Liz",
-                    email=u"liz@royal.gov.uk",
-                    postcode=u"SW1A 1AA"
-                )
-            )
-            Framework.query.filter_by(slug='g-cloud-5') \
-                .update(dict(status='live'))
-            Framework.query.filter_by(slug='g-cloud-7') \
-                .update(dict(status='open'))
-            db.session.commit()
+        )
+        Framework.query.filter_by(slug='g-cloud-5') \
+            .update(dict(status='live'))
+        Framework.query.filter_by(slug='g-cloud-7') \
+            .update(dict(status='open'))
+        db.session.commit()
 
         create_draft_json = {
             'updated_by': 'joeblogs',
@@ -1163,18 +1156,17 @@ class TestCompleteDraft(BaseApplicationTest, JSONUpdateTestMixin):
     def setup(self):
         super(TestCompleteDraft, self).setup()
 
-        with self.app.app_context():
-            db.session.add(Supplier(supplier_id=1, name=u"Supplier 1"))
-            db.session.add(
-                ContactInformation(
-                    supplier_id=1,
-                    contact_name=u"Test",
-                    email=u"supplier@user.dmdev",
-                    postcode=u"SW1A 1AA"
-                )
+        db.session.add(Supplier(supplier_id=1, name=u"Supplier 1"))
+        db.session.add(
+            ContactInformation(
+                supplier_id=1,
+                contact_name=u"Test",
+                email=u"supplier@user.dmdev",
+                postcode=u"SW1A 1AA"
             )
-            Framework.query.filter_by(slug='g-cloud-7').update(dict(status='open'))
-            db.session.commit()
+        )
+        Framework.query.filter_by(slug='g-cloud-7').update(dict(status='open'))
+        db.session.commit()
         draft_json = load_example_listing("G7-SCS")
         draft_json['frameworkSlug'] = 'g-cloud-7'
         create_draft_json = {
@@ -1281,21 +1273,20 @@ class TestDOSServices(BaseApplicationTest, FixtureMixin):
         self.create_draft_json['services'] = payload
         self.create_draft_json['services']['frameworkSlug'] = 'digital-outcomes-and-specialists'
 
-        with self.app.app_context():
-            self.set_framework_status('digital-outcomes-and-specialists', 'open')
+        self.set_framework_status('digital-outcomes-and-specialists', 'open')
 
-            db.session.add(
-                Supplier(supplier_id=1, name=u"Supplier 1")
+        db.session.add(
+            Supplier(supplier_id=1, name=u"Supplier 1")
+        )
+        db.session.add(
+            ContactInformation(
+                supplier_id=1,
+                contact_name=u"Liz",
+                email=u"liz@royal.gov.uk",
+                postcode=u"SW1A 1AA"
             )
-            db.session.add(
-                ContactInformation(
-                    supplier_id=1,
-                    contact_name=u"Liz",
-                    email=u"liz@royal.gov.uk",
-                    postcode=u"SW1A 1AA"
-                )
-            )
-            db.session.commit()
+        )
+        db.session.commit()
 
     def _post_dos_draft(self, draft_json=None):
         res = self.client.post(
@@ -1531,18 +1522,17 @@ class TestUpdateDraftStatus(BaseApplicationTest, JSONUpdateTestMixin):
     def setup(self):
         super(TestUpdateDraftStatus, self).setup()
 
-        with self.app.app_context():
-            db.session.add(Supplier(supplier_id=1, name=u"Supplier 1"))
-            db.session.add(
-                ContactInformation(
-                    supplier_id=1,
-                    contact_name=u"Test",
-                    email=u"supplier@user.dmdev",
-                    postcode=u"SW1A 1AA"
-                )
+        db.session.add(Supplier(supplier_id=1, name=u"Supplier 1"))
+        db.session.add(
+            ContactInformation(
+                supplier_id=1,
+                contact_name=u"Test",
+                email=u"supplier@user.dmdev",
+                postcode=u"SW1A 1AA"
             )
-            Framework.query.filter_by(slug='g-cloud-7').update(dict(status='open'))
-            db.session.commit()
+        )
+        Framework.query.filter_by(slug='g-cloud-7').update(dict(status='open'))
+        db.session.commit()
         draft_json = load_example_listing("G7-SCS")
         draft_json['frameworkSlug'] = 'g-cloud-7'
         create_draft_json = {

--- a/tests/main/views/test_frameworks.py
+++ b/tests/main/views/test_frameworks.py
@@ -12,27 +12,26 @@ from tests.helpers import FixtureMixin
 
 class TestListFrameworks(BaseApplicationTest):
     def test_all_frameworks_are_returned(self):
-        with self.app.app_context():
-            response = self.client.get('/frameworks')
-            data = json.loads(response.get_data())
+        response = self.client.get('/frameworks')
+        data = json.loads(response.get_data())
 
-            assert response.status_code == 200
-            assert len(data['frameworks']) == len(Framework.query.all())
-            assert set(data['frameworks'][0].keys()) == set([
-                'clarificationQuestionsOpen',
-                'framework',
-                'frameworkAgreementVersion',
-                'frameworkAgreementDetails',
-                'id',
-                'lots',
-                'name',
-                'slug',
-                'status',
-                'variations',
-                'countersignerName',
-                'applicationCloseDate',
-                'allowDeclarationReuse',
-            ])
+        assert response.status_code == 200
+        assert len(data['frameworks']) == len(Framework.query.all())
+        assert set(data['frameworks'][0].keys()) == set([
+            'clarificationQuestionsOpen',
+            'framework',
+            'frameworkAgreementVersion',
+            'frameworkAgreementDetails',
+            'id',
+            'lots',
+            'name',
+            'slug',
+            'status',
+            'variations',
+            'countersignerName',
+            'applicationCloseDate',
+            'allowDeclarationReuse',
+        ])
 
 
 class TestCreateFramework(BaseApplicationTest):
@@ -60,94 +59,85 @@ class TestCreateFramework(BaseApplicationTest):
         super(TestCreateFramework, self).teardown()
 
     def test_create_a_framework(self):
-        with self.app.app_context():
-            response = self.client.post("/frameworks",
-                                        data=json.dumps(self.framework()),
-                                        content_type="application/json")
+        response = self.client.post("/frameworks",
+                                    data=json.dumps(self.framework()),
+                                    content_type="application/json")
 
-            assert response.status_code == 201
+        assert response.status_code == 201
 
-            framework = Framework.query.filter(Framework.slug == "example").first()
+        framework = Framework.query.filter(Framework.slug == "example").first()
 
-            assert framework.name == "Example"
-            assert len(framework.lots) == 4
+        assert framework.name == "Example"
+        assert len(framework.lots) == 4
 
     def test_create_adds_audit_event(self):
-        with self.app.app_context():
-            self.client.post("/frameworks",
-                             data=json.dumps(self.framework()),
-                             content_type="application/json")
+        self.client.post("/frameworks",
+                         data=json.dumps(self.framework()),
+                         content_type="application/json")
 
-            response = self.client.get("/audit-events")
+        response = self.client.get("/audit-events")
 
-            data = json.loads(response.get_data(as_text=True))
+        data = json.loads(response.get_data(as_text=True))
 
-            assert len(data["auditEvents"]) == 1
-            assert data["auditEvents"][0]["type"] == "create_framework"
+        assert len(data["auditEvents"]) == 1
+        assert data["auditEvents"][0]["type"] == "create_framework"
 
     def test_create_fails_if_framework_already_exists(self):
-        with self.app.app_context():
-            self.client.post("/frameworks",
-                             data=json.dumps(self.framework()),
-                             content_type="application/json")
+        self.client.post("/frameworks",
+                         data=json.dumps(self.framework()),
+                         content_type="application/json")
 
-            response = self.client.post("/frameworks",
-                                        data=json.dumps(self.framework()),
-                                        content_type="application/json")
+        response = self.client.post("/frameworks",
+                                    data=json.dumps(self.framework()),
+                                    content_type="application/json")
 
-            assert response.status_code == 400
-            assert json.loads(response.get_data(as_text=True))["error"] == "Slug 'example' already in use"
+        assert response.status_code == 400
+        assert json.loads(response.get_data(as_text=True))["error"] == "Slug 'example' already in use"
 
     def test_create_fails_if_status_is_invalid(self):
-        with self.app.app_context():
-            response = self.client.post("/frameworks",
-                                        data=json.dumps(self.framework(status="invalid")),
-                                        content_type="application/json")
+        response = self.client.post("/frameworks",
+                                    data=json.dumps(self.framework(status="invalid")),
+                                    content_type="application/json")
 
-            assert response.status_code == 400
-            assert json.loads(response.get_data(as_text=True))["error"] == "Invalid status value 'invalid'"
+        assert response.status_code == 400
+        assert json.loads(response.get_data(as_text=True))["error"] == "Invalid status value 'invalid'"
 
     def test_create_fails_if_clarification_questions_open_is_invalid(self):
-        with self.app.app_context():
-            response = self.client.post("/frameworks",
-                                        data=json.dumps(self.framework(clarificationQuestionsOpen="invalid")),
-                                        content_type="application/json")
+        response = self.client.post("/frameworks",
+                                    data=json.dumps(self.framework(clarificationQuestionsOpen="invalid")),
+                                    content_type="application/json")
 
-            assert response.status_code == 400
-            assert json.loads(response.get_data(as_text=True))["error"] == "Invalid framework"
+        assert response.status_code == 400
+        assert json.loads(response.get_data(as_text=True))["error"] == "Invalid framework"
 
     def test_create_fails_if_lot_slug_is_invalid(self):
-        with self.app.app_context():
-            response = self.client.post("/frameworks",
-                                        data=json.dumps(self.framework(lots=["saas", "invalid", "bad"])),
-                                        content_type="application/json")
+        response = self.client.post("/frameworks",
+                                    data=json.dumps(self.framework(lots=["saas", "invalid", "bad"])),
+                                    content_type="application/json")
 
-            assert response.status_code == 400
-            assert json.loads(response.get_data(as_text=True))["error"] == "Invalid lot slugs: bad, invalid"
+        assert response.status_code == 400
+        assert json.loads(response.get_data(as_text=True))["error"] == "Invalid lot slugs: bad, invalid"
 
     def test_create_fails_if_slug_is_invalid(self):
-        with self.app.app_context():
-            response = self.client.post("/frameworks",
-                                        data=json.dumps(self.framework(slug="this is/invalid")),
-                                        content_type="application/json")
+        response = self.client.post("/frameworks",
+                                    data=json.dumps(self.framework(slug="this is/invalid")),
+                                    content_type="application/json")
 
-            assert response.status_code == 400
-            assert json.loads(response.get_data(as_text=True))["error"] == "Invalid slug value 'this is/invalid'"
+        assert response.status_code == 400
+        assert json.loads(response.get_data(as_text=True))["error"] == "Invalid slug value 'this is/invalid'"
 
 
 class TestGetFramework(BaseApplicationTest):
     def test_a_single_framework_is_returned(self):
-        with self.app.app_context():
-            response = self.client.get('/frameworks/g-cloud-7')
-            data = json.loads(response.get_data())
+        response = self.client.get('/frameworks/g-cloud-7')
+        data = json.loads(response.get_data())
 
-            assert response.status_code == 200
-            assert data['frameworks']['slug'] == 'g-cloud-7'
-            assert 'status' in data['frameworks']
+        assert response.status_code == 200
+        assert data['frameworks']['slug'] == 'g-cloud-7'
+        assert 'status' in data['frameworks']
 
     def test_framework_lots_are_returned(self):
-        with self.app.app_context():
-            response = self.client.get('/frameworks/g-cloud-7')
+        response = self.client.get('/frameworks/g-cloud-7')
 
         data = json.loads(response.get_data())
         assert data['frameworks']['lots'] == [
@@ -190,10 +180,9 @@ class TestGetFramework(BaseApplicationTest):
         ]
 
     def test_a_404_is_raised_if_it_does_not_exist(self):
-        with self.app.app_context():
-            response = self.client.get('/frameworks/biscuits-for-gov')
+        response = self.client.get('/frameworks/biscuits-for-gov')
 
-            assert response.status_code == 404
+        assert response.status_code == 404
 
 
 class TestUpdateFramework(BaseApplicationTest, JSONUpdateTestMixin):
@@ -243,16 +232,15 @@ class TestUpdateFramework(BaseApplicationTest, JSONUpdateTestMixin):
         )
 
     def test_returns_404_on_non_existent_framework(self, open_example_framework):
-        with self.app.app_context():
-            response = self.client.post(
-                '/frameworks/example-framework-2',
-                data=json.dumps({'frameworks': {
-                    'status': 'expired'
-                }, 'updated_by': 'example user'}),
-                content_type="application/json"
-            )
+        response = self.client.post(
+            '/frameworks/example-framework-2',
+            data=json.dumps({'frameworks': {
+                'status': 'expired'
+            }, 'updated_by': 'example user'}),
+            content_type="application/json"
+        )
 
-            assert response.status_code == 404
+        assert response.status_code == 404
 
     def test_can_update_whitelisted_fields(self, open_example_framework):
         valid_attributes_and_values = {
@@ -260,28 +248,27 @@ class TestUpdateFramework(BaseApplicationTest, JSONUpdateTestMixin):
             if key in self.attribute_whitelist
         }
 
-        with self.app.app_context():
-            for key, value in valid_attributes_and_values.items():
-                response = self.post_framework_update({
-                    key: value
-                })
+        for key, value in valid_attributes_and_values.items():
+            response = self.post_framework_update({
+                key: value
+            })
 
-                assert response.status_code == 200
-                post_data = json.loads(response.get_data())['frameworks']
+            assert response.status_code == 200
+            post_data = json.loads(response.get_data())['frameworks']
 
-                # certain keys of `frameworkAgreementDetails` are un-nested and returned with other top-level keys
-                if isinstance(value, dict):
-                    for nested_key, nested_value in value.items():
-                        if nested_key in ("countersignerName", "frameworkAgreementVersion", "variations",):
-                            assert post_data[nested_key] == nested_value
+            # certain keys of `frameworkAgreementDetails` are un-nested and returned with other top-level keys
+            if isinstance(value, dict):
+                for nested_key, nested_value in value.items():
+                    if nested_key in ("countersignerName", "frameworkAgreementVersion", "variations",):
+                        assert post_data[nested_key] == nested_value
 
-                assert post_data[key] == value
+            assert post_data[key] == value
 
-                # check the same data was actually persisted
-                get_data = json.loads(
-                    self.client.get('/frameworks/example-framework').get_data()
-                )['frameworks']
-                assert post_data == get_data
+            # check the same data was actually persisted
+            get_data = json.loads(
+                self.client.get('/frameworks/example-framework').get_data()
+            )['frameworks']
+            assert post_data == get_data
 
     def test_cannot_update_non_whitelisted_fields(self, open_example_framework):
         invalid_attributes_and_values = {
@@ -291,33 +278,30 @@ class TestUpdateFramework(BaseApplicationTest, JSONUpdateTestMixin):
         # add some random key
         invalid_attributes_and_values.update({'beverage': 'Clamato'})
 
-        with self.app.app_context():
-            for key, value in invalid_attributes_and_values.items():
-                response = self.post_framework_update({
-                    key: value
-                })
-
-                assert response.status_code == 400
-                data = json.loads(response.get_data())['error']
-                assert data == "Invalid keys for framework update: '{}'".format(key)
-
-    def test_cannot_update_framework_with_invalid_status(self, open_example_framework):
-        with self.app.app_context():
+        for key, value in invalid_attributes_and_values.items():
             response = self.post_framework_update({
-                'status': 'invalid'
+                key: value
             })
 
             assert response.status_code == 400
             data = json.loads(response.get_data())['error']
-            assert 'Invalid status value' in data
+            assert data == "Invalid keys for framework update: '{}'".format(key)
+
+    def test_cannot_update_framework_with_invalid_status(self, open_example_framework):
+        response = self.post_framework_update({
+            'status': 'invalid'
+        })
+
+        assert response.status_code == 400
+        data = json.loads(response.get_data())['error']
+        assert 'Invalid status value' in data
 
     def test_passing_in_an_empty_update_is_a_failure(self, open_example_framework):
-        with self.app.app_context():
-            response = self.post_framework_update({})
+        response = self.post_framework_update({})
 
-            assert response.status_code == 400
-            data = json.loads(response.get_data())['error']
-            assert data == "Framework update expects a payload"
+        assert response.status_code == 400
+        data = json.loads(response.get_data())['error']
+        assert data == "Framework update expects a payload"
 
     def test_schema_validation_for_framework_agreement_details(self, open_example_framework):
         invalid_framework_agreement_details = [
@@ -369,12 +353,11 @@ class TestUpdateFramework(BaseApplicationTest, JSONUpdateTestMixin):
             {}
         ]
 
-        with self.app.app_context():
-            for invalid_value in invalid_framework_agreement_details:
-                response = self.post_framework_update({
-                    'frameworkAgreementDetails': invalid_value
-                })
-                assert response.status_code == 400
+        for invalid_value in invalid_framework_agreement_details:
+            response = self.post_framework_update({
+                'frameworkAgreementDetails': invalid_value
+            })
+            assert response.status_code == 400
 
     @mock.patch('app.db.session.commit')
     def test_update_framework_catches_db_errors(self, db_commit, open_example_framework):
@@ -384,77 +367,72 @@ class TestUpdateFramework(BaseApplicationTest, JSONUpdateTestMixin):
             if key in self.attribute_whitelist
         }
 
-        with self.app.app_context():
-            for key, value in valid_attributes_and_values.items():
-                response = self.post_framework_update({
-                    key: value
-                })
+        for key, value in valid_attributes_and_values.items():
+            response = self.post_framework_update({
+                key: value
+            })
 
-                assert response.status_code == 400
-                assert "Could not commit" in json.loads(response.get_data())["error"]
+            assert response.status_code == 400
+            assert "Could not commit" in json.loads(response.get_data())["error"]
 
 
 class TestFrameworkStats(BaseApplicationTest, FixtureMixin):
     def make_declaration(self, framework_id, supplier_ids, status=None):
-        with self.app.app_context():
-            db.session.query(
-                SupplierFramework
-            ).filter(
-                SupplierFramework.framework_id == framework_id,
-                SupplierFramework.supplier_id.in_(supplier_ids)
-            ).update({
-                SupplierFramework.declaration: {'status': status}
-            }, synchronize_session=False)
+        db.session.query(
+            SupplierFramework
+        ).filter(
+            SupplierFramework.framework_id == framework_id,
+            SupplierFramework.supplier_id.in_(supplier_ids)
+        ).update({
+            SupplierFramework.declaration: {'status': status}
+        }, synchronize_session=False)
 
-            db.session.commit()
+        db.session.commit()
 
     def register_framework_interest(self, framework_id, supplier_ids):
-        with self.app.app_context():
-            for supplier_id in supplier_ids:
-                db.session.add(
-                    SupplierFramework(
-                        framework_id=framework_id,
-                        supplier_id=supplier_id,
-                        declaration={}
-                    )
+        for supplier_id in supplier_ids:
+            db.session.add(
+                SupplierFramework(
+                    framework_id=framework_id,
+                    supplier_id=supplier_id,
+                    declaration={}
                 )
-            db.session.commit()
+            )
+        db.session.commit()
 
     def create_drafts(self, framework_id, supplier_id_count_pairs, status='not-submitted'):
-        with self.app.app_context():
-            framework = Framework.query.get(framework_id)
-            framework_lots = framework.lots
-            for supplier_id, count in supplier_id_count_pairs:
-                for ind in range(count):
-                    db.session.add(
-                        DraftService(
-                            lot=framework_lots[ind % 4],
-                            framework_id=framework_id,
-                            supplier_id=supplier_id,
-                            data={},
-                            status=status
-                        )
-                    )
-
-            db.session.commit()
-
-    def create_users(self, supplier_ids, logged_in_at):
-        with self.app.app_context():
-            for supplier_id in supplier_ids:
+        framework = Framework.query.get(framework_id)
+        framework_lots = framework.lots
+        for supplier_id, count in supplier_id_count_pairs:
+            for ind in range(count):
                 db.session.add(
-                    User(
-                        name='supplier user',
-                        email_address='supplier-{}@user.dmdev'.format(supplier_id),
-                        password='testpassword',
-                        active=True,
-                        password_changed_at=datetime.datetime.utcnow(),
-                        role='supplier',
+                    DraftService(
+                        lot=framework_lots[ind % 4],
+                        framework_id=framework_id,
                         supplier_id=supplier_id,
-                        logged_in_at=logged_in_at
+                        data={},
+                        status=status
                     )
                 )
 
-            db.session.commit()
+        db.session.commit()
+
+    def create_users(self, supplier_ids, logged_in_at):
+        for supplier_id in supplier_ids:
+            db.session.add(
+                User(
+                    name='supplier user',
+                    email_address='supplier-{}@user.dmdev'.format(supplier_id),
+                    password='testpassword',
+                    active=True,
+                    password_changed_at=datetime.datetime.utcnow(),
+                    role='supplier',
+                    supplier_id=supplier_id,
+                    logged_in_at=logged_in_at
+                )
+            )
+
+        db.session.commit()
 
     def setup_supplier_data(self):
         self.setup_dummy_suppliers(30)
@@ -474,8 +452,7 @@ class TestFrameworkStats(BaseApplicationTest, FixtureMixin):
         )
 
     def setup_framework_data(self, framework_slug):
-        with self.app.app_context():
-            framework = Framework.query.filter(Framework.slug == framework_slug).first()
+        framework = Framework.query.filter(Framework.slug == framework_slug).first()
 
         self.register_framework_interest(framework.id, range(20))
         self.make_declaration(framework.id, [1, 3, 5, 7, 9, 11], status='started')
@@ -568,18 +545,17 @@ class TestFrameworkStats(BaseApplicationTest, FixtureMixin):
 
     def test_stats_handles_null_declarations(self):
         self.setup_data('g-cloud-7')
-        with self.app.app_context():
-            framework = Framework.query.filter(Framework.slug == 'g-cloud-7').first()
-            db.session.query(
-                SupplierFramework
-            ).filter(
-                SupplierFramework.framework_id == framework.id,
-                SupplierFramework.supplier_id.in_([0, 1])
-            ).update({
-                SupplierFramework.declaration: None
-            }, synchronize_session=False)
+        framework = Framework.query.filter(Framework.slug == 'g-cloud-7').first()
+        db.session.query(
+            SupplierFramework
+        ).filter(
+            SupplierFramework.framework_id == framework.id,
+            SupplierFramework.supplier_id.in_([0, 1])
+        ).update({
+            SupplierFramework.declaration: None
+        }, synchronize_session=False)
 
-            db.session.commit()
+        db.session.commit()
 
         response = self.client.get('/frameworks/g-cloud-7/stats')
 
@@ -609,195 +585,194 @@ class TestGetFrameworkSuppliers(BaseApplicationTest, FixtureMixin):
             self.setup_dummy_user(id=123, role='supplier')
             self.setup_dummy_user(id=321, role='admin-ccs-sourcing')
 
-        with self.app.app_context():
-            db.session.execute("UPDATE frameworks SET status='open' WHERE slug='g-cloud-7'")
-            db.session.execute("UPDATE frameworks SET status='open' WHERE slug='g-cloud-8'")
-            db.session.commit()
+        db.session.execute("UPDATE frameworks SET status='open' WHERE slug='g-cloud-7'")
+        db.session.execute("UPDATE frameworks SET status='open' WHERE slug='g-cloud-8'")
+        db.session.commit()
 
-            with freeze_time("2016-10-10", tick=True):
-                # Supplier zero is on G-Cloud 7
+        with freeze_time("2016-10-10", tick=True):
+            # Supplier zero is on G-Cloud 7
+            response = self.client.put(
+                '/suppliers/0/frameworks/g-cloud-7',
+                data=json.dumps({
+                    'updated_by': 'example'
+                }),
+                content_type='application/json')
+            assert response.status_code == 201, response.get_data(as_text=True)
+
+            response = self.client.post(
+                '/suppliers/0/frameworks/g-cloud-7',
+                data=json.dumps({
+                    'updated_by': 'example',
+                    'frameworkInterest': {'onFramework': True}
+                }),
+                content_type='application/json')
+            assert response.status_code == 200, response.get_data(as_text=True)
+
+            response = self.client.post(
+                '/agreements',
+                data=json.dumps({
+                    'updated_by': 'example',
+                    'agreement': {'supplierId': 0, 'frameworkSlug': 'g-cloud-7'},
+                }),
+                content_type='application/json')
+            assert response.status_code == 201, response.get_data(as_text=True)
+            data = json.loads(response.get_data())
+            agreement_id = data['agreement']['id']
+
+            response = self.client.post(
+                '/agreements/{}'.format(agreement_id),
+                data=json.dumps({
+                    'updated_by': 'example',
+                    'agreement': {'signedAgreementPath': '/path-to-g-cloud-7.pdf'},
+                }),
+                content_type='application/json')
+            assert response.status_code == 200, response.get_data(as_text=True)
+
+            response = self.client.post(
+                '/agreements/{}/sign'.format(agreement_id),
+                data=json.dumps({
+                    'updated_by': 'example',
+                    'agreement': {},
+                }),
+                content_type='application/json')
+            assert response.status_code == 200, response.get_data(as_text=True)
+
+        # (Almost) everyone is on G-Cloud 8
+        for supplier_id in range(11):
+            with freeze_time(datetime.datetime(2016, 10, supplier_id + 2)):
                 response = self.client.put(
-                    '/suppliers/0/frameworks/g-cloud-7',
+                    '/suppliers/{}/frameworks/g-cloud-8'.format(supplier_id),
                     data=json.dumps({
                         'updated_by': 'example'
                     }),
                     content_type='application/json')
                 assert response.status_code == 201, response.get_data(as_text=True)
 
-                response = self.client.post(
-                    '/suppliers/0/frameworks/g-cloud-7',
+            with freeze_time(datetime.datetime(2016, 10, supplier_id + 2, 10)):
+                response = self.client.put(
+                    '/suppliers/{}/frameworks/g-cloud-8/declaration'.format(supplier_id),
                     data=json.dumps({
                         'updated_by': 'example',
-                        'frameworkInterest': {'onFramework': True}
-                    }),
-                    content_type='application/json')
-                assert response.status_code == 200, response.get_data(as_text=True)
-
-                response = self.client.post(
-                    '/agreements',
-                    data=json.dumps({
-                        'updated_by': 'example',
-                        'agreement': {'supplierId': 0, 'frameworkSlug': 'g-cloud-7'},
+                        'declaration': {
+                            "status": "complete",
+                            "firstRegistered": "16/06/1904",
+                        },
                     }),
                     content_type='application/json')
                 assert response.status_code == 201, response.get_data(as_text=True)
-                data = json.loads(response.get_data())
-                agreement_id = data['agreement']['id']
 
+            with freeze_time(datetime.datetime(2016, 10, supplier_id + 3)):
                 response = self.client.post(
-                    '/agreements/{}'.format(agreement_id),
+                    '/suppliers/{}/frameworks/g-cloud-8'.format(supplier_id),
                     data=json.dumps({
                         'updated_by': 'example',
-                        'agreement': {'signedAgreementPath': '/path-to-g-cloud-7.pdf'},
+                        'frameworkInterest': {
+                            'onFramework': True,
+                        },
                     }),
                     content_type='application/json')
                 assert response.status_code == 200, response.get_data(as_text=True)
 
-                response = self.client.post(
-                    '/agreements/{}/sign'.format(agreement_id),
-                    data=json.dumps({
-                        'updated_by': 'example',
-                        'agreement': {},
-                    }),
-                    content_type='application/json')
-                assert response.status_code == 200, response.get_data(as_text=True)
-
-            # (Almost) everyone is on G-Cloud 8
-            for supplier_id in range(11):
-                with freeze_time(datetime.datetime(2016, 10, supplier_id + 2)):
-                    response = self.client.put(
-                        '/suppliers/{}/frameworks/g-cloud-8'.format(supplier_id),
-                        data=json.dumps({
-                            'updated_by': 'example'
-                        }),
-                        content_type='application/json')
-                    assert response.status_code == 201, response.get_data(as_text=True)
-
-                with freeze_time(datetime.datetime(2016, 10, supplier_id + 2, 10)):
-                    response = self.client.put(
-                        '/suppliers/{}/frameworks/g-cloud-8/declaration'.format(supplier_id),
-                        data=json.dumps({
-                            'updated_by': 'example',
-                            'declaration': {
-                                "status": "complete",
-                                "firstRegistered": "16/06/1904",
-                            },
-                        }),
-                        content_type='application/json')
-                    assert response.status_code == 201, response.get_data(as_text=True)
-
-                with freeze_time(datetime.datetime(2016, 10, supplier_id + 3)):
-                    response = self.client.post(
-                        '/suppliers/{}/frameworks/g-cloud-8'.format(supplier_id),
-                        data=json.dumps({
-                            'updated_by': 'example',
-                            'frameworkInterest': {
-                                'onFramework': True,
-                            },
-                        }),
-                        content_type='application/json')
-                    assert response.status_code == 200, response.get_data(as_text=True)
-
-            # Suppliers 1-10 have started to return a G-Cloud 8 agreement (created a draft)
-            agreement_ids = {}
-            for supplier_id in range(1, 11):
-                with freeze_time(datetime.datetime(2016, 11, (supplier_id + 1) * 2)):
-                    response = self.client.post(
-                        '/agreements',
-                        data=json.dumps({
-                            'updated_by': 'example',
-                            'agreement': {'supplierId': supplier_id, 'frameworkSlug': 'g-cloud-8'},
-                        }),
-                        content_type='application/json'
-                    )
-                    assert response.status_code == 201, response.get_data(as_text=True)
-                    data = json.loads(response.get_data())
-                    agreement_ids[supplier_id] = data['agreement']['id']
-
-            # (supplier 10 created a superfluous agreement which they then didn't use
-            with freeze_time(datetime.datetime(2016, 11, 26)):
+        # Suppliers 1-10 have started to return a G-Cloud 8 agreement (created a draft)
+        agreement_ids = {}
+        for supplier_id in range(1, 11):
+            with freeze_time(datetime.datetime(2016, 11, (supplier_id + 1) * 2)):
                 response = self.client.post(
                     '/agreements',
                     data=json.dumps({
                         'updated_by': 'example',
-                        'agreement': {'supplierId': 10, 'frameworkSlug': 'g-cloud-8'},
+                        'agreement': {'supplierId': supplier_id, 'frameworkSlug': 'g-cloud-8'},
                     }),
                     content_type='application/json'
                 )
                 assert response.status_code == 201, response.get_data(as_text=True)
+                data = json.loads(response.get_data())
+                agreement_ids[supplier_id] = data['agreement']['id']
 
-            for supplier_id in range(1, 11):
-                with freeze_time(datetime.datetime(2016, 11, (supplier_id + 1) * 2, 10)):
-                    response = self.client.post(
-                        '/agreements/{}'.format(agreement_ids[supplier_id]),
-                        data=json.dumps({
-                            'updated_by': 'example',
-                            'agreement': {
-                                'signedAgreementPath': 'path/to/agreement/{}.pdf'.format(supplier_id),
-                                'signedAgreementDetails': {
-                                    'signerName': 'name_{}'.format(supplier_id),
-                                    'signerRole': 'job_{}'.format(supplier_id)
-                                },
-                            }
-                        }),
-                        content_type='application/json'
-                    )
-                    assert response.status_code == 200, response.get_data(as_text=True)
+        # (supplier 10 created a superfluous agreement which they then didn't use
+        with freeze_time(datetime.datetime(2016, 11, 26)):
+            response = self.client.post(
+                '/agreements',
+                data=json.dumps({
+                    'updated_by': 'example',
+                    'agreement': {'supplierId': 10, 'frameworkSlug': 'g-cloud-8'},
+                }),
+                content_type='application/json'
+            )
+            assert response.status_code == 201, response.get_data(as_text=True)
 
-            # Suppliers 3-10 have returned their G-Cloud 8 agreement
-            for supplier_id in range(3, 11):
-                with freeze_time(datetime.datetime(2016, 11, 30, 11 - supplier_id)):
-                    response = self.client.post(
-                        '/agreements/{}/sign'.format(agreement_ids[supplier_id]),
-                        data=json.dumps({
-                            'updated_by': 'example',
-                            'agreement': {
-                                'signedAgreementDetails': {
-                                    'uploaderUserId': 123,
-                                },
+        for supplier_id in range(1, 11):
+            with freeze_time(datetime.datetime(2016, 11, (supplier_id + 1) * 2, 10)):
+                response = self.client.post(
+                    '/agreements/{}'.format(agreement_ids[supplier_id]),
+                    data=json.dumps({
+                        'updated_by': 'example',
+                        'agreement': {
+                            'signedAgreementPath': 'path/to/agreement/{}.pdf'.format(supplier_id),
+                            'signedAgreementDetails': {
+                                'signerName': 'name_{}'.format(supplier_id),
+                                'signerRole': 'job_{}'.format(supplier_id)
                             },
-                        }),
-                        content_type='application/json'
-                    )
-                    assert response.status_code == 200, response.get_data(as_text=True)
+                        }
+                    }),
+                    content_type='application/json'
+                )
+                assert response.status_code == 200, response.get_data(as_text=True)
 
-            # Supplier 4 and 9's agreements were put on hold (only 4 subsequently remained on hold)
-            for supplier_id in (4, 9,):
-                with freeze_time(datetime.datetime(2016, 11, 30, 12 - (supplier_id // 3))):
-                    response = self.client.post(
-                        '/agreements/{}/on-hold'.format(agreement_ids[supplier_id]),
-                        data=json.dumps({'updated_by': 'example'}),
-                        content_type='application/json'
-                    )
-                    assert response.status_code == 200, response.get_data(as_text=True)
+        # Suppliers 3-10 have returned their G-Cloud 8 agreement
+        for supplier_id in range(3, 11):
+            with freeze_time(datetime.datetime(2016, 11, 30, 11 - supplier_id)):
+                response = self.client.post(
+                    '/agreements/{}/sign'.format(agreement_ids[supplier_id]),
+                    data=json.dumps({
+                        'updated_by': 'example',
+                        'agreement': {
+                            'signedAgreementDetails': {
+                                'uploaderUserId': 123,
+                            },
+                        },
+                    }),
+                    content_type='application/json'
+                )
+                assert response.status_code == 200, response.get_data(as_text=True)
 
-            # Suppliers 6-10 have been approved for countersignature
-            for supplier_id in range(6, 11):
-                with freeze_time(datetime.datetime(2016, 11, 30, 15 - supplier_id)):
-                    response = self.client.post(
-                        '/agreements/{}/approve'.format(agreement_ids[supplier_id]),
-                        data=json.dumps({
-                            'updated_by': 'example',
-                            "agreement": {'userId': 321},
-                        }),
-                        content_type='application/json'
-                    )
-                    assert response.status_code == 200, response.get_data(as_text=True)
+        # Supplier 4 and 9's agreements were put on hold (only 4 subsequently remained on hold)
+        for supplier_id in (4, 9,):
+            with freeze_time(datetime.datetime(2016, 11, 30, 12 - (supplier_id // 3))):
+                response = self.client.post(
+                    '/agreements/{}/on-hold'.format(agreement_ids[supplier_id]),
+                    data=json.dumps({'updated_by': 'example'}),
+                    content_type='application/json'
+                )
+                assert response.status_code == 200, response.get_data(as_text=True)
 
-            # Suppliers 7-10 have countersigned agreements
-            for supplier_id in range(7, 11):
-                with freeze_time(datetime.datetime(2016, 12, 25, 5 + supplier_id)):
-                    response = self.client.post(
-                        '/agreements/{}'.format(agreement_ids[supplier_id]),
-                        data=json.dumps({
-                            'updated_by': 'example',
-                            'agreement': {
-                                'countersignedAgreementPath': 'path/to/countersigned{}.pdf'.format(supplier_id)
-                            }
-                        }),
-                        content_type='application/json'
-                    )
-                    assert response.status_code == 200, response.get_data(as_text=True)
+        # Suppliers 6-10 have been approved for countersignature
+        for supplier_id in range(6, 11):
+            with freeze_time(datetime.datetime(2016, 11, 30, 15 - supplier_id)):
+                response = self.client.post(
+                    '/agreements/{}/approve'.format(agreement_ids[supplier_id]),
+                    data=json.dumps({
+                        'updated_by': 'example',
+                        "agreement": {'userId': 321},
+                    }),
+                    content_type='application/json'
+                )
+                assert response.status_code == 200, response.get_data(as_text=True)
+
+        # Suppliers 7-10 have countersigned agreements
+        for supplier_id in range(7, 11):
+            with freeze_time(datetime.datetime(2016, 12, 25, 5 + supplier_id)):
+                response = self.client.post(
+                    '/agreements/{}'.format(agreement_ids[supplier_id]),
+                    data=json.dumps({
+                        'updated_by': 'example',
+                        'agreement': {
+                            'countersignedAgreementPath': 'path/to/countersigned{}.pdf'.format(supplier_id)
+                        }
+                    }),
+                    content_type='application/json'
+                )
+                assert response.status_code == 200, response.get_data(as_text=True)
 
     def test_list_suppliers_combined(self, live_g8_framework):
         # it would be nice to implement the following as individual tests, but the setup method is too expensive and has
@@ -949,26 +924,23 @@ class TestGetFrameworkInterest(BaseApplicationTest, FixtureMixin):
 
     def register_g7_interest(self, num):
         self.setup_dummy_suppliers(num)
-        with self.app.app_context():
-            for supplier_id in range(num):
-                db.session.add(
-                    SupplierFramework(
-                        framework_id=4,
-                        supplier_id=supplier_id
-                    )
+        for supplier_id in range(num):
+            db.session.add(
+                SupplierFramework(
+                    framework_id=4,
+                    supplier_id=supplier_id
                 )
-            db.session.commit()
+            )
+        db.session.commit()
 
     def test_interested_suppliers_are_returned(self):
-        with self.app.app_context():
-            response = self.client.get('/frameworks/g-cloud-7/interest')
+        response = self.client.get('/frameworks/g-cloud-7/interest')
 
-            assert response.status_code == 200
-            data = json.loads(response.get_data())
-            assert data['interestedSuppliers'] == [0, 1, 2, 3, 4]
+        assert response.status_code == 200
+        data = json.loads(response.get_data())
+        assert data['interestedSuppliers'] == [0, 1, 2, 3, 4]
 
     def test_a_404_is_raised_if_it_does_not_exist(self):
-        with self.app.app_context():
-            response = self.client.get('/frameworks/biscuits-for-gov/interest')
+        response = self.client.get('/frameworks/biscuits-for-gov/interest')
 
-            assert response.status_code == 404
+        assert response.status_code == 404

--- a/tests/main/views/test_services.py
+++ b/tests/main/views/test_services.py
@@ -17,43 +17,42 @@ from dmapiclient.audit import AuditTypes
 
 class TestListServicesOrdering(BaseApplicationTest, FixtureMixin):
     def setup_services(self):
-        with self.app.app_context():
-            self.app.config['DM_API_SERVICES_PAGE_SIZE'] = 10
+        self.app.config['DM_API_SERVICES_PAGE_SIZE'] = 10
 
-            g5_saas = load_example_listing("G5")
-            g5_paas = load_example_listing("G5")
-            g6_paas_2 = load_example_listing("G6-PaaS")
-            g6_iaas_1 = load_example_listing("G6-IaaS")
-            g6_paas_1 = load_example_listing("G6-PaaS")
-            g6_saas = load_example_listing("G6-SaaS")
-            g6_iaas_2 = load_example_listing("G6-IaaS")
+        g5_saas = load_example_listing("G5")
+        g5_paas = load_example_listing("G5")
+        g6_paas_2 = load_example_listing("G6-PaaS")
+        g6_iaas_1 = load_example_listing("G6-IaaS")
+        g6_paas_1 = load_example_listing("G6-PaaS")
+        g6_saas = load_example_listing("G6-SaaS")
+        g6_iaas_2 = load_example_listing("G6-IaaS")
 
-            db.session.add(
-                Supplier(supplier_id=1, name=u"Supplier 1")
+        db.session.add(
+            Supplier(supplier_id=1, name=u"Supplier 1")
+        )
+
+        def insert_service(listing, service_id, lot_id, framework_id):
+            self.setup_dummy_service(
+                service_id=service_id,
+                lot_id=lot_id,
+                framework_id=framework_id,
+                **listing
             )
 
-            def insert_service(listing, service_id, lot_id, framework_id):
-                self.setup_dummy_service(
-                    service_id=service_id,
-                    lot_id=lot_id,
-                    framework_id=framework_id,
-                    **listing
-                )
+        # override certain fields to create ordering difference
+        g6_iaas_1['serviceName'] = "b service name"
+        g6_iaas_2['serviceName'] = "a service name"
+        g6_paas_1['serviceName'] = "b service name"
+        g6_paas_2['serviceName'] = "a service name"
+        g5_paas['lot'] = "PaaS"
 
-            # override certain fields to create ordering difference
-            g6_iaas_1['serviceName'] = "b service name"
-            g6_iaas_2['serviceName'] = "a service name"
-            g6_paas_1['serviceName'] = "b service name"
-            g6_paas_2['serviceName'] = "a service name"
-            g5_paas['lot'] = "PaaS"
-
-            insert_service(g5_paas, "123-g5-paas", 2, 3)
-            insert_service(g5_saas, "123-g5-saas", 1, 3)
-            insert_service(g6_iaas_1, "123-g6-iaas-1", 3, 1)
-            insert_service(g6_iaas_2, "123-g6-iaas-2", 3, 1)
-            insert_service(g6_paas_1, "123-g6-paas-1", 2, 1)
-            insert_service(g6_paas_2, "123-g6-paas-2", 2, 1)
-            insert_service(g6_saas, "123-g6-saas", 1, 1)
+        insert_service(g5_paas, "123-g5-paas", 2, 3)
+        insert_service(g5_saas, "123-g5-saas", 1, 3)
+        insert_service(g6_iaas_1, "123-g6-iaas-1", 3, 1)
+        insert_service(g6_iaas_2, "123-g6-iaas-2", 3, 1)
+        insert_service(g6_paas_1, "123-g6-paas-1", 2, 1)
+        insert_service(g6_paas_2, "123-g6-paas-2", 2, 1)
+        insert_service(g6_saas, "123-g6-saas", 1, 1)
 
     def test_should_order_supplier_services_by_framework_lot_name(self):
         self.setup_services()
@@ -92,32 +91,31 @@ class TestListServicesOrdering(BaseApplicationTest, FixtureMixin):
 
 class TestListServices(BaseApplicationTest, FixtureMixin):
     def setup_services(self):
-        with self.app.app_context():
-            self.setup_dummy_suppliers(1)
-            self.set_framework_status('digital-outcomes-and-specialists', 'live')
-            self.setup_dummy_service(
-                service_id='10000000001',
-                supplier_id=0,
-                framework_id=5,  # Digital Outcomes and Specialists
-                lot_id=5,  # digital-outcomes
-                data={"locations": [
-                    "London", "Offsite", "Scotland", "Wales"
-                ]
-                })
-            self.setup_dummy_service(
-                service_id='10000000002',
-                supplier_id=0,
-                framework_id=5,  # Digital Outcomes and Specialists
-                lot_id=6,  # digital-specialists
-                data={"agileCoachLocations": ["London", "Offsite", "Scotland", "Wales"]}
-            )
-            self.setup_dummy_service(
-                service_id='10000000003',
-                supplier_id=0,
-                framework_id=5,  # Digital Outcomes and Specialists
-                lot_id=6,  # digital-specialists
-                data={"agileCoachLocations": ["Wales"]}
-            )
+        self.setup_dummy_suppliers(1)
+        self.set_framework_status('digital-outcomes-and-specialists', 'live')
+        self.setup_dummy_service(
+            service_id='10000000001',
+            supplier_id=0,
+            framework_id=5,  # Digital Outcomes and Specialists
+            lot_id=5,  # digital-outcomes
+            data={"locations": [
+                "London", "Offsite", "Scotland", "Wales"
+            ]
+            })
+        self.setup_dummy_service(
+            service_id='10000000002',
+            supplier_id=0,
+            framework_id=5,  # Digital Outcomes and Specialists
+            lot_id=6,  # digital-specialists
+            data={"agileCoachLocations": ["London", "Offsite", "Scotland", "Wales"]}
+        )
+        self.setup_dummy_service(
+            service_id='10000000003',
+            supplier_id=0,
+            framework_id=5,  # Digital Outcomes and Specialists
+            lot_id=6,  # digital-specialists
+            data={"agileCoachLocations": ["Wales"]}
+        )
 
     def test_list_services_with_no_services(self):
         response = self.client.get('/services')
@@ -148,61 +146,58 @@ class TestListServices(BaseApplicationTest, FixtureMixin):
             assert False, "Should be able to parse date"
 
     def test_list_services_gets_only_active_frameworks(self):
-        with self.app.app_context():
-            # the side effect of this method is to create four suppliers with ids between 0-3
-            self.setup_dummy_services_including_unpublished(1)
-            self.setup_dummy_service(
-                service_id='2000000999',
-                status='published',
-                supplier_id=0,
-                framework_id=2)
+        # the side effect of this method is to create four suppliers with ids between 0-3
+        self.setup_dummy_services_including_unpublished(1)
+        self.setup_dummy_service(
+            service_id='2000000999',
+            status='published',
+            supplier_id=0,
+            framework_id=2)
 
-            response = self.client.get('/services')
-            data = json.loads(response.get_data())
+        response = self.client.get('/services')
+        data = json.loads(response.get_data())
 
-            assert response.status_code == 200
-            assert len(data['services']) == 3
+        assert response.status_code == 200
+        assert len(data['services']) == 3
 
     def test_list_services_with_given_frameworks(self):
-        with self.app.app_context():
-            self.setup_dummy_services_including_unpublished(1)
+        self.setup_dummy_services_including_unpublished(1)
 
-            self.setup_dummy_service(
-                service_id='2000000998',
-                status='published',
-                framework_id=2)
-            self.setup_dummy_service(
-                service_id='2000000999',
-                status='published',
-                framework_id=3)
+        self.setup_dummy_service(
+            service_id='2000000998',
+            status='published',
+            framework_id=2)
+        self.setup_dummy_service(
+            service_id='2000000999',
+            status='published',
+            framework_id=3)
 
-            response = self.client.get('/services?framework=g-cloud-4')
-            data = json.loads(response.get_data())
+        response = self.client.get('/services?framework=g-cloud-4')
+        data = json.loads(response.get_data())
 
-            assert response.status_code == 200
-            assert len(data['services']) == 1
+        assert response.status_code == 200
+        assert len(data['services']) == 1
 
-            response = self.client.get('/services?framework=g-cloud-4,g-cloud-5')
-            data = json.loads(response.get_data())
+        response = self.client.get('/services?framework=g-cloud-4,g-cloud-5')
+        data = json.loads(response.get_data())
 
-            assert response.status_code == 200
-            assert len(data['services']) == 2
+        assert response.status_code == 200
+        assert len(data['services']) == 2
 
     def test_gets_only_active_frameworks_with_status_filter(self):
-        with self.app.app_context():
-            # the side effect of this method is to create four suppliers with ids between 0-3
-            self.setup_dummy_services_including_unpublished(1)
-            self.setup_dummy_service(
-                service_id='2000000999',
-                status='published',
-                supplier_id=0,
-                framework_id=2)
+        # the side effect of this method is to create four suppliers with ids between 0-3
+        self.setup_dummy_services_including_unpublished(1)
+        self.setup_dummy_service(
+            service_id='2000000999',
+            status='published',
+            supplier_id=0,
+            framework_id=2)
 
-            response = self.client.get('/services?status=published')
-            data = json.loads(response.get_data())
+        response = self.client.get('/services?status=published')
+        data = json.loads(response.get_data())
 
-            assert response.status_code == 200
-            assert len(data['services']) == 1
+        assert response.status_code == 200
+        assert len(data['services']) == 1
 
     def test_list_services_gets_only_published(self):
         self.setup_dummy_services_including_unpublished(1)
@@ -319,16 +314,15 @@ class TestListServices(BaseApplicationTest, FixtureMixin):
         os.environ['DM_HTTP_PROTO'] = 'https'
         app = create_app('test')
 
-        with app.app_context():
-            client = app.test_client()
+        client = app.test_client()
 
-            app.wsgi_app = WSGIApplicationWithEnvironment(
-                app.wsgi_app,
-                HTTP_AUTHORIZATION='Bearer {}'.format(self.app.config['DM_API_AUTH_TOKENS'])
-            )
+        app.wsgi_app = WSGIApplicationWithEnvironment(
+            app.wsgi_app,
+            HTTP_AUTHORIZATION='Bearer {}'.format(self.app.config['DM_API_AUTH_TOKENS'])
+        )
 
-            response = client.get('/')
-            data = json.loads(response.get_data())
+        response = client.get('/')
+        data = json.loads(response.get_data())
 
         if prev_environ is None:
             del os.environ['DM_HTTP_PROTO']
@@ -446,26 +440,25 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin, FixtureMixin):
         payload = load_example_listing("G6-SaaS")
         self.payload_g4 = load_example_listing("G4")
         self.service_id = str(payload['id'])
-        with self.app.app_context():
-            db.session.add(
-                Supplier(supplier_id=1, name=u"Supplier 1")
+        db.session.add(
+            Supplier(supplier_id=1, name=u"Supplier 1")
+        )
+        db.session.add(
+            ContactInformation(
+                supplier_id=1,
+                contact_name=u"Liz",
+                email=u"liz@royal.gov.uk",
+                postcode=u"SW1A 1AA"
             )
-            db.session.add(
-                ContactInformation(
-                    supplier_id=1,
-                    contact_name=u"Liz",
-                    email=u"liz@royal.gov.uk",
-                    postcode=u"SW1A 1AA"
-                )
-            )
-            self.setup_dummy_service(
-                service_id=self.service_id,
-                **payload
-            )
-            self.setup_dummy_service(
-                service_id=self.payload_g4['id'],
-                **self.payload_g4
-            )
+        )
+        self.setup_dummy_service(
+            service_id=self.service_id,
+            **payload
+        )
+        self.setup_dummy_service(
+            service_id=self.payload_g4['id'],
+            **self.payload_g4
+        )
 
     def _post_service_update(self, service_data, service_id=None, user_role=None):
         return self.client.post(
@@ -506,252 +499,236 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin, FixtureMixin):
 
     @mock.patch('app.main.views.services.index_service', autospec=True)
     def test_no_content_type_causes_failure(self, index_service):
-        with self.app.app_context():
-            response = self.client.post(
-                '/services/{}'.format(self.service_id),
-                data=json.dumps(
-                    {'updated_by': 'joeblogs',
-                     'services': {
-                         'serviceName': 'new service name'}}))
+        response = self.client.post(
+            '/services/{}'.format(self.service_id),
+            data=json.dumps(
+                {'updated_by': 'joeblogs',
+                 'services': {
+                     'serviceName': 'new service name'}}))
 
-            assert response.status_code == 400
-            assert b'Unexpected Content-Type' in response.get_data()
-            assert index_service.called is False
+        assert response.status_code == 400
+        assert b'Unexpected Content-Type' in response.get_data()
+        assert index_service.called is False
 
     @mock.patch('app.main.views.services.index_service', autospec=True)
     def test_invalid_content_type_causes_failure(self, index_service):
-        with self.app.app_context():
-            response = self.client.post(
-                '/services/{}'.format(self.service_id),
-                data=json.dumps(
-                    {'updated_by': 'joeblogs',
-                     'services': {
-                         'serviceName': 'new service name'}}),
-                content_type='application/octet-stream')
+        response = self.client.post(
+            '/services/{}'.format(self.service_id),
+            data=json.dumps(
+                {'updated_by': 'joeblogs',
+                 'services': {
+                     'serviceName': 'new service name'}}),
+            content_type='application/octet-stream')
 
-            assert response.status_code == 400
-            assert b'Unexpected Content-Type' in response.get_data()
-            assert index_service.called is False
+        assert response.status_code == 400
+        assert b'Unexpected Content-Type' in response.get_data()
+        assert index_service.called is False
 
     @mock.patch('app.main.views.services.index_service', autospec=True)
     def test_invalid_json_causes_failure(self, index_service):
-        with self.app.app_context():
-            response = self.client.post(
-                '/services/{}'.format(self.service_id),
-                data="ouiehdfiouerhfuehr",
-                content_type='application/json')
+        response = self.client.post(
+            '/services/{}'.format(self.service_id),
+            data="ouiehdfiouerhfuehr",
+            content_type='application/json')
 
-            assert response.status_code == 400
-            assert b'Invalid JSON' in response.get_data()
-            assert index_service.called is False
+        assert response.status_code == 400
+        assert b'Invalid JSON' in response.get_data()
+        assert index_service.called is False
 
     @mock.patch('app.service_utils.index_object', autospec=True)
     def test_can_post_a_valid_service_update(self, index_object):
-        with self.app.app_context():
-            response = self._post_service_update({'serviceName': 'new service name'})
-            assert response.status_code == 200
+        response = self._post_service_update({'serviceName': 'new service name'})
+        assert response.status_code == 200
 
-            service = Service.query.filter(
-                Service.service_id == self.service_id
-            ).one()
-            index_object.assert_called_once_with(
-                doc_type='services',
-                framework=service.framework.slug,
-                object_id=service.service_id,
-                serialized_object=service.serialize()
-            )
+        service = Service.query.filter(
+            Service.service_id == self.service_id
+        ).one()
+        index_object.assert_called_once_with(
+            doc_type='services',
+            framework=service.framework.slug,
+            object_id=service.service_id,
+            serialized_object=service.serialize()
+        )
 
-            response = self.client.get('/services/{}'.format(self.service_id))
-            data = json.loads(response.get_data())
-            assert data['services']['serviceName'] == 'new service name'
-            assert response.status_code == 200
+        response = self.client.get('/services/{}'.format(self.service_id))
+        data = json.loads(response.get_data())
+        assert data['services']['serviceName'] == 'new service name'
+        assert response.status_code == 200
 
     @mock.patch('app.main.views.services.index_service', autospec=True)
     def test_valid_service_update_creates_audit_event(self, index_service):
-        with self.app.app_context():
-            response = self._post_service_update({'serviceName': 'new service name'})
-            assert response.status_code == 200
-            assert index_service.called is True
+        response = self._post_service_update({'serviceName': 'new service name'})
+        assert response.status_code == 200
+        assert index_service.called is True
 
-            audit_response = self.client.get('/audit-events')
-            assert audit_response.status_code == 200
-            data = json.loads(audit_response.get_data())
+        audit_response = self.client.get('/audit-events')
+        assert audit_response.status_code == 200
+        data = json.loads(audit_response.get_data())
 
-            assert len(data['auditEvents']) == 1
+        assert len(data['auditEvents']) == 1
 
-            update_event = data['auditEvents'][0]
-            assert update_event['type'] == 'update_service'
-            assert update_event['user'] == 'joeblogs'
-            assert update_event['data']['serviceId'] == self.service_id
+        update_event = data['auditEvents'][0]
+        assert update_event['type'] == 'update_service'
+        assert update_event['user'] == 'joeblogs'
+        assert update_event['data']['serviceId'] == self.service_id
 
     @mock.patch('app.main.views.services.index_service', autospec=True)
     def test_valid_service_update_by_admin_creates_audit_event_with_correct_audit_type(self, index_service):
-        with self.app.app_context():
-            response = self._post_service_update({'serviceName': 'new service name'}, user_role='admin')
-            assert response.status_code == 200
-            assert index_service.called is True
+        response = self._post_service_update({'serviceName': 'new service name'}, user_role='admin')
+        assert response.status_code == 200
+        assert index_service.called is True
 
-            audit_response = self.client.get('/audit-events')
-            assert audit_response.status_code == 200
-            data = json.loads(audit_response.get_data())
+        audit_response = self.client.get('/audit-events')
+        assert audit_response.status_code == 200
+        data = json.loads(audit_response.get_data())
 
-            assert len(data['auditEvents']) == 1
+        assert len(data['auditEvents']) == 1
 
-            update_event = data['auditEvents'][0]
-            assert update_event['type'] == 'update_service_admin'
-            assert update_event['user'] == 'joeblogs'
-            assert update_event['data']['serviceId'] == self.service_id
+        update_event = data['auditEvents'][0]
+        assert update_event['type'] == 'update_service_admin'
+        assert update_event['user'] == 'joeblogs'
+        assert update_event['data']['serviceId'] == self.service_id
 
     @mock.patch('app.main.views.services.index_service', autospec=True)
     def test_service_update_audit_event_links_to_both_archived_services(self, index_service):
-        with self.app.app_context():
-            for name in ['new service name', 'new new service name']:
-                index_service.reset_mock()
-                response = self._post_service_update({'serviceName': name})
-                assert response.status_code == 200
-                assert index_service.called is True
+        for name in ['new service name', 'new new service name']:
+            index_service.reset_mock()
+            response = self._post_service_update({'serviceName': name})
+            assert response.status_code == 200
+            assert index_service.called is True
 
-            audit_response = self.client.get('/audit-events')
-            assert audit_response.status_code == 200
-            data = json.loads(audit_response.get_data())
+        audit_response = self.client.get('/audit-events')
+        assert audit_response.status_code == 200
+        data = json.loads(audit_response.get_data())
 
-            assert len(data['auditEvents']) == 2
-            update_event = data['auditEvents'][1]
+        assert len(data['auditEvents']) == 2
+        update_event = data['auditEvents'][1]
 
-            old_version = update_event['links']['oldArchivedService']
-            new_version = update_event['links']['newArchivedService']
+        old_version = update_event['links']['oldArchivedService']
+        new_version = update_event['links']['newArchivedService']
 
-            assert '/archived-services/' in old_version
-            assert '/archived-services/' in new_version
-            assert int(old_version.split('/')[-1]) + 1 == int(new_version.split('/')[-1])
-            assert data['auditEvents'][0]['data']['supplierName'] == 'Supplier 1'
-            assert data['auditEvents'][0]['data']['supplierId'] == 1
+        assert '/archived-services/' in old_version
+        assert '/archived-services/' in new_version
+        assert int(old_version.split('/')[-1]) + 1 == int(new_version.split('/')[-1])
+        assert data['auditEvents'][0]['data']['supplierName'] == 'Supplier 1'
+        assert data['auditEvents'][0]['data']['supplierId'] == 1
 
     @mock.patch('app.main.views.services.index_service', autospec=True)
     def test_can_post_a_valid_service_update_on_several_fields(self, index_service):
-        with self.app.app_context():
-            response = self._post_service_update({
-                'serviceName': 'new service name',
-                'incidentEscalation': False,
-                'serviceTypes': ['Software development tools']}
-            )
-            assert response.status_code == 200
-            assert index_service.called is True
+        response = self._post_service_update({
+            'serviceName': 'new service name',
+            'incidentEscalation': False,
+            'serviceTypes': ['Software development tools']}
+        )
+        assert response.status_code == 200
+        assert index_service.called is True
 
-            response = self.client.get('/services/{}'.format(self.service_id))
-            data = json.loads(response.get_data())
-            assert data['services']['serviceName'] == 'new service name'
-            assert data['services']['incidentEscalation'] is False
-            assert data['services']['serviceTypes'][0] == 'Software development tools'
-            assert response.status_code == 200
+        response = self.client.get('/services/{}'.format(self.service_id))
+        data = json.loads(response.get_data())
+        assert data['services']['serviceName'] == 'new service name'
+        assert data['services']['incidentEscalation'] is False
+        assert data['services']['serviceTypes'][0] == 'Software development tools'
+        assert response.status_code == 200
 
     @mock.patch('app.main.views.services.index_service', autospec=True)
     def test_can_post_a_valid_service_update_with_list(self, index_service):
-        with self.app.app_context():
-            support_types = ['Service desk', 'Email', 'Phone', 'Live chat', 'Onsite']
-            response = self._post_service_update({'supportTypes': support_types})
-            assert response.status_code == 200
-            assert index_service.called is True
+        support_types = ['Service desk', 'Email', 'Phone', 'Live chat', 'Onsite']
+        response = self._post_service_update({'supportTypes': support_types})
+        assert response.status_code == 200
+        assert index_service.called is True
 
-            response = self.client.get('/services/{}'.format(self.service_id))
-            data = json.loads(response.get_data())
+        response = self.client.get('/services/{}'.format(self.service_id))
+        data = json.loads(response.get_data())
 
-            assert all(i in support_types for i in data['services']['supportTypes']) is True
-            assert response.status_code == 200
+        assert all(i in support_types for i in data['services']['supportTypes']) is True
+        assert response.status_code == 200
 
     @mock.patch('app.main.views.services.index_service', autospec=True)
     def test_can_post_a_valid_service_update_with_object(self, index_service):
-        with self.app.app_context():
-            identity_authentication_controls = {
-                "value": ["Authentication federation"],
-                "assurance": "CESG-assured components"
-            }
-            response = self._post_service_update({'identityAuthenticationControls': identity_authentication_controls})
-            assert response.status_code == 200
-            assert index_service.called is True
+        identity_authentication_controls = {
+            "value": ["Authentication federation"],
+            "assurance": "CESG-assured components"
+        }
+        response = self._post_service_update({'identityAuthenticationControls': identity_authentication_controls})
+        assert response.status_code == 200
+        assert index_service.called is True
 
-            response = self.client.get('/services/{}'.format(self.service_id))
-            data = json.loads(response.get_data())
+        response = self.client.get('/services/{}'.format(self.service_id))
+        data = json.loads(response.get_data())
 
-            updated_auth_controls = \
-                data['services']['identityAuthenticationControls']
-            assert response.status_code == 200
-            assert updated_auth_controls['assurance'] == 'CESG-assured components'
-            assert len(updated_auth_controls['value']) == 1
-            assert ('Authentication federation' in updated_auth_controls['value']) is True
+        updated_auth_controls = \
+            data['services']['identityAuthenticationControls']
+        assert response.status_code == 200
+        assert updated_auth_controls['assurance'] == 'CESG-assured components'
+        assert len(updated_auth_controls['value']) == 1
+        assert ('Authentication federation' in updated_auth_controls['value']) is True
 
     @mock.patch('app.main.views.services.index_service', autospec=True)
     def test_invalid_field_not_accepted_on_update(self, index_service):
-        with self.app.app_context():
-            response = self._post_service_update({'thisIsInvalid': 'so I should never see this'})
+        response = self._post_service_update({'thisIsInvalid': 'so I should never see this'})
 
-            assert response.status_code == 400
-            assert 'Additional properties are not allowed' in "{}".format(
-                json.loads(response.get_data())['error']['_form']
-            )
-            assert index_service.called is False
+        assert response.status_code == 400
+        assert 'Additional properties are not allowed' in "{}".format(
+            json.loads(response.get_data())['error']['_form']
+        )
+        assert index_service.called is False
 
     @mock.patch('app.main.views.services.index_service', autospec=True)
     def test_invalid_field_value_not_accepted_on_update(self, index_service):
-        with self.app.app_context():
-            response = self._post_service_update({'priceUnit': 'per Truth'})
+        response = self._post_service_update({'priceUnit': 'per Truth'})
 
-            assert response.status_code == 400
-            assert "no_unit_specified" in json.loads(response.get_data())['error']['priceUnit']
-            assert index_service.called is False
+        assert response.status_code == 400
+        assert "no_unit_specified" in json.loads(response.get_data())['error']['priceUnit']
+        assert index_service.called is False
 
     @mock.patch('app.main.views.services.index_service', autospec=True)
     def test_updated_service_is_archived_right_away(self, index_service):
-        with self.app.app_context():
-            response = self._post_service_update({'serviceName': 'new service name'})
-            assert response.status_code == 200
-            assert index_service.called is True
+        response = self._post_service_update({'serviceName': 'new service name'})
+        assert response.status_code == 200
+        assert index_service.called is True
 
-            archived_state = self.client.get(
-                '/archived-services?service-id=' + self.service_id).get_data()
-            archived_service_json = json.loads(archived_state)['services'][-1]
+        archived_state = self.client.get(
+            '/archived-services?service-id=' + self.service_id).get_data()
+        archived_service_json = json.loads(archived_state)['services'][-1]
 
-            assert archived_service_json['serviceName'] == 'new service name'
+        assert archived_service_json['serviceName'] == 'new service name'
 
     @mock.patch('app.main.views.services.index_service', autospec=True)
     def test_updated_service_archive_is_listed_in_chronological_order(self, index_service):
-        with self.app.app_context():
-            for name in ['new service name', 'new new service name']:
-                response = self._post_service_update({'serviceName': name})
-                assert response.status_code == 200
-                assert index_service.called is True
+        for name in ['new service name', 'new new service name']:
+            response = self._post_service_update({'serviceName': name})
+            assert response.status_code == 200
+            assert index_service.called is True
 
-            archived_state = self.client.get(
-                '/archived-services?service-id=' +
-                self.service_id).get_data()
-            archived_service_json = json.loads(archived_state)['services']
+        archived_state = self.client.get(
+            '/archived-services?service-id=' +
+            self.service_id).get_data()
+        archived_service_json = json.loads(archived_state)['services']
 
-            # initial service creation is done using `setup_dummy_service` in setup(), which skips the archiving process
-            # only the two updates done at the beginning of this test will be archived
-            assert [s['serviceName'] for s in archived_service_json] == ['new service name', 'new new service name']
+        # initial service creation is done using `setup_dummy_service` in setup(), which skips the archiving process
+        # only the two updates done at the beginning of this test will be archived
+        assert [s['serviceName'] for s in archived_service_json] == ['new service name', 'new new service name']
 
     @mock.patch('app.main.views.services.index_service', autospec=True)
     def test_updated_service_should_be_archived_on_each_update(self, index_service):
-        with self.app.app_context():
-            for i in range(5):
-                index_service.reset_mock()
-                response = self._post_service_update({'serviceName': 'new service name' + str(i)})
-                assert response.status_code == 200
-                assert index_service.called is True
+        for i in range(5):
+            index_service.reset_mock()
+            response = self._post_service_update({'serviceName': 'new service name' + str(i)})
+            assert response.status_code == 200
+            assert index_service.called is True
 
-            archived_state = self.client.get(
-                '/archived-services?service-id=' + self.service_id).get_data()
-            assert len(json.loads(archived_state)['services']) == 5
+        archived_state = self.client.get(
+            '/archived-services?service-id=' + self.service_id).get_data()
+        assert len(json.loads(archived_state)['services']) == 5
 
     @mock.patch('app.main.views.services.index_service', autospec=True)
     def test_writing_full_service_back(self, index_service):
-        with self.app.app_context():
-            response = self.client.get('/services/{}'.format(self.service_id))
-            data = json.loads(response.get_data())
-            response = self._post_service_update(data['services'])
+        response = self.client.get('/services/{}'.format(self.service_id))
+        data = json.loads(response.get_data())
+        response = self._post_service_update(data['services'])
 
-            assert response.status_code == 200
-            assert index_service.called is True
+        assert response.status_code == 200
+        assert index_service.called is True
 
     @mock.patch('app.main.views.services.index_service', autospec=True)
     def test_should_404_if_no_archived_service_found_by_pk(self, index_service):
@@ -809,37 +786,34 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin, FixtureMixin):
     def test_json_postgres_field_should_not_include_column_fields(self, index_service):
         non_json_fields = [
             'supplierName', 'links', 'frameworkSlug', 'updatedAt', 'createdAt', 'frameworkName', 'status', 'id']
-        with self.app.app_context():
-            response = self.client.get('/services/{}'.format(self.service_id))
-            data = json.loads(response.get_data())
+        response = self.client.get('/services/{}'.format(self.service_id))
+        data = json.loads(response.get_data())
 
-            response = self._post_service_update(data['services'])
-            assert response.status_code == 200
-            assert index_service.called is True
+        response = self._post_service_update(data['services'])
+        assert response.status_code == 200
+        assert index_service.called is True
 
-            service = Service.query.filter(Service.service_id == self.service_id).first()
+        service = Service.query.filter(Service.service_id == self.service_id).first()
 
-            for key in non_json_fields:
-                assert key not in service.data
+        for key in non_json_fields:
+            assert key not in service.data
 
     @mock.patch('app.service_utils.db.session.commit')
     @mock.patch('app.main.views.services.index_service', autospec=True)
     def test_should_not_index_on_service_post_if_db_exception(self, index_service, db_session_commit):
-        with self.app.app_context():
-            db_session_commit.side_effect = IntegrityError(
-                'message', 'statement', 'params', 'orig')
+        db_session_commit.side_effect = IntegrityError(
+            'message', 'statement', 'params', 'orig')
 
-            self.client.get('/services/{}'.format(self.service_id))
-            assert index_service.called is False
+        self.client.get('/services/{}'.format(self.service_id))
+        assert index_service.called is False
 
     @mock.patch('app.utils.search_api_client')
     def test_should_ignore_index_error(self, search_api_client):
-        with self.app.app_context():
-            search_api_client.index.side_effect = HTTPError()
+        search_api_client.index.side_effect = HTTPError()
 
-            response = self.client.get('/services/{}'.format(self.service_id))
+        response = self.client.get('/services/{}'.format(self.service_id))
 
-            assert response.status_code == 200, response.get_data()
+        assert response.status_code == 200, response.get_data()
 
 
 class TestUpdateServiceStatus(BaseApplicationTest, FixtureMixin):
@@ -849,32 +823,30 @@ class TestUpdateServiceStatus(BaseApplicationTest, FixtureMixin):
 
         valid_statuses = ServiceTableMixin.STATUSES
 
-        with self.app.app_context():
-            db.session.add(
-                Supplier(supplier_id=1, name=u"Supplier 1")
+        db.session.add(
+            Supplier(supplier_id=1, name=u"Supplier 1")
+        )
+
+        for index, status in enumerate(valid_statuses):
+            payload = load_example_listing("G6-SaaS")
+
+            # give each service a different id.
+            new_id = int(payload['id']) + index
+            payload['id'] = "{}".format(new_id)
+
+            self.services[status] = payload.copy()
+
+            self.setup_dummy_service(
+                service_id=self.services[status]['id'],
+                status=status,
+                **payload
             )
 
-            for index, status in enumerate(valid_statuses):
-                payload = load_example_listing("G6-SaaS")
-
-                # give each service a different id.
-                new_id = int(payload['id']) + index
-                payload['id'] = "{}".format(new_id)
-
-                self.services[status] = payload.copy()
-
-                self.setup_dummy_service(
-                    service_id=self.services[status]['id'],
-                    status=status,
-                    **payload
-                )
-
-            assert db.session.query(Service).count() == 3
+        assert db.session.query(Service).count() == 3
 
     def _get_service_from_database_by_service_id(self, service_id):
-        with self.app.app_context():
-            return Service.query.filter(
-                Service.service_id == service_id).first()
+        return Service.query.filter(
+            Service.service_id == service_id).first()
 
     def _post_update_status(self, old_status, new_status,
                             service_is_indexed, service_is_deleted,
@@ -882,40 +854,39 @@ class TestUpdateServiceStatus(BaseApplicationTest, FixtureMixin):
 
         with mock.patch('app.service_utils.index_object') as index_object:
             with mock.patch('app.service_utils.search_api_client') as service_utils_search_api_client:
-                with self.app.app_context():
-                    response = self.client.post(
-                        '/services/{0}/status/{1}'.format(
-                            self.services[old_status]['id'],
-                            new_status
-                        ),
-                        data=json.dumps(
-                            {'updated_by': 'joeblogs'}),
-                        content_type='application/json'
-                    )
+                response = self.client.post(
+                    '/services/{0}/status/{1}'.format(
+                        self.services[old_status]['id'],
+                        new_status
+                    ),
+                    data=json.dumps(
+                        {'updated_by': 'joeblogs'}),
+                    content_type='application/json'
+                )
 
-                    # Check response after posting an update
-                    assert response.status_code == expected_status_code
+                # Check response after posting an update
+                assert response.status_code == expected_status_code
 
-                    # Exit function if update was not successful
-                    if expected_status_code != 200:
-                        return
+                # Exit function if update was not successful
+                if expected_status_code != 200:
+                    return
 
-                    service = self._get_service_from_database_by_service_id(
-                        self.services[old_status]['id'])
+                service = self._get_service_from_database_by_service_id(
+                    self.services[old_status]['id'])
 
-                    # Check that service in database has been updated
-                    assert new_status == service.status
-                    # Check that search_api_client is doing the right thing
-                    if service_is_indexed:
-                        assert index_object.called is True
-                    else:
-                        assert index_object.called is False
+                # Check that service in database has been updated
+                assert new_status == service.status
+                # Check that search_api_client is doing the right thing
+                if service_is_indexed:
+                    assert index_object.called is True
+                else:
+                    assert index_object.called is False
 
-                    if service_is_deleted:
-                        service_utils_search_api_client.delete.assert_called_with(index=service.framework.slug,
-                                                                                  service_id=service.service_id)
-                    else:
-                        assert not service_utils_search_api_client.delete.called
+                if service_is_deleted:
+                    service_utils_search_api_client.delete.assert_called_with(index=service.framework.slug,
+                                                                              service_id=service.service_id)
+                else:
+                    assert not service_utils_search_api_client.delete.called
 
     def test_should_index_on_service_status_changed_to_published(self):
 
@@ -999,53 +970,50 @@ class TestPutService(BaseApplicationTest, JSONUpdateTestMixin, FixtureMixin):
         super(TestPutService, self).setup()
         self.service = load_example_listing("G6-SaaS")
         self.service_id = self.service['id']
-        with self.app.app_context():
-            # need a supplier_id of '1' because our service has it hardcoded
-            self.setup_dummy_suppliers(2)
-            db.session.commit()
+        # need a supplier_id of '1' because our service has it hardcoded
+        self.setup_dummy_suppliers(2)
+        db.session.commit()
 
     @mock.patch('app.service_utils.index_object', autospec=True)
     def test_should_update_service_with_valid_statuses(self, index_object):
         valid_statuses = ServiceTableMixin.STATUSES
 
-        with self.app.app_context():
-            self.setup_dummy_service(
-                service_id=self.service_id,
-                **self.service
+        self.setup_dummy_service(
+            service_id=self.service_id,
+            **self.service
+        )
+        for status in valid_statuses:
+            response = self.client.post(
+                '/services/{0}/status/{1}'.format(
+                    self.service_id,
+                    status
+                ),
+                data=json.dumps(
+                    {'updated_by': 'joeblogs'}),
+                content_type='application/json'
             )
-            for status in valid_statuses:
-                response = self.client.post(
-                    '/services/{0}/status/{1}'.format(
-                        self.service_id,
-                        status
-                    ),
-                    data=json.dumps(
-                        {'updated_by': 'joeblogs'}),
-                    content_type='application/json'
+            service = Service.query.filter(
+                Service.service_id == self.service_id
+            ).one()
+            assert response.status_code == 200
+            data = json.loads(response.get_data())
+            assert status == data['services']['status']
+            if status in ('disabled', 'enabled'):
+                assert index_object.called is False
+            else:
+                index_object.assert_called_once_with(
+                    doc_type='services',
+                    framework=service.framework.slug,
+                    object_id=service.service_id,
+                    serialized_object=service.serialize()
                 )
-                service = Service.query.filter(
-                    Service.service_id == self.service_id
-                ).one()
-                assert response.status_code == 200
-                data = json.loads(response.get_data())
-                assert status == data['services']['status']
-                if status in ('disabled', 'enabled'):
-                    assert index_object.called is False
-                else:
-                    index_object.assert_called_once_with(
-                        doc_type='services',
-                        framework=service.framework.slug,
-                        object_id=service.service_id,
-                        serialized_object=service.serialize()
-                    )
 
     @mock.patch('app.main.views.services.index_service', autospec=True)
     def test_update_service_status_creates_audit_event(self, index_service):
-        with self.app.app_context():
-            self.setup_dummy_service(
-                service_id=self.service_id,
-                **self.service
-            )
+        self.setup_dummy_service(
+            service_id=self.service_id,
+            **self.service
+        )
         response = self.client.post(
             '/services/{0}/status/{1}'.format(
                 self.service_id,
@@ -1080,11 +1048,10 @@ class TestPutService(BaseApplicationTest, JSONUpdateTestMixin, FixtureMixin):
 
     @mock.patch('app.main.views.services.index_service', autospec=True)
     def test_should_400_with_invalid_statuses(self, index_service):
-        with self.app.app_context():
-            self.setup_dummy_service(
-                service_id=self.service_id,
-                **self.service
-            )
+        self.setup_dummy_service(
+            service_id=self.service_id,
+            **self.service
+        )
         invalid_statuses = [
             "unpublished",  # not a permissible state
             "enabeld",  # typo
@@ -1126,130 +1093,125 @@ class TestPutService(BaseApplicationTest, JSONUpdateTestMixin, FixtureMixin):
         non_json_fields = [
             'supplierName', 'links', 'frameworkSlug', 'updatedAt', 'createdAt', 'frameworkName', 'status', 'id',
             'supplierId', 'updatedAt', 'createdAt']
-        with self.app.app_context():
-            response = self.client.put(
-                '/services/{}'.format(self.service_id),
-                data=json.dumps({
-                    'updated_by': 'joeblogs',
-                    'services': self.service,
-                }),
-                content_type='application/json')
+        response = self.client.put(
+            '/services/{}'.format(self.service_id),
+            data=json.dumps({
+                'updated_by': 'joeblogs',
+                'services': self.service,
+            }),
+            content_type='application/json')
 
-            assert response.status_code == 201
+        assert response.status_code == 201
 
-            service = Service.query.filter(Service.service_id == self.service_id).first()
-            for key in non_json_fields:
-                assert key not in service.data
+        service = Service.query.filter(Service.service_id == self.service_id).first()
+        for key in non_json_fields:
+            assert key not in service.data
 
     @mock.patch('app.search_api_client')
     def test_add_a_new_service(self, search_api_client):
-        with self.app.app_context():
-            search_api_client.index.return_value = "bar"
+        search_api_client.index.return_value = "bar"
 
-            response = self.client.put(
-                '/services/{}'.format(self.service_id),
-                data=json.dumps({
-                    'updated_by': 'joeblogs',
-                    'services': self.service
-                }),
-                content_type='application/json')
+        response = self.client.put(
+            '/services/{}'.format(self.service_id),
+            data=json.dumps({
+                'updated_by': 'joeblogs',
+                'services': self.service
+            }),
+            content_type='application/json')
 
-            assert response.status_code == 201
-            now = datetime.utcnow()
+        assert response.status_code == 201
+        now = datetime.utcnow()
 
-            response = self.client.get("/services/{}".format(self.service_id))
-            service = json.loads(response.get_data())["services"]
+        response = self.client.get("/services/{}".format(self.service_id))
+        service = json.loads(response.get_data())["services"]
 
-            assert service["id"] == self.service_id
-            assert service["supplierId"] == self.service['supplierId']
-            assert (
-                datetime.strptime(service["createdAt"], DATETIME_FORMAT).strftime("%Y-%m-%dT%H:%M:%SZ") ==
-                self.service['createdAt'])
-            assert abs(datetime.strptime(service["updatedAt"], DATETIME_FORMAT) - now) <= timedelta(seconds=2)
+        assert service["id"] == self.service_id
+        assert service["supplierId"] == self.service['supplierId']
+        assert (
+            datetime.strptime(service["createdAt"], DATETIME_FORMAT).strftime("%Y-%m-%dT%H:%M:%SZ") ==
+            self.service['createdAt'])
+        assert abs(datetime.strptime(service["updatedAt"], DATETIME_FORMAT) - now) <= timedelta(seconds=2)
 
     @mock.patch('app.search_api_client')
     def test_whitespace_is_stripped_on_import(self, search_api_client):
-        with self.app.app_context():
-            search_api_client.index.return_value = "bar"
-            self.service['serviceSummary'] = "    A new summary with   space    "
-            self.service['serviceFeatures'] = [
-                "    ",
-                "    A feature   with space    ",
-                "",
-                "    A second feature with space   "
-            ]
+        search_api_client.index.return_value = "bar"
+        self.service['serviceSummary'] = "    A new summary with   space    "
+        self.service['serviceFeatures'] = [
+            "    ",
+            "    A feature   with space    ",
+            "",
+            "    A second feature with space   "
+        ]
 
-            response = self.client.put(
-                '/services/{}'.format(self.service_id),
-                data=json.dumps(
-                    {
-                        'updated_by': 'joeblogs',
-                        'services': self.service}
-                ),
-                content_type='application/json')
+        response = self.client.put(
+            '/services/{}'.format(self.service_id),
+            data=json.dumps(
+                {
+                    'updated_by': 'joeblogs',
+                    'services': self.service}
+            ),
+            content_type='application/json')
 
-            assert response.status_code == 201, response.get_data()
+        assert response.status_code == 201, response.get_data()
 
-            response = self.client.get("/services/{}".format(self.service_id))
-            service = json.loads(response.get_data())["services"]
+        response = self.client.get("/services/{}".format(self.service_id))
+        service = json.loads(response.get_data())["services"]
 
-            assert service["serviceSummary"] == "A new summary with   space"
-            assert len(service["serviceFeatures"]) == 2
-            assert service["serviceFeatures"][0] == "A feature   with space"
-            assert service["serviceFeatures"][1] == "A second feature with space"
+        assert service["serviceSummary"] == "A new summary with   space"
+        assert len(service["serviceFeatures"]) == 2
+        assert service["serviceFeatures"][0] == "A feature   with space"
+        assert service["serviceFeatures"][1] == "A second feature with space"
 
     @mock.patch('app.search_api_client')
     def test_add_a_new_service_creates_audit_event(self, search_api_client):
-        with self.app.app_context():
-            response = self.client.put(
-                '/services/{}'.format(self.service_id),
-                data=json.dumps(
-                    {
-                        'updated_by': 'joeblogs',
-                        'services': self.service}
-                ),
-                content_type='application/json')
+        response = self.client.put(
+            '/services/{}'.format(self.service_id),
+            data=json.dumps(
+                {
+                    'updated_by': 'joeblogs',
+                    'services': self.service}
+            ),
+            content_type='application/json')
 
-            assert response.status_code == 201
+        assert response.status_code == 201
 
-            audit_response = self.client.get('/audit-events')
-            assert audit_response.status_code == 200
-            data = json.loads(audit_response.get_data())
+        audit_response = self.client.get('/audit-events')
+        assert audit_response.status_code == 200
+        data = json.loads(audit_response.get_data())
 
-            assert len(data['auditEvents']) == 1
-            assert data['auditEvents'][0]['type'] == 'import_service'
-            assert data['auditEvents'][0]['user'] == 'joeblogs'
-            assert data['auditEvents'][0]['data']['serviceId'] == self.service_id
-            assert data['auditEvents'][0]['data']['supplierName'] == "Supplier 1"
-            assert data['auditEvents'][0]['data']['supplierId'] == self.service["supplierId"]
-            assert data['auditEvents'][0]['data']['oldArchivedServiceId'] is None
-            assert 'old_archived_service' not in data['auditEvents'][0]['links']
-            assert isinstance(data['auditEvents'][0]['data']['newArchivedServiceId'], int)
-            assert 'newArchivedService' in data['auditEvents'][0]['links']
+        assert len(data['auditEvents']) == 1
+        assert data['auditEvents'][0]['type'] == 'import_service'
+        assert data['auditEvents'][0]['user'] == 'joeblogs'
+        assert data['auditEvents'][0]['data']['serviceId'] == self.service_id
+        assert data['auditEvents'][0]['data']['supplierName'] == "Supplier 1"
+        assert data['auditEvents'][0]['data']['supplierId'] == self.service["supplierId"]
+        assert data['auditEvents'][0]['data']['oldArchivedServiceId'] is None
+        assert 'old_archived_service' not in data['auditEvents'][0]['links']
+        assert isinstance(data['auditEvents'][0]['data']['newArchivedServiceId'], int)
+        assert 'newArchivedService' in data['auditEvents'][0]['links']
 
     def test_add_a_new_service_with_status_disabled(self):
-        with self.app.app_context():
-            payload = load_example_listing("G4")
-            payload['id'] = "4-disabled"
-            payload['status'] = "disabled"
-            response = self.client.put(
-                '/services/4-disabled',
-                data=json.dumps({
-                    'updated_by': 'joeblogs',
-                    'services': payload
-                }),
-                content_type='application/json')
+        payload = load_example_listing("G4")
+        payload['id'] = "4-disabled"
+        payload['status'] = "disabled"
+        response = self.client.put(
+            '/services/4-disabled',
+            data=json.dumps({
+                'updated_by': 'joeblogs',
+                'services': payload
+            }),
+            content_type='application/json')
 
-            for field in ['id', 'lot', 'supplierId', 'status']:
-                payload.pop(field, None)
-            assert response.status_code == 201, response.get_data()
-            now = datetime.utcnow()
-            service = Service.query.filter(Service.service_id == "4-disabled").first()
-            assert service.status == 'disabled'
-            for key in service.data:
-                assert service.data[key] == payload[key]
-            assert abs(service.created_at - service.updated_at) <= timedelta(seconds=0.5)
-            assert abs(now - service.created_at) <= timedelta(seconds=2)
+        for field in ['id', 'lot', 'supplierId', 'status']:
+            payload.pop(field, None)
+        assert response.status_code == 201, response.get_data()
+        now = datetime.utcnow()
+        service = Service.query.filter(Service.service_id == "4-disabled").first()
+        assert service.status == 'disabled'
+        for key in service.data:
+            assert service.data[key] == payload[key]
+        assert abs(service.created_at - service.updated_at) <= timedelta(seconds=0.5)
+        assert abs(now - service.created_at) <= timedelta(seconds=2)
 
     def test_when_service_payload_has_mismatched_id(self):
         mismatched_id = int(self.service_id) * 2
@@ -1331,170 +1293,164 @@ class TestPutService(BaseApplicationTest, JSONUpdateTestMixin, FixtureMixin):
         assert "23.45 is not of type" in json.loads(response.get_data())['error']['priceMin']
 
     def test_add_a_service_with_unknown_supplier_id(self):
-        with self.app.app_context():
-            self.service['supplierId'] = 100
-            response = self.client.put(
-                '/services/{}'.format(self.service_id),
-                data=json.dumps({
-                    'updated_by': 'joeblogs',
-                    'services': self.service
-                }),
-                content_type='application/json')
+        self.service['supplierId'] = 100
+        response = self.client.put(
+            '/services/{}'.format(self.service_id),
+            data=json.dumps({
+                'updated_by': 'joeblogs',
+                'services': self.service
+            }),
+            content_type='application/json')
 
-            assert response.status_code == 400
-            assert "Invalid supplier ID '100'" in json.loads(response.get_data())['error']
+        assert response.status_code == 400
+        assert "Invalid supplier ID '100'" in json.loads(response.get_data())['error']
 
     def test_supplier_name_in_service_data_is_shadowed(self):
-        with self.app.app_context():
-            self.service['supplierId'] = 1
-            self.service['supplierName'] = u'New Name'
+        self.service['supplierId'] = 1
+        self.service['supplierName'] = u'New Name'
 
-            response = self.client.put(
-                '/services/{}'.format(self.service_id),
-                data=json.dumps({
-                    'updated_by': 'joeblogs',
-                    'services': self.service
-                }),
-                content_type='application/json')
+        response = self.client.put(
+            '/services/{}'.format(self.service_id),
+            data=json.dumps({
+                'updated_by': 'joeblogs',
+                'services': self.service
+            }),
+            content_type='application/json')
 
-            assert response.status_code == 201
+        assert response.status_code == 201
 
-            response = self.client.get('/services/{}'.format(self.service_id))
-            data = json.loads(response.get_data())
+        response = self.client.get('/services/{}'.format(self.service_id))
+        data = json.loads(response.get_data())
 
-            assert response.status_code == 200
-            assert data['services']['supplierName'] == u'Supplier 1'
+        assert response.status_code == 200
+        assert data['services']['supplierName'] == u'Supplier 1'
 
     @mock.patch('app.search_api_client')
     def test_cannot_update_existing_service_by_put(self, search_api_client):
-        with self.app.app_context():
-            search_api_client.return_value = "bar"
-            self.client.put(
-                '/services/{}'.format(self.service_id),
-                data=json.dumps({
-                    'updated_by': 'joeblogs',
-                    'services': self.service
-                }),
-                content_type='application/json')
+        search_api_client.return_value = "bar"
+        self.client.put(
+            '/services/{}'.format(self.service_id),
+            data=json.dumps({
+                'updated_by': 'joeblogs',
+                'services': self.service
+            }),
+            content_type='application/json')
 
-            response = self.client.get("/services/{}".format(self.service_id))
-            new_service_id = json.loads(response.get_data())["services"]["id"]
+        response = self.client.get("/services/{}".format(self.service_id))
+        new_service_id = json.loads(response.get_data())["services"]["id"]
 
-            response = self.client.put(
-                '/services/{}'.format(new_service_id),
-                data=json.dumps({
-                    'updated_by': 'joeblogs',
-                    'services': self.service
-                }),
-                content_type='application/json')
-            assert response.status_code == 400
-            assert json.loads(response.get_data())["error"] == "Cannot update service by PUT"
+        response = self.client.put(
+            '/services/{}'.format(new_service_id),
+            data=json.dumps({
+                'updated_by': 'joeblogs',
+                'services': self.service
+            }),
+            content_type='application/json')
+        assert response.status_code == 400
+        assert json.loads(response.get_data())["error"] == "Cannot update service by PUT"
 
     @mock.patch('app.service_utils.index_object', autospec=True)
     def test_should_index_on_service_put(self, index_object):
-        with self.app.app_context():
-            payload = load_example_listing("G6-IaaS")
-            payload['id'] = "1234567890123456"
-            self.client.put(
-                '/services/1234567890123456',
-                data=json.dumps(
-                    {
-                        'updated_by': 'joeblogs',
-                        'services': payload}
-                ),
-                content_type='application/json')
+        payload = load_example_listing("G6-IaaS")
+        payload['id'] = "1234567890123456"
+        self.client.put(
+            '/services/1234567890123456',
+            data=json.dumps(
+                {
+                    'updated_by': 'joeblogs',
+                    'services': payload}
+            ),
+            content_type='application/json')
 
-            service = Service.query.filter(
-                Service.service_id == '1234567890123456'
-            ).one()
+        service = Service.query.filter(
+            Service.service_id == '1234567890123456'
+        ).one()
 
-            index_object.assert_called_once_with(
-                doc_type='services',
-                framework=service.framework.slug,
-                object_id=service.service_id,
-                serialized_object=service.serialize()
-            )
+        index_object.assert_called_once_with(
+            doc_type='services',
+            framework=service.framework.slug,
+            object_id=service.service_id,
+            serialized_object=service.serialize()
+        )
 
     @mock.patch('app.utils.search_api_client')
     def test_should_ignore_index_error_on_service_put(self, search_api_client):
-        with self.app.app_context():
-            search_api_client.index.side_effect = HTTPError()
+        search_api_client.index.side_effect = HTTPError()
 
-            payload = load_example_listing("G6-IaaS")
-            payload['id'] = "1234567890123456"
-            response = self.client.put(
-                '/services/1234567890123456',
-                data=json.dumps(
-                    {
-                        'updated_by': 'joeblogs',
-                        'services': payload}
-                ),
-                content_type='application/json')
+        payload = load_example_listing("G6-IaaS")
+        payload['id'] = "1234567890123456"
+        response = self.client.put(
+            '/services/1234567890123456',
+            data=json.dumps(
+                {
+                    'updated_by': 'joeblogs',
+                    'services': payload}
+            ),
+            content_type='application/json')
 
-            assert response.status_code == 201
+        assert response.status_code == 201
 
 
 class TestGetService(BaseApplicationTest):
     def setup(self):
         super(TestGetService, self).setup()
         now = datetime.utcnow()
-        with self.app.app_context():
-            db.session.add(Framework(
-                id=123,
-                name="expired",
-                slug="expired",
-                framework="g-cloud",
-                status="expired",
-            ))
-            db.session.commit()
-            db.session.add(FrameworkLot(
-                framework_id=123,
-                lot_id=1
-            ))
-            db.session.add(
-                Supplier(supplier_id=1, name=u"Supplier 1")
+        db.session.add(Framework(
+            id=123,
+            name="expired",
+            slug="expired",
+            framework="g-cloud",
+            status="expired",
+        ))
+        db.session.commit()
+        db.session.add(FrameworkLot(
+            framework_id=123,
+            lot_id=1
+        ))
+        db.session.add(
+            Supplier(supplier_id=1, name=u"Supplier 1")
+        )
+        db.session.add(
+            ContactInformation(
+                supplier_id=1,
+                contact_name=u"Liz",
+                email=u"liz@royal.gov.uk",
+                postcode=u"SW1A 1AA"
             )
-            db.session.add(
-                ContactInformation(
-                    supplier_id=1,
-                    contact_name=u"Liz",
-                    email=u"liz@royal.gov.uk",
-                    postcode=u"SW1A 1AA"
-                )
-            )
-            db.session.add(Service(service_id="123-published-456",
-                                   supplier_id=1,
-                                   updated_at=now,
-                                   created_at=now,
-                                   status='published',
-                                   data={'foo': 'bar'},
-                                   lot_id=1,
-                                   framework_id=1))
-            db.session.add(Service(service_id="123-disabled-456",
-                                   supplier_id=1,
-                                   updated_at=now,
-                                   created_at=now,
-                                   status='disabled',
-                                   data={'foo': 'bar'},
-                                   lot_id=1,
-                                   framework_id=1))
-            db.session.add(Service(service_id="123-enabled-456",
-                                   supplier_id=1,
-                                   updated_at=now,
-                                   created_at=now,
-                                   status='enabled',
-                                   data={'foo': 'bar'},
-                                   lot_id=1,
-                                   framework_id=1))
-            db.session.add(Service(service_id="123-expired-456",
-                                   supplier_id=1,
-                                   updated_at=now,
-                                   created_at=now,
-                                   status='enabled',
-                                   data={'foo': 'bar'},
-                                   lot_id=1,
-                                   framework_id=123))
-            db.session.commit()
+        )
+        db.session.add(Service(service_id="123-published-456",
+                               supplier_id=1,
+                               updated_at=now,
+                               created_at=now,
+                               status='published',
+                               data={'foo': 'bar'},
+                               lot_id=1,
+                               framework_id=1))
+        db.session.add(Service(service_id="123-disabled-456",
+                               supplier_id=1,
+                               updated_at=now,
+                               created_at=now,
+                               status='disabled',
+                               data={'foo': 'bar'},
+                               lot_id=1,
+                               framework_id=1))
+        db.session.add(Service(service_id="123-enabled-456",
+                               supplier_id=1,
+                               updated_at=now,
+                               created_at=now,
+                               status='enabled',
+                               data={'foo': 'bar'},
+                               lot_id=1,
+                               framework_id=1))
+        db.session.add(Service(service_id="123-expired-456",
+                               supplier_id=1,
+                               updated_at=now,
+                               created_at=now,
+                               status='enabled',
+                               data={'foo': 'bar'},
+                               lot_id=1,
+                               framework_id=123))
+        db.session.commit()
 
     def test_get_non_existent_service(self):
         response = self.client.get('/services/9999999999')
@@ -1548,52 +1504,50 @@ class TestGetService(BaseApplicationTest):
 
     def test_get_service_returns_empty_unavailability_audit_if_published(self):
         # create an audit event for the disabled service
-        with self.app.app_context():
-            service = Service.query.filter(
-                Service.service_id == '123-published-456'
-            ).first()
-            audit_event = AuditEvent(
-                audit_type=AuditTypes.update_service_status,
-                db_object=service,
-                user='joeblogs',
-                data={
-                    "supplierId": 1,
-                    "newArchivedServiceId": 2,
-                    "new_status": "published",
-                    "supplierName": "Supplier 1",
-                    "serviceId": "123-published-456",
-                    "old_status": "disabled",
-                    "oldArchivedServiceId": 1
-                }
-            )
-            db.session.add(audit_event)
-            db.session.commit()
+        service = Service.query.filter(
+            Service.service_id == '123-published-456'
+        ).first()
+        audit_event = AuditEvent(
+            audit_type=AuditTypes.update_service_status,
+            db_object=service,
+            user='joeblogs',
+            data={
+                "supplierId": 1,
+                "newArchivedServiceId": 2,
+                "new_status": "published",
+                "supplierName": "Supplier 1",
+                "serviceId": "123-published-456",
+                "old_status": "disabled",
+                "oldArchivedServiceId": 1
+            }
+        )
+        db.session.add(audit_event)
+        db.session.commit()
         response = self.client.get('/services/123-disabled-456')
         data = json.loads(response.get_data())
         assert data['serviceMadeUnavailableAuditEvent'] is None
 
     def test_get_service_returns_unavailability_audit_if_disabled(self):
         # create an audit event for the disabled service
-        with self.app.app_context():
-            service = Service.query.filter(
-                Service.service_id == '123-disabled-456'
-            ).first()
-            audit_event = AuditEvent(
-                audit_type=AuditTypes.update_service_status,
-                db_object=service,
-                user='joeblogs',
-                data={
-                    "supplierId": 1,
-                    "newArchivedServiceId": 2,
-                    "new_status": "disabled",
-                    "supplierName": "Supplier 1",
-                    "serviceId": "123-disabled-456",
-                    "old_status": "published",
-                    "oldArchivedServiceId": 1
-                }
-            )
-            db.session.add(audit_event)
-            db.session.commit()
+        service = Service.query.filter(
+            Service.service_id == '123-disabled-456'
+        ).first()
+        audit_event = AuditEvent(
+            audit_type=AuditTypes.update_service_status,
+            db_object=service,
+            user='joeblogs',
+            data={
+                "supplierId": 1,
+                "newArchivedServiceId": 2,
+                "new_status": "disabled",
+                "supplierName": "Supplier 1",
+                "serviceId": "123-disabled-456",
+                "old_status": "published",
+                "oldArchivedServiceId": 1
+            }
+        )
+        db.session.add(audit_event)
+        db.session.commit()
         response = self.client.get('/services/123-disabled-456')
         data = json.loads(response.get_data())
         assert data['serviceMadeUnavailableAuditEvent']['type'] == 'update_service_status'
@@ -1605,31 +1559,30 @@ class TestGetService(BaseApplicationTest):
 
     def test_get_service_returns_unavailability_audit_if_published_but_framework_is_expired(self):
         # create an audit event for the disabled service
-        with self.app.app_context():
-            # get expired framework
-            framework = Framework.query.filter(
-                Framework.id == 123
-            ).first()
-            # create an audit event for the framework status change
-            audit_event = AuditEvent(
-                audit_type=AuditTypes.framework_update,
-                db_object=framework,
-                user='joeblogs',
-                data={
-                    "update": {
-                        "status": "expired",
-                        "clarificationQuestionsOpen": "true"
-                    }
+        # get expired framework
+        framework = Framework.query.filter(
+            Framework.id == 123
+        ).first()
+        # create an audit event for the framework status change
+        audit_event = AuditEvent(
+            audit_type=AuditTypes.framework_update,
+            db_object=framework,
+            user='joeblogs',
+            data={
+                "update": {
+                    "status": "expired",
+                    "clarificationQuestionsOpen": "true"
                 }
-            )
-            # make a published service use the expired framework
-            Service.query.filter(
-                Service.service_id == '123-published-456'
-            ).update({
-                'framework_id': 123
-            })
-            db.session.add(audit_event)
-            db.session.commit()
+            }
+        )
+        # make a published service use the expired framework
+        Service.query.filter(
+            Service.service_id == '123-published-456'
+        ).update({
+            'framework_id': 123
+        })
+        db.session.add(audit_event)
+        db.session.commit()
         response = self.client.get('/services/123-published-456')
         data = json.loads(response.get_data())
         assert data['serviceMadeUnavailableAuditEvent']['type'] == 'framework_update'
@@ -1639,31 +1592,30 @@ class TestGetService(BaseApplicationTest):
 
     def test_get_service_returns_correct_unavailability_audit_if_disabled_but_framework_is_expired(self):
         # create an audit event for the disabled service
-        with self.app.app_context():
-            # get expired framework
-            framework = Framework.query.filter(
-                Framework.id == 123
-            ).first()
-            # create an audit event for the framework status change
-            audit_event = AuditEvent(
-                audit_type=AuditTypes.framework_update,
-                db_object=framework,
-                user='joeblogs',
-                data={
-                    "update": {
-                        "status": "expired",
-                        "clarificationQuestionsOpen": "true"
-                    }
+        # get expired framework
+        framework = Framework.query.filter(
+            Framework.id == 123
+        ).first()
+        # create an audit event for the framework status change
+        audit_event = AuditEvent(
+            audit_type=AuditTypes.framework_update,
+            db_object=framework,
+            user='joeblogs',
+            data={
+                "update": {
+                    "status": "expired",
+                    "clarificationQuestionsOpen": "true"
                 }
-            )
-            # make a disabled service use the expired framework
-            Service.query.filter(
-                Service.service_id == '123-disabled-456'
-            ).update({
-                'framework_id': 123
-            })
-            db.session.add(audit_event)
-            db.session.commit()
+            }
+        )
+        # make a disabled service use the expired framework
+        Service.query.filter(
+            Service.service_id == '123-disabled-456'
+        ).update({
+            'framework_id': 123
+        })
+        db.session.add(audit_event)
+        db.session.commit()
         response = self.client.get('/services/123-disabled-456')
         data = json.loads(response.get_data())
         assert data['serviceMadeUnavailableAuditEvent']['type'] == 'framework_update'
@@ -1676,38 +1628,37 @@ class TestRevertServiceBase(BaseApplicationTest, FixtureMixin):
 
     def setup(self):
         super(TestRevertServiceBase, self).setup()
-        with self.app.app_context():
-            self.set_framework_status("g-cloud-7", "live")
-            self.supplier_ids = self.setup_dummy_suppliers(2)
-            g7_scs = load_example_listing("G7-SCS")
-            g7_scs.update({
-                "framework_id": db.session.query(Framework.id).filter(Framework.slug == "g-cloud-7").scalar(),
-                "lot_id": db.session.query(Lot.id).filter(Lot.slug == "scs").scalar(),
-            })
-            self.raw_service_ids = (
-                self.setup_dummy_service("1234123412340001", **dict(g7_scs, serviceName=g7_scs["serviceName"] + " 1")),
-                self.setup_dummy_service("1234123412340002", **dict(g7_scs, serviceName=g7_scs["serviceName"] + " 2")),
-                self.setup_dummy_service("1234123412340003", **dict(g7_scs, serviceName=g7_scs["serviceName"] + " 3")),
-            )
+        self.set_framework_status("g-cloud-7", "live")
+        self.supplier_ids = self.setup_dummy_suppliers(2)
+        g7_scs = load_example_listing("G7-SCS")
+        g7_scs.update({
+            "framework_id": db.session.query(Framework.id).filter(Framework.slug == "g-cloud-7").scalar(),
+            "lot_id": db.session.query(Lot.id).filter(Lot.slug == "scs").scalar(),
+        })
+        self.raw_service_ids = (
+            self.setup_dummy_service("1234123412340001", **dict(g7_scs, serviceName=g7_scs["serviceName"] + " 1")),
+            self.setup_dummy_service("1234123412340002", **dict(g7_scs, serviceName=g7_scs["serviceName"] + " 2")),
+            self.setup_dummy_service("1234123412340003", **dict(g7_scs, serviceName=g7_scs["serviceName"] + " 3")),
+        )
 
-            self.archived_service_ids = (
-                self.setup_dummy_service("1234123412340001", model=ArchivedService, **dict(
-                    g7_scs,
-                    serviceSummary="Definitely the best",
-                )),
-                self.setup_dummy_service("1234123412340001", model=ArchivedService, **dict(
-                    g7_scs,
-                    serviceSummary="Assuredly the best",
-                )),
-                self.setup_dummy_service("1234123412340001", model=ArchivedService, **dict(
-                    g7_scs,
-                    serviceSummary=None,
-                )),
-                self.setup_dummy_service("1234123412340002", model=ArchivedService, **dict(
-                    g7_scs,
-                    serviceSummary="Not the best",
-                )),
-            )
+        self.archived_service_ids = (
+            self.setup_dummy_service("1234123412340001", model=ArchivedService, **dict(
+                g7_scs,
+                serviceSummary="Definitely the best",
+            )),
+            self.setup_dummy_service("1234123412340001", model=ArchivedService, **dict(
+                g7_scs,
+                serviceSummary="Assuredly the best",
+            )),
+            self.setup_dummy_service("1234123412340001", model=ArchivedService, **dict(
+                g7_scs,
+                serviceSummary=None,
+            )),
+            self.setup_dummy_service("1234123412340002", model=ArchivedService, **dict(
+                g7_scs,
+                serviceSummary="Not the best",
+            )),
+        )
 
 
 @mock.patch('app.main.views.services.index_service', autospec=True)
@@ -1721,10 +1672,9 @@ class TestRevertService(TestRevertServiceBase):
         )
         assert response.status_code == 404
 
-        with self.app.app_context():
-            assert not AuditEvent.query.filter(AuditEvent.type == AuditTypes.update_service.name).all()
-            assert ArchivedService.query.count() == 4
-            assert index_service.called is False
+        assert not AuditEvent.query.filter(AuditEvent.type == AuditTypes.update_service.name).all()
+        assert ArchivedService.query.count() == 4
+        assert index_service.called is False
 
     def test_archived_service_mismatch(self, index_service):
         response = self.client.post(
@@ -1735,13 +1685,12 @@ class TestRevertService(TestRevertServiceBase):
         assert response.status_code == 400
         assert "correspond" in json.loads(response.get_data())['error']
 
-        with self.app.app_context():
-            assert not AuditEvent.query.filter(AuditEvent.type == AuditTypes.update_service.name).all()
-            assert Service.query.filter(
-                Service.service_id == "1234123412340001"
-            ).one().data["serviceSummary"] == "Probably the best cloud service in the world"
-            assert ArchivedService.query.count() == 4
-            assert index_service.called is False
+        assert not AuditEvent.query.filter(AuditEvent.type == AuditTypes.update_service.name).all()
+        assert Service.query.filter(
+            Service.service_id == "1234123412340001"
+        ).one().data["serviceSummary"] == "Probably the best cloud service in the world"
+        assert ArchivedService.query.count() == 4
+        assert index_service.called is False
 
     def test_non_existent_archived_service(self, index_service):
         response = self.client.post(
@@ -1752,13 +1701,12 @@ class TestRevertService(TestRevertServiceBase):
         assert response.status_code == 400
         assert "ArchivedService" in json.loads(response.get_data())['error']
 
-        with self.app.app_context():
-            assert not AuditEvent.query.filter(AuditEvent.type == AuditTypes.update_service.name).all()
-            assert Service.query.filter(
-                Service.service_id == "1234123412340001"
-            ).one().data["serviceSummary"] == "Probably the best cloud service in the world"
-            assert ArchivedService.query.count() == 4
-            assert index_service.called is False
+        assert not AuditEvent.query.filter(AuditEvent.type == AuditTypes.update_service.name).all()
+        assert Service.query.filter(
+            Service.service_id == "1234123412340001"
+        ).one().data["serviceSummary"] == "Probably the best cloud service in the world"
+        assert ArchivedService.query.count() == 4
+        assert index_service.called is False
 
     def test_archived_service_doesnt_validate(self, index_service):
         response = self.client.post(
@@ -1769,41 +1717,39 @@ class TestRevertService(TestRevertServiceBase):
         assert response.status_code == 400
         assert json.loads(response.get_data())['error'] == {'serviceSummary': 'answer_required'}
 
-        with self.app.app_context():
-            assert not AuditEvent.query.filter(AuditEvent.type == AuditTypes.update_service.name).all()
-            assert Service.query.filter(
-                Service.service_id == "1234123412340001"
-            ).one().data["serviceSummary"] == "Probably the best cloud service in the world"
-            assert ArchivedService.query.count() == 4
-            assert index_service.called is False
+        assert not AuditEvent.query.filter(AuditEvent.type == AuditTypes.update_service.name).all()
+        assert Service.query.filter(
+            Service.service_id == "1234123412340001"
+        ).one().data["serviceSummary"] == "Probably the best cloud service in the world"
+        assert ArchivedService.query.count() == 4
+        assert index_service.called is False
 
 
 class TestRevertServiceHappyPath(TestRevertServiceBase):
 
     @mock.patch('app.service_utils.index_object', autospec=True)
     def test_happy_path(self, index_object):
-        with self.app.app_context():
-            response = self.client.post(
-                '/services/1234123412340001/revert',
-                content_type='application/json',
-                data=json.dumps({"updated_by": "papli@example.com", "archivedServiceId": self.archived_service_ids[1]}),
-            )
-            assert response.status_code == 200
+        response = self.client.post(
+            '/services/1234123412340001/revert',
+            content_type='application/json',
+            data=json.dumps({"updated_by": "papli@example.com", "archivedServiceId": self.archived_service_ids[1]}),
+        )
+        assert response.status_code == 200
 
-            service = Service.query.filter(
-                Service.service_id == "1234123412340001"
-            ).one()
-            assert service.data["serviceSummary"] == "Assuredly the best"
-            assert tuple(
-                (event.user, event.data["fromArchivedServiceId"],)
-                for event in AuditEvent.query.filter(AuditEvent.type == AuditTypes.update_service.name).all()
-            ) == (
-                ("papli@example.com", self.archived_service_ids[1],),
-            )
-            assert ArchivedService.query.count() == 5
-            index_object.assert_called_once_with(
-                doc_type='services',
-                framework=service.framework.slug,
-                object_id=service.service_id,
-                serialized_object=service.serialize()
-            )
+        service = Service.query.filter(
+            Service.service_id == "1234123412340001"
+        ).one()
+        assert service.data["serviceSummary"] == "Assuredly the best"
+        assert tuple(
+            (event.user, event.data["fromArchivedServiceId"],)
+            for event in AuditEvent.query.filter(AuditEvent.type == AuditTypes.update_service.name).all()
+        ) == (
+            ("papli@example.com", self.archived_service_ids[1],),
+        )
+        assert ArchivedService.query.count() == 5
+        index_object.assert_called_once_with(
+            doc_type='services',
+            framework=service.framework.slug,
+            object_id=service.service_id,
+            serialized_object=service.serialize()
+        )

--- a/tests/models/test_buyer_domains.py
+++ b/tests/models/test_buyer_domains.py
@@ -6,14 +6,13 @@ from tests.bases import BaseApplicationTest
 class TestBuyerEmailDomains(BaseApplicationTest):
 
     def test_create_new_buyer_email_domain(self):
-        with self.app.app_context():
 
-            buyer_domain = BuyerEmailDomain(domain_name="superkalifragilisticexpialidocious.org.uk")
-            db.session.add(buyer_domain)
-            db.session.commit()
+        buyer_domain = BuyerEmailDomain(domain_name="superkalifragilisticexpialidocious.org.uk")
+        db.session.add(buyer_domain)
+        db.session.commit()
 
-            assert buyer_domain.id is not None
-            assert buyer_domain.domain_name == "superkalifragilisticexpialidocious.org.uk"
+        assert buyer_domain.id is not None
+        assert buyer_domain.domain_name == "superkalifragilisticexpialidocious.org.uk"
 
     def test_buyer_email_domain_serialization(self):
         buyer_domain = BuyerEmailDomain(domain_name="superkalifragilisticexpialidocious.org.uk")

--- a/tests/models/test_direct_award.py
+++ b/tests/models/test_direct_award.py
@@ -13,65 +13,61 @@ from tests.helpers import (FixtureMixin, DIRECT_AWARD_PROJECT_NAME, DIRECT_AWARD
 
 class TestProjects(BaseApplicationTest, FixtureMixin):
     def test_create_new_project(self):
-        with self.app.app_context():
-            self.setup_dummy_user(role='buyer')
+        self.setup_dummy_user(role='buyer')
 
-            project = DirectAwardProject(name=DIRECT_AWARD_PROJECT_NAME, users=User.query.all())
-            db.session.add(project)
-            db.session.commit()
+        project = DirectAwardProject(name=DIRECT_AWARD_PROJECT_NAME, users=User.query.all())
+        db.session.add(project)
+        db.session.commit()
 
-            assert project.id is not None
-            assert project.external_id is not None
-            assert project.name == DIRECT_AWARD_PROJECT_NAME
-            assert isinstance(project.created_at, datetime)
-            assert project.locked_at is None
-            assert project.active is True
+        assert project.id is not None
+        assert project.external_id is not None
+        assert project.name == DIRECT_AWARD_PROJECT_NAME
+        assert isinstance(project.created_at, datetime)
+        assert project.locked_at is None
+        assert project.active is True
 
     def test_serialize_project_contains_required_keys(self):
-        with self.app.app_context():
-            self.setup_dummy_user(role='buyer')
+        self.setup_dummy_user(role='buyer')
 
-            project = DirectAwardProject(name=DIRECT_AWARD_PROJECT_NAME, users=User.query.all())
-            db.session.add(project)
-            db.session.commit()
+        project = DirectAwardProject(name=DIRECT_AWARD_PROJECT_NAME, users=User.query.all())
+        db.session.add(project)
+        db.session.commit()
 
-            serialized_project = project.serialize()
-            project_keys_set = set(serialized_project.keys())
-            assert {'id', 'name', 'createdAt', 'lockedAt', 'active'} <= project_keys_set
-            assert serialized_project['id'] == project.external_id
+        serialized_project = project.serialize()
+        project_keys_set = set(serialized_project.keys())
+        assert {'id', 'name', 'createdAt', 'lockedAt', 'active'} <= project_keys_set
+        assert serialized_project['id'] == project.external_id
 
-            # We aren't serializing with_users=True, so we better not get them.
-            assert 'users' not in project_keys_set
+        # We aren't serializing with_users=True, so we better not get them.
+        assert 'users' not in project_keys_set
 
     def test_serialize_project_includes_users_if_requested(self):
-        with self.app.app_context():
-            self.setup_dummy_user(role='buyer')
+        self.setup_dummy_user(role='buyer')
 
-            project = DirectAwardProject(name=DIRECT_AWARD_PROJECT_NAME, users=User.query.all())
-            db.session.add(project)
-            db.session.commit()
+        project = DirectAwardProject(name=DIRECT_AWARD_PROJECT_NAME, users=User.query.all())
+        db.session.add(project)
+        db.session.commit()
 
-            serialized_project = project.serialize(with_users=True)
-            project_keys_set = set(serialized_project.keys())
-            # Must send at least these keys.
-            assert {'id', 'name', 'createdAt', 'lockedAt', 'active', 'users'} <= project_keys_set
-            assert serialized_project['id'] == project.external_id
+        serialized_project = project.serialize(with_users=True)
+        project_keys_set = set(serialized_project.keys())
+        # Must send at least these keys.
+        assert {'id', 'name', 'createdAt', 'lockedAt', 'active', 'users'} <= project_keys_set
+        assert serialized_project['id'] == project.external_id
 
-            # Must send these keys exactly - don't want to unknowingly expose more info.
-            for user in serialized_project['users']:
-                assert {'active', 'emailAddress', 'id', 'name', 'role'} == set(user.keys())
+        # Must send these keys exactly - don't want to unknowingly expose more info.
+        for user in serialized_project['users']:
+            assert {'active', 'emailAddress', 'id', 'name', 'role'} == set(user.keys())
 
     def test_create_new_project_creates_project_users(self):
-        with self.app.app_context():
-            self.setup_dummy_user(role='buyer')
+        self.setup_dummy_user(role='buyer')
 
-            assert len(DirectAwardProjectUser.query.all()) == 0
+        assert len(DirectAwardProjectUser.query.all()) == 0
 
-            project = DirectAwardProject(name=DIRECT_AWARD_PROJECT_NAME, users=User.query.all())
-            db.session.add(project)
-            db.session.commit()
+        project = DirectAwardProject(name=DIRECT_AWARD_PROJECT_NAME, users=User.query.all())
+        db.session.add(project)
+        db.session.commit()
 
-            assert len(DirectAwardProjectUser.query.all()) == len(User.query.all())
+        assert len(DirectAwardProjectUser.query.all()) == len(User.query.all())
 
 
 class TestProjectUsers(BaseApplicationTest, FixtureMixin):
@@ -83,26 +79,25 @@ class TestProjectUsers(BaseApplicationTest, FixtureMixin):
                                  (True, True, False)
                              ))
     def test_project_user_fk_constraints(self, create_project, create_user, expect_error):
-        with self.app.app_context():
-            if create_project:
-                project = DirectAwardProject(id=1, name=DIRECT_AWARD_PROJECT_NAME, users=[])
-                db.session.add(project)
+        if create_project:
+            project = DirectAwardProject(id=1, name=DIRECT_AWARD_PROJECT_NAME, users=[])
+            db.session.add(project)
+            db.session.commit()
+
+        if create_user:
+            self.setup_dummy_user(role='buyer', id=2)
+
+        project_user = DirectAwardProjectUser(project_id=1, user_id=2)
+        db.session.add(project_user)
+
+        if expect_error:
+            with pytest.raises(IntegrityError):
                 db.session.commit()
+        else:
+            db.session.commit()
 
-            if create_user:
-                self.setup_dummy_user(role='buyer', id=2)
-
-            project_user = DirectAwardProjectUser(project_id=1, user_id=2)
-            db.session.add(project_user)
-
-            if expect_error:
-                with pytest.raises(IntegrityError):
-                    db.session.commit()
-            else:
-                db.session.commit()
-
-                assert project_user.project_id == 1
-                assert project_user.user_id == 2
+            assert project_user.project_id == 1
+            assert project_user.user_id == 2
 
 
 class TestSearches(BaseApplicationTest, FixtureMixin):
@@ -111,14 +106,13 @@ class TestSearches(BaseApplicationTest, FixtureMixin):
         project_id, project_external_id = self.create_direct_award_project(user_id=user_id)
         search_id = self.create_direct_award_project_search(created_by=user_id, project_id=project_id)
 
-        with self.app.app_context():
-            search = DirectAwardSearch.query.get(search_id)
-            assert search.id == search_id
-            assert search.project_id == project_id
-            assert isinstance(search.created_at, datetime)
-            assert search.searched_at is None
-            assert search.search_url == DIRECT_AWARD_SEARCH_RELATIVE_URL
-            assert search.active is True
+        search = DirectAwardSearch.query.get(search_id)
+        assert search.id == search_id
+        assert search.project_id == project_id
+        assert isinstance(search.created_at, datetime)
+        assert search.searched_at is None
+        assert search.search_url == DIRECT_AWARD_SEARCH_RELATIVE_URL
+        assert search.active is True
 
     def test_only_one_search_active_per_project_is_enforced(self):
         user_id = self.setup_dummy_user(role='buyer')
@@ -133,9 +127,8 @@ class TestSearches(BaseApplicationTest, FixtureMixin):
         project_id, project_external_id = self.create_direct_award_project(user_id=user_id)
         search_id = self.create_direct_award_project_search(created_by=user_id, project_id=project_id)
 
-        with self.app.app_context():
-            search = DirectAwardSearch.query.get(search_id)
-            search_keys_set = set(search.serialize().keys())
+        search = DirectAwardSearch.query.get(search_id)
+        search_keys_set = set(search.serialize().keys())
 
         assert {'id', 'createdAt', 'searchedAt', 'projectId', 'searchUrl', 'active'} <= search_keys_set
 
@@ -159,16 +152,15 @@ class TestSearches(BaseApplicationTest, FixtureMixin):
         project_id, project_external_id = self.create_direct_award_project(user_id=user_id)
         search_id = self.create_direct_award_project_search(created_by=user_id, project_id=project_id)
 
-        with self.app.app_context():
-            search = DirectAwardSearch.query.get(search_id)
-            project = DirectAwardProject.query.get(project_id)
-            project.locked_at = datetime.utcnow()
-            db.session.add(project)
-            db.session.commit()
+        search = DirectAwardSearch.query.get(search_id)
+        project = DirectAwardProject.query.get(project_id)
+        project.locked_at = datetime.utcnow()
+        db.session.add(project)
+        db.session.commit()
 
-            for prop in ['id', 'created_by', 'project_id', 'created_at', 'searched_at', 'search_url', 'active']:
-                with pytest.raises(ValidationError):
-                    setattr(search, prop, getattr(search, prop))
+        for prop in ['id', 'created_by', 'project_id', 'created_at', 'searched_at', 'search_url', 'active']:
+            with pytest.raises(ValidationError):
+                setattr(search, prop, getattr(search, prop))
 
 
 class TestProjectSearchResultEntries(BaseApplicationTest, FixtureMixin):
@@ -180,20 +172,19 @@ class TestProjectSearchResultEntries(BaseApplicationTest, FixtureMixin):
                                  (True, True, False)
                              ))
     def test_search_result_entries_fk_constraints(self, create_user, create_project, expect_error):
-        with self.app.app_context():
-            if create_user:
-                self.setup_dummy_user(role='buyer', id=1)
+        if create_user:
+            self.setup_dummy_user(role='buyer', id=1)
 
-            if create_project:
-                project = DirectAwardProject(id=1, name=DIRECT_AWARD_PROJECT_NAME, users=[])
-                db.session.add(project)
+        if create_project:
+            project = DirectAwardProject(id=1, name=DIRECT_AWARD_PROJECT_NAME, users=[])
+            db.session.add(project)
+            db.session.commit()
+
+        project_user = DirectAwardProjectUser(project_id=1, user_id=1)
+        db.session.add(project_user)
+
+        if expect_error:
+            with pytest.raises(IntegrityError):
                 db.session.commit()
-
-            project_user = DirectAwardProjectUser(project_id=1, user_id=1)
-            db.session.add(project_user)
-
-            if expect_error:
-                with pytest.raises(IntegrityError):
-                    db.session.commit()
-            else:
-                db.session.commit()
+        else:
+            db.session.commit()

--- a/tests/models/test_main.py
+++ b/tests/models/test_main.py
@@ -21,29 +21,28 @@ from tests.helpers import FixtureMixin
 
 class TestUser(BaseApplicationTest, FixtureMixin):
     def test_should_not_return_password_on_user(self):
-        with self.app.app_context():
-            self.setup_default_buyer_domain()
+        self.setup_default_buyer_domain()
 
-            now = datetime.utcnow()
-            user = User(
-                email_address='email@digital.gov.uk',
-                name='name',
-                role='buyer',
-                password='password',
-                active=True,
-                failed_login_count=0,
-                created_at=now,
-                updated_at=now,
-                password_changed_at=now
-            )
+        now = datetime.utcnow()
+        user = User(
+            email_address='email@digital.gov.uk',
+            name='name',
+            role='buyer',
+            password='password',
+            active=True,
+            failed_login_count=0,
+            created_at=now,
+            updated_at=now,
+            password_changed_at=now
+        )
 
-            assert user.serialize()['emailAddress'] == "email@digital.gov.uk"
-            assert user.serialize()['name'] == "name"
-            assert user.serialize()['role'] == "buyer"
-            assert 'password' not in user.serialize()
+        assert user.serialize()['emailAddress'] == "email@digital.gov.uk"
+        assert user.serialize()['name'] == "name"
+        assert user.serialize()['role'] == "buyer"
+        assert 'password' not in user.serialize()
 
     def test_buyer_user_requires_valid_email_domain(self):
-        with self.app.app_context(), pytest.raises(ValidationError) as exc:
+        with pytest.raises(ValidationError) as exc:
             self.setup_default_buyer_domain()
             valid_buyer_user = User(
                 email_address='email@digital.gov.uk',
@@ -59,7 +58,7 @@ class TestUser(BaseApplicationTest, FixtureMixin):
 
     @pytest.mark.parametrize('role', User.ADMIN_ROLES)
     def test_admin_user_requires_whitelisted_email_domain(self, role):
-        with self.app.app_context(), pytest.raises(ValidationError) as exc:
+        with pytest.raises(ValidationError) as exc:
             valid_admin_user = User(
                 email_address='email@digital.cabinet-office.gov.uk',
                 name='name',
@@ -72,7 +71,7 @@ class TestUser(BaseApplicationTest, FixtureMixin):
         assert str(exc.value) == 'invalid_admin_domain'
 
     def test_user_with_invalid_email_domain_cannot_be_changed_to_buyer_role(self):
-        with self.app.app_context(), pytest.raises(ValidationError) as exc:
+        with pytest.raises(ValidationError) as exc:
             self.setup_default_buyer_domain()
             valid_admin_user = User(
                 email_address='email@crowncommercial.gov.uk',
@@ -88,7 +87,7 @@ class TestUser(BaseApplicationTest, FixtureMixin):
 
     @pytest.mark.parametrize('role', User.ADMIN_ROLES)
     def test_user_with_invalid_email_domain_cannot_be_changed_to_admin_role(self, role):
-        with self.app.app_context(), pytest.raises(ValidationError) as exc:
+        with pytest.raises(ValidationError) as exc:
             self.setup_default_buyer_domain()
             valid_buyer_user = User(
                 email_address='email@digital.gov.uk',
@@ -130,54 +129,50 @@ class TestFrameworks(BaseApplicationTest):
 class TestBriefs(BaseApplicationTest, FixtureMixin):
     def setup(self):
         super(TestBriefs, self).setup()
-        with self.app.app_context():
-            self.framework = Framework.query.filter(Framework.slug == 'digital-outcomes-and-specialists').first()
-            self.lot = self.framework.get_lot('digital-outcomes')
+        self.framework = Framework.query.filter(Framework.slug == 'digital-outcomes-and-specialists').first()
+        self.lot = self.framework.get_lot('digital-outcomes')
 
     def test_create_a_new_brief(self):
-        with self.app.app_context():
-            brief = Brief(data={}, framework=self.framework, lot=self.lot)
-            db.session.add(brief)
-            db.session.commit()
+        brief = Brief(data={}, framework=self.framework, lot=self.lot)
+        db.session.add(brief)
+        db.session.commit()
 
-            assert isinstance(brief.created_at, datetime)
-            assert isinstance(brief.updated_at, datetime)
-            assert brief.id is not None
-            assert brief.data == dict()
-            assert brief.is_a_copy is False
+        assert isinstance(brief.created_at, datetime)
+        assert isinstance(brief.updated_at, datetime)
+        assert brief.id is not None
+        assert brief.data == dict()
+        assert brief.is_a_copy is False
 
     def test_updating_a_brief_updates_dates(self):
-        with self.app.app_context():
-            brief = Brief(data={}, framework=self.framework, lot=self.lot)
-            db.session.add(brief)
-            db.session.commit()
+        brief = Brief(data={}, framework=self.framework, lot=self.lot)
+        db.session.add(brief)
+        db.session.commit()
 
-            updated_at = brief.updated_at
-            created_at = brief.created_at
+        updated_at = brief.updated_at
+        created_at = brief.created_at
 
-            brief.data = {'foo': 'bar'}
-            db.session.add(brief)
-            db.session.commit()
+        brief.data = {'foo': 'bar'}
+        db.session.add(brief)
+        db.session.commit()
 
-            assert brief.created_at == created_at
-            assert brief.updated_at > updated_at
+        assert brief.created_at == created_at
+        assert brief.updated_at > updated_at
 
     def test_update_from_json(self):
-        with self.app.app_context():
-            brief = Brief(data={}, framework=self.framework, lot=self.lot)
-            db.session.add(brief)
-            db.session.commit()
+        brief = Brief(data={}, framework=self.framework, lot=self.lot)
+        db.session.add(brief)
+        db.session.commit()
 
-            updated_at = brief.updated_at
-            created_at = brief.created_at
+        updated_at = brief.updated_at
+        created_at = brief.created_at
 
-            brief.update_from_json({"foo": "bar"})
-            db.session.add(brief)
-            db.session.commit()
+        brief.update_from_json({"foo": "bar"})
+        db.session.add(brief)
+        db.session.commit()
 
-            assert brief.created_at == created_at
-            assert brief.updated_at > updated_at
-            assert brief.data == {'foo': 'bar'}
+        assert brief.created_at == created_at
+        assert brief.updated_at > updated_at
+        assert brief.data == {'foo': 'bar'}
 
     def test_foreign_fields_stripped_from_brief_data(self):
         brief = Brief(data={}, framework=self.framework, lot=self.lot)
@@ -233,79 +228,71 @@ class TestBriefs(BaseApplicationTest, FixtureMixin):
         assert brief.clarification_questions_published_by == datetime(2016, 3, 9, 23, 59, 59)
 
     def test_buyer_users_can_be_added_to_a_brief(self):
-        with self.app.app_context():
-            self.setup_dummy_user(role='buyer')
+        self.setup_dummy_user(role='buyer')
 
-            brief = Brief(data={}, framework=self.framework, lot=self.lot,
-                          users=User.query.all())
-
-            assert len(brief.users) == 1
-
-    def test_non_buyer_users_cannot_be_added_to_a_brief(self):
-        with self.app.app_context():
-            self.setup_dummy_user(role='admin')
-
-            with pytest.raises(ValidationError):
-                Brief(data={}, framework=self.framework, lot=self.lot,
+        brief = Brief(data={}, framework=self.framework, lot=self.lot,
                       users=User.query.all())
 
-    def test_brief_lot_must_be_associated_to_the_framework(self):
-        with self.app.app_context():
-            other_framework = Framework.query.filter(Framework.slug == 'g-cloud-7').first()
+        assert len(brief.users) == 1
 
-            brief = Brief(data={}, framework=other_framework, lot=self.lot)
-            db.session.add(brief)
-            with pytest.raises(IntegrityError):
-                db.session.commit()
+    def test_non_buyer_users_cannot_be_added_to_a_brief(self):
+        self.setup_dummy_user(role='admin')
+
+        with pytest.raises(ValidationError):
+            Brief(data={}, framework=self.framework, lot=self.lot,
+                  users=User.query.all())
+
+    def test_brief_lot_must_be_associated_to_the_framework(self):
+        other_framework = Framework.query.filter(Framework.slug == 'g-cloud-7').first()
+
+        brief = Brief(data={}, framework=other_framework, lot=self.lot)
+        db.session.add(brief)
+        with pytest.raises(IntegrityError):
+            db.session.commit()
 
     def test_brief_lot_must_require_briefs(self):
-        with self.app.app_context():
-            with pytest.raises(ValidationError):
-                Brief(data={},
-                      framework=self.framework,
-                      lot=self.framework.get_lot('user-research-studios'))
+        with pytest.raises(ValidationError):
+            Brief(data={},
+                  framework=self.framework,
+                  lot=self.framework.get_lot('user-research-studios'))
 
     def test_cannot_update_lot_by_id(self):
-        with self.app.app_context():
-            with pytest.raises(ValidationError):
-                Brief(data={},
-                      framework=self.framework,
-                      lot_id=self.framework.get_lot('user-research-studios').id)
+        with pytest.raises(ValidationError):
+            Brief(data={},
+                  framework=self.framework,
+                  lot_id=self.framework.get_lot('user-research-studios').id)
 
     def test_add_brief_clarification_question(self):
-        with self.app.app_context():
-            brief = Brief(data={}, framework=self.framework, lot=self.lot, status="live")
-            db.session.add(brief)
-            db.session.commit()
+        brief = Brief(data={}, framework=self.framework, lot=self.lot, status="live")
+        db.session.add(brief)
+        db.session.commit()
 
-            brief.add_clarification_question(
-                "How do you expect to deliver this?",
-                "By the power of Grayskull")
-            db.session.commit()
+        brief.add_clarification_question(
+            "How do you expect to deliver this?",
+            "By the power of Grayskull")
+        db.session.commit()
 
-            assert len(brief.clarification_questions) == 1
-            assert len(BriefClarificationQuestion.query.filter(
-                BriefClarificationQuestion._brief_id == brief.id
-            ).all()) == 1
+        assert len(brief.clarification_questions) == 1
+        assert len(BriefClarificationQuestion.query.filter(
+            BriefClarificationQuestion._brief_id == brief.id
+        ).all()) == 1
 
     def test_new_clarification_questions_get_added_to_the_end(self):
-        with self.app.app_context():
-            brief = Brief(data={}, framework=self.framework, lot=self.lot, status="live")
-            db.session.add(brief)
-            brief.add_clarification_question("How?", "This")
-            brief.add_clarification_question("When", "Then")
-            db.session.commit()
+        brief = Brief(data={}, framework=self.framework, lot=self.lot, status="live")
+        db.session.add(brief)
+        brief.add_clarification_question("How?", "This")
+        brief.add_clarification_question("When", "Then")
+        db.session.commit()
 
-            assert brief.clarification_questions[0].question == "How?"
-            assert brief.clarification_questions[1].question == "When"
+        assert brief.clarification_questions[0].question == "How?"
+        assert brief.clarification_questions[1].question == "When"
 
 
 class TestBriefStatuses(BaseApplicationTest, FixtureMixin):
     def setup(self):
         super(TestBriefStatuses, self).setup()
-        with self.app.app_context():
-            self.framework = Framework.query.filter(Framework.slug == 'digital-outcomes-and-specialists').first()
-            self.lot = self.framework.get_lot('digital-outcomes')
+        self.framework = Framework.query.filter(Framework.slug == 'digital-outcomes-and-specialists').first()
+        self.lot = self.framework.get_lot('digital-outcomes')
 
     def test_status_defaults_to_draft(self):
         brief = Brief(data={}, framework=self.framework, lot=self.lot)
@@ -324,17 +311,16 @@ class TestBriefStatuses(BaseApplicationTest, FixtureMixin):
         assert brief.applications_closed_at < datetime.utcnow()
 
     def test_awarded_status_for_a_brief_with_an_awarded_brief_response(self):
-        with self.app.app_context():
-            self.setup_dummy_suppliers(1)
-            brief = Brief(data={}, framework=self.framework, lot=self.lot, published_at=datetime(2000, 1, 1))
-            brief_response = BriefResponse(brief=brief, supplier_id=0, submitted_at=datetime.utcnow(), data={})
-            brief_response.award_details = {"confirmed": "details"}
-            brief_response.awarded_at = datetime(2016, 12, 12, 1, 1, 1)
-            db.session.add_all([brief, brief_response])
-            db.session.commit()
+        self.setup_dummy_suppliers(1)
+        brief = Brief(data={}, framework=self.framework, lot=self.lot, published_at=datetime(2000, 1, 1))
+        brief_response = BriefResponse(brief=brief, supplier_id=0, submitted_at=datetime.utcnow(), data={})
+        brief_response.award_details = {"confirmed": "details"}
+        brief_response.awarded_at = datetime(2016, 12, 12, 1, 1, 1)
+        db.session.add_all([brief, brief_response])
+        db.session.commit()
 
-            brief = Brief.query.get(brief.id)
-            assert brief.status == 'awarded'
+        brief = Brief.query.get(brief.id)
+        assert brief.status == 'awarded'
 
     def test_publishing_a_brief_sets_published_at(self):
         brief = Brief(data={}, framework=self.framework, lot=self.lot)
@@ -411,272 +397,257 @@ class TestBriefStatuses(BaseApplicationTest, FixtureMixin):
             assert e.value.message == "Cannot change brief status from 'withdrawn' to '{}'".format(status)
 
     def test_status_order_sorts_briefs_by_search_result_status_ordering(self):
-        with self.app.app_context():
-            draft_brief = Brief(data={}, framework=self.framework, lot=self.lot)
-            live_brief = Brief(data={}, framework=self.framework, lot=self.lot, published_at=datetime.utcnow())
-            withdrawn_brief = Brief(
-                data={}, framework=self.framework, lot=self.lot,
-                published_at=datetime.utcnow() - timedelta(days=1), withdrawn_at=datetime.utcnow()
-            )
-            closed_brief = Brief(data={}, framework=self.framework, lot=self.lot, published_at=datetime(2000, 1, 1))
-            cancelled_brief = Brief(
-                data={}, framework=self.framework, lot=self.lot, published_at=datetime(2000, 1, 1),
-                cancelled_at=datetime(2000, 2, 2)
-            )
-            unsuccessful_brief = Brief(
-                data={}, framework=self.framework, lot=self.lot, published_at=datetime(2000, 1, 1),
-                unsuccessful_at=datetime(2000, 2, 2)
-            )
+        draft_brief = Brief(data={}, framework=self.framework, lot=self.lot)
+        live_brief = Brief(data={}, framework=self.framework, lot=self.lot, published_at=datetime.utcnow())
+        withdrawn_brief = Brief(
+            data={}, framework=self.framework, lot=self.lot,
+            published_at=datetime.utcnow() - timedelta(days=1), withdrawn_at=datetime.utcnow()
+        )
+        closed_brief = Brief(data={}, framework=self.framework, lot=self.lot, published_at=datetime(2000, 1, 1))
+        cancelled_brief = Brief(
+            data={}, framework=self.framework, lot=self.lot, published_at=datetime(2000, 1, 1),
+            cancelled_at=datetime(2000, 2, 2)
+        )
+        unsuccessful_brief = Brief(
+            data={}, framework=self.framework, lot=self.lot, published_at=datetime(2000, 1, 1),
+            unsuccessful_at=datetime(2000, 2, 2)
+        )
 
-            awarded_brief = Brief(data={}, framework=self.framework, lot=self.lot, published_at=datetime(2000, 1, 1))
-            self.setup_dummy_suppliers(1)
-            brief_response = BriefResponse(
-                brief=awarded_brief, data={}, supplier_id=0, submitted_at=datetime(2000, 2, 1),
-                award_details={'pending': True}
-            )
-            db.session.add_all([
-                draft_brief, live_brief, withdrawn_brief, closed_brief, awarded_brief, brief_response,
-                cancelled_brief, unsuccessful_brief
-            ])
-            db.session.commit()
-            # award the BriefResponse
-            brief_response.awarded_at = datetime(2001, 1, 1)
-            db.session.add(brief_response)
-            db.session.commit()
+        awarded_brief = Brief(data={}, framework=self.framework, lot=self.lot, published_at=datetime(2000, 1, 1))
+        self.setup_dummy_suppliers(1)
+        brief_response = BriefResponse(
+            brief=awarded_brief, data={}, supplier_id=0, submitted_at=datetime(2000, 2, 1),
+            award_details={'pending': True}
+        )
+        db.session.add_all([
+            draft_brief, live_brief, withdrawn_brief, closed_brief, awarded_brief, brief_response,
+            cancelled_brief, unsuccessful_brief
+        ])
+        db.session.commit()
+        # award the BriefResponse
+        brief_response.awarded_at = datetime(2001, 1, 1)
+        db.session.add(brief_response)
+        db.session.commit()
 
-            expected_result = [
-                live_brief.status, closed_brief.status, awarded_brief.status,
-                cancelled_brief.status, unsuccessful_brief.status,
-                draft_brief.status, withdrawn_brief.status
-            ]
-            query_result = [
-                q.status for q in Brief.query.order_by(Brief.status_order, Brief.published_at.desc(), Brief.id)
-            ]
+        expected_result = [
+            live_brief.status, closed_brief.status, awarded_brief.status,
+            cancelled_brief.status, unsuccessful_brief.status,
+            draft_brief.status, withdrawn_brief.status
+        ]
+        query_result = [
+            q.status for q in Brief.query.order_by(Brief.status_order, Brief.published_at.desc(), Brief.id)
+        ]
 
-            assert query_result == expected_result
+        assert query_result == expected_result
 
 
 class TestBriefQueries(BaseApplicationTest, FixtureMixin):
     def setup(self):
         super(TestBriefQueries, self).setup()
-        with self.app.app_context():
-            self.framework = Framework.query.filter(Framework.slug == 'digital-outcomes-and-specialists').first()
-            self.lot = self.framework.get_lot('digital-outcomes')
+        self.framework = Framework.query.filter(Framework.slug == 'digital-outcomes-and-specialists').first()
+        self.lot = self.framework.get_lot('digital-outcomes')
 
     def test_query_draft_brief(self):
-        with self.app.app_context():
-            db.session.add(Brief(data={}, framework=self.framework, lot=self.lot))
-            db.session.commit()
+        db.session.add(Brief(data={}, framework=self.framework, lot=self.lot))
+        db.session.commit()
 
-            assert Brief.query.filter(Brief.status == 'draft').count() == 1
-            assert Brief.query.filter(Brief.status == 'live').count() == 0
-            assert Brief.query.filter(Brief.status == 'withdrawn').count() == 0
-            assert Brief.query.filter(Brief.status == 'closed').count() == 0
-            assert Brief.query.filter(Brief.status == 'awarded').count() == 0
-            assert Brief.query.filter(Brief.status == 'cancelled').count() == 0
-            assert Brief.query.filter(Brief.status == 'unsuccessful').count() == 0
+        assert Brief.query.filter(Brief.status == 'draft').count() == 1
+        assert Brief.query.filter(Brief.status == 'live').count() == 0
+        assert Brief.query.filter(Brief.status == 'withdrawn').count() == 0
+        assert Brief.query.filter(Brief.status == 'closed').count() == 0
+        assert Brief.query.filter(Brief.status == 'awarded').count() == 0
+        assert Brief.query.filter(Brief.status == 'cancelled').count() == 0
+        assert Brief.query.filter(Brief.status == 'unsuccessful').count() == 0
 
-            # Check python implementation gives same result as the sql implementation
-            assert Brief.query.all()[0].status == 'draft'
+        # Check python implementation gives same result as the sql implementation
+        assert Brief.query.all()[0].status == 'draft'
 
     def test_query_live_brief(self):
-        with self.app.app_context():
-            db.session.add(Brief(data={}, framework=self.framework, lot=self.lot, published_at=datetime.utcnow()))
-            db.session.commit()
+        db.session.add(Brief(data={}, framework=self.framework, lot=self.lot, published_at=datetime.utcnow()))
+        db.session.commit()
 
-            assert Brief.query.filter(Brief.status == 'draft').count() == 0
-            assert Brief.query.filter(Brief.status == 'live').count() == 1
-            assert Brief.query.filter(Brief.status == 'withdrawn').count() == 0
-            assert Brief.query.filter(Brief.status == 'closed').count() == 0
-            assert Brief.query.filter(Brief.status == 'awarded').count() == 0
-            assert Brief.query.filter(Brief.status == 'cancelled').count() == 0
-            assert Brief.query.filter(Brief.status == 'unsuccessful').count() == 0
+        assert Brief.query.filter(Brief.status == 'draft').count() == 0
+        assert Brief.query.filter(Brief.status == 'live').count() == 1
+        assert Brief.query.filter(Brief.status == 'withdrawn').count() == 0
+        assert Brief.query.filter(Brief.status == 'closed').count() == 0
+        assert Brief.query.filter(Brief.status == 'awarded').count() == 0
+        assert Brief.query.filter(Brief.status == 'cancelled').count() == 0
+        assert Brief.query.filter(Brief.status == 'unsuccessful').count() == 0
 
-            # Check python implementation gives same result as the sql implementation
-            assert Brief.query.all()[0].status == 'live'
+        # Check python implementation gives same result as the sql implementation
+        assert Brief.query.all()[0].status == 'live'
 
     def test_query_withdrawn_brief(self):
-        with self.app.app_context():
-            db.session.add(Brief(
-                data={}, framework=self.framework, lot=self.lot,
-                published_at=datetime.utcnow() - timedelta(days=1), withdrawn_at=datetime.utcnow()
-            ))
-            db.session.commit()
+        db.session.add(Brief(
+            data={}, framework=self.framework, lot=self.lot,
+            published_at=datetime.utcnow() - timedelta(days=1), withdrawn_at=datetime.utcnow()
+        ))
+        db.session.commit()
 
-            assert Brief.query.filter(Brief.status == 'draft').count() == 0
-            assert Brief.query.filter(Brief.status == 'live').count() == 0
-            assert Brief.query.filter(Brief.status == 'withdrawn').count() == 1
-            assert Brief.query.filter(Brief.status == 'closed').count() == 0
-            assert Brief.query.filter(Brief.status == 'awarded').count() == 0
-            assert Brief.query.filter(Brief.status == 'cancelled').count() == 0
-            assert Brief.query.filter(Brief.status == 'unsuccessful').count() == 0
+        assert Brief.query.filter(Brief.status == 'draft').count() == 0
+        assert Brief.query.filter(Brief.status == 'live').count() == 0
+        assert Brief.query.filter(Brief.status == 'withdrawn').count() == 1
+        assert Brief.query.filter(Brief.status == 'closed').count() == 0
+        assert Brief.query.filter(Brief.status == 'awarded').count() == 0
+        assert Brief.query.filter(Brief.status == 'cancelled').count() == 0
+        assert Brief.query.filter(Brief.status == 'unsuccessful').count() == 0
 
-            # Check python implementation gives same result as the sql implementation
-            assert Brief.query.all()[0].status == 'withdrawn'
+        # Check python implementation gives same result as the sql implementation
+        assert Brief.query.all()[0].status == 'withdrawn'
 
     def test_query_closed_brief(self):
-        with self.app.app_context():
-            db.session.add(Brief(data={}, framework=self.framework, lot=self.lot, published_at=datetime(2000, 1, 1)))
-            db.session.commit()
+        db.session.add(Brief(data={}, framework=self.framework, lot=self.lot, published_at=datetime(2000, 1, 1)))
+        db.session.commit()
 
-            assert Brief.query.filter(Brief.status == 'draft').count() == 0
-            assert Brief.query.filter(Brief.status == 'live').count() == 0
-            assert Brief.query.filter(Brief.status == 'withdrawn').count() == 0
-            assert Brief.query.filter(Brief.status == 'closed').count() == 1
-            assert Brief.query.filter(Brief.status == 'awarded').count() == 0
-            assert Brief.query.filter(Brief.status == 'cancelled').count() == 0
-            assert Brief.query.filter(Brief.status == 'unsuccessful').count() == 0
+        assert Brief.query.filter(Brief.status == 'draft').count() == 0
+        assert Brief.query.filter(Brief.status == 'live').count() == 0
+        assert Brief.query.filter(Brief.status == 'withdrawn').count() == 0
+        assert Brief.query.filter(Brief.status == 'closed').count() == 1
+        assert Brief.query.filter(Brief.status == 'awarded').count() == 0
+        assert Brief.query.filter(Brief.status == 'cancelled').count() == 0
+        assert Brief.query.filter(Brief.status == 'unsuccessful').count() == 0
 
-            # Check python implementation gives same result as the sql implementation
-            assert Brief.query.all()[0].status == 'closed'
+        # Check python implementation gives same result as the sql implementation
+        assert Brief.query.all()[0].status == 'closed'
 
     def test_query_cancelled_brief(self):
-        with self.app.app_context():
-            db.session.add(
-                Brief(
-                    data={}, framework=self.framework, lot=self.lot, published_at=datetime(2000, 1, 1),
-                    cancelled_at=datetime(2000, 2, 2)
-                )
+        db.session.add(
+            Brief(
+                data={}, framework=self.framework, lot=self.lot, published_at=datetime(2000, 1, 1),
+                cancelled_at=datetime(2000, 2, 2)
             )
-            db.session.commit()
+        )
+        db.session.commit()
 
-            assert Brief.query.filter(Brief.status == 'draft').count() == 0
-            assert Brief.query.filter(Brief.status == 'live').count() == 0
-            assert Brief.query.filter(Brief.status == 'withdrawn').count() == 0
-            assert Brief.query.filter(Brief.status == 'closed').count() == 0
-            assert Brief.query.filter(Brief.status == 'awarded').count() == 0
-            assert Brief.query.filter(Brief.status == 'cancelled').count() == 1
-            assert Brief.query.filter(Brief.status == 'unsuccessful').count() == 0
+        assert Brief.query.filter(Brief.status == 'draft').count() == 0
+        assert Brief.query.filter(Brief.status == 'live').count() == 0
+        assert Brief.query.filter(Brief.status == 'withdrawn').count() == 0
+        assert Brief.query.filter(Brief.status == 'closed').count() == 0
+        assert Brief.query.filter(Brief.status == 'awarded').count() == 0
+        assert Brief.query.filter(Brief.status == 'cancelled').count() == 1
+        assert Brief.query.filter(Brief.status == 'unsuccessful').count() == 0
 
-            # Check python implementation gives same result as the sql implementation
-            assert Brief.query.all()[0].status == 'cancelled'
+        # Check python implementation gives same result as the sql implementation
+        assert Brief.query.all()[0].status == 'cancelled'
 
     def test_query_unsuccessful_brief(self):
-        with self.app.app_context():
-            db.session.add(
-                Brief(
-                    data={}, framework=self.framework, lot=self.lot, published_at=datetime(2000, 1, 1),
-                    unsuccessful_at=datetime(2000, 2, 2)
-                )
+        db.session.add(
+            Brief(
+                data={}, framework=self.framework, lot=self.lot, published_at=datetime(2000, 1, 1),
+                unsuccessful_at=datetime(2000, 2, 2)
             )
-            db.session.commit()
+        )
+        db.session.commit()
 
-            assert Brief.query.filter(Brief.status == 'draft').count() == 0
-            assert Brief.query.filter(Brief.status == 'live').count() == 0
-            assert Brief.query.filter(Brief.status == 'withdrawn').count() == 0
-            assert Brief.query.filter(Brief.status == 'closed').count() == 0
-            assert Brief.query.filter(Brief.status == 'awarded').count() == 0
-            assert Brief.query.filter(Brief.status == 'cancelled').count() == 0
-            assert Brief.query.filter(Brief.status == 'unsuccessful').count() == 1
+        assert Brief.query.filter(Brief.status == 'draft').count() == 0
+        assert Brief.query.filter(Brief.status == 'live').count() == 0
+        assert Brief.query.filter(Brief.status == 'withdrawn').count() == 0
+        assert Brief.query.filter(Brief.status == 'closed').count() == 0
+        assert Brief.query.filter(Brief.status == 'awarded').count() == 0
+        assert Brief.query.filter(Brief.status == 'cancelled').count() == 0
+        assert Brief.query.filter(Brief.status == 'unsuccessful').count() == 1
 
-            # Check python implementation gives same result as the sql implementation
-            assert Brief.query.all()[0].status == 'unsuccessful'
+        # Check python implementation gives same result as the sql implementation
+        assert Brief.query.all()[0].status == 'unsuccessful'
 
     def test_query_awarded_brief(self):
-        with self.app.app_context():
-            brief = Brief(data={}, framework=self.framework, lot=self.lot, published_at=datetime(2000, 1, 1))
-            self.setup_dummy_suppliers(1)
-            brief_response = BriefResponse(
-                brief=brief, data={}, supplier_id=0, submitted_at=datetime(2000, 2, 1),
-                award_details={'pending': True}
-            )
-            db.session.add_all([brief, brief_response])
-            db.session.commit()
-            # award the BriefResponse
-            brief_response.awarded_at = datetime(2001, 1, 1)
-            db.session.add(brief_response)
-            db.session.commit()
+        brief = Brief(data={}, framework=self.framework, lot=self.lot, published_at=datetime(2000, 1, 1))
+        self.setup_dummy_suppliers(1)
+        brief_response = BriefResponse(
+            brief=brief, data={}, supplier_id=0, submitted_at=datetime(2000, 2, 1),
+            award_details={'pending': True}
+        )
+        db.session.add_all([brief, brief_response])
+        db.session.commit()
+        # award the BriefResponse
+        brief_response.awarded_at = datetime(2001, 1, 1)
+        db.session.add(brief_response)
+        db.session.commit()
 
-            assert Brief.query.filter(Brief.status == 'awarded').count() == 1
-            # Check python implementation gives same result as the sql implementation
-            assert Brief.query.all()[0].status == 'awarded'
+        assert Brief.query.filter(Brief.status == 'awarded').count() == 1
+        # Check python implementation gives same result as the sql implementation
+        assert Brief.query.all()[0].status == 'awarded'
 
     def test_query_brief_applications_closed_at_date_for_brief_with_no_requirements_length(self):
-        with self.app.app_context():
-            db.session.add(Brief(data={}, framework=self.framework, lot=self.lot,
-                                 published_at=datetime(2016, 3, 3, 12, 30, 1, 2)))
-            db.session.commit()
-            assert Brief.query.filter(Brief.applications_closed_at == datetime(2016, 3, 17, 23, 59, 59)).count() == 1
+        db.session.add(Brief(data={}, framework=self.framework, lot=self.lot,
+                             published_at=datetime(2016, 3, 3, 12, 30, 1, 2)))
+        db.session.commit()
+        assert Brief.query.filter(Brief.applications_closed_at == datetime(2016, 3, 17, 23, 59, 59)).count() == 1
 
     def test_query_brief_applications_closed_at_date_for_one_week_brief(self):
-        with self.app.app_context():
-            db.session.add(Brief(data={'requirementsLength': '1 week'}, framework=self.framework, lot=self.lot,
-                                 published_at=datetime(2016, 3, 3, 12, 30, 1, 2)))
-            db.session.commit()
-            assert Brief.query.filter(Brief.applications_closed_at == datetime(2016, 3, 10, 23, 59, 59)).count() == 1
+        db.session.add(Brief(data={'requirementsLength': '1 week'}, framework=self.framework, lot=self.lot,
+                             published_at=datetime(2016, 3, 3, 12, 30, 1, 2)))
+        db.session.commit()
+        assert Brief.query.filter(Brief.applications_closed_at == datetime(2016, 3, 10, 23, 59, 59)).count() == 1
 
     def test_query_brief_applications_closed_at_date_for_two_week_brief(self):
-        with self.app.app_context():
-            db.session.add(Brief(data={'requirementsLength': '2 weeks'}, framework=self.framework, lot=self.lot,
-                                 published_at=datetime(2016, 3, 3, 12, 30, 1, 2)))
-            db.session.commit()
-            assert Brief.query.filter(Brief.applications_closed_at == datetime(2016, 3, 17, 23, 59, 59)).count() == 1
+        db.session.add(Brief(data={'requirementsLength': '2 weeks'}, framework=self.framework, lot=self.lot,
+                             published_at=datetime(2016, 3, 3, 12, 30, 1, 2)))
+        db.session.commit()
+        assert Brief.query.filter(Brief.applications_closed_at == datetime(2016, 3, 17, 23, 59, 59)).count() == 1
 
     def test_query_brief_applications_closed_at_date_for_mix_of_brief_lengths(self):
-        with self.app.app_context():
-            db.session.add(Brief(data={'requirementsLength': '1 week'}, framework=self.framework, lot=self.lot,
-                                 published_at=datetime(2016, 3, 10, 12, 30, 1, 2)))
-            db.session.add(Brief(data={'requirementsLength': '2 weeks'}, framework=self.framework, lot=self.lot,
-                                 published_at=datetime(2016, 3, 3, 12, 30, 1, 2)))
-            db.session.add(Brief(data={}, framework=self.framework, lot=self.lot,
-                                 published_at=datetime(2016, 3, 3, 12, 30, 1, 2)))
-            db.session.commit()
-            assert Brief.query.filter(Brief.applications_closed_at == datetime(2016, 3, 17, 23, 59, 59)).count() == 3
+        db.session.add(Brief(data={'requirementsLength': '1 week'}, framework=self.framework, lot=self.lot,
+                             published_at=datetime(2016, 3, 10, 12, 30, 1, 2)))
+        db.session.add(Brief(data={'requirementsLength': '2 weeks'}, framework=self.framework, lot=self.lot,
+                             published_at=datetime(2016, 3, 3, 12, 30, 1, 2)))
+        db.session.add(Brief(data={}, framework=self.framework, lot=self.lot,
+                             published_at=datetime(2016, 3, 3, 12, 30, 1, 2)))
+        db.session.commit()
+        assert Brief.query.filter(Brief.applications_closed_at == datetime(2016, 3, 17, 23, 59, 59)).count() == 3
 
     # TODO: add cases for querying created_at/updated_at auto timestamps with freeze_time
 
     @pytest.mark.parametrize('inclusive,expected_count', [(True, 2), (False, 1)])
     @pytest.mark.parametrize('datestamp_attr', ['published_at', 'withdrawn_at', 'cancelled_at', 'unsuccessful_at'])
     def test_query_brief_has_datetime_field_before_and_after(self, datestamp_attr, inclusive, expected_count):
-        with self.app.app_context():
-            new_briefs = [Brief(data={}, framework=self.framework, lot=self.lot) for i in range(3)]
-            setattr(new_briefs[0], datestamp_attr, datetime(2016, 12, 31, 23, 59, 59, 999999))  # < date
-            setattr(new_briefs[1], datestamp_attr, datetime(2017, 1, 1, 0, 0, 0))  # <= and >= date
-            setattr(new_briefs[2], datestamp_attr, datetime(2017, 1, 1, 0, 0, 1))  # > date
+        new_briefs = [Brief(data={}, framework=self.framework, lot=self.lot) for i in range(3)]
+        setattr(new_briefs[0], datestamp_attr, datetime(2016, 12, 31, 23, 59, 59, 999999))  # < date
+        setattr(new_briefs[1], datestamp_attr, datetime(2017, 1, 1, 0, 0, 0))  # <= and >= date
+        setattr(new_briefs[2], datestamp_attr, datetime(2017, 1, 1, 0, 0, 1))  # > date
 
-            db.session.add_all(new_briefs)
-            db.session.commit()
+        db.session.add_all(new_briefs)
+        db.session.commit()
 
-            briefs_before = Brief.query.has_datetime_field_before(
-                datestamp_attr, start_datetime=datetime(2017, 1, 1, 0, 0, 0), inclusive=inclusive
-            )
-            assert briefs_before.count() == expected_count
+        briefs_before = Brief.query.has_datetime_field_before(
+            datestamp_attr, start_datetime=datetime(2017, 1, 1, 0, 0, 0), inclusive=inclusive
+        )
+        assert briefs_before.count() == expected_count
 
-            briefs_after = Brief.query.has_datetime_field_after(
-                datestamp_attr, start_datetime=datetime(2017, 1, 1, 0, 0, 0), inclusive=inclusive
-            )
-            assert briefs_after.count() == expected_count
+        briefs_after = Brief.query.has_datetime_field_after(
+            datestamp_attr, start_datetime=datetime(2017, 1, 1, 0, 0, 0), inclusive=inclusive
+        )
+        assert briefs_after.count() == expected_count
 
     def test_query_brief_has_datetime_field_before_requires_datetime(self):
-        with self.app.app_context(), pytest.raises(ValueError) as e:
+        with pytest.raises(ValueError) as e:
             Brief.query.has_datetime_field_before('published_on', start_datetime='2017-01-01')
         assert str(e.value) == 'Datetime object required'
 
     def test_query_brief_has_datetime_field_after_requires_datetime(self):
-        with self.app.app_context(), pytest.raises(ValueError) as e:
+        with pytest.raises(ValueError) as e:
             Brief.query.has_datetime_field_after('published_on', start_datetime='2017-01-01')
         assert str(e.value) == 'Datetime object required'
 
     @pytest.mark.parametrize('inclusive,expected_count', [(True, 2), (False, 0)])
     @pytest.mark.parametrize('datestamp_attr', ['published_at', 'withdrawn_at', 'cancelled_at', 'unsuccessful_at'])
     def test_query_brief_has_datetime_field_between(self, datestamp_attr, inclusive, expected_count):
-        with self.app.app_context():
-            new_briefs = [Brief(data={}, framework=self.framework, lot=self.lot) for i in range(4)]
-            setattr(new_briefs[0], datestamp_attr, datetime(2016, 12, 31, 23, 59, 59, 999999))  # < date range
-            setattr(new_briefs[1], datestamp_attr, datetime(2017, 1, 1, 0, 0, 0))  # <= date range
-            setattr(new_briefs[2], datestamp_attr, datetime(2017, 1, 3, 0, 0, 0))  # >= date range
-            setattr(new_briefs[3], datestamp_attr, datetime(2017, 1, 3, 0, 0, 1))  # > date range
+        new_briefs = [Brief(data={}, framework=self.framework, lot=self.lot) for i in range(4)]
+        setattr(new_briefs[0], datestamp_attr, datetime(2016, 12, 31, 23, 59, 59, 999999))  # < date range
+        setattr(new_briefs[1], datestamp_attr, datetime(2017, 1, 1, 0, 0, 0))  # <= date range
+        setattr(new_briefs[2], datestamp_attr, datetime(2017, 1, 3, 0, 0, 0))  # >= date range
+        setattr(new_briefs[3], datestamp_attr, datetime(2017, 1, 3, 0, 0, 1))  # > date range
 
-            db.session.add_all(new_briefs)
-            db.session.commit()
+        db.session.add_all(new_briefs)
+        db.session.commit()
 
-            briefs = Brief.query.has_datetime_field_between(
-                datestamp_attr,
-                start_datetime=datetime(2017, 1, 1, 0, 0, 0),
-                end_datetime=datetime(2017, 1, 3, 0, 0, 0),
-                inclusive=inclusive
-            )
-            assert briefs.count() == expected_count
+        briefs = Brief.query.has_datetime_field_between(
+            datestamp_attr,
+            start_datetime=datetime(2017, 1, 1, 0, 0, 0),
+            end_datetime=datetime(2017, 1, 3, 0, 0, 0),
+            inclusive=inclusive
+        )
+        assert briefs.count() == expected_count
 
     @pytest.mark.parametrize(
         'start_date,end_date', [
@@ -684,7 +655,7 @@ class TestBriefQueries(BaseApplicationTest, FixtureMixin):
         ]
     )
     def test_query_brief_has_datetime_field_between_requires_datetime(self, start_date, end_date):
-        with self.app.app_context(), pytest.raises(ValueError) as e:
+        with pytest.raises(ValueError) as e:
             Brief.query.has_datetime_field_between('published_at', start_datetime=start_date, end_datetime=end_date)
         assert str(e.value) == 'Datetime object required'
 
@@ -692,9 +663,8 @@ class TestBriefQueries(BaseApplicationTest, FixtureMixin):
 class TestAwardedBriefs(BaseApplicationTest, FixtureMixin):
     def setup(self):
         super(TestAwardedBriefs, self).setup()
-        with self.app.app_context():
-            self.framework = Framework.query.filter(Framework.slug == 'digital-outcomes-and-specialists').first()
-            self.lot = self.framework.get_lot('digital-outcomes')
+        self.framework = Framework.query.filter(Framework.slug == 'digital-outcomes-and-specialists').first()
+        self.lot = self.framework.get_lot('digital-outcomes')
 
     def _setup_brief_and_awarded_brief_response(self, awarded_at=True, pending=True):
         self.setup_dummy_suppliers(1)
@@ -716,68 +686,62 @@ class TestAwardedBriefs(BaseApplicationTest, FixtureMixin):
         return brief.id, brief_response.id
 
     def test_awarded_brief_response_when_there_is_an_award(self):
-        with self.app.app_context():
-            self.setup_dummy_suppliers(1)
-            brief = Brief(data={}, framework=self.framework, lot=self.lot, published_at=datetime(2000, 1, 1))
-            brief_response1 = BriefResponse(brief=brief, supplier_id=0, submitted_at=datetime.utcnow(), data={})
-            brief_response2 = BriefResponse(brief=brief, supplier_id=0, submitted_at=datetime.utcnow(), data={})
-            brief_response2.award_details = {"confirmed": "details"}
-            brief_response2.awarded_at = datetime(2016, 12, 12, 1, 1, 1)
-            db.session.add_all([brief, brief_response1, brief_response2])
-            db.session.commit()
+        self.setup_dummy_suppliers(1)
+        brief = Brief(data={}, framework=self.framework, lot=self.lot, published_at=datetime(2000, 1, 1))
+        brief_response1 = BriefResponse(brief=brief, supplier_id=0, submitted_at=datetime.utcnow(), data={})
+        brief_response2 = BriefResponse(brief=brief, supplier_id=0, submitted_at=datetime.utcnow(), data={})
+        brief_response2.award_details = {"confirmed": "details"}
+        brief_response2.awarded_at = datetime(2016, 12, 12, 1, 1, 1)
+        db.session.add_all([brief, brief_response1, brief_response2])
+        db.session.commit()
 
-            brief = Brief.query.get(brief.id)
-            assert brief.awarded_brief_response.id == brief_response2.id
+        brief = Brief.query.get(brief.id)
+        assert brief.awarded_brief_response.id == brief_response2.id
 
     def test_no_awarded_brief_response_if_brief_responses_but_no_award(self):
-        with self.app.app_context():
-            self.setup_dummy_suppliers(1)
-            brief = Brief(data={}, framework=self.framework, lot=self.lot, published_at=datetime(2000, 1, 1))
-            brief_response1 = BriefResponse(brief=brief, supplier_id=0, submitted_at=datetime.utcnow(), data={})
-            brief_response2 = BriefResponse(brief=brief, supplier_id=0, submitted_at=datetime.utcnow(), data={})
-            db.session.add_all([brief, brief_response1, brief_response2])
-            db.session.commit()
+        self.setup_dummy_suppliers(1)
+        brief = Brief(data={}, framework=self.framework, lot=self.lot, published_at=datetime(2000, 1, 1))
+        brief_response1 = BriefResponse(brief=brief, supplier_id=0, submitted_at=datetime.utcnow(), data={})
+        brief_response2 = BriefResponse(brief=brief, supplier_id=0, submitted_at=datetime.utcnow(), data={})
+        db.session.add_all([brief, brief_response1, brief_response2])
+        db.session.commit()
 
-            brief = Brief.query.get(brief.id)
-            assert brief.awarded_brief_response is None
+        brief = Brief.query.get(brief.id)
+        assert brief.awarded_brief_response is None
 
     def test_no_awarded_brief_response_if_no_brief_responses(self):
-        with self.app.app_context():
-            brief = Brief(data={}, framework=self.framework, lot=self.lot, published_at=datetime(2000, 1, 1))
-            db.session.add(brief)
-            db.session.commit()
+        brief = Brief(data={}, framework=self.framework, lot=self.lot, published_at=datetime(2000, 1, 1))
+        db.session.add(brief)
+        db.session.commit()
 
-            brief = Brief.query.get(brief.id)
-            assert brief.awarded_brief_response is None
+        brief = Brief.query.get(brief.id)
+        assert brief.awarded_brief_response is None
 
     def test_brief_serialize_includes_awarded_brief_response_id_if_overall_status_awarded(self):
-        with self.app.app_context():
-            brief_id, brief_response_id = self._setup_brief_and_awarded_brief_response(pending=False)
-            brief = Brief.query.get(brief_id)
-            assert brief.status == 'awarded'
-            with mock.patch('app.models.main.url_for') as url_for:
-                url_for.side_effect = lambda *args, **kwargs: (args, kwargs)
-                assert brief.serialize().get('awardedBriefResponseId') == brief_response_id
+        brief_id, brief_response_id = self._setup_brief_and_awarded_brief_response(pending=False)
+        brief = Brief.query.get(brief_id)
+        assert brief.status == 'awarded'
+        with mock.patch('app.models.main.url_for') as url_for:
+            url_for.side_effect = lambda *args, **kwargs: (args, kwargs)
+            assert brief.serialize().get('awardedBriefResponseId') == brief_response_id
 
     def test_brief_serialize_does_not_include_awarded_brief_response_if_award_is_pending(self):
-        with self.app.app_context():
-            brief_id, brief_response_id = self._setup_brief_and_awarded_brief_response(awarded_at=False)
-            brief = Brief.query.get(brief_id)
-            assert brief.status == 'closed'
-            with mock.patch('app.models.main.url_for') as url_for:
-                url_for.side_effect = lambda *args, **kwargs: (args, kwargs)
-                assert brief.serialize().get('awardedBriefResponseId') is None
+        brief_id, brief_response_id = self._setup_brief_and_awarded_brief_response(awarded_at=False)
+        brief = Brief.query.get(brief_id)
+        assert brief.status == 'closed'
+        with mock.patch('app.models.main.url_for') as url_for:
+            url_for.side_effect = lambda *args, **kwargs: (args, kwargs)
+            assert brief.serialize().get('awardedBriefResponseId') is None
 
     def test_brief_serialize_does_not_include_awarded_brief_response_if_no_awarded_brief_response(self):
-        with self.app.app_context():
-            brief = Brief(data={}, framework=self.framework, lot=self.lot, published_at=datetime(2000, 1, 1))
-            db.session.add(brief)
-            db.session.commit()
-            brief = Brief.query.get(brief.id)
-            assert brief.status == 'closed'
-            with mock.patch('app.models.main.url_for') as url_for:
-                url_for.side_effect = lambda *args, **kwargs: (args, kwargs)
-                assert brief.serialize().get('awardedBriefResponseId') is None
+        brief = Brief(data={}, framework=self.framework, lot=self.lot, published_at=datetime(2000, 1, 1))
+        db.session.add(brief)
+        db.session.commit()
+        brief = Brief.query.get(brief.id)
+        assert brief.status == 'closed'
+        with mock.patch('app.models.main.url_for') as url_for:
+            url_for.side_effect = lambda *args, **kwargs: (args, kwargs)
+            assert brief.serialize().get('awardedBriefResponseId') is None
 
 
 class TestCopyBrief(BaseApplicationTest, FixtureMixin):
@@ -862,23 +826,22 @@ class TestCopyBrief(BaseApplicationTest, FixtureMixin):
 class TestBriefResponses(BaseApplicationTest, FixtureMixin):
     def setup(self):
         super(TestBriefResponses, self).setup()
-        with self.app.app_context():
-            framework = Framework.query.filter(Framework.slug == 'digital-outcomes-and-specialists').first()
-            self.brief_title = 'My Test Brief Title'
-            self.brief = self._create_brief()
-            db.session.add(self.brief)
-            db.session.commit()
-            self.brief_id = self.brief.id
+        framework = Framework.query.filter(Framework.slug == 'digital-outcomes-and-specialists').first()
+        self.brief_title = 'My Test Brief Title'
+        self.brief = self._create_brief()
+        db.session.add(self.brief)
+        db.session.commit()
+        self.brief_id = self.brief.id
 
-            self.setup_dummy_suppliers(1)
-            self.supplier = Supplier.query.filter(Supplier.supplier_id == 0).first()
-            supplier_framework = SupplierFramework(
-                supplier=self.supplier,
-                framework=framework,
-                declaration={'organisationSize': 'small'}
-            )
-            db.session.add(supplier_framework)
-            db.session.commit()
+        self.setup_dummy_suppliers(1)
+        self.supplier = Supplier.query.filter(Supplier.supplier_id == 0).first()
+        supplier_framework = SupplierFramework(
+            supplier=self.supplier,
+            framework=framework,
+            declaration={'organisationSize': 'small'}
+        )
+        db.session.add(supplier_framework)
+        db.session.commit()
 
     def _create_brief(self, published_at=datetime(2016, 3, 3, 12, 30, 1, 3)):
         framework = Framework.query.filter(Framework.slug == 'digital-outcomes-and-specialists').first()
@@ -891,16 +854,15 @@ class TestBriefResponses(BaseApplicationTest, FixtureMixin):
         )
 
     def test_create_a_new_brief_response(self):
-        with self.app.app_context():
-            brief_response = BriefResponse(data={}, brief=self.brief, supplier=self.supplier)
-            db.session.add(brief_response)
-            db.session.commit()
+        brief_response = BriefResponse(data={}, brief=self.brief, supplier=self.supplier)
+        db.session.add(brief_response)
+        db.session.commit()
 
-            assert brief_response.id is not None
-            assert brief_response.supplier_id == 0
-            assert brief_response.brief_id == self.brief.id
-            assert isinstance(brief_response.created_at, datetime)
-            assert brief_response.data == {}
+        assert brief_response.id is not None
+        assert brief_response.supplier_id == 0
+        assert brief_response.brief_id == self.brief.id
+        assert isinstance(brief_response.created_at, datetime)
+        assert brief_response.data == {}
 
     def test_foreign_fields_are_removed_from_brief_response_data(self):
         brief_response = BriefResponse(data={})
@@ -929,246 +891,234 @@ class TestBriefResponses(BaseApplicationTest, FixtureMixin):
         assert brief_response.status == 'draft'
 
     def test_awarded_status_for_brief_response_with_awarded_at_datestamp(self):
-        with self.app.app_context():
-            brief = Brief.query.get(self.brief_id)
-            brief_response = BriefResponse(
-                brief=brief,
-                data={},
-                supplier_id=0,
-                submitted_at=datetime.utcnow(),
-                award_details={'pending': True},
-            )
-            brief_response.award_details = {'confirmed': 'details'},
-            brief_response.awarded_at = datetime(2016, 1, 1)
-            db.session.add(brief_response)
-            db.session.commit()
+        brief = Brief.query.get(self.brief_id)
+        brief_response = BriefResponse(
+            brief=brief,
+            data={},
+            supplier_id=0,
+            submitted_at=datetime.utcnow(),
+            award_details={'pending': True},
+        )
+        brief_response.award_details = {'confirmed': 'details'},
+        brief_response.awarded_at = datetime(2016, 1, 1)
+        db.session.add(brief_response)
+        db.session.commit()
 
-            assert BriefResponse.query.filter(BriefResponse.status == 'awarded').count() == 1
+        assert BriefResponse.query.filter(BriefResponse.status == 'awarded').count() == 1
 
     def test_awarded_status_for_pending_awarded_brief_response(self):
-        with self.app.app_context():
-            brief = Brief.query.get(self.brief_id)
-            brief_response = BriefResponse(
-                brief=brief,
-                data={},
-                supplier_id=0,
-                submitted_at=datetime.utcnow(),
-                award_details={'pending': True}
-            )
-            db.session.add(brief_response)
-            db.session.commit()
+        brief = Brief.query.get(self.brief_id)
+        brief_response = BriefResponse(
+            brief=brief,
+            data={},
+            supplier_id=0,
+            submitted_at=datetime.utcnow(),
+            award_details={'pending': True}
+        )
+        db.session.add(brief_response)
+        db.session.commit()
 
-            assert BriefResponse.query.filter(BriefResponse.status == 'pending-awarded').count() == 1
+        assert BriefResponse.query.filter(BriefResponse.status == 'pending-awarded').count() == 1
 
     def test_query_draft_brief_response(self):
-        with self.app.app_context():
-            db.session.add(BriefResponse(brief_id=self.brief_id, supplier_id=0, data={}))
-            db.session.commit()
+        db.session.add(BriefResponse(brief_id=self.brief_id, supplier_id=0, data={}))
+        db.session.commit()
 
-            assert BriefResponse.query.filter(BriefResponse.status == 'draft').count() == 1
-            assert BriefResponse.query.filter(BriefResponse.status == 'submitted').count() == 0
+        assert BriefResponse.query.filter(BriefResponse.status == 'draft').count() == 1
+        assert BriefResponse.query.filter(BriefResponse.status == 'submitted').count() == 0
 
-            # Check python implementation gives same result as the sql implementation
-            assert BriefResponse.query.all()[0].status == 'draft'
+        # Check python implementation gives same result as the sql implementation
+        assert BriefResponse.query.all()[0].status == 'draft'
 
     def test_query_submitted_brief_response(self):
-        with self.app.app_context():
-            db.session.add(BriefResponse(
-                brief_id=self.brief_id, supplier_id=0, submitted_at=datetime.utcnow(),
-                data={})
-            )
-            db.session.commit()
+        db.session.add(BriefResponse(
+            brief_id=self.brief_id, supplier_id=0, submitted_at=datetime.utcnow(),
+            data={})
+        )
+        db.session.commit()
 
-            assert BriefResponse.query.filter(BriefResponse.status == 'submitted').count() == 1
-            assert BriefResponse.query.filter(BriefResponse.status == 'draft').count() == 0
+        assert BriefResponse.query.filter(BriefResponse.status == 'submitted').count() == 1
+        assert BriefResponse.query.filter(BriefResponse.status == 'draft').count() == 0
 
-            # Check python implementation gives same result as the sql implementation
-            assert BriefResponse.query.all()[0].status == 'submitted'
+        # Check python implementation gives same result as the sql implementation
+        assert BriefResponse.query.all()[0].status == 'submitted'
 
     def test_brief_response_can_be_serialized(self):
-        with self.app.app_context():
-            brief_response = BriefResponse(
-                data={'foo': 'bar'}, brief=self.brief, supplier=self.supplier, submitted_at=datetime(2016, 9, 28)
-            )
-            db.session.add(brief_response)
-            db.session.commit()
+        brief_response = BriefResponse(
+            data={'foo': 'bar'}, brief=self.brief, supplier=self.supplier, submitted_at=datetime(2016, 9, 28)
+        )
+        db.session.add(brief_response)
+        db.session.commit()
 
-            with mock.patch('app.models.main.url_for') as url_for:
-                url_for.side_effect = lambda *args, **kwargs: (args, kwargs)
-                assert brief_response.serialize() == {
-                    'id': brief_response.id,
-                    'brief': {
-                        'applicationsClosedAt': '2016-03-10T23:59:59.000000Z',
-                        'id': self.brief.id,
-                        'status': self.brief.status,
-                        'title': self.brief_title,
-                        'frameworkSlug': self.brief.framework.slug
-                    },
-                    'briefId': self.brief.id,
-                    'supplierId': 0,
-                    'supplierName': 'Supplier 0',
-                    'supplierOrganisationSize': 'small',
-                    'createdAt': mock.ANY,
-                    'submittedAt': '2016-09-28T00:00:00.000000Z',
-                    'status': 'submitted',
-                    'foo': 'bar',
-                    'links': {
-                        'self': (('main.get_brief_response',), {'brief_response_id': brief_response.id}),
-                        'brief': (('main.get_brief',), {'brief_id': self.brief.id}),
-                        'supplier': (('main.get_supplier',), {'supplier_id': 0}),
-                    }
+        with mock.patch('app.models.main.url_for') as url_for:
+            url_for.side_effect = lambda *args, **kwargs: (args, kwargs)
+            assert brief_response.serialize() == {
+                'id': brief_response.id,
+                'brief': {
+                    'applicationsClosedAt': '2016-03-10T23:59:59.000000Z',
+                    'id': self.brief.id,
+                    'status': self.brief.status,
+                    'title': self.brief_title,
+                    'frameworkSlug': self.brief.framework.slug
+                },
+                'briefId': self.brief.id,
+                'supplierId': 0,
+                'supplierName': 'Supplier 0',
+                'supplierOrganisationSize': 'small',
+                'createdAt': mock.ANY,
+                'submittedAt': '2016-09-28T00:00:00.000000Z',
+                'status': 'submitted',
+                'foo': 'bar',
+                'links': {
+                    'self': (('main.get_brief_response',), {'brief_response_id': brief_response.id}),
+                    'brief': (('main.get_brief',), {'brief_id': self.brief.id}),
+                    'supplier': (('main.get_supplier',), {'supplier_id': 0}),
                 }
+            }
 
     def test_brief_response_can_be_serialized_with_no_submitted_at_time(self):
-        with self.app.app_context():
-            brief_response = BriefResponse(
-                data={'foo': 'bar'}, brief=self.brief, supplier=self.supplier
-            )
-            db.session.add(brief_response)
-            db.session.commit()
+        brief_response = BriefResponse(
+            data={'foo': 'bar'}, brief=self.brief, supplier=self.supplier
+        )
+        db.session.add(brief_response)
+        db.session.commit()
 
-            with mock.patch('app.models.main.url_for') as url_for:
-                url_for.side_effect = lambda *args, **kwargs: (args, kwargs)
-                assert brief_response.serialize() == {
-                    'id': brief_response.id,
-                    'briefId': self.brief.id,
-                    'brief': {
-                        'applicationsClosedAt': '2016-03-10T23:59:59.000000Z',
-                        'id': self.brief.id,
-                        'status': self.brief.status,
-                        'title': self.brief_title,
-                        'frameworkSlug': self.brief.framework.slug
-                    },
-                    'supplierId': 0,
-                    'supplierName': 'Supplier 0',
-                    'supplierOrganisationSize': 'small',
-                    'createdAt': mock.ANY,
-                    'status': 'draft',
-                    'foo': 'bar',
-                    'links': {
-                        'self': (('main.get_brief_response',), {'brief_response_id': brief_response.id}),
-                        'brief': (('main.get_brief',), {'brief_id': self.brief.id}),
-                        'supplier': (('main.get_supplier',), {'supplier_id': 0}),
-                    }
+        with mock.patch('app.models.main.url_for') as url_for:
+            url_for.side_effect = lambda *args, **kwargs: (args, kwargs)
+            assert brief_response.serialize() == {
+                'id': brief_response.id,
+                'briefId': self.brief.id,
+                'brief': {
+                    'applicationsClosedAt': '2016-03-10T23:59:59.000000Z',
+                    'id': self.brief.id,
+                    'status': self.brief.status,
+                    'title': self.brief_title,
+                    'frameworkSlug': self.brief.framework.slug
+                },
+                'supplierId': 0,
+                'supplierName': 'Supplier 0',
+                'supplierOrganisationSize': 'small',
+                'createdAt': mock.ANY,
+                'status': 'draft',
+                'foo': 'bar',
+                'links': {
+                    'self': (('main.get_brief_response',), {'brief_response_id': brief_response.id}),
+                    'brief': (('main.get_brief',), {'brief_id': self.brief.id}),
+                    'supplier': (('main.get_supplier',), {'supplier_id': 0}),
                 }
+            }
 
     def test_brief_response_serialization_includes_award_details_if_status_awarded(self):
-        with self.app.app_context():
-            brief_response = BriefResponse(
-                data={'foo': 'bar'}, brief=self.brief, supplier=self.supplier, submitted_at=datetime(2016, 9, 28)
-            )
-            db.session.add(brief_response)
-            db.session.commit()
-            brief_response.award_details = {
+        brief_response = BriefResponse(
+            data={'foo': 'bar'}, brief=self.brief, supplier=self.supplier, submitted_at=datetime(2016, 9, 28)
+        )
+        db.session.add(brief_response)
+        db.session.commit()
+        brief_response.award_details = {
+            "awardedContractStartDate": "2020-12-31",
+            "awardedContractValue": "99.95"
+        }
+        brief_response.awarded_at = datetime(2016, 1, 1)
+        db.session.add(brief_response)
+        db.session.commit()
+
+        with mock.patch('app.models.main.url_for') as url_for:
+            url_for.side_effect = lambda *args, **kwargs: (args, kwargs)
+            assert brief_response.serialize()['awardDetails'] == {
                 "awardedContractStartDate": "2020-12-31",
                 "awardedContractValue": "99.95"
             }
-            brief_response.awarded_at = datetime(2016, 1, 1)
-            db.session.add(brief_response)
-            db.session.commit()
-
-            with mock.patch('app.models.main.url_for') as url_for:
-                url_for.side_effect = lambda *args, **kwargs: (args, kwargs)
-                assert brief_response.serialize()['awardDetails'] == {
-                    "awardedContractStartDate": "2020-12-31",
-                    "awardedContractValue": "99.95"
-                }
 
     def test_brief_response_serialization_includes_pending_flag_if_status_pending_awarded(self):
-        with self.app.app_context():
-            brief_response = BriefResponse(
-                data={'foo': 'bar'}, brief=self.brief, supplier=self.supplier, submitted_at=datetime(2016, 9, 28)
-            )
-            db.session.add(brief_response)
-            db.session.commit()
-            brief_response.award_details = {"pending": True}
-            db.session.add(brief_response)
-            db.session.commit()
+        brief_response = BriefResponse(
+            data={'foo': 'bar'}, brief=self.brief, supplier=self.supplier, submitted_at=datetime(2016, 9, 28)
+        )
+        db.session.add(brief_response)
+        db.session.commit()
+        brief_response.award_details = {"pending": True}
+        db.session.add(brief_response)
+        db.session.commit()
 
-            with mock.patch('app.models.main.url_for') as url_for:
-                url_for.side_effect = lambda *args, **kwargs: (args, kwargs)
-                assert brief_response.serialize()['awardDetails'] == {"pending": True}
+        with mock.patch('app.models.main.url_for') as url_for:
+            url_for.side_effect = lambda *args, **kwargs: (args, kwargs)
+            assert brief_response.serialize()['awardDetails'] == {"pending": True}
 
     def test_brief_response_awarded_at_index_raises_integrity_error_on_more_than_one_award_per_brief(self):
         timestamp = datetime(2016, 12, 31, 12, 1, 2, 3)
-        with self.app.app_context():
-            brief = Brief.query.get(self.brief_id)
-            brief_response1 = BriefResponse(
-                data={}, brief=brief, supplier=self.supplier, submitted_at=datetime.utcnow(),
-                award_details={'pending': True},
-            )
-            brief_response1.award_details = {'confirmed': 'details'},
-            brief_response1.awarded_at = timestamp
-            brief_response2 = BriefResponse(
-                data={}, brief=brief, supplier=self.supplier, submitted_at=datetime.utcnow(),
-                award_details={'pending': True},
-            )
-            brief_response2.award_details = {'confirmed': 'details'},
-            brief_response2.awarded_at = timestamp
-            db.session.add_all([brief_response1, brief_response2])
-            with pytest.raises(IntegrityError) as exc:
-                db.session.commit()
-            assert 'duplicate key value violates unique constraint' in str(exc.value)
+        brief = Brief.query.get(self.brief_id)
+        brief_response1 = BriefResponse(
+            data={}, brief=brief, supplier=self.supplier, submitted_at=datetime.utcnow(),
+            award_details={'pending': True},
+        )
+        brief_response1.award_details = {'confirmed': 'details'},
+        brief_response1.awarded_at = timestamp
+        brief_response2 = BriefResponse(
+            data={}, brief=brief, supplier=self.supplier, submitted_at=datetime.utcnow(),
+            award_details={'pending': True},
+        )
+        brief_response2.award_details = {'confirmed': 'details'},
+        brief_response2.awarded_at = timestamp
+        db.session.add_all([brief_response1, brief_response2])
+        with pytest.raises(IntegrityError) as exc:
+            db.session.commit()
+        assert 'duplicate key value violates unique constraint' in str(exc.value)
 
     def test_brief_response_awarded_index_can_save_awards_for_unique_briefs(self):
         timestamp = datetime(2016, 12, 31, 12, 1, 2, 3)
-        with self.app.app_context():
-            brief = Brief.query.get(self.brief_id)
-            brief2 = self._create_brief()
-            db.session.add(brief2)
-            brief_response1 = BriefResponse(
-                data={}, brief=brief, supplier=self.supplier, submitted_at=datetime.utcnow(),
-                award_details={'pending': True}
-            )
-            brief_response1.awarded_at = timestamp
-            brief_response1.award_details = {'confirmed': 'details'}
-            brief_response2 = BriefResponse(
-                data={}, brief=brief, supplier=self.supplier, submitted_at=datetime.utcnow(),
-                award_details={'pending': True}, awarded_at=None
-            )
-            brief_response3 = BriefResponse(
-                data={}, brief=brief2, supplier=self.supplier, submitted_at=datetime.utcnow(),
-                award_details={'pending': True}, awarded_at=None
-            )
-            brief_response4 = BriefResponse(
-                data={}, brief=brief2, supplier=self.supplier, submitted_at=datetime.utcnow(),
-                award_details={'pending': True}
-            )
-            brief_response4.awarded_at = timestamp
-            brief_response4.award_details = {'confirmed': 'details'}
+        brief = Brief.query.get(self.brief_id)
+        brief2 = self._create_brief()
+        db.session.add(brief2)
+        brief_response1 = BriefResponse(
+            data={}, brief=brief, supplier=self.supplier, submitted_at=datetime.utcnow(),
+            award_details={'pending': True}
+        )
+        brief_response1.awarded_at = timestamp
+        brief_response1.award_details = {'confirmed': 'details'}
+        brief_response2 = BriefResponse(
+            data={}, brief=brief, supplier=self.supplier, submitted_at=datetime.utcnow(),
+            award_details={'pending': True}, awarded_at=None
+        )
+        brief_response3 = BriefResponse(
+            data={}, brief=brief2, supplier=self.supplier, submitted_at=datetime.utcnow(),
+            award_details={'pending': True}, awarded_at=None
+        )
+        brief_response4 = BriefResponse(
+            data={}, brief=brief2, supplier=self.supplier, submitted_at=datetime.utcnow(),
+            award_details={'pending': True}
+        )
+        brief_response4.awarded_at = timestamp
+        brief_response4.award_details = {'confirmed': 'details'}
 
-            db.session.add_all([brief_response1, brief_response2, brief_response3, brief_response4])
-            db.session.commit()
+        db.session.add_all([brief_response1, brief_response2, brief_response3, brief_response4])
+        db.session.commit()
 
-            for b in [brief_response1, brief_response2, brief_response3, brief_response4]:
-                assert b.id
+        for b in [brief_response1, brief_response2, brief_response3, brief_response4]:
+            assert b.id
 
     def test_brief_response_awarded_index_can_save_multiple_non_awarded_responses(self):
-        with self.app.app_context():
-            brief = Brief.query.get(self.brief_id)
-            brief_response1 = BriefResponse(
-                data={}, brief=brief, supplier=self.supplier, submitted_at=datetime.utcnow(), awarded_at=None
-            )
-            brief_response2 = BriefResponse(
-                data={}, brief=brief, supplier=self.supplier, submitted_at=datetime.utcnow(), awarded_at=None
-            )
-            db.session.add_all([brief_response1, brief_response2])
-            db.session.commit()
+        brief = Brief.query.get(self.brief_id)
+        brief_response1 = BriefResponse(
+            data={}, brief=brief, supplier=self.supplier, submitted_at=datetime.utcnow(), awarded_at=None
+        )
+        brief_response2 = BriefResponse(
+            data={}, brief=brief, supplier=self.supplier, submitted_at=datetime.utcnow(), awarded_at=None
+        )
+        db.session.add_all([brief_response1, brief_response2])
+        db.session.commit()
 
-            for b in [brief_response1, brief_response2]:
-                assert b.id
+        for b in [brief_response1, brief_response2]:
+            assert b.id
 
     def test_brief_response_awarded_index_sets_default_value(self):
-        with self.app.app_context():
-            brief_response = BriefResponse(data={}, brief=self.brief, supplier=self.supplier)
-            db.session.add(brief_response)
-            db.session.commit()
+        brief_response = BriefResponse(data={}, brief=self.brief, supplier=self.supplier)
+        db.session.add(brief_response)
+        db.session.commit()
 
-            assert brief_response.id
-            assert brief_response.awarded_at is None
+        assert brief_response.id
+        assert brief_response.awarded_at is None
 
     def test_brief_response_can_not_be_awarded_if_brief_is_not_closed(self):
-        with self.app.app_context(), pytest.raises(ValidationError) as e:
+        with pytest.raises(ValidationError) as e:
             brief = self._create_brief(published_at=datetime.utcnow())
             brief_response = BriefResponse(data={}, brief=brief, supplier=self.supplier)
             db.session.add_all([brief, brief_response])
@@ -1182,7 +1132,7 @@ class TestBriefResponses(BaseApplicationTest, FixtureMixin):
         assert 'Brief response can not be awarded if the brief is not closed' in e.value.message
 
     def test_brief_response_can_not_be_awarded_if_brief_response_has_not_been_submitted(self):
-        with self.app.app_context(), pytest.raises(ValidationError) as e:
+        with pytest.raises(ValidationError) as e:
             brief_response = BriefResponse(data={}, brief=self.brief, supplier=self.supplier)
             db.session.add(brief_response)
             db.session.commit()
@@ -1195,23 +1145,22 @@ class TestBriefResponses(BaseApplicationTest, FixtureMixin):
         assert 'Brief response can not be awarded if response has not been submitted' in e.value.message
 
     def test_can_remove_award_details_from_brief_response_if_brief_not_awarded(self):
-        with self.app.app_context():
-            brief_response = BriefResponse(
-                data={}, brief=self.brief, supplier=self.supplier, submitted_at=datetime.utcnow()
-            )
-            db.session.add(brief_response)
-            db.session.commit()
-            # Pending award to this brief response
-            brief_response.award_details = {'pending': True}
-            db.session.add(brief_response)
-            db.session.commit()
-            # There's still time to change our minds...
-            brief_response.award_details = {}
-            db.session.add(brief_response)
-            db.session.commit()
+        brief_response = BriefResponse(
+            data={}, brief=self.brief, supplier=self.supplier, submitted_at=datetime.utcnow()
+        )
+        db.session.add(brief_response)
+        db.session.commit()
+        # Pending award to this brief response
+        brief_response.award_details = {'pending': True}
+        db.session.add(brief_response)
+        db.session.commit()
+        # There's still time to change our minds...
+        brief_response.award_details = {}
+        db.session.add(brief_response)
+        db.session.commit()
 
     def test_cannot_remove_award_from_brief_response_if_brief_awarded(self):
-        with self.app.app_context(), pytest.raises(ValidationError) as e:
+        with pytest.raises(ValidationError) as e:
             brief_response = BriefResponse(
                 data={}, brief=self.brief, supplier=self.supplier, submitted_at=datetime.utcnow()
             )
@@ -1231,51 +1180,48 @@ class TestBriefResponses(BaseApplicationTest, FixtureMixin):
 class TestBriefClarificationQuestion(BaseApplicationTest):
     def setup(self):
         super(TestBriefClarificationQuestion, self).setup()
-        with self.app.app_context():
-            self.framework = Framework.query.filter(Framework.slug == 'digital-outcomes-and-specialists').first()
-            self.lot = self.framework.get_lot('digital-outcomes')
-            self.brief = Brief(data={}, framework=self.framework, lot=self.lot, status="live")
-            db.session.add(self.brief)
-            db.session.commit()
+        self.framework = Framework.query.filter(Framework.slug == 'digital-outcomes-and-specialists').first()
+        self.lot = self.framework.get_lot('digital-outcomes')
+        self.brief = Brief(data={}, framework=self.framework, lot=self.lot, status="live")
+        db.session.add(self.brief)
+        db.session.commit()
 
-            # Reload objects after session commit
-            self.framework = Framework.query.get(self.framework.id)
-            self.lot = Lot.query.get(self.lot.id)
-            self.brief = Brief.query.get(self.brief.id)
+        # Reload objects after session commit
+        self.framework = Framework.query.get(self.framework.id)
+        self.lot = Lot.query.get(self.lot.id)
+        self.brief = Brief.query.get(self.brief.id)
 
     def test_brief_must_be_live(self):
-        with self.app.app_context():
-            brief = Brief(data={}, framework=self.framework, lot=self.lot, status="draft")
-            with pytest.raises(ValidationError) as e:
-                BriefClarificationQuestion(brief=brief, question="Why?", answer="Because")
+        brief = Brief(data={}, framework=self.framework, lot=self.lot, status="draft")
+        with pytest.raises(ValidationError) as e:
+            BriefClarificationQuestion(brief=brief, question="Why?", answer="Because")
 
-            assert str(e.value.message) == "Brief status must be 'live', not 'draft'"
+        assert str(e.value.message) == "Brief status must be 'live', not 'draft'"
 
     def test_cannot_update_brief_by_id(self):
-        with self.app.app_context(), pytest.raises(ValidationError) as e:
+        with pytest.raises(ValidationError) as e:
             BriefClarificationQuestion(brief_id=self.brief.id, question="Why?", answer="Because")
 
         assert str(e.value.message) == "Cannot update brief_id directly, use brief relationship"
 
     def test_published_at_is_set_on_creation(self):
-        with self.app.app_context():
-            question = BriefClarificationQuestion(
-                brief=self.brief, question="Why?", answer="Because")
+        question = BriefClarificationQuestion(
+            brief=self.brief, question="Why?", answer="Because")
 
-            db.session.add(question)
-            db.session.commit()
+        db.session.add(question)
+        db.session.commit()
 
-            assert isinstance(question.published_at, datetime)
+        assert isinstance(question.published_at, datetime)
 
     def test_question_must_not_be_null(self):
-        with self.app.app_context(), pytest.raises(IntegrityError):
+        with pytest.raises(IntegrityError):
             question = BriefClarificationQuestion(brief=self.brief, answer="Because")
 
             db.session.add(question)
             db.session.commit()
 
     def test_question_must_not_be_empty(self):
-        with self.app.app_context(), pytest.raises(ValidationError) as e:
+        with pytest.raises(ValidationError) as e:
             question = BriefClarificationQuestion(brief=self.brief, question="", answer="Because")
             question.validate()
 
@@ -1283,7 +1229,7 @@ class TestBriefClarificationQuestion(BaseApplicationTest):
 
     def test_questions_must_not_be_more_than_100_words(self):
         long_question = " ".join(["word"] * 101)
-        with self.app.app_context(), pytest.raises(ValidationError) as e:
+        with pytest.raises(ValidationError) as e:
             question = BriefClarificationQuestion(brief=self.brief, question=long_question, answer="Because")
             question.validate()
 
@@ -1291,7 +1237,7 @@ class TestBriefClarificationQuestion(BaseApplicationTest):
 
     def test_question_must_not_be_more_than_5000_characters(self):
         long_question = "a" * 5001
-        with self.app.app_context(), pytest.raises(ValidationError) as e:
+        with pytest.raises(ValidationError) as e:
             question = BriefClarificationQuestion(brief=self.brief, question=long_question, answer="Because")
             question.validate()
 
@@ -1299,19 +1245,18 @@ class TestBriefClarificationQuestion(BaseApplicationTest):
 
     def test_questions_can_be_100_words(self):
         question = " ".join(["word"] * 100)
-        with self.app.app_context():
-            question = BriefClarificationQuestion(brief=self.brief, question=question, answer="Because")
-            question.validate()
+        question = BriefClarificationQuestion(brief=self.brief, question=question, answer="Because")
+        question.validate()
 
     def test_answer_must_not_be_null(self):
-        with self.app.app_context(), pytest.raises(IntegrityError):
+        with pytest.raises(IntegrityError):
             question = BriefClarificationQuestion(brief=self.brief, question="Why?")
 
             db.session.add(question)
             db.session.commit()
 
     def test_answer_must_not_be_empty(self):
-        with self.app.app_context(), pytest.raises(ValidationError) as e:
+        with pytest.raises(ValidationError) as e:
             question = BriefClarificationQuestion(brief=self.brief, question="Why?", answer="")
             question.validate()
 
@@ -1319,7 +1264,7 @@ class TestBriefClarificationQuestion(BaseApplicationTest):
 
     def test_answers_must_not_be_more_than_100_words(self):
         long_answer = " ".join(["word"] * 101)
-        with self.app.app_context(), pytest.raises(ValidationError) as e:
+        with pytest.raises(ValidationError) as e:
             question = BriefClarificationQuestion(brief=self.brief, question="Why?", answer=long_answer)
             question.validate()
 
@@ -1327,7 +1272,7 @@ class TestBriefClarificationQuestion(BaseApplicationTest):
 
     def test_answer_must_not_be_more_than_5000_characters(self):
         long_answer = "a" * 5001
-        with self.app.app_context(), pytest.raises(ValidationError) as e:
+        with pytest.raises(ValidationError) as e:
             question = BriefClarificationQuestion(brief=self.brief, question="Why?", answer=long_answer)
             question.validate()
 
@@ -1335,20 +1280,18 @@ class TestBriefClarificationQuestion(BaseApplicationTest):
 
     def test_answers_can_be_100_words(self):
         answer = " ".join(["word"] * 100)
-        with self.app.app_context():
-            question = BriefClarificationQuestion(brief=self.brief, question="Why?", answer=answer)
-            question.validate()
+        question = BriefClarificationQuestion(brief=self.brief, question="Why?", answer=answer)
+        question.validate()
 
 
 class TestSuppliers(BaseApplicationTest, FixtureMixin):
     def setup(self):
         super(TestSuppliers, self).setup()
-        with self.app.app_context():
-            self.setup_dummy_suppliers(1)
-            self.supplier = Supplier.query.filter(Supplier.supplier_id == 0).first()
-            self.contact_id = ContactInformation.query.filter(
-                ContactInformation.supplier_id == self.supplier.supplier_id
-            ).first().id
+        self.setup_dummy_suppliers(1)
+        self.supplier = Supplier.query.filter(Supplier.supplier_id == 0).first()
+        self.contact_id = ContactInformation.query.filter(
+            ContactInformation.supplier_id == self.supplier.supplier_id
+        ).first().id
 
     def _update_supplier_from_json_with_all_details(self):
         update_data = {
@@ -1395,97 +1338,93 @@ class TestSuppliers(BaseApplicationTest, FixtureMixin):
             }
 
     def test_update_from_json(self):
-        with self.app.app_context():
-            initial_id = self.supplier.id
-            initial_sid = self.supplier.supplier_id
+        initial_id = self.supplier.id
+        initial_sid = self.supplier.supplier_id
 
-            self._update_supplier_from_json_with_all_details()
+        self._update_supplier_from_json_with_all_details()
 
-            # Check IDs can't be updated
-            assert self.supplier.id == initial_id
-            assert self.supplier.supplier_id == initial_sid
+        # Check IDs can't be updated
+        assert self.supplier.id == initial_id
+        assert self.supplier.supplier_id == initial_sid
 
-            # Check everything else has been updated to the correct value
-            assert self.supplier.name == "String and Sticky Tape Inc."
-            assert self.supplier.duns_number == "01010101"
-            assert self.supplier.description == "All your parcel wrapping needs catered for"
-            assert self.supplier.companies_house_number == "98765432"
-            assert self.supplier.registered_name == "Tape and String Inc."
-            assert self.supplier.registration_country == "Wales"
-            assert self.supplier.other_company_registration_number == ""
-            assert self.supplier.registration_date == datetime(1973, 8, 10, 0, 0)
-            assert self.supplier.vat_number == "321321321"
-            assert self.supplier.organisation_size == "medium"
-            assert self.supplier.trading_status == "Sticky"
+        # Check everything else has been updated to the correct value
+        assert self.supplier.name == "String and Sticky Tape Inc."
+        assert self.supplier.duns_number == "01010101"
+        assert self.supplier.description == "All your parcel wrapping needs catered for"
+        assert self.supplier.companies_house_number == "98765432"
+        assert self.supplier.registered_name == "Tape and String Inc."
+        assert self.supplier.registration_country == "Wales"
+        assert self.supplier.other_company_registration_number == ""
+        assert self.supplier.registration_date == datetime(1973, 8, 10, 0, 0)
+        assert self.supplier.vat_number == "321321321"
+        assert self.supplier.organisation_size == "medium"
+        assert self.supplier.trading_status == "Sticky"
 
-            # Check that serialization of a supplier with all details added looks as it should
-            with mock.patch('app.models.main.url_for') as url_for:
-                url_for.side_effect = lambda *args, **kwargs: (args, kwargs)
-                assert self.supplier.serialize() == {
-                    'companiesHouseNumber': '98765432',
-                    'contactInformation': [
-                        {
-                            'contactName': u'Contact for Supplier 0',
-                            'email': u'0@contact.com',
-                            'id': self.contact_id,
-                            'links': {
-                                'self': (
-                                    ('main.update_contact_information',),
-                                    {'contact_id': self.contact_id, 'supplier_id': 0}
-                                )
-                            },
-                            'postcode': u'SW1A 1AA',
-                        }
-                    ],
-                    'description': 'All your parcel wrapping needs catered for',
-                    'dunsNumber': '01010101',
-                    'id': 0,
-                    'links': {'self': (('main.get_supplier',), {'supplier_id': 0})},
-                    'name': 'String and Sticky Tape Inc.',
-                    'organisationSize': 'medium',
-                    'otherCompanyRegistrationNumber': '',
-                    'registeredName': 'Tape and String Inc.',
-                    'registrationCountry': 'Wales',
-                    'registrationDate': '1973-08-10',
-                    'tradingStatus': 'Sticky',
-                    'vatNumber': '321321321',
-                }
+        # Check that serialization of a supplier with all details added looks as it should
+        with mock.patch('app.models.main.url_for') as url_for:
+            url_for.side_effect = lambda *args, **kwargs: (args, kwargs)
+            assert self.supplier.serialize() == {
+                'companiesHouseNumber': '98765432',
+                'contactInformation': [
+                    {
+                        'contactName': u'Contact for Supplier 0',
+                        'email': u'0@contact.com',
+                        'id': self.contact_id,
+                        'links': {
+                            'self': (
+                                ('main.update_contact_information',),
+                                {'contact_id': self.contact_id, 'supplier_id': 0}
+                            )
+                        },
+                        'postcode': u'SW1A 1AA',
+                    }
+                ],
+                'description': 'All your parcel wrapping needs catered for',
+                'dunsNumber': '01010101',
+                'id': 0,
+                'links': {'self': (('main.get_supplier',), {'supplier_id': 0})},
+                'name': 'String and Sticky Tape Inc.',
+                'organisationSize': 'medium',
+                'otherCompanyRegistrationNumber': '',
+                'registeredName': 'Tape and String Inc.',
+                'registrationCountry': 'Wales',
+                'registrationDate': '1973-08-10',
+                'tradingStatus': 'Sticky',
+                'vatNumber': '321321321',
+            }
 
     def test_update_from_json_error_for_badly_formatted_date(self):
-        with self.app.app_context():
-            with pytest.raises(ValidationError) as exception_info:
-                self.supplier.update_from_json({"registrationDate": "July 4, 1776"})
-            assert "Registration date format must be %Y-%m-%d" in "{}".format(exception_info.value)
+        with pytest.raises(ValidationError) as exception_info:
+            self.supplier.update_from_json({"registrationDate": "July 4, 1776"})
+        assert "Registration date format must be %Y-%m-%d" in "{}".format(exception_info.value)
 
 
 class TestServices(BaseApplicationTest, FixtureMixin):
     def test_framework_is_live_only_returns_live_frameworks(self):
-        with self.app.app_context():
-            # the side effect of this method is to create four suppliers with ids between 0-3
-            self.setup_dummy_services_including_unpublished(1)
-            self.setup_dummy_service(
-                service_id='1000000000',
-                supplier_id=0,
-                status='published',
-                framework_id=2)
+        # the side effect of this method is to create four suppliers with ids between 0-3
+        self.setup_dummy_services_including_unpublished(1)
+        self.setup_dummy_service(
+            service_id='1000000000',
+            supplier_id=0,
+            status='published',
+            framework_id=2)
 
-            services = Service.query.framework_is_live()
+        services = Service.query.framework_is_live()
 
-            assert Service.query.count() == 4
-            assert services.count() == 3
-            assert(all(s.framework.status == 'live' for s in services))
+        assert Service.query.count() == 4
+        assert services.count() == 3
+        assert(all(s.framework.status == 'live' for s in services))
 
     def test_lot_must_be_associated_to_the_framework(self):
-        with self.app.app_context():
-            self.setup_dummy_suppliers(1)
-            with pytest.raises(IntegrityError) as excinfo:
-                self.setup_dummy_service(
-                    service_id='10000000001',
-                    supplier_id=0,
-                    framework_id=5,  # Digital Outcomes and Specialists
-                    lot_id=1)  # SaaS
+        self.setup_dummy_suppliers(1)
+        with pytest.raises(IntegrityError) as excinfo:
+            self.setup_dummy_service(
+                service_id='10000000001',
+                supplier_id=0,
+                framework_id=5,  # Digital Outcomes and Specialists
+                lot_id=1)  # SaaS
 
-            assert 'not present in table "framework_lots"' in "{}".format(excinfo.value)
+        assert 'not present in table "framework_lots"' in "{}".format(excinfo.value)
 
     def test_default_ordering(self):
         def add_service(service_id, framework_id, lot_id, service_name):
@@ -1496,98 +1435,93 @@ class TestServices(BaseApplicationTest, FixtureMixin):
                 lot_id=lot_id,
                 data={'serviceName': service_name})
 
-        with self.app.app_context():
-            self.setup_dummy_suppliers(1)
-            add_service('1000000990', 3, 3, 'zzz')
-            add_service('1000000991', 3, 3, 'aaa')
-            add_service('1000000992', 3, 1, 'zzz')
-            add_service('1000000993', 1, 3, 'zzz')
-            db.session.commit()
+        self.setup_dummy_suppliers(1)
+        add_service('1000000990', 3, 3, 'zzz')
+        add_service('1000000991', 3, 3, 'aaa')
+        add_service('1000000992', 3, 1, 'zzz')
+        add_service('1000000993', 1, 3, 'zzz')
+        db.session.commit()
 
-            services = Service.query.default_order()
+        services = Service.query.default_order()
 
-            assert [s.service_id for s in services] == ['1000000993', '1000000992', '1000000991', '1000000990']
+        assert [s.service_id for s in services] == ['1000000993', '1000000992', '1000000991', '1000000990']
 
     def test_has_statuses(self):
-        with self.app.app_context():
-            self.setup_dummy_services_including_unpublished(1)
+        self.setup_dummy_services_including_unpublished(1)
 
-            services = Service.query.has_statuses('published')
+        services = Service.query.has_statuses('published')
 
-            assert services.count() == 1
+        assert services.count() == 1
 
     def test_in_lot(self):
-        with self.app.app_context():
-            self.setup_dummy_suppliers(1)
-            self.setup_dummy_service(
-                service_id='10000000001',
-                supplier_id=0,
-                framework_id=5,  # Digital Outcomes and Specialists
-                lot_id=5)  # digital-outcomes
-            self.setup_dummy_service(
-                service_id='10000000002',
-                supplier_id=0,
-                framework_id=5,  # Digital Outcomes and Specialists
-                lot_id=6)  # digital-specialists
-            self.setup_dummy_service(
-                service_id='10000000003',
-                supplier_id=0,
-                framework_id=5,  # Digital Outcomes and Specialists
-                lot_id=6)  # digital-specialists
+        self.setup_dummy_suppliers(1)
+        self.setup_dummy_service(
+            service_id='10000000001',
+            supplier_id=0,
+            framework_id=5,  # Digital Outcomes and Specialists
+            lot_id=5)  # digital-outcomes
+        self.setup_dummy_service(
+            service_id='10000000002',
+            supplier_id=0,
+            framework_id=5,  # Digital Outcomes and Specialists
+            lot_id=6)  # digital-specialists
+        self.setup_dummy_service(
+            service_id='10000000003',
+            supplier_id=0,
+            framework_id=5,  # Digital Outcomes and Specialists
+            lot_id=6)  # digital-specialists
 
-            services = Service.query.in_lot('digital-specialists')
-            assert services.count() == 2
+        services = Service.query.in_lot('digital-specialists')
+        assert services.count() == 2
 
     def test_data_has_key(self):
-        with self.app.app_context():
-            self.setup_dummy_suppliers(1)
-            self.setup_dummy_service(
-                service_id='10000000001',
-                supplier_id=0,
-                framework_id=5,  # Digital Outcomes and Specialists
-                lot_id=6,  # digital-specialists
-                data={'key1': 'foo', 'key2': 'bar'})
-            self.setup_dummy_service(
-                service_id='10000000002',
-                supplier_id=0,
-                framework_id=5,  # Digital Outcomes and Specialists
-                lot_id=6,  # digital-specialists
-                data={'key1': 'blah'})
-            services = Service.query.data_has_key('key1')
-            assert services.count() == 2
+        self.setup_dummy_suppliers(1)
+        self.setup_dummy_service(
+            service_id='10000000001',
+            supplier_id=0,
+            framework_id=5,  # Digital Outcomes and Specialists
+            lot_id=6,  # digital-specialists
+            data={'key1': 'foo', 'key2': 'bar'})
+        self.setup_dummy_service(
+            service_id='10000000002',
+            supplier_id=0,
+            framework_id=5,  # Digital Outcomes and Specialists
+            lot_id=6,  # digital-specialists
+            data={'key1': 'blah'})
+        services = Service.query.data_has_key('key1')
+        assert services.count() == 2
 
-            services = Service.query.data_has_key('key2')
-            assert services.count() == 1
+        services = Service.query.data_has_key('key2')
+        assert services.count() == 1
 
-            services = Service.query.data_has_key('key3')
-            assert services.count() == 0
+        services = Service.query.data_has_key('key3')
+        assert services.count() == 0
 
     def test_data_key_contains_value(self):
-        with self.app.app_context():
-            self.setup_dummy_suppliers(1)
-            self.setup_dummy_service(
-                service_id='10000000001',
-                supplier_id=0,
-                framework_id=5,  # Digital Outcomes and Specialists
-                lot_id=6,  # digital-specialists
-                data={'key1': ['foo1', 'foo2'], 'key2': ['bar1']})
-            self.setup_dummy_service(
-                service_id='10000000002',
-                supplier_id=0,
-                framework_id=5,  # Digital Outcomes and Specialists
-                lot_id=6,  # digital-specialists
-                data={'key1': ['foo1', 'foo3']})
-            services = Service.query.data_key_contains_value('key1', 'foo1')
-            assert services.count() == 2
+        self.setup_dummy_suppliers(1)
+        self.setup_dummy_service(
+            service_id='10000000001',
+            supplier_id=0,
+            framework_id=5,  # Digital Outcomes and Specialists
+            lot_id=6,  # digital-specialists
+            data={'key1': ['foo1', 'foo2'], 'key2': ['bar1']})
+        self.setup_dummy_service(
+            service_id='10000000002',
+            supplier_id=0,
+            framework_id=5,  # Digital Outcomes and Specialists
+            lot_id=6,  # digital-specialists
+            data={'key1': ['foo1', 'foo3']})
+        services = Service.query.data_key_contains_value('key1', 'foo1')
+        assert services.count() == 2
 
-            services = Service.query.data_key_contains_value('key2', 'bar1')
-            assert services.count() == 1
+        services = Service.query.data_key_contains_value('key2', 'bar1')
+        assert services.count() == 1
 
-            services = Service.query.data_key_contains_value('key3', 'foo1')
-            assert services.count() == 0
+        services = Service.query.data_key_contains_value('key3', 'foo1')
+        assert services.count() == 0
 
-            services = Service.query.data_key_contains_value('key1', 'bar1')
-            assert services.count() == 0
+        services = Service.query.data_key_contains_value('key1', 'bar1')
+        assert services.count() == 0
 
     def test_service_status(self):
         service = Service(status='enabled')
@@ -1600,35 +1534,33 @@ class TestServices(BaseApplicationTest, FixtureMixin):
             service.status = 'invalid'
 
     def test_has_statuses_should_accept_multiple_statuses(self):
-        with self.app.app_context():
-            self.setup_dummy_services_including_unpublished(1)
+        self.setup_dummy_services_including_unpublished(1)
 
-            services = Service.query.has_statuses('published', 'disabled')
+        services = Service.query.has_statuses('published', 'disabled')
 
-            assert services.count() == 2
+        assert services.count() == 2
 
     def test_update_from_json(self):
-        with self.app.app_context():
-            self.setup_dummy_suppliers(1)
-            self.setup_dummy_service(
-                service_id='1000000000',
-                supplier_id=0,
-                status='published',
-                framework_id=2)
+        self.setup_dummy_suppliers(1)
+        self.setup_dummy_service(
+            service_id='1000000000',
+            supplier_id=0,
+            status='published',
+            framework_id=2)
 
-            service = Service.query.filter(Service.service_id == '1000000000').first()
+        service = Service.query.filter(Service.service_id == '1000000000').first()
 
-            updated_at = service.updated_at
-            created_at = service.created_at
+        updated_at = service.updated_at
+        created_at = service.created_at
 
-            service.update_from_json({'foo': 'bar'})
+        service.update_from_json({'foo': 'bar'})
 
-            db.session.add(service)
-            db.session.commit()
+        db.session.add(service)
+        db.session.commit()
 
-            assert service.created_at == created_at
-            assert service.updated_at > updated_at
-            assert service.data == {'foo': 'bar', 'serviceName': 'Service 1000000000'}
+        assert service.created_at == created_at
+        assert service.updated_at > updated_at
+        assert service.data == {'foo': 'bar', 'serviceName': 'Service 1000000000'}
 
 
 class TestSupplierFrameworks(BaseApplicationTest, FixtureMixin):
@@ -1648,67 +1580,64 @@ class TestSupplierFrameworks(BaseApplicationTest, FixtureMixin):
         # the intention of this test is to ensure a SupplierFramework without any FrameworkAgreements is visible through
         # the default query - i.e. none of our custom relationships are causing it to do an inner join which would
         # cause such a SupplierFramework to be invisible
-        with self.app.app_context():
-            self.setup_dummy_suppliers(1)
+        self.setup_dummy_suppliers(1)
 
-            supplier_framework = SupplierFramework(supplier_id=0, framework_id=1)
-            db.session.add(supplier_framework)
-            db.session.commit()
+        supplier_framework = SupplierFramework(supplier_id=0, framework_id=1)
+        db.session.add(supplier_framework)
+        db.session.commit()
 
-            assert len(
-                SupplierFramework.query.filter(
-                    SupplierFramework.supplier_id == 0
-                ).all()
-            ) == 1
+        assert len(
+            SupplierFramework.query.filter(
+                SupplierFramework.supplier_id == 0
+            ).all()
+        ) == 1
 
     def test_prefill_declaration_from_framework(self):
-        with self.app.app_context():
-            self.setup_dummy_suppliers(2)
+        self.setup_dummy_suppliers(2)
 
-            supplier_framework0 = SupplierFramework(supplier_id=0, framework_id=1)
-            db.session.add(supplier_framework0)
+        supplier_framework0 = SupplierFramework(supplier_id=0, framework_id=1)
+        db.session.add(supplier_framework0)
 
-            supplier_framework1 = SupplierFramework(
-                supplier_id=0,
-                framework_id=2,
-                prefill_declaration_from_framework_id=1,
-            )
-            db.session.add(supplier_framework1)
+        supplier_framework1 = SupplierFramework(
+            supplier_id=0,
+            framework_id=2,
+            prefill_declaration_from_framework_id=1,
+        )
+        db.session.add(supplier_framework1)
 
+        db.session.commit()
+
+        # check the relationships operate properly
+        assert supplier_framework1.prefill_declaration_from_framework is supplier_framework0.framework
+        assert supplier_framework1.prefill_declaration_from_supplier_framework is supplier_framework0
+
+        # check the serialization does the right thing
+        assert supplier_framework0.serialize()["prefillDeclarationFromFrameworkSlug"] is None
+        assert supplier_framework1.serialize()["prefillDeclarationFromFrameworkSlug"] == \
+            supplier_framework0.framework.slug
+
+        # before we tear things down we'll test prefill_declaration_from_framework's
+        # SupplierFramework->SupplierFramework constraint
+        db.session.delete(supplier_framework0)
+        with pytest.raises(IntegrityError):
+            # this should fail because it removes the sf that supplier_framework1 implicitly points to
             db.session.commit()
-
-            # check the relationships operate properly
-            assert supplier_framework1.prefill_declaration_from_framework is supplier_framework0.framework
-            assert supplier_framework1.prefill_declaration_from_supplier_framework is supplier_framework0
-
-            # check the serialization does the right thing
-            assert supplier_framework0.serialize()["prefillDeclarationFromFrameworkSlug"] is None
-            assert supplier_framework1.serialize()["prefillDeclarationFromFrameworkSlug"] == \
-                supplier_framework0.framework.slug
-
-            # before we tear things down we'll test prefill_declaration_from_framework's
-            # SupplierFramework->SupplierFramework constraint
-            db.session.delete(supplier_framework0)
-            with pytest.raises(IntegrityError):
-                # this should fail because it removes the sf that supplier_framework1 implicitly points to
-                db.session.commit()
 
 
 class TestLot(BaseApplicationTest):
     def test_lot_data_is_serialized(self):
-        with self.app.app_context():
-            self.framework = Framework.query.filter(Framework.slug == 'digital-outcomes-and-specialists').first()
-            self.lot = self.framework.get_lot('user-research-studios')
+        self.framework = Framework.query.filter(Framework.slug == 'digital-outcomes-and-specialists').first()
+        self.lot = self.framework.get_lot('user-research-studios')
 
-            assert self.lot.serialize() == {
-                u'id': 7,
-                u'name': u'User research studios',
-                u'slug': u'user-research-studios',
-                u'allowsBrief': False,
-                u'oneServiceLimit': False,
-                u'unitSingular': u'lab',
-                u'unitPlural': u'labs',
-            }
+        assert self.lot.serialize() == {
+            u'id': 7,
+            u'name': u'User research studios',
+            u'slug': u'user-research-studios',
+            u'allowsBrief': False,
+            u'oneServiceLimit': False,
+            u'unitSingular': u'lab',
+            u'unitPlural': u'labs',
+        }
 
 
 class TestFrameworkSupplierIds(BaseApplicationTest):
@@ -1716,219 +1645,204 @@ class TestFrameworkSupplierIds(BaseApplicationTest):
 
     def test_1_supplier(self, draft_service):
         """Test that when one supplier exists in the framework that only supplier is shown."""
-        with self.app.app_context():
-            ds = DraftService.query.filter(DraftService.service_id == draft_service['serviceId']).first()
-            f = Framework.query.filter(Framework.id == ds.framework_id).first()
-            supplier_ids_with_completed_service = f.get_supplier_ids_for_completed_service()
-            assert len(supplier_ids_with_completed_service) == 1
-            assert ds.supplier.supplier_id in supplier_ids_with_completed_service
+        ds = DraftService.query.filter(DraftService.service_id == draft_service['serviceId']).first()
+        f = Framework.query.filter(Framework.id == ds.framework_id).first()
+        supplier_ids_with_completed_service = f.get_supplier_ids_for_completed_service()
+        assert len(supplier_ids_with_completed_service) == 1
+        assert ds.supplier.supplier_id in supplier_ids_with_completed_service
 
     def test_submitted_shows(self, draft_service):
         """Test sevice with status 'submitted' is shown."""
-        with self.app.app_context():
-            ds = DraftService.query.filter(DraftService.service_id == draft_service['serviceId']).first()
-            f = Framework.query.filter(Framework.id == ds.framework_id).first()
-            supplier_ids_with_completed_service = f.get_supplier_ids_for_completed_service()
-            assert ds.status == 'submitted'
-            assert ds.supplier.supplier_id in supplier_ids_with_completed_service
+        ds = DraftService.query.filter(DraftService.service_id == draft_service['serviceId']).first()
+        f = Framework.query.filter(Framework.id == ds.framework_id).first()
+        supplier_ids_with_completed_service = f.get_supplier_ids_for_completed_service()
+        assert ds.status == 'submitted'
+        assert ds.supplier.supplier_id in supplier_ids_with_completed_service
 
     def test_failed_shows(self, draft_service):
         """Test sevice with status 'failed' is shown."""
-        with self.app.app_context():
-            ds = DraftService.query.filter(DraftService.service_id == draft_service['serviceId']).first()
-            ds.status = 'failed'
-            db.session.add(ds)
-            db.session.commit()
-            f = Framework.query.filter(Framework.id == ds.framework_id).first()
-            supplier_ids_with_completed_service = f.get_supplier_ids_for_completed_service()
-            assert ds.status == 'failed'
-            assert ds.supplier.supplier_id in supplier_ids_with_completed_service
+        ds = DraftService.query.filter(DraftService.service_id == draft_service['serviceId']).first()
+        ds.status = 'failed'
+        db.session.add(ds)
+        db.session.commit()
+        f = Framework.query.filter(Framework.id == ds.framework_id).first()
+        supplier_ids_with_completed_service = f.get_supplier_ids_for_completed_service()
+        assert ds.status == 'failed'
+        assert ds.supplier.supplier_id in supplier_ids_with_completed_service
 
     def test_not_submitted_does_not_show(self, draft_service):
         """Test sevice with status 'not-submitted' is not shown."""
-        with self.app.app_context():
-            ds = DraftService.query.filter(DraftService.service_id == draft_service['serviceId']).first()
-            ds.status = 'not-submitted'
-            db.session.add(ds)
-            db.session.commit()
-            f = Framework.query.filter(Framework.id == ds.framework_id).first()
-            supplier_ids_with_completed_service = f.get_supplier_ids_for_completed_service()
-            assert ds.status == 'not-submitted'
-            assert ds.supplier.supplier_id not in supplier_ids_with_completed_service
+        ds = DraftService.query.filter(DraftService.service_id == draft_service['serviceId']).first()
+        ds.status = 'not-submitted'
+        db.session.add(ds)
+        db.session.commit()
+        f = Framework.query.filter(Framework.id == ds.framework_id).first()
+        supplier_ids_with_completed_service = f.get_supplier_ids_for_completed_service()
+        assert ds.status == 'not-submitted'
+        assert ds.supplier.supplier_id not in supplier_ids_with_completed_service
 
     def test_no_suppliers(self, open_example_framework):
         """Test a framework with no suppliers on it returns no submitted services."""
-        with self.app.app_context():
-            f = Framework.query.filter(Framework.id == open_example_framework['id']).first()
-            supplier_ids_with_completed_service = f.get_supplier_ids_for_completed_service()
-            assert len(supplier_ids_with_completed_service) == 0
+        f = Framework.query.filter(Framework.id == open_example_framework['id']).first()
+        supplier_ids_with_completed_service = f.get_supplier_ids_for_completed_service()
+        assert len(supplier_ids_with_completed_service) == 0
 
 
 class TestFrameworkSupplierIdsMany(BaseApplicationTest, FixtureMixin):
     """Test multiple suppliers, multiple services."""
 
     def test_multiple_services(self):
-        with self.app.app_context():
-            self.setup_dos_2_framework()
-            lot = Lot.query.first()
-            self.fl_query = {
-                'framework_id': 101,
-                'lot_id': lot.id
-            }
-            fl = FrameworkLot(**self.fl_query)
-            db.session.add(fl)
-            db.session.commit()
+        self.setup_dos_2_framework()
+        lot = Lot.query.first()
+        self.fl_query = {
+            'framework_id': 101,
+            'lot_id': lot.id
+        }
+        fl = FrameworkLot(**self.fl_query)
+        db.session.add(fl)
+        db.session.commit()
 
-            # Set u 5 dummy suppliers
-            self.setup_dummy_suppliers(5)
-            supplier_ids = range(5)
-            # 5 sets of statuses for their respective services.
-            service_status_choices = [
-                ('failed',),
-                ('not-submitted',),
-                ('failed', 'failed', 'failed', 'not-submitted', 'submitted', 'submitted', 'not-submitted', 'failed'),
-                (),
-                ('not-submitted', 'submitted', 'not-submitted', 'not-submitted', 'failed')
-            ]
-            # For the supplier, service_status sets create the services and draft services.
-            count = 0
-            for supplier_id, service_statuses in zip(supplier_ids, service_status_choices):
-                for service_status in service_statuses:
-                    service_id = str(count) * 10
-                    count += 1
-                    self.setup_dummy_service(service_id, supplier_id=supplier_id, **self.fl_query)
+        # Set u 5 dummy suppliers
+        self.setup_dummy_suppliers(5)
+        supplier_ids = range(5)
+        # 5 sets of statuses for their respective services.
+        service_status_choices = [
+            ('failed',),
+            ('not-submitted',),
+            ('failed', 'failed', 'failed', 'not-submitted', 'submitted', 'submitted', 'not-submitted', 'failed'),
+            (),
+            ('not-submitted', 'submitted', 'not-submitted', 'not-submitted', 'failed')
+        ]
+        # For the supplier, service_status sets create the services and draft services.
+        count = 0
+        for supplier_id, service_statuses in zip(supplier_ids, service_status_choices):
+            for service_status in service_statuses:
+                service_id = str(count) * 10
+                count += 1
+                self.setup_dummy_service(service_id, supplier_id=supplier_id, **self.fl_query)
 
-                    db.session.commit()
-                    with mock.patch('app.models.main.url_for', autospec=lambda i, **values: 'test.url/test'):
-                        ds = DraftService.from_service(Service.query.filter(Service.service_id == service_id).first())
-                        ds.status = service_status
-                    db.session.add(ds)
-                    db.session.commit()
-            # Assert that only those suppliers whose service_status list contains failed and/ or submitted are returned.
-            framework = Framework.query.filter(Framework.id == 101).first()
-            assert sorted(framework.get_supplier_ids_for_completed_service()) == [0, 2, 4]
+                db.session.commit()
+                with mock.patch('app.models.main.url_for', autospec=lambda i, **values: 'test.url/test'):
+                    ds = DraftService.from_service(Service.query.filter(Service.service_id == service_id).first())
+                    ds.status = service_status
+                db.session.add(ds)
+                db.session.commit()
+        # Assert that only those suppliers whose service_status list contains failed and/ or submitted are returned.
+        framework = Framework.query.filter(Framework.id == 101).first()
+        assert sorted(framework.get_supplier_ids_for_completed_service()) == [0, 2, 4]
 
 
 class TestFrameworkAgreements(BaseApplicationTest, FixtureMixin):
     def setup(self):
         super(TestFrameworkAgreements, self).setup()
-        with self.app.app_context():
-            self.setup_dummy_suppliers(1)
+        self.setup_dummy_suppliers(1)
 
-            supplier_framework = SupplierFramework(supplier_id=0, framework_id=1)
-            db.session.add(supplier_framework)
-            db.session.commit()
+        supplier_framework = SupplierFramework(supplier_id=0, framework_id=1)
+        db.session.add(supplier_framework)
+        db.session.commit()
 
     def test_supplier_has_to_be_associated_with_a_framework(self):
-        with self.app.app_context():
-            # Supplier 0 and SupplierFramework(supplier_id=0, framework_id=1) are created in setup() so these IDs exist
-            framework_agreement = FrameworkAgreement(supplier_id=0, framework_id=1)
-            db.session.add(framework_agreement)
-            db.session.commit()
+        # Supplier 0 and SupplierFramework(supplier_id=0, framework_id=1) are created in setup() so these IDs exist
+        framework_agreement = FrameworkAgreement(supplier_id=0, framework_id=1)
+        db.session.add(framework_agreement)
+        db.session.commit()
 
-            assert framework_agreement.id
+        assert framework_agreement.id
 
     def test_supplier_cannot_have_a_framework_agreement_for_a_framework_they_are_not_associated_with(self):
-        with self.app.app_context():
-            # SupplierFramework(supplier_id=0, framework_id=2) does not exist so this should fail
-            framework_agreement = FrameworkAgreement(supplier_id=0, framework_id=2)
-            db.session.add(framework_agreement)
+        # SupplierFramework(supplier_id=0, framework_id=2) does not exist so this should fail
+        framework_agreement = FrameworkAgreement(supplier_id=0, framework_id=2)
+        db.session.add(framework_agreement)
 
-            with pytest.raises(IntegrityError):
-                db.session.commit()
+        with pytest.raises(IntegrityError):
+            db.session.commit()
 
     def test_new_framework_agreement_status_is_draft(self):
-        with self.app.app_context():
-            framework_agreement = FrameworkAgreement(supplier_id=0, framework_id=1)
-            db.session.add(framework_agreement)
-            db.session.commit()
+        framework_agreement = FrameworkAgreement(supplier_id=0, framework_id=1)
+        db.session.add(framework_agreement)
+        db.session.commit()
 
-            # Check python implementation gives same result as the sql implementation
-            assert framework_agreement.status == 'draft'
-            assert FrameworkAgreement.query.all()[0].status == 'draft'
+        # Check python implementation gives same result as the sql implementation
+        assert framework_agreement.status == 'draft'
+        assert FrameworkAgreement.query.all()[0].status == 'draft'
 
     def test_partially_signed_framework_agreement_status_is_draft(self):
-        with self.app.app_context():
-            framework_agreement = FrameworkAgreement(
-                supplier_id=0,
-                framework_id=1,
-                signed_agreement_details={'agreement': 'details'},
-                signed_agreement_path='path'
-            )
-            db.session.add(framework_agreement)
-            db.session.commit()
+        framework_agreement = FrameworkAgreement(
+            supplier_id=0,
+            framework_id=1,
+            signed_agreement_details={'agreement': 'details'},
+            signed_agreement_path='path'
+        )
+        db.session.add(framework_agreement)
+        db.session.commit()
 
-            # Check python implementation gives same result as the sql implementation
-            assert framework_agreement.status == 'draft'
-            assert FrameworkAgreement.query.all()[0].status == 'draft'
+        # Check python implementation gives same result as the sql implementation
+        assert framework_agreement.status == 'draft'
+        assert FrameworkAgreement.query.all()[0].status == 'draft'
 
     def test_signed_framework_agreement_status_is_signed(self):
-        with self.app.app_context():
-            framework_agreement = FrameworkAgreement(
-                supplier_id=0,
-                framework_id=1,
-                signed_agreement_details={'agreement': 'details'},
-                signed_agreement_path='path',
-                signed_agreement_returned_at=datetime.utcnow()
-            )
-            db.session.add(framework_agreement)
-            db.session.commit()
+        framework_agreement = FrameworkAgreement(
+            supplier_id=0,
+            framework_id=1,
+            signed_agreement_details={'agreement': 'details'},
+            signed_agreement_path='path',
+            signed_agreement_returned_at=datetime.utcnow()
+        )
+        db.session.add(framework_agreement)
+        db.session.commit()
 
-            # Check python implementation gives same result as the sql implementation
-            assert framework_agreement.status == 'signed'
-            assert FrameworkAgreement.query.all()[0].status == 'signed'
+        # Check python implementation gives same result as the sql implementation
+        assert framework_agreement.status == 'signed'
+        assert FrameworkAgreement.query.all()[0].status == 'signed'
 
     def test_on_hold_framework_agreement_status_is_on_hold(self):
-        with self.app.app_context():
-            framework_agreement = FrameworkAgreement(
-                supplier_id=0,
-                framework_id=1,
-                signed_agreement_details={'agreement': 'details'},
-                signed_agreement_path='path',
-                signed_agreement_returned_at=datetime.utcnow(),
-                signed_agreement_put_on_hold_at=datetime.utcnow()
-            )
-            db.session.add(framework_agreement)
-            db.session.commit()
+        framework_agreement = FrameworkAgreement(
+            supplier_id=0,
+            framework_id=1,
+            signed_agreement_details={'agreement': 'details'},
+            signed_agreement_path='path',
+            signed_agreement_returned_at=datetime.utcnow(),
+            signed_agreement_put_on_hold_at=datetime.utcnow()
+        )
+        db.session.add(framework_agreement)
+        db.session.commit()
 
-            # Check python implementation gives same result as the sql implementation
-            assert framework_agreement.status == 'on-hold'
-            assert FrameworkAgreement.query.all()[0].status == 'on-hold'
+        # Check python implementation gives same result as the sql implementation
+        assert framework_agreement.status == 'on-hold'
+        assert FrameworkAgreement.query.all()[0].status == 'on-hold'
 
     def test_approved_framework_agreement_status_is_approved(self):
-        with self.app.app_context():
-            framework_agreement = FrameworkAgreement(
-                supplier_id=0,
-                framework_id=1,
-                signed_agreement_details={'agreement': 'details'},
-                signed_agreement_path='path',
-                signed_agreement_returned_at=datetime.utcnow(),
-                countersigned_agreement_returned_at=datetime.utcnow()
-            )
-            db.session.add(framework_agreement)
-            db.session.commit()
+        framework_agreement = FrameworkAgreement(
+            supplier_id=0,
+            framework_id=1,
+            signed_agreement_details={'agreement': 'details'},
+            signed_agreement_path='path',
+            signed_agreement_returned_at=datetime.utcnow(),
+            countersigned_agreement_returned_at=datetime.utcnow()
+        )
+        db.session.add(framework_agreement)
+        db.session.commit()
 
-            # Check python implementation gives same result as the sql implementation
-            assert framework_agreement.status == 'approved'
-            assert FrameworkAgreement.query.all()[0].status == 'approved'
+        # Check python implementation gives same result as the sql implementation
+        assert framework_agreement.status == 'approved'
+        assert FrameworkAgreement.query.all()[0].status == 'approved'
 
     def test_countersigned_framework_agreement_status_is_countersigned(self):
-        with self.app.app_context():
-            framework_agreement = FrameworkAgreement(
-                supplier_id=0,
-                framework_id=1,
-                signed_agreement_details={'agreement': 'details'},
-                signed_agreement_path='path',
-                signed_agreement_returned_at=datetime.utcnow(),
-                countersigned_agreement_returned_at=datetime.utcnow(),
-                countersigned_agreement_path='/path/to/the/countersignedAgreement.pdf'
-            )
-            db.session.add(framework_agreement)
-            db.session.commit()
+        framework_agreement = FrameworkAgreement(
+            supplier_id=0,
+            framework_id=1,
+            signed_agreement_details={'agreement': 'details'},
+            signed_agreement_path='path',
+            signed_agreement_returned_at=datetime.utcnow(),
+            countersigned_agreement_returned_at=datetime.utcnow(),
+            countersigned_agreement_path='/path/to/the/countersignedAgreement.pdf'
+        )
+        db.session.add(framework_agreement)
+        db.session.commit()
 
-            # Check python implementation gives same result as the sql implementation
-            assert framework_agreement.status == 'countersigned'
-            assert FrameworkAgreement.query.all()[0].status == 'countersigned'
+        # Check python implementation gives same result as the sql implementation
+        assert framework_agreement.status == 'countersigned'
+        assert FrameworkAgreement.query.all()[0].status == 'countersigned'
 
     def test_most_recent_signature_time(self):
         framework_agreement = FrameworkAgreement(
@@ -1962,12 +1876,11 @@ class TestCurrentFrameworkAgreement(BaseApplicationTest, FixtureMixin):
 
     def setup(self):
         super(TestCurrentFrameworkAgreement, self).setup()
-        with self.app.app_context():
-            self.setup_dummy_suppliers(1)
+        self.setup_dummy_suppliers(1)
 
-            supplier_framework = SupplierFramework(supplier_id=0, framework_id=1)
-            db.session.add(supplier_framework)
-            db.session.commit()
+        supplier_framework = SupplierFramework(supplier_id=0, framework_id=1)
+        db.session.add(supplier_framework)
+        db.session.commit()
 
     def get_supplier_framework(self):
         return SupplierFramework.query.filter(
@@ -1976,86 +1889,77 @@ class TestCurrentFrameworkAgreement(BaseApplicationTest, FixtureMixin):
         ).first()
 
     def test_current_framework_agreement_with_no_agreements(self):
-        with self.app.app_context():
-            supplier_framework = self.get_supplier_framework()
-            assert supplier_framework.current_framework_agreement is None
+        supplier_framework = self.get_supplier_framework()
+        assert supplier_framework.current_framework_agreement is None
 
     def test_current_framework_agreement_with_one_draft_only(self):
-        with self.app.app_context():
-            db.session.add(FrameworkAgreement(id=5, **self.BASE_AGREEMENT_KWARGS))
-            db.session.commit()
-            supplier_framework = self.get_supplier_framework()
-            assert supplier_framework.current_framework_agreement is None
+        db.session.add(FrameworkAgreement(id=5, **self.BASE_AGREEMENT_KWARGS))
+        db.session.commit()
+        supplier_framework = self.get_supplier_framework()
+        assert supplier_framework.current_framework_agreement is None
 
     def test_current_framework_agreement_with_multiple_drafts(self):
-        with self.app.app_context():
-            db.session.add(FrameworkAgreement(id=5, **self.BASE_AGREEMENT_KWARGS))
-            db.session.add(FrameworkAgreement(id=6, **self.BASE_AGREEMENT_KWARGS))
-            db.session.commit()
-            supplier_framework = self.get_supplier_framework()
-            assert supplier_framework.current_framework_agreement is None
+        db.session.add(FrameworkAgreement(id=5, **self.BASE_AGREEMENT_KWARGS))
+        db.session.add(FrameworkAgreement(id=6, **self.BASE_AGREEMENT_KWARGS))
+        db.session.commit()
+        supplier_framework = self.get_supplier_framework()
+        assert supplier_framework.current_framework_agreement is None
 
     def test_current_framework_agreement_with_one_signed(self):
-        with self.app.app_context():
-            db.session.add(FrameworkAgreement(
-                id=5, signed_agreement_returned_at=datetime(2016, 10, 9, 12, 00, 00), **self.BASE_AGREEMENT_KWARGS)
-            )
-            supplier_framework = self.get_supplier_framework()
-            assert supplier_framework.current_framework_agreement.id == 5
+        db.session.add(FrameworkAgreement(
+            id=5, signed_agreement_returned_at=datetime(2016, 10, 9, 12, 00, 00), **self.BASE_AGREEMENT_KWARGS)
+        )
+        supplier_framework = self.get_supplier_framework()
+        assert supplier_framework.current_framework_agreement.id == 5
 
     def test_current_framework_agreement_with_multiple_signed(self):
-        with self.app.app_context():
-            db.session.add(FrameworkAgreement(
-                id=5, signed_agreement_returned_at=datetime(2016, 10, 9, 12, 00, 00), **self.BASE_AGREEMENT_KWARGS)
-            )
-            db.session.add(FrameworkAgreement(
-                id=6, signed_agreement_returned_at=datetime(2016, 10, 10, 12, 00, 00), **self.BASE_AGREEMENT_KWARGS)
-            )
-            supplier_framework = self.get_supplier_framework()
-            assert supplier_framework.current_framework_agreement.id == 6
+        db.session.add(FrameworkAgreement(
+            id=5, signed_agreement_returned_at=datetime(2016, 10, 9, 12, 00, 00), **self.BASE_AGREEMENT_KWARGS)
+        )
+        db.session.add(FrameworkAgreement(
+            id=6, signed_agreement_returned_at=datetime(2016, 10, 10, 12, 00, 00), **self.BASE_AGREEMENT_KWARGS)
+        )
+        supplier_framework = self.get_supplier_framework()
+        assert supplier_framework.current_framework_agreement.id == 6
 
     def test_current_framework_agreement_with_signed_and_old_draft_does_not_return_draft(self):
-        with self.app.app_context():
-            db.session.add(FrameworkAgreement(id=5, **self.BASE_AGREEMENT_KWARGS))
-            db.session.add(FrameworkAgreement(
-                id=6, signed_agreement_returned_at=datetime(2016, 10, 10, 12, 00, 00), **self.BASE_AGREEMENT_KWARGS)
-            )
-            supplier_framework = self.get_supplier_framework()
-            assert supplier_framework.current_framework_agreement.id == 6
+        db.session.add(FrameworkAgreement(id=5, **self.BASE_AGREEMENT_KWARGS))
+        db.session.add(FrameworkAgreement(
+            id=6, signed_agreement_returned_at=datetime(2016, 10, 10, 12, 00, 00), **self.BASE_AGREEMENT_KWARGS)
+        )
+        supplier_framework = self.get_supplier_framework()
+        assert supplier_framework.current_framework_agreement.id == 6
 
     def test_current_framework_agreement_with_signed_and_new_draft_does_not_return_draft(self):
-        with self.app.app_context():
-            db.session.add(FrameworkAgreement(id=6, **self.BASE_AGREEMENT_KWARGS))
-            db.session.add(FrameworkAgreement(
-                id=5, signed_agreement_returned_at=datetime(2016, 10, 10, 12, 00, 00), **self.BASE_AGREEMENT_KWARGS)
-            )
-            supplier_framework = self.get_supplier_framework()
-            assert supplier_framework.current_framework_agreement.id == 5
+        db.session.add(FrameworkAgreement(id=6, **self.BASE_AGREEMENT_KWARGS))
+        db.session.add(FrameworkAgreement(
+            id=5, signed_agreement_returned_at=datetime(2016, 10, 10, 12, 00, 00), **self.BASE_AGREEMENT_KWARGS)
+        )
+        supplier_framework = self.get_supplier_framework()
+        assert supplier_framework.current_framework_agreement.id == 5
 
     def test_current_framework_agreement_with_signed_and_new_countersigned(self):
-        with self.app.app_context():
-            db.session.add(FrameworkAgreement(
-                id=5, signed_agreement_returned_at=datetime(2016, 10, 9, 12, 00, 00), **self.BASE_AGREEMENT_KWARGS)
-            )
-            db.session.add(FrameworkAgreement(
-                id=6,
-                signed_agreement_returned_at=datetime(2016, 10, 10, 12, 00, 00),
-                countersigned_agreement_returned_at=datetime(2016, 10, 11, 12, 00, 00),
-                **self.BASE_AGREEMENT_KWARGS)
-            )
-            supplier_framework = self.get_supplier_framework()
-            assert supplier_framework.current_framework_agreement.id == 6
+        db.session.add(FrameworkAgreement(
+            id=5, signed_agreement_returned_at=datetime(2016, 10, 9, 12, 00, 00), **self.BASE_AGREEMENT_KWARGS)
+        )
+        db.session.add(FrameworkAgreement(
+            id=6,
+            signed_agreement_returned_at=datetime(2016, 10, 10, 12, 00, 00),
+            countersigned_agreement_returned_at=datetime(2016, 10, 11, 12, 00, 00),
+            **self.BASE_AGREEMENT_KWARGS)
+        )
+        supplier_framework = self.get_supplier_framework()
+        assert supplier_framework.current_framework_agreement.id == 6
 
     def test_current_framework_agreement_with_countersigned_and_new_signed(self):
-        with self.app.app_context():
-            db.session.add(FrameworkAgreement(
-                id=5, signed_agreement_returned_at=datetime(2016, 10, 11, 12, 00, 00), **self.BASE_AGREEMENT_KWARGS)
-            )
-            db.session.add(FrameworkAgreement(
-                id=6,
-                signed_agreement_returned_at=datetime(2016, 10, 9, 12, 00, 00),
-                countersigned_agreement_returned_at=datetime(2016, 10, 10, 12, 00, 00),
-                **self.BASE_AGREEMENT_KWARGS)
-            )
-            supplier_framework = self.get_supplier_framework()
-            assert supplier_framework.current_framework_agreement.id == 5
+        db.session.add(FrameworkAgreement(
+            id=5, signed_agreement_returned_at=datetime(2016, 10, 11, 12, 00, 00), **self.BASE_AGREEMENT_KWARGS)
+        )
+        db.session.add(FrameworkAgreement(
+            id=6,
+            signed_agreement_returned_at=datetime(2016, 10, 9, 12, 00, 00),
+            countersigned_agreement_returned_at=datetime(2016, 10, 10, 12, 00, 00),
+            **self.BASE_AGREEMENT_KWARGS)
+        )
+        supplier_framework = self.get_supplier_framework()
+        assert supplier_framework.current_framework_agreement.id == 5

--- a/tests/test_brief_utils.py
+++ b/tests/test_brief_utils.py
@@ -8,29 +8,27 @@ from tests.bases import BaseApplicationTest
 @mock.patch('app.brief_utils.index_object', autospec=True)
 class TestIndexBriefs(BaseApplicationTest):
     def test_live_dos_2_brief_is_indexed(self, index_object, live_dos2_framework):
-        with self.app.app_context():
-            dos2 = Framework.query.filter(Framework.slug == 'digital-outcomes-and-specialists-2').first()
+        dos2 = Framework.query.filter(Framework.slug == 'digital-outcomes-and-specialists-2').first()
 
-            with mock.patch.object(Brief, "serialize", return_value={'serialized': 'object'}):
-                lot = Lot.query.filter(Lot.slug == 'digital-outcomes').one()
-                brief = Brief(status='live', framework=dos2, data={'requirementsLength': '1 week'}, lot=lot)
-                db.session.add(brief)
-                db.session.commit()
-                index_brief(brief)
+        with mock.patch.object(Brief, "serialize", return_value={'serialized': 'object'}):
+            lot = Lot.query.filter(Lot.slug == 'digital-outcomes').one()
+            brief = Brief(status='live', framework=dos2, data={'requirementsLength': '1 week'}, lot=lot)
+            db.session.add(brief)
+            db.session.commit()
+            index_brief(brief)
 
-            index_object.assert_called_once_with(
-                framework='digital-outcomes-and-specialists-2',
-                doc_type='briefs',
-                object_id=1,
-                serialized_object={'serialized': 'object'},
-            )
+        index_object.assert_called_once_with(
+            framework='digital-outcomes-and-specialists-2',
+            doc_type='briefs',
+            object_id=1,
+            serialized_object={'serialized': 'object'},
+        )
 
     def test_draft_dos_2_brief_is_not_indexed(self, index_object, live_dos2_framework):
-        with self.app.app_context():
-            dos2 = Framework.query.filter(Framework.slug == 'digital-outcomes-and-specialists-2').first()
+        dos2 = Framework.query.filter(Framework.slug == 'digital-outcomes-and-specialists-2').first()
 
-            with mock.patch.object(Brief, "serialize", return_value={'serialized': 'object'}):
-                brief = Brief(status='draft', framework=dos2, data={'requirementsLength': '1 week'})
-                index_brief(brief)
+        with mock.patch.object(Brief, "serialize", return_value={'serialized': 'object'}):
+            brief = Brief(status='draft', framework=dos2, data={'requirementsLength': '1 week'})
+            index_brief(brief)
 
-            assert index_object.called is False
+        assert index_object.called is False

--- a/tests/test_service_utils.py
+++ b/tests/test_service_utils.py
@@ -11,48 +11,44 @@ class TestIndexServices(BaseApplicationTest):
     def test_live_g_cloud_8_published_service_is_indexed(
             self, index_object, live_g8_framework
     ):
-        with self.app.app_context():
-            g8 = Framework.query.filter(Framework.slug == 'g-cloud-8').first()
+        g8 = Framework.query.filter(Framework.slug == 'g-cloud-8').first()
 
-            with mock.patch.object(Service, "serialize", return_value={'serialized': 'object'}):
-                service = Service(status='published', framework=g8)
-                index_service(service)
+        with mock.patch.object(Service, "serialize", return_value={'serialized': 'object'}):
+            service = Service(status='published', framework=g8)
+            index_service(service)
 
-            index_object.assert_called_once_with(
-                framework='g-cloud-8',
-                doc_type='services',
-                object_id=None,
-                serialized_object={'serialized': 'object'},
-            )
+        index_object.assert_called_once_with(
+            framework='g-cloud-8',
+            doc_type='services',
+            object_id=None,
+            serialized_object={'serialized': 'object'},
+        )
 
     def test_live_g_cloud_8_enabled_service_is_not_indexed(
             self, index_object, live_g8_framework
     ):
-        with self.app.app_context():
-            g8 = Framework.query.filter(Framework.slug == 'g-cloud-8').first()
+        g8 = Framework.query.filter(Framework.slug == 'g-cloud-8').first()
 
-            with mock.patch.object(Service, "serialize"):
-                service = Service(status='enabled', framework=g8)
-                index_service(service)
+        with mock.patch.object(Service, "serialize"):
+            service = Service(status='enabled', framework=g8)
+            index_service(service)
 
-            assert not index_object.called
+        assert not index_object.called
 
     def test_live_dos_published_service_is_not_indexed(self, index_object, live_dos_framework):
-        with self.app.app_context():
-            dos = Framework.query.filter(Framework.slug == 'digital-outcomes-and-specialists').first()
+        dos = Framework.query.filter(Framework.slug == 'digital-outcomes-and-specialists').first()
 
-            with mock.patch.object(Service, "serialize"):
-                service = Service(status='published', framework=dos)
-                index_service(service)
+        with mock.patch.object(Service, "serialize"):
+            service = Service(status='published', framework=dos)
+            index_service(service)
 
-            assert not index_object.called
+        assert not index_object.called
 
     def test_expired_g_cloud_6_published_service_is_not_indexed(self, index_object, expired_g6_framework):
-        with self.app.app_context():
-            g6 = Framework.query.filter(Framework.slug == 'g-cloud-6').first()
+        g6 = Framework.query.filter(Framework.slug == 'g-cloud-6').first()
 
-            with mock.patch.object(Service, "serialize"):
-                service = Service(status='published', framework=g6)
-                index_service(service)
+        with mock.patch.object(Service, "serialize"):
+            service = Service(status='published', framework=g6)
+            index_service(service)
 
-            assert not index_object.called
+        assert not index_object.called

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -29,20 +29,18 @@ def test_link():
 
 class TestJSONHasRequiredKeys(BaseApplicationTest):
     def test_json_has_required_keys(self):
-        with self.app.app_context():
-            sample_json = {"name": "Linus",
-                           "favourite_kitten": "all of them"}
-            keys = ["name", "favourite_kitten", "gender"]
-            with pytest.raises(HTTPException):
-                json_has_required_keys(sample_json, keys)
+        sample_json = {"name": "Linus",
+                       "favourite_kitten": "all of them"}
+        keys = ["name", "favourite_kitten", "gender"]
+        with pytest.raises(HTTPException):
+            json_has_required_keys(sample_json, keys)
 
 
 class TestJSONHasMatchingId(BaseApplicationTest):
     def test_json_has_matching_id(self):
         self.data = {"id": 123456}
-        with self.app.app_context():
-            with pytest.raises(HTTPException):
-                json_has_matching_id(self.data, 78910)
+        with pytest.raises(HTTPException):
+            json_has_matching_id(self.data, 78910)
 
 
 class TestKeyFilterJSON(object):
@@ -78,19 +76,18 @@ class TestKeyFilterJSON(object):
 @mock.patch('app.utils.search_api_client', autospec=True)
 class TestIndexObject(BaseApplicationTest):
     def test_calls_the_search_api_index_method_correctly(self, search_api_client):
-        with self.app.app_context():
-            for framework, doc_type_to_index_mapping in current_app.config['DM_FRAMEWORK_TO_ES_INDEX'].items():
-                for doc_type, index_name in doc_type_to_index_mapping.items():
+        for framework, doc_type_to_index_mapping in current_app.config['DM_FRAMEWORK_TO_ES_INDEX'].items():
+            for doc_type, index_name in doc_type_to_index_mapping.items():
 
-                    index_object(framework, doc_type, 123, {'serialized': 'object'})
+                index_object(framework, doc_type, 123, {'serialized': 'object'})
 
-                    search_api_client.index.assert_called_once_with(
-                        index_name=index_name,
-                        object_id=123,
-                        serialized_object={'serialized': 'object'},
-                        doc_type=doc_type,
-                    )
-                    search_api_client.reset_mock()
+                search_api_client.index.assert_called_once_with(
+                    index_name=index_name,
+                    object_id=123,
+                    serialized_object={'serialized': 'object'},
+                    doc_type=doc_type,
+                )
+                search_api_client.reset_mock()
 
     @mock.patch('app.utils.current_app')
     def test_logs_an_error_message_if_no_mapping_found(self, current_app, search_api_client):
@@ -133,7 +130,7 @@ class TestResultResponses(BaseApplicationTest):
         return result
 
     def test_single_result_response(self):
-        with self.app.app_context() and self.app.test_request_context("/"):
+        with self.app.test_request_context("/"):
             result = self._get_single_result_mock()
 
             response = single_result_response("name", result)
@@ -142,7 +139,7 @@ class TestResultResponses(BaseApplicationTest):
             result.serialize.assert_called_once()
 
     def test_single_result_response_with_serialize_kwargs(self):
-        with self.app.app_context() and self.app.test_request_context("/"):
+        with self.app.test_request_context("/"):
             result = self._get_single_result_mock()
 
             response = single_result_response("name", result, {"do": "this"})
@@ -159,7 +156,7 @@ class TestResultResponses(BaseApplicationTest):
         return result, results_query
 
     def test_list_result_response(self):
-        with self.app.app_context() and self.app.test_request_context("/"):
+        with self.app.test_request_context("/"):
             result, results_query = self._get_list_result_mocks()
 
             response = list_result_response("name", results_query)
@@ -171,7 +168,7 @@ class TestResultResponses(BaseApplicationTest):
             assert result.serialize.call_count == 2
 
     def test_list_result_response_with_serialize_kwargs(self):
-        with self.app.app_context() and self.app.test_request_context("/"):
+        with self.app.test_request_context("/"):
             result, results_query = self._get_list_result_mocks()
 
             response = list_result_response("name", results_query, {"do": "this"})
@@ -198,7 +195,7 @@ class TestResultResponses(BaseApplicationTest):
 
     @mock.patch('app.utils.pagination_links', autospec=True)
     def test_paginated_result_response(self, pagination_links):
-        with self.app.app_context() and self.app.test_request_context("/"):
+        with self.app.test_request_context("/"):
             result, results_query, pagination = self._get_paginated_result_mocks()
             pagination_links.return_value = {"paginated": "links"}
 
@@ -215,7 +212,7 @@ class TestResultResponses(BaseApplicationTest):
 
     @mock.patch('app.utils.pagination_links', autospec=True)
     def test_paginated_result_response_with_serialize_kwargs(self, pagination_links):
-        with self.app.app_context() and self.app.test_request_context("/"):
+        with self.app.test_request_context("/"):
             result, results_query, pagination = self._get_paginated_result_mocks()
             pagination_links.return_value = {"paginated": "links"}
 


### PR DESCRIPTION
  Remove extraneous `with self.app.app_context()` calls  …
The app context is now provided by the tests.bases.BaseApplicationTest.setup.
This makes these calls, within tests, which previously allowed access to the db, unneeded.
See information here on the app context:
http://flask.pocoo.org/docs/0.12/appcontext/

And see the commit here:
cfcbdea
(introduces a app_context push and pop in the BaseApplicationTest.setup/teardown respectively)