### PR TITLE
Add 'allowDeclarationReuse' to args whitelist for update_framework

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -83,7 +83,8 @@ def update_framework(framework_slug):
     attribute_whitelist = {
         'status': 'status',
         'clarificationQuestionsOpen': 'clarification_questions_open',
-        'frameworkAgreementDetails': 'framework_agreement_details'
+        'frameworkAgreementDetails': 'framework_agreement_details',
+        'allowDeclarationReuse': 'allow_declaration_reuse',
     }
 
     updater_json = validate_and_return_updater_request()

--- a/tests/main/views/test_frameworks.py
+++ b/tests/main/views/test_frameworks.py
@@ -213,12 +213,14 @@ class TestUpdateFramework(BaseApplicationTest, JSONUpdateTestMixin):
             'status': "standstill",
             'clarificationQuestionsOpen': False,
             'lots': ['saas', 'paas', 'iaas', 'scs'],
+            'allowDeclarationReuse': True,
         }
 
         self.attribute_whitelist = [
             'frameworkAgreementDetails',
             'status',
             'clarificationQuestionsOpen',
+            'allowDeclarationReuse',
         ]
 
     def post_framework_update(self, update):


### PR DESCRIPTION
Trello ticket: https://trello.com/c/bY39wcF4/7-api-frameworks-update-endpoint-should-allow-setting-allowdeclarationreuse