### PR TITLE
Pre-fetch awarded_brief_response relationship for /brief-responses

### DIFF
--- a/app/main/views/brief_responses.py
+++ b/app/main/views/brief_responses.py
@@ -226,6 +226,7 @@ def list_brief_responses():
     brief_responses = brief_responses.options(
         db.defaultload(BriefResponse.brief).defaultload(Brief.framework).lazyload("*"),
         db.defaultload(BriefResponse.brief).defaultload(Brief.lot).lazyload("*"),
+        db.defaultload(BriefResponse.brief).defaultload(Brief.awarded_brief_response).lazyload("*"),
         db.defaultload(BriefResponse.supplier).lazyload("*"),
     )
 


### PR DESCRIPTION
https://trello.com/c/SptNj93b/229-slow-requests-on-brief-responses-endpoint

The `/brief-responses` endpoint was very slow, triggering an alert on our metrics during the data export job.

Adding the prefetch for the award relationship improves the endpoint response time by a factor of 10! Bonus: the tests also run about ~20% faster.

Not sure if this will affect the memory usage @idavidmcdonald (just looking at the old PR you linked to on the Trello ticket)?