### PR TITLE
Ensure db transaction is closed

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -59,8 +59,7 @@ def isolation_level(level):
     def decorator(view):
         @wraps(view)
         def view_wrapper(*args, **kwargs):
-            if flask_featureflags.is_active('TRANSACTION_ISOLATION'):
-                db.session.connection(execution_options={'isolation_level': level})
+            db.session.connection(execution_options={'isolation_level': level})
             return view(*args, **kwargs)
         return view_wrapper
     return decorator

--- a/config.py
+++ b/config.py
@@ -1,5 +1,5 @@
 import os
-from dmutils.status import enabled_since, get_version_label
+from dmutils.status import get_version_label
 
 
 class Config:
@@ -23,8 +23,6 @@ class Config:
 
     # Feature Flags
     RAISE_ERROR_ON_MISSING_FEATURES = True
-
-    FEATURE_FLAGS_TRANSACTION_ISOLATION = False
 
     DM_API_SERVICES_PAGE_SIZE = 100
     DM_API_SUPPLIERS_PAGE_SIZE = 100
@@ -73,8 +71,6 @@ class Test(Config):
 
     DM_API_PROJECTS_PAGE_SIZE = 5
 
-    FEATURE_FLAGS_TRANSACTION_ISOLATION = enabled_since('2015-08-27')
-
 
 class Development(Config):
     DEBUG = True
@@ -93,7 +89,7 @@ class Live(Config):
 
 
 class Preview(Live):
-    FEATURE_FLAGS_TRANSACTION_ISOLATION = enabled_since('2015-08-27')
+    pass
 
 
 class Staging(Live):

--- a/tests/bases.py
+++ b/tests/bases.py
@@ -20,6 +20,7 @@ class TestClient(FlaskClient):
     """
 
     def open(self, *args, **kwargs):
+        db.session.close()
         app_context = self.application.app_context()
         app_context.push()
 

--- a/tests/main/views/test_brief_response.py
+++ b/tests/main/views/test_brief_response.py
@@ -286,7 +286,7 @@ class TestCreateBriefResponse(BaseBriefResponseTest, JSONUpdateTestMixin):
                     'framework_id': framework_id,
                 },
             )
-
+            db.session.commit()
             res = self.create_brief_response()
             data = json.loads(res.get_data(as_text=True))
 
@@ -422,7 +422,7 @@ class TestUpdateBriefResponse(BaseBriefResponseTest):
                 "UPDATE frameworks SET status=:status WHERE slug='digital-outcomes-and-specialists'",
                 {'status': framework_status},
             )
-
+            db.session.commit()
             res = self._update_brief_response(
                 self.brief_response_id,
                 {'respondToEmailAddress': 'newemail@email.com'}

--- a/tests/main/views/test_drafts.py
+++ b/tests/main/views/test_drafts.py
@@ -147,7 +147,7 @@ class TestDraftServices(BaseApplicationTest, FixtureMixin):
                     lot_id=1,
                     framework_id=1)
             )
-
+        db.session.commit()
         for service_id in service_ids:
             self.client.put(
                 '/draft-services/copy-from/{}'.format(service_id),

--- a/tests/test_brief_utils.py
+++ b/tests/test_brief_utils.py
@@ -7,28 +7,32 @@ from tests.bases import BaseApplicationTest
 
 @mock.patch('app.brief_utils.index_object', autospec=True)
 class TestIndexBriefs(BaseApplicationTest):
-    def test_live_dos_2_brief_is_indexed(self, index_object, live_dos2_framework):
+    def setup(self, *args, **kwargs):
+        super(TestIndexBriefs, self).setup(*args, **kwargs)
+
         dos2 = Framework.query.filter(Framework.slug == 'digital-outcomes-and-specialists-2').first()
+        lot = Lot.query.filter(Lot.slug == 'digital-outcomes').one()
+        self.brief = Brief(status='draft', framework=dos2, data={'requirementsLength': '1 week'}, lot=lot)
+        db.session.add(self.brief)
+        db.session.commit()
+
+    def test_live_dos_2_brief_is_indexed(self, index_object, live_dos2_framework):
+        self.brief.status = 'live'
+        db.session.commit()
 
         with mock.patch.object(Brief, "serialize", return_value={'serialized': 'object'}):
-            lot = Lot.query.filter(Lot.slug == 'digital-outcomes').one()
-            brief = Brief(status='live', framework=dos2, data={'requirementsLength': '1 week'}, lot=lot)
-            db.session.add(brief)
-            db.session.commit()
-            index_brief(brief)
+            index_brief(self.brief)
 
         index_object.assert_called_once_with(
             framework='digital-outcomes-and-specialists-2',
             doc_type='briefs',
-            object_id=brief.id,
+            object_id=self.brief.id,
             serialized_object={'serialized': 'object'},
         )
 
     def test_draft_dos_2_brief_is_not_indexed(self, index_object, live_dos2_framework):
-        dos2 = Framework.query.filter(Framework.slug == 'digital-outcomes-and-specialists-2').first()
 
         with mock.patch.object(Brief, "serialize", return_value={'serialized': 'object'}):
-            brief = Brief(status='draft', framework=dos2, data={'requirementsLength': '1 week'})
-            index_brief(brief)
+            index_brief(self.brief)
 
         assert index_object.called is False


### PR DESCRIPTION
This warning on our tests:
```SAWarning: Connection is already established for the given bind; execution_options ignored```

Highlighted that we were allowing open db transactions to bleed into our view code when testing.
In this PR the open session transactions are closed before the request to the view is made causing the view to create its own transaction.

This broke some of our tests because they were relying on this incorrect behaviour, adding objects to the transaction but not committing them, leaving the transaction open, then operating on them in the view. These have been updated to issue commits before the request to the view.

We also remove the feature flag for using `'SERIALIZED'` transaction isolation level allowing this to be used in production. Specifically, and only, on the `edit_draft_service` view.