### PR TITLE
Healthcheck to include test of search API to reflect this app's dependency on it.

### DIFF
--- a/app/status/views.py
+++ b/app/status/views.py
@@ -5,10 +5,11 @@ from . import status
 from . import utils
 from ..models import Framework
 from dmutils.status import get_flags
+from app import search_api_client
 
 
 @status.route('/_status')
-def status_no_db():
+def status():
 
     if 'ignore-dependencies' in request.args:
         return jsonify(
@@ -16,21 +17,48 @@ def status_no_db():
         ), 200
 
     version = current_app.config['VERSION']
+    apis = [
+        {
+            'name': 'Search API',
+            'key': 'search_api_status',
+            'status': search_api_client.get_status()
+        },
+    ]  # list for consistency with other apps - a chunk of this should move into utils?
 
-    try:
-        return jsonify(
-            status="ok",
-            frameworks={f.slug: f.status for f in Framework.query.all()},
-            version=version,
-            db_version=utils.get_db_version(),
-            flags=get_flags(current_app)
-        )
+    apis_with_errors = []
 
-    except SQLAlchemyError:
-        current_app.logger.exception('Error connecting to database')
-        return jsonify(
-            status="error",
-            version=version,
-            message="Error connecting to database",
-            flags=get_flags(current_app)
-        ), 500
+    for api in apis:
+        if api['status'] is None or api['status']['status'] != "ok":
+            apis_with_errors.append(api['name'])
+
+    # if no errors found, return as is.  Else, return an error and a message
+    if not apis_with_errors:
+        try:
+            return jsonify(
+                {api['key']: api['status'] for api in apis},
+                status="ok",
+                frameworks={f.slug: f.status for f in Framework.query.all()},
+                version=version,
+                db_version=utils.get_db_version(),
+                flags=get_flags(current_app)
+            )
+        except SQLAlchemyError:
+            current_app.logger.exception('Error connecting to database')
+            return jsonify(
+                status="error",
+                version=version,
+                message="Error connecting to database",
+                flags=get_flags(current_app)
+            ), 500
+
+    message = "Error connecting to {}.".format(
+        ", ".join(apis_with_errors)
+    )
+
+    return jsonify(
+        {api['key']: api['status'] for api in apis},
+        status="error",
+        version=version,
+        message=message,
+        flags=get_flags(current_app)
+    ), 500

--- a/tests/main/views/test_status.py
+++ b/tests/main/views/test_status.py
@@ -1,16 +1,60 @@
 from tests.bases import BaseApplicationTest
 from sqlalchemy.exc import SQLAlchemyError
 import mock
+import json
 
 
 class TestStatus(BaseApplicationTest):
+    def setup_method(self, method):
+        self._search_api_client_patch = mock.patch('app.status.views.search_api_client', autospec=True)
+        self._search_api_client = self._search_api_client_patch.start()
+        self._search_api_client.get_status.return_value = {
+            'status': 'ok'
+        }
 
-    def test_should_return_200_from_elb_status_check(self):
+    def teardown_method(self, method):
+        self._search_api_client_patch.stop()
+
+    def test_should_return_200_from_healthcheck(self):
         status_response = self.client.get('/_status?ignore-dependencies')
         assert status_response.status_code == 200
+        assert self._search_api_client.called is False
 
     @mock.patch('app.status.utils.get_db_version')
     def test_catches_db_error_and_return_500(self, get_db_version):
         get_db_version.side_effect = SQLAlchemyError()
         status_response = self.client.get('/_status')
         assert status_response.status_code == 500
+
+    def test_status_ok(self):
+        status_response = self.client.get('/_status')
+        assert status_response.status_code == 200
+
+        json_data = json.loads(status_response.get_data().decode('utf-8'))
+        assert "{}".format(json_data['search_api_status']['status']) == "ok"
+
+    def test_status_error_in_upstream_api(self):
+        self._search_api_client.get_status.return_value = {
+            'status': 'error',
+            'app_version': None,
+            'message': 'Borked'
+        }
+
+        response = self.client.get('/_status')
+        assert response.status_code == 500
+
+        json_data = json.loads(response.get_data().decode('utf-8'))
+
+        assert "{}".format(json_data['status']) == "error"
+        assert "{}".format(json_data['search_api_status']['status']) == "error"
+
+    def test_status_no_response_in_upstream_api(self):
+        self._search_api_client.get_status.return_value = None
+
+        response = self.client.get('/_status')
+        assert response.status_code == 500
+
+        json_data = json.loads(response.get_data().decode('utf-8'))
+
+        assert "{}".format(json_data['status']) == "error"
+        assert json_data.get('search_api_status') is None


### PR DESCRIPTION
This is basically copy-pasta'd from the buyer app, we have a [tech debt ticket](https://trello.com/c/syRUnDx3/34-make-status-blueprint-shared-and-reusable) already about resolving that.

https://trello.com/c/K20ImpOe/94-api-status-should-reflect-search-api-dependency

PS renamed the function because it blatantly has been using the database for some number of years.