### PR TITLE
Allow IntegrityErrors to be serialized

### DIFF
--- a/app/main/views/agreements.py
+++ b/app/main/views/agreements.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from flask import jsonify, abort
+from flask import abort
 from sqlalchemy.exc import IntegrityError
 from dmapiclient.audit import AuditTypes
 
@@ -137,7 +137,7 @@ def update_framework_agreement(agreement_id):
         db.session.commit()
     except IntegrityError as e:
         db.session.rollback()
-        return jsonify(message="Database Error: {0}".format(e)), 400
+        abort(400, format(e))
 
     return single_result_response(RESOURCE_NAME, framework_agreement), 200
 
@@ -187,7 +187,7 @@ def sign_framework_agreement(agreement_id):
         db.session.commit()
     except IntegrityError as e:
         db.session.rollback()
-        return jsonify(message="Database Error: {0}".format(e)), 400
+        abort(400, format(e))
 
     return single_result_response(RESOURCE_NAME, framework_agreement), 200
 
@@ -224,7 +224,7 @@ def put_signed_framework_agreement_on_hold(agreement_id):
         db.session.commit()
     except IntegrityError as e:
         db.session.rollback()
-        return jsonify(message="Database Error: {0}".format(e)), 400
+        abort(400, format(e))
 
     return single_result_response(RESOURCE_NAME, framework_agreement), 200
 
@@ -288,6 +288,6 @@ def approve_for_countersignature(agreement_id):
         db.session.commit()
     except IntegrityError as e:
         db.session.rollback()
-        return jsonify(message="Database Error: {0}".format(e)), 400
+        abort(400, format(e))
 
     return single_result_response(RESOURCE_NAME, framework_agreement), 200

--- a/app/main/views/agreements.py
+++ b/app/main/views/agreements.py
@@ -54,7 +54,7 @@ def create_framework_agreement():
         db.session.flush()
     except IntegrityError as e:
         db.session.rollback()
