### PR TITLE
Brief model: remove @hybrid_property decorator from properties that couldn't have possibly worked as hybrid properties

### DIFF
--- a/app/models/main.py
+++ b/app/models/main.py
@@ -1292,7 +1292,7 @@ class Brief(db.Model):
             else_=two_week_addition_function
         )
 
-    @hybrid_property
+    @property
     def clarification_questions_closed_at(self_or_cls):
         if self_or_cls.published_at is None:
             return None
@@ -1300,7 +1300,7 @@ class Brief(db.Model):
 
         return get_publishing_dates(brief_publishing_date_and_length)['questions_close']
 
-    @hybrid_property
+    @property
     def clarification_questions_published_by(self_or_cls):
         if self_or_cls.published_at is None:
             return None


### PR DESCRIPTION
Trello: there is none, sue me.

Hybrid properties are able to compile (a certain subset of) python **expressions** to sql, not whole procedural code blocks. Control flow based on instance values is **certainly** not possible. So these can only ever have been used as regular properties. switch them to such lest people get further confused about what magic SQLAlchemy is actually able to do.