### PR TITLE
Add validation for country-picker values

### DIFF
--- a/app/models/main.py
+++ b/app/models/main.py
@@ -293,6 +293,9 @@ class Supplier(db.Model):
     # Companies House numbers consist of 8 numbers, or 2 letters followed by 6 numbers
     COMPANIES_HOUSE_NUMBER_REGEX = re.compile('^([0-9]{2}|[A-Za-z]{2})[0-9]{6}$')
 
+    # The registration country values that come from our country picker select are in this format
+    REGISTRATION_COUNTRY_REGEX = re.compile('^(country|territory):[A-Z]{2}$')
+
     # NOTE other tables tend to make foreign key references to `supplier_id` instead of this
     id = db.Column(db.Integer, primary_key=True)
     supplier_id = db.Column(db.BigInteger, Sequence('suppliers_supplier_id_seq'), index=True, unique=True,
@@ -331,6 +334,13 @@ class Supplier(db.Model):
     def validates_companies_house_number(self, key, value):
         if value and not self.COMPANIES_HOUSE_NUMBER_REGEX.match(value):
             raise ValidationError("Invalid companies house number '{}'".format(value))
+
+        return value
+
+    @validates('registration_country')
+    def validates_registration_country(self, key, value):
+        if value and not self.REGISTRATION_COUNTRY_REGEX.match(value):
+            raise ValidationError("Invalid registration country '{}'".format(value))
 
         return value
 

--- a/app/models/main.py
+++ b/app/models/main.py
@@ -293,8 +293,13 @@ class Supplier(db.Model):
     # Companies House numbers consist of 8 numbers, or 2 letters followed by 6 numbers
     COMPANIES_HOUSE_NUMBER_REGEX = re.compile('^([0-9]{2}|[A-Za-z]{2})[0-9]{6}$')
 
-    # The registration country values that come from our country picker select are in this format
-    REGISTRATION_COUNTRY_REGEX = re.compile('^(country|territory):[A-Z]{2}$')
+    # The registration country values that come from our country picker select are in the format
+    # "country" or "territory" followed by a colon and either a 2-letter country code OR three-letter/two-dash-two
+    # alphanumeric territory code, for example:
+    # country:GB, territory:XQZ, territory:UM-67, territory:AE-RK
+    REGISTRATION_COUNTRY_REGEX = re.compile(
+        '^(country:[A-Z]{2}|territory:[A-Z]{2,3}(-[A-Z0-9]{2})?)$'
+    )
 
     # NOTE other tables tend to make foreign key references to `supplier_id` instead of this
     id = db.Column(db.Integer, primary_key=True)

--- a/tests/main/views/test_frameworks.py
+++ b/tests/main/views/test_frameworks.py
@@ -391,7 +391,7 @@ class TestUpdateFrameworkPending(BaseApplicationTest):
         supplier_constants.KEY_REGISTERED_NAME: "Sam's Sweaters",
         supplier_constants.KEY_ORGANISATION_SIZE: "small",
         supplier_constants.KEY_REGISTRATION_DATE: "2018-01-01T12:00:00",
-        supplier_constants.KEY_REGISTRATION_COUNTRY: "gb",
+        supplier_constants.KEY_REGISTRATION_COUNTRY: "country:GB",
         supplier_constants.KEY_REGISTRATION_BUILDING: "1 Sweater Lane",
         supplier_constants.KEY_REGISTRATION_TOWN: "Milton Keynes",
         supplier_constants.KEY_REGISTRATION_POSTCODE: "SW3 8T",

--- a/tests/main/views/test_suppliers.py
+++ b/tests/main/views/test_suppliers.py
@@ -471,7 +471,7 @@ class TestUpdateSupplier(BaseApplicationTest, JSONUpdateTestMixin):
             "dunsNumber": "010101",
             "otherCompanyRegistrationNumber": "A11",
             "registeredName": "New Name Inc.",
-            "registrationCountry": "Guatamala",
+            "registrationCountry": "country:GT",
             "registrationDate": "1969-07-20",
             "vatNumber": "12312312",
             "organisationSize": "micro",
@@ -490,7 +490,7 @@ class TestUpdateSupplier(BaseApplicationTest, JSONUpdateTestMixin):
         assert supplier.companies_house_number == "AA123456"
         assert supplier.other_company_registration_number == "A11"
         assert supplier.registered_name == "New Name Inc."
-        assert supplier.registration_country == "Guatamala"
+        assert supplier.registration_country == "country:GT"
         assert supplier.registration_date == datetime(1969, 7, 20, 0, 0)
         assert supplier.vat_number == "12312312"
         assert supplier.organisation_size == "micro"
@@ -571,6 +571,12 @@ class TestUpdateSupplier(BaseApplicationTest, JSONUpdateTestMixin):
     def test_update_succeeds_with_valid_trading_status(self, trading_status):
         response = self.update_request({"tradingStatus": trading_status})
         assert response.status_code == 200
+
+    def test_update_with_bad_registration_country(self):
+        # Country picker data is in the format "country:gb"
+        response = self.update_request({"registrationCountry": "Wales"})
+        assert response.status_code == 400
+        assert "Invalid registration country" in response.get_data(as_text=True)
 
 
 class TestUpdateContactInformation(BaseApplicationTest, JSONUpdateTestMixin):

--- a/tests/main/views/test_suppliers.py
+++ b/tests/main/views/test_suppliers.py
@@ -578,6 +578,32 @@ class TestUpdateSupplier(BaseApplicationTest, JSONUpdateTestMixin):
         assert response.status_code == 400
         assert "Invalid registration country" in response.get_data(as_text=True)
 
+    @pytest.mark.parametrize('country_code, expected_response',
+                             (("country:GB", 200),
+                              ("country:gb", 400),
+                              ("country:GBA", 400),
+                              ("country:AB-12", 400),
+                              ("territory:AX", 200),
+                              ("territory:ax", 400),
+                              ("territory:GBA", 200),
+                              ("territory:gba", 400),
+                              ("territory:AB-12", 200),
+                              ("territory:ab-12", 400),
+                              ("territory:AB-CD", 200),
+                              ("territory:ab-cd", 400),
+                              ("territory:ABC-12", 200),
+                              ("territory:AB-123", 400),
+                              ("Wales", 400),
+                              ))
+    def test_update_with_registration_countries(self, country_code, expected_response):
+        response = self.update_request({"registrationCountry": country_code})
+        error_message_is_displayed = "Invalid registration country" in response.get_data(as_text=True)
+        assert response.status_code == expected_response
+        if expected_response == 200:
+            assert not error_message_is_displayed
+        else:
+            assert error_message_is_displayed
+
 
 class TestUpdateContactInformation(BaseApplicationTest, JSONUpdateTestMixin):
     method = "post"

--- a/tests/models/test_main.py
+++ b/tests/models/test_main.py
@@ -1334,7 +1334,7 @@ class TestSuppliers(BaseApplicationTest, FixtureMixin):
             "description": "All your parcel wrapping needs catered for",
             "companiesHouseNumber": "98765432",
             "registeredName": "Tape and String Inc.",
-            "registrationCountry": "Wales",
+            "registrationCountry": "country:GB",
             "otherCompanyRegistrationNumber": "",
             "registrationDate": "1973-08-10",
             "vatNumber": "321321321",
@@ -1385,7 +1385,7 @@ class TestSuppliers(BaseApplicationTest, FixtureMixin):
         assert self.supplier.description == "All your parcel wrapping needs catered for"
         assert self.supplier.companies_house_number == "98765432"
         assert self.supplier.registered_name == "Tape and String Inc."
-        assert self.supplier.registration_country == "Wales"
+        assert self.supplier.registration_country == "country:GB"
         assert self.supplier.other_company_registration_number == ""
         assert self.supplier.registration_date == datetime(1973, 8, 10, 0, 0)
         assert self.supplier.vat_number == "321321321"
@@ -1419,7 +1419,7 @@ class TestSuppliers(BaseApplicationTest, FixtureMixin):
                 'organisationSize': 'medium',
                 'otherCompanyRegistrationNumber': '',
                 'registeredName': 'Tape and String Inc.',
-                'registrationCountry': 'Wales',
+                'registrationCountry': 'country:GB',
                 'registrationDate': '1973-08-10',
                 'tradingStatus': 'sole trader',
                 'vatNumber': '321321321',


### PR DESCRIPTION
The accessible country picker select widget we're now using stores vales as "country" or "territory" followed by a colon followed by a two-capital-letters country code.

We want to enforce this format in the database, for consistency.

Adding the validation here now will enforce it for all future updates. A migration will be needed to update the existing "gb" values to "country:GB".

## NOTE
I thought this would be OK to just go in whenever, but actually we'll need the migration to update existing "gb" values to "country:GB" first, because if a supplier with `registration_country` already set to "gb" tries to update their details (e.g. contact name, etc.) then the update will fail because of the now-invalid country data.

Still, be good to get this reviewed and ready to go for when the time comes.