-        abort(400, e.orig)
+        abort(400, format(e))
 
     audit_event = AuditEvent(
         audit_type=AuditTypes.create_agreement,

--- a/app/main/views/audits.py
+++ b/app/main/views/audits.py
@@ -227,7 +227,7 @@ def acknowledge_audit(audit_id):
 
     except IntegrityError as e:
         db.session.rollback()
-        abort(400, e.orig)
+        abort(400, format(e))
 
     return single_result_response(RESOURCE_NAME, audit_event), 200
 
@@ -284,7 +284,7 @@ def acknowledge_including_previous(
 
     except IntegrityError as e:
         db.session.rollback()
-        abort(400, e.orig)
+        abort(400, format(e))
 
     # returning the list of affected ids, each one in its own dict seems the most rest-ful way (but least memory
     # efficient - well spotted) of returning this information. you would think of these as the most abbreviated

--- a/app/main/views/brief_responses.py
+++ b/app/main/views/brief_responses.py
@@ -76,7 +76,7 @@ def create_brief_response():
         db.session.flush()
     except IntegrityError as e:
         db.session.rollback()
-        abort(400, e.orig)
+        abort(400, format(e))
 
     audit = AuditEvent(
         audit_type=AuditTypes.create_brief_response,
@@ -143,7 +143,7 @@ def update_brief_response(brief_response_id):
         db.session.commit()
     except IntegrityError as e:
         db.session.rollback()
-        abort(400, e.orig)
+        abort(400, format(e))
 
     return single_result_response(RESOURCE_NAME, brief_response), 200
 
@@ -191,7 +191,7 @@ def submit_brief_response(brief_response_id):
         db.session.commit()
     except IntegrityError as e:
         db.session.rollback()
-        abort(400, e.orig)
+        abort(400, format(e))
 
     return single_result_response(RESOURCE_NAME, brief_response), 200
 

--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -54,7 +54,7 @@ def create_brief():
         db.session.flush()
     except IntegrityError as e:
         db.session.rollback()
-        abort(400, e.orig)
+        abort(400, format(e))
 
     audit = AuditEvent(
         audit_type=AuditTypes.create_brief,
@@ -366,7 +366,7 @@ def copy_brief(brief_id):
         db.session.flush()
     except IntegrityError as e:
         db.session.rollback()
-        abort(400, e.orig)
+        abort(400, format(e))
 
     audit = AuditEvent(
         audit_type=AuditTypes.create_brief,
@@ -442,7 +442,7 @@ def add_clarification_question(brief_id):
         db.session.flush()
     except IntegrityError as e:
         db.session.rollback()
-        abort(400, e.orig)
+        abort(400, format(e))
 
     audit = AuditEvent(
         audit_type=AuditTypes.add_brief_clarification_question,

--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -416,7 +416,7 @@ def delete_draft_brief(brief_id):
         db.session.commit()
     except IntegrityError as e:
         db.session.rollback()
-        abort(400, "Database Error: {0}".format(e))
+        abort(400, format(e))
 
     return jsonify(message="done"), 200
 

--- a/app/main/views/buyer_domains.py
+++ b/app/main/views/buyer_domains.py
@@ -37,7 +37,7 @@ def create_buyer_email_domain():
         db.session.flush()
     except IntegrityError as e:
         db.session.rollback()
-        abort(400, e.orig)
+        abort(400, format(e))
 
     audit = AuditEvent(
         audit_type=AuditTypes.create_buyer_email_domain,

--- a/app/main/views/direct_award.py
+++ b/app/main/views/direct_award.py
@@ -97,7 +97,7 @@ def create_project():
 
             retries += 1
             if retries >= 5:
-                abort(400, str(e.orig))
+                abort(400, format(e))
 
     audit = AuditEvent(
         audit_type=AuditTypes.create_project,
@@ -184,7 +184,7 @@ def create_project_search(project_external_id):
 
     except IntegrityError as e:
         db.session.rollback()
-        abort(400, e.orig)
+        abort(400, format(e))
 
     audit = AuditEvent(
         audit_type=AuditTypes.create_project_search,

--- a/app/main/views/drafts.py
+++ b/app/main/views/drafts.py
@@ -70,7 +70,7 @@ def copy_draft_service_from_existing_service(service_id):
         db.session.commit()
     except IntegrityError as e:
         db.session.rollback()
-        abort(400, "Database Error: {0}".format(e))
+        abort(400, format(e))
 
     return single_result_response(RESOURCE_NAME, draft), 201
 
@@ -113,7 +113,7 @@ def edit_draft_service(draft_id):
         db.session.commit()
     except IntegrityError as e:
         db.session.rollback()
-        abort(400, "Database Error: {0}".format(e))
+        abort(400, format(e))
 
     return single_result_response(RESOURCE_NAME, draft), 200
 
@@ -206,7 +206,7 @@ def delete_draft_service(draft_id):
         db.session.commit()
     except IntegrityError as e:
         db.session.rollback()
-        abort(400, "Database Error: {0}".format(e))
+        abort(400, format(e))
 
     return jsonify(message="done"), 200
 
@@ -321,7 +321,7 @@ def create_new_draft_service():
         db.session.commit()
     except IntegrityError as e:
         db.session.rollback()
-        abort(400, "Database Error: {0}".format(e))
+        abort(400, format(e))
 
     return single_result_response(RESOURCE_NAME, draft), 201
 
@@ -354,7 +354,7 @@ def complete_draft_service(draft_id):
         db.session.commit()
     except IntegrityError as e:
         db.session.rollback()
-        abort(400, "Database Error: {0}".format(e))
+        abort(400, format(e))
 
     return single_result_response(RESOURCE_NAME, draft), 200
 
@@ -392,7 +392,7 @@ def update_draft_service_status(draft_id):
         db.session.commit()
     except IntegrityError as e:
         db.session.rollback()
-        abort(400, "Database Error: {0}".format(e))
+        abort(400, format(e))
 
     return single_result_response(RESOURCE_NAME, draft), 200
 
@@ -425,6 +425,6 @@ def copy_draft_service(draft_id):
         db.session.commit()
     except IntegrityError as e:
         db.session.rollback()
-        abort(400, "Database Error: {0}".format(e))
+        abort(400, format(e))
 
     return single_result_response(RESOURCE_NAME, draft_copy), 201

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -124,7 +124,7 @@ def update_framework(framework_slug):
         db.session.commit()
     except IntegrityError as e:
         db.session.rollback()
-        abort(400, "Database Error: {}".format(e))
+        abort(400, format(e))
 
     return single_result_response(RESOURCE_NAME, framework), 200
 

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -136,7 +136,7 @@ def import_supplier(supplier_id):
         db.session.commit()
     except IntegrityError as e:
         db.session.rollback()
-        abort(400, "Database Error: {0}".format(e))
+        abort(400, format(e))
 
     return single_result_response(RESOURCE_NAME, supplier), 201
 
@@ -163,7 +163,7 @@ def create_supplier():
         db.session.commit()
     except IntegrityError as e:
         db.session.rollback()
-        return jsonify(message="Database Error: {0}".format(e)), 400
+        abort(400, format(e))
 
     return single_result_response(RESOURCE_NAME, supplier), 201
 
@@ -204,7 +204,7 @@ def update_supplier(supplier_id):
         db.session.commit()
     except IntegrityError as e:
         db.session.rollback()
-        abort(400, "Database Error: {0}".format(e))
+        abort(400, format(e))
 
     return single_result_response(RESOURCE_NAME, supplier), 200
 
@@ -245,7 +245,7 @@ def update_contact_information(supplier_id, contact_id):
         db.session.commit()
     except IntegrityError as e:
         db.session.rollback()
-        abort(400, "Database Error: {0}".format(e))
+        abort(400, format(e))
 
     return single_result_response("contactInformation", contact), 200
 
@@ -291,7 +291,7 @@ def set_a_declaration(supplier_id, framework_slug):
         db.session.commit()
     except IntegrityError as e:
         db.session.rollback()
-        abort(400, "Database Error: {}".format(e))
+        abort(400, format(e))
 
     return jsonify(declaration=supplier_framework.declaration), status_code
 
@@ -393,7 +393,7 @@ def register_framework_interest(supplier_id, framework_slug):
         db.session.commit()
     except IntegrityError as e:
         db.session.rollback()
-        return jsonify(message="Database Error: {0}".format(e)), 400
+        abort(400, format(e))
 
     return single_result_response("frameworkInterest", interest_record), 201
 
@@ -451,7 +451,7 @@ def update_supplier_framework(supplier_id, framework_slug):
         db.session.commit()
     except IntegrityError as e:
         db.session.rollback()
-        return jsonify(message="Database Error: {0}".format(e)), 400
+        abort(400, format(e))
 
     return single_result_response("frameworkInterest", interest_record), 200
 
@@ -526,7 +526,7 @@ def agree_framework_variation(supplier_id, framework_slug, variation_slug):
         db.session.commit()
     except IntegrityError as e:
         db.session.rollback()
-        return jsonify(message="Database Error: {0}".format(e)), 400
+        abort(400, format(e))
 
     return jsonify(
         agreedVariations=SupplierFramework.serialize_agreed_variation(agreed_variations[variation_slug]),

--- a/app/service_utils.py
+++ b/app/service_utils.py
@@ -124,7 +124,7 @@ def commit_and_archive_service(updated_service, update_details,
         db.session.commit()
     except IntegrityError as e:
         db.session.rollback()
-        abort(400, e.orig)
+        abort(400, format(e))
 
 
 def index_service(service):

--- a/tests/main/views/test_suppliers.py
+++ b/tests/main/views/test_suppliers.py
@@ -932,7 +932,7 @@ class TestPostSupplier(BaseApplicationTest, JSONTestMixin):
         response = self.post_supplier(payload2)
         assert response.status_code == 400
         data = json.loads(response.get_data())
-        assert 'duplicate key value violates unique constraint "ix_suppliers_duns_number"' in data['message']
+        assert 'duplicate key value violates unique constraint "ix_suppliers_duns_number"' in data['error']
 
 
 class TestGetSupplierFrameworks(BaseApplicationTest):


### PR DESCRIPTION
https://trello.com/c/vzTF64Q7/160-sqlalchemy-integrityerrors-in-the-api-cant-be-serialized-so-the-actual-error-message-is-hidden

We had seen 500s in the app if an IntegrityError, `e`, was caught and
we passed `e.orig` into the `abort` function. This is because
`e.orig` refers to the original DB-API IntegrityError that is
raised by the database adapater (psycopg2 in our case). The pyscopg2
IntegrityError is not JSON serializable and we ran into problems.

We can instead use `format` to allow our exception to be
displayed as a string. This is a pattern we are already using in
the many other catching of IntegrityErrors across the app.
  