### PR TITLE
Copy supplier account info to declaration

### DIFF
--- a/app/supplier_constants.py
+++ b/app/supplier_constants.py
@@ -1,0 +1,15 @@
+# Here we define a set of hardcoded keys that we use when denormalizing data from Supplier/ContactInformation tables
+# into the SupplierFramework.declaration field. These are only used internally by the API - the frontends currently
+# do not need knowledge of them, so there is no reason to centralise them e.g. in utils at this time.
+KEY_DUNS_NUMBER = 'supplierDunsNumber'
+KEY_ORGANISATION_SIZE = 'supplierOrganisationSize'
+KEY_REGISTERED_NAME = 'supplierRegisteredName'
+KEY_REGISTRATION_BUILDING = 'supplierRegisteredBuilding'
+KEY_REGISTRATION_COUNTRY = 'supplierRegisteredCountry'
+KEY_REGISTRATION_DATE = 'supplierRegistrationDate'
+KEY_REGISTRATION_NUMBER = 'supplierCompanyRegistrationNumber'
+KEY_REGISTRATION_POSTCODE = 'supplierRegisteredPostcode'
+KEY_REGISTRATION_TOWN = 'supplierRegisteredTown'
+KEY_TRADING_NAME = 'supplierTradingName'
+KEY_TRADING_STATUS = 'supplierTradingStatus'
+KEY_VAT_NUMBER = 'supplierVatNumber'

--- a/tests/main/views/test_frameworks.py
+++ b/tests/main/views/test_frameworks.py
@@ -3,11 +3,15 @@ import datetime
 from flask import json
 from freezegun import freeze_time
 import mock
+import pytest
 from sqlalchemy.exc import IntegrityError
 
 from tests.bases import BaseApplicationTest, JSONUpdateTestMixin
 from app.models import db, Framework, SupplierFramework, DraftService, User, FrameworkLot
+from app.models.main import ContactInformation, Supplier
 from tests.helpers import FixtureMixin
+
+from app import supplier_constants
 
 
 class TestListFrameworks(BaseApplicationTest):
@@ -185,7 +189,7 @@ class TestGetFramework(BaseApplicationTest):
         assert response.status_code == 404
 
 
-class TestUpdateFramework(BaseApplicationTest, JSONUpdateTestMixin):
+class TestUpdateFramework(BaseApplicationTest, JSONUpdateTestMixin, FixtureMixin):
     endpoint = '/frameworks/example'
     method = 'post'
 
@@ -376,6 +380,148 @@ class TestUpdateFramework(BaseApplicationTest, JSONUpdateTestMixin):
 
             assert response.status_code == 400
             assert "Could not commit" in json.loads(response.get_data())["error"]
