### PR TITLE
Filter brief responses by awarded_at date

### DIFF
--- a/app/main/views/brief_responses.py
+++ b/app/main/views/brief_responses.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from dmutils.formats import DATE_FORMAT
 
 from flask import abort, request, current_app
 from sqlalchemy.exc import IntegrityError, DataError
@@ -210,6 +211,7 @@ def list_brief_responses():
     page = get_valid_page_or_1()
     brief_id = get_int_or_400(request.args, 'brief_id')
     supplier_id = get_int_or_400(request.args, 'supplier_id')
+    awarded_at = request.args.get('awarded_at')
 
     if request.args.get('status'):
         statuses = request.args['status'].split(',')
@@ -222,6 +224,12 @@ def list_brief_responses():
 
     if brief_id is not None:
         brief_responses = brief_responses.filter(BriefResponse.brief_id == brief_id)
+
+    if awarded_at is not None:
+        day_start = datetime.strptime(awarded_at, DATE_FORMAT)
+        day_end = datetime(day_start.year, day_start.month, day_start.day, 23, 59, 59, 999999)
+        # Inclusive date range filtering
+        brief_responses = brief_responses.filter(BriefResponse.awarded_at.between(day_start, day_end))
 
     brief_responses = brief_responses.options(
         db.defaultload(BriefResponse.brief).defaultload(Brief.framework).lazyload("*"),

--- a/app/models/main.py
+++ b/app/models/main.py
@@ -1656,10 +1656,9 @@ class BriefResponse(db.Model):
     def serialize(self):
         data = self.data.copy()
         parent_brief = self.brief.serialize()
-        parent_brief_fields = ['id', 'title', 'status', 'applicationsClosedAt', 'frameworkSlug']
         data.update({
             'id': self.id,
-            'brief': {key: parent_brief[key] for key in parent_brief_fields if key in parent_brief},
+            'brief': self._parent_brief_fields(parent_brief),
             'briefId': self.brief_id,
             'supplierId': self.supplier_id,
             'supplierName': self.supplier.name,
@@ -1686,6 +1685,16 @@ class BriefResponse(db.Model):
             })
 
         return purge_nulls_from_data(data)
+
+    def _parent_brief_fields(self, parent_brief):
+        return {
+            **self._unpack_fields(self.PARENT_BRIEF_FIELDS, parent_brief),
+            **{'framework': self._unpack_fields(self.FRAMEWORK_FIELDS, parent_brief)}
+        }
+
+    @staticmethod
+    def _unpack_fields(required_fields, collection):
+        return {key: collection[key] for key in required_fields if key in collection}
 
 
 # The following is the code to fetch the supplier_framework of a BriefResponse.

--- a/app/models/main.py
+++ b/app/models/main.py
@@ -1663,9 +1663,12 @@ class BriefResponse(db.Model):
     def serialize(self):
         data = self.data.copy()
         parent_brief = self.brief.serialize()
+        parent_brief_fields = ['id', 'title', 'status', 'applicationsClosedAt', 'framework']
         data.update({
             'id': self.id,
-            'brief': self._parent_brief_fields(parent_brief),
+            'brief': {
+                **{key: parent_brief[key] for key in parent_brief_fields if key in parent_brief},
+            },
             'briefId': self.brief_id,
             'supplierId': self.supplier_id,
             'supplierName': self.supplier.name,
@@ -1693,16 +1696,6 @@ class BriefResponse(db.Model):
             })
 
         return purge_nulls_from_data(data)
-
-    def _parent_brief_fields(self, parent_brief):
-        return {
-            **self._unpack_fields(self.PARENT_BRIEF_FIELDS, parent_brief),
-            **{'framework': self._unpack_fields(self.FRAMEWORK_FIELDS, parent_brief)}
-        }
-
-    @staticmethod
-    def _unpack_fields(required_fields, collection):
-        return {key: collection[key] for key in required_fields if key in collection}
 
 
 # The following is the code to fetch the supplier_framework of a BriefResponse.

--- a/app/models/main.py
+++ b/app/models/main.py
@@ -1484,10 +1484,17 @@ class Brief(db.Model):
         data.update({
             'id': self.id,
             'status': self.status,
+            # TODO: remove top-level 'frameworkFoo' fields (use 'framework'git ad sub-dict instead)
             'frameworkSlug': self.framework.slug,
             'frameworkFramework': self.framework.framework,
             'frameworkName': self.framework.name,
             'frameworkStatus': self.framework.status,
+            'framework': {
+                'family': self.framework.framework,
+                'name': self.framework.name,
+                'slug': self.framework.slug,
+                'status': self.framework.status,
+            },
             'isACopy': self.is_a_copy,
             'lot': self.lot.slug,  # deprecated, use lotSlug instead
             'lotSlug': self.lot.slug,

--- a/app/models/main.py
+++ b/app/models/main.py
@@ -1677,7 +1677,8 @@ class BriefResponse(db.Model):
 
         if self.status == "awarded":
             data.update({
-                'awardDetails': self.award_details
+                'awardDetails': self.award_details,
+                'awardedAt': self.awarded_at.strftime(DATETIME_FORMAT)
             })
         elif self.status == 'pending-awarded':
             data.update({

--- a/tests/main/views/test_brief_response.py
+++ b/tests/main/views/test_brief_response.py
@@ -1,5 +1,5 @@
 """Tests for brief response views in app/views/brief_responses.py."""
-from datetime import datetime
+from datetime import datetime, timedelta
 from freezegun import freeze_time
 import json
 import mock
@@ -771,7 +771,8 @@ class TestListBriefResponses(BaseBriefResponseTest):
         assert res.status_code == 200
         assert len(data['briefResponses']) == 3
         assert all(
-            br['brief']['frameworkSlug'] == "digital-outcomes-and-specialists-2" for br in data['briefResponses']
+            br['brief']['framework']['frameworkSlug'] == "digital-outcomes-and-specialists-2"
+            for br in data['briefResponses']
         )
         assert 'self' in data['links']
 
@@ -798,10 +799,12 @@ class TestListBriefResponses(BaseBriefResponseTest):
         assert res.status_code == 200
         assert len(data['briefResponses']) == 4
         dos1_br = [
-            br for br in data['briefResponses'] if br['brief']['frameworkSlug'] == "digital-outcomes-and-specialists"
+            br for br in data['briefResponses']
+            if br['brief']['framework']['frameworkSlug'] == "digital-outcomes-and-specialists"
         ]
         dos2_br = [
-            br for br in data['briefResponses'] if br['brief']['frameworkSlug'] == "digital-outcomes-and-specialists"
+            br for br in data['briefResponses']
+            if br['brief']['framework']['frameworkSlug'] == "digital-outcomes-and-specialists"
         ]
         assert len(dos1_br) == len(dos2_br) == 2
 

--- a/tests/main/views/test_brief_response.py
+++ b/tests/main/views/test_brief_response.py
@@ -9,6 +9,7 @@ from dmapiclient.audit import AuditTypes
 
 from app.main.views.brief_responses import COMPLETED_BRIEF_RESPONSE_STATUSES
 from app.models import db, Lot, Brief, BriefResponse, AuditEvent, Service, Framework, SupplierFramework
+from dmutils.formats import DATE_FORMAT, DATETIME_FORMAT
 from tests.bases import BaseApplicationTest, JSONUpdateTestMixin
 from tests.helpers import FixtureMixin
 
@@ -882,3 +883,4 @@ class TestListBriefResponses(BaseBriefResponseTest):
 
         assert res.status_code == 200
         assert len(data['briefResponses']) == 1
+        assert data['briefResponses'][0]['awardedAt'] == yesterday.strftime(DATETIME_FORMAT)

--- a/tests/main/views/test_brief_response.py
+++ b/tests/main/views/test_brief_response.py
@@ -75,13 +75,13 @@ class BaseBriefResponseTest(BaseApplicationTest, FixtureMixin):
 
         return brief_response.id
 
-    def setup_dummy_awarded_brief_response(self, brief_id=None):
+    def setup_dummy_awarded_brief_response(self, brief_id=None, awarded_at=None):
         self.setup_dummy_briefs(1, status="closed", brief_start=brief_id or self.brief_id)
         awarded_brief_response_id = self.setup_dummy_brief_response(
             brief_id=brief_id or self.brief_id, award_details={'pending': True}
         )
         awarded_brief_response = BriefResponse.query.get(awarded_brief_response_id)
-        awarded_brief_response.awarded_at = datetime.utcnow()
+        awarded_brief_response.awarded_at = awarded_at or datetime.utcnow()
         db.session.add(awarded_brief_response)
         db.session.commit()
 
@@ -771,7 +771,7 @@ class TestListBriefResponses(BaseBriefResponseTest):
         assert res.status_code == 200
         assert len(data['briefResponses']) == 3
         assert all(
-            br['brief']['framework']['frameworkSlug'] == "digital-outcomes-and-specialists-2"
+            br['brief']['framework']['slug'] == "digital-outcomes-and-specialists-2"
             for br in data['briefResponses']
         )
         assert 'self' in data['links']
@@ -800,11 +800,11 @@ class TestListBriefResponses(BaseBriefResponseTest):
         assert len(data['briefResponses']) == 4
         dos1_br = [
             br for br in data['briefResponses']
-            if br['brief']['framework']['frameworkSlug'] == "digital-outcomes-and-specialists"
+            if br['brief']['framework']['slug'] == "digital-outcomes-and-specialists"
         ]
         dos2_br = [
             br for br in data['briefResponses']
-            if br['brief']['framework']['frameworkSlug'] == "digital-outcomes-and-specialists"
+            if br['brief']['framework']['slug'] == "digital-outcomes-and-specialists"
         ]
         assert len(dos1_br) == len(dos2_br) == 2
 
@@ -869,3 +869,16 @@ class TestListBriefResponses(BaseBriefResponseTest):
 
         assert res.status_code == 200
         assert len(data['briefResponses']) == 4
+
+    def test_filter_responses_awarded_yesterday(self):
+        yesterday = datetime.utcnow() - timedelta(days=1)
+        self.setup_dummy_brief_response(submitted_at=None)
+        self.setup_dummy_awarded_brief_response(brief_id=111, awarded_at=yesterday)
+        self.setup_dummy_awarded_brief_response(brief_id=222, awarded_at=yesterday - timedelta(days=5))
+        self.setup_dummy_brief_response(award_details={"pending": True})
+
+        res = self.list_brief_responses(awarded_at=yesterday.strftime(DATE_FORMAT))
+        data = json.loads(res.get_data(as_text=True))
+
+        assert res.status_code == 200
+        assert len(data['briefResponses']) == 1

--- a/tests/main/views/test_briefs.py
+++ b/tests/main/views/test_briefs.py
@@ -414,16 +414,20 @@ class TestGetBrief(FrameworkSetupAndTeardown):
         assert res.status_code == 200
         expected_data = COMPLETE_DIGITAL_SPECIALISTS_BRIEF.copy()
 
-        framework = Framework.query.filter(Framework.slug == 'digital-outcomes-and-specialists').first()
-
         expected_data.update(
             {
                 'id': 1,
                 'status': 'draft',
-                'frameworkSlug': framework.slug,
-                'frameworkFramework': framework.framework,
-                'frameworkName': framework.name,
-                'frameworkStatus': framework.status,
+                'frameworkSlug': 'digital-outcomes-and-specialists',
+                'frameworkFramework': 'digital-outcomes-and-specialists',
+                'frameworkName': 'Digital Outcomes and Specialists',
+                'frameworkStatus': 'live',
+                'framework': {
+                    'family': 'digital-outcomes-and-specialists',
+                    'name': 'Digital Outcomes and Specialists',
+                    'slug': 'digital-outcomes-and-specialists',
+                    'status': 'live',
+                },
                 'isACopy': False,
                 'lot': 'digital-specialists',
                 'lotSlug': 'digital-specialists',

--- a/tests/models/test_main.py
+++ b/tests/models/test_main.py
@@ -959,7 +959,10 @@ class TestBriefResponses(BaseApplicationTest, FixtureMixin):
                     'id': self.brief.id,
                     'status': self.brief.status,
                     'title': self.brief_title,
-                    'frameworkSlug': self.brief.framework.slug
+                    'framework': {
+                        'frameworkFramework': self.brief.framework.framework,
+                        'frameworkSlug': self.brief.framework.slug
+                    }
                 },
                 'briefId': self.brief.id,
                 'supplierId': 0,
@@ -993,7 +996,10 @@ class TestBriefResponses(BaseApplicationTest, FixtureMixin):
                     'id': self.brief.id,
                     'status': self.brief.status,
                     'title': self.brief_title,
-                    'frameworkSlug': self.brief.framework.slug
+                    'framework': {
+                        'frameworkFramework': self.brief.framework.framework,
+                        'frameworkSlug': self.brief.framework.slug
+                    }
                 },
                 'supplierId': 0,
                 'supplierName': 'Supplier 0',

--- a/tests/models/test_main.py
+++ b/tests/models/test_main.py
@@ -960,8 +960,10 @@ class TestBriefResponses(BaseApplicationTest, FixtureMixin):
                     'status': self.brief.status,
                     'title': self.brief_title,
                     'framework': {
-                        'frameworkFramework': self.brief.framework.framework,
-                        'frameworkSlug': self.brief.framework.slug
+                        'family': 'digital-outcomes-and-specialists',
+                        'name': 'Digital Outcomes and Specialists',
+                        'slug': 'digital-outcomes-and-specialists',
+                        'status': self.brief.framework.status
                     }
                 },
                 'briefId': self.brief.id,
@@ -997,8 +999,10 @@ class TestBriefResponses(BaseApplicationTest, FixtureMixin):
                     'status': self.brief.status,
                     'title': self.brief_title,
                     'framework': {
-                        'frameworkFramework': self.brief.framework.framework,
-                        'frameworkSlug': self.brief.framework.slug
+                        'family': 'digital-outcomes-and-specialists',
+                        'name': 'Digital Outcomes and Specialists',
+                        'slug': 'digital-outcomes-and-specialists',
+                        'status': self.brief.framework.status
                     }
                 },
                 'supplierId': 0,

--- a/tests/test_brief_utils.py
+++ b/tests/test_brief_utils.py
@@ -20,7 +20,7 @@ class TestIndexBriefs(BaseApplicationTest):
         index_object.assert_called_once_with(
             framework='digital-outcomes-and-specialists-2',
             doc_type='briefs',
-            object_id=1,
+            object_id=brief.id,
             serialized_object={'serialized': 'object'},
         )
 


### PR DESCRIPTION
The framework family is used when building the url in email alerts to suppliers. We need to surface this in the BriefResponse serialization when notifying them of briefs being awarded. 

`awarded_at` can now be passed into the api as a date in the form of YYY-MM-DD, and the query filters BriefResponses awarded between `00:00:00` and `23:59:59` on that date.

We also now nest framework-related fields together in both the Brief and BriefResponse serializations (there is some duplication on the Brief serialization - we agreed we should move to using this in the future).

https://trello.com/c/LsEbL3jP

(Commits cherry picked from https://github.com/alphagov/digitalmarketplace-api/pull/735 - full discussion there.)