+
+
+class TestUpdateFrameworkPending(BaseApplicationTest):
+    EXPECTED_FRAMEWORK_DECLARATION_SUPPLIER_INFO = {
+        supplier_constants.KEY_VAT_NUMBER: "123456789",
+        supplier_constants.KEY_DUNS_NUMBER: "987654321",
+        supplier_constants.KEY_TRADING_NAME: "Sam's Sweaters",
+        supplier_constants.KEY_TRADING_STATUS: "limited company",
+        supplier_constants.KEY_REGISTERED_NAME: "Sam's Sweaters",
+        supplier_constants.KEY_ORGANISATION_SIZE: "small",
+        supplier_constants.KEY_REGISTRATION_DATE: "2018-01-01T12:00:00",
+        supplier_constants.KEY_REGISTRATION_COUNTRY: "gb",
+        supplier_constants.KEY_REGISTRATION_BUILDING: "1 Sweater Lane",
+        supplier_constants.KEY_REGISTRATION_TOWN: "Milton Keynes",
+        supplier_constants.KEY_REGISTRATION_POSTCODE: "SW3 8T",
+        supplier_constants.KEY_REGISTRATION_NUMBER: "000123000",
+    }
+
+    def setup(self):
+        super(TestUpdateFrameworkPending, self).setup()
+
+        self.framework = Framework(id=999, slug='g-cloud-10', name='G-Cloud 10', framework='g-cloud', status='open',
+                                   clarification_questions_open=False, allow_declaration_reuse=True)
+        db.session.add(self.framework)
+        db.session.commit()
+
+        expected_info = self.EXPECTED_FRAMEWORK_DECLARATION_SUPPLIER_INFO
+
+        self.supplier = Supplier(supplier_id=1,
+                                 name=expected_info["supplierTradingName"], description='',
+                                 organisation_size=expected_info['supplierOrganisationSize'],
+                                 trading_status=expected_info['supplierTradingStatus'],
+                                 vat_number=expected_info['supplierVatNumber'],
+                                 duns_number=expected_info['supplierDunsNumber'],
+                                 registration_date=expected_info['supplierRegistrationDate'],
+                                 other_company_registration_number=expected_info["supplierCompanyRegistrationNumber"],
+                                 registration_country=expected_info["supplierRegisteredCountry"],
+                                 registered_name=expected_info["supplierRegisteredName"],
+                                 )
+
+        self.contact_info = ContactInformation(supplier_id=1,
+                                               contact_name='Contact for Supplier 1',
+                                               email='1@contact.com',
+                                               address1=expected_info['supplierRegisteredBuilding'],
+                                               city=expected_info['supplierRegisteredTown'],
+                                               postcode=expected_info['supplierRegisteredPostcode']
+                                               )
+
+        self.supplier_framework = SupplierFramework(framework_id=self.framework.id,
+                                                    supplier_id=1,
+                                                    declaration={}
+                                                    )
+
+        db.session.add(self.supplier)
+        db.session.add(self.contact_info)
+        db.session.add(self.supplier_framework)
+        db.session.commit()
+
+    def teardown(self):
+        SupplierFramework.query.delete()
+        ContactInformation.query.delete()
+        Supplier.query.delete()
+
+        super(TestUpdateFrameworkPending, self).teardown()
+
+    def _update_framework_status(self, new_status='pending'):
+        self.client.post(
+            '/frameworks/g-cloud-10',
+            data=json.dumps({
+                'frameworks': {'status': new_status},
+                'updated_by': 'example user'
+            }),
+            content_type="application/json"
+        )
+
+    def _assert_declaration_matches(self, expected_declaration_data):
+        supplier_framework = SupplierFramework.query.filter(SupplierFramework.supplier_id == 1).first()
+        assert supplier_framework.declaration == expected_declaration_data
+
+    @pytest.mark.parametrize('framework_start_status, framework_new_status, expected_declaration_data',
+                             (
+                                 ('coming', 'open', {}),
+                                 ('open', 'pending', EXPECTED_FRAMEWORK_DECLARATION_SUPPLIER_INFO),
+                                 ('pending', 'pending', {}),
+                                 ('pending', 'live', {})
+                             ))
+    def test_updating_framework_to_pending_copies_supplier_information_to_declaration(self,
+                                                                                      framework_start_status,
+                                                                                      framework_new_status,
+                                                                                      expected_declaration_data):
+        self.framework.status = framework_start_status
+        db.session.add(self.framework)
+        db.session.commit()
+
+        self._update_framework_status(framework_new_status)
+
+        self._assert_declaration_matches(expected_declaration_data)
+
+    def test_updating_framework_merges_json_and_overwrites_existing_keys_in_declaration(self):
+        start_declaration = {
+            "new-key": "should remain",
+            supplier_constants.KEY_TRADING_NAME: "existing key to be overwritten"
+        }
+        self.supplier_framework.declaration = start_declaration
+        db.session.commit()
+
+        self._update_framework_status()
+
+        self._assert_declaration_matches({**start_declaration, **self.EXPECTED_FRAMEWORK_DECLARATION_SUPPLIER_INFO})
+
+    def test_updating_framework_to_pending_uses_first_contact_information_entry(self):
+        """Digital Marketplace theoretically supports multiple contact informations per supplier. When copying contact
+        information across to fill in the supplier declaration, we want to take the details of the first (lowest id)
+        contact information associated with the account."""
+        db.session.add(ContactInformation(supplier_id=1,
+                                          contact_name='Our awesome contact',
+                                          email='2_is_the_new_1@contact.com',
+                                          address1="Twilight's Library",
+                                          city="Ponyville",
+                                          postcode="PO42"))
+        db.session.commit()
+
+        self._update_framework_status()
+
+        self._assert_declaration_matches(self.EXPECTED_FRAMEWORK_DECLARATION_SUPPLIER_INFO)
+
+    def test_updating_framework_includes_keys_with_none_value_for_null_supplier_account_information(self):
+        self.supplier.registration_date = None
+        self.supplier.vat_number = None
+        self.supplier.registered_name = None
+        self.contact_info.city = None
+        db.session.commit()
+
+        self._update_framework_status()
+
+        expected_declaration_data = self.EXPECTED_FRAMEWORK_DECLARATION_SUPPLIER_INFO.copy()
+        expected_declaration_data[supplier_constants.KEY_REGISTRATION_DATE] = None
+        expected_declaration_data[supplier_constants.KEY_VAT_NUMBER] = None
+        expected_declaration_data[supplier_constants.KEY_REGISTERED_NAME] = None
+        expected_declaration_data[supplier_constants.KEY_REGISTRATION_TOWN] = None
+
+        self._assert_declaration_matches(expected_declaration_data)
 
 
 class TestFrameworkStats(BaseApplicationTest, FixtureMixin):


### PR DESCRIPTION
## Summary
Paired PR with @CrystalPea.

Now that we no longer ask supplier account questions as part of a framework application's declaration, we need to patch supplier declarations with the information we already have. When a framework is set to `pending` (i.e. applications close), we will inject the relevant data we hold in the Supplier/ContactInformation tables into the SupplierFramework.declaration for every supplier who is applying to get onto the framework. We will do this even if the supplier's application is incomplete. Where this is the case, any empty fields will be stored under their corresponding key in the JSON blob as nulls/Nones.

We hardcode a number of keys to inject into the `SupplierFramework.declaration` JSON blob. These aren't currently needed by any of the frontends, so we won't centralise these keys yet.

After much effort and many attempts (thanks @katstevens & @benvand for your time), I couldn't coerce SQLAlchemy into running the query we need through the ORM mechanism, so I've resorted to using a raw SQL statement. Given that our G-Cloud framework has thousands of suppliers, the statement needs to be executed fully on the DB-side as the performance hit from shunting data back and forth between the DB and the API probably would not be acceptable.

## Ticket
https://trello.com/c/lUQOcuSS/16-api-populate-declaration-with-supplier-data-when-framework-becomes-pending
