### PR TITLE
Fall back to created_at if no _logged_in_at timestamp

### DIFF
--- a/app/models/main.py
+++ b/app/models/main.py
@@ -825,8 +825,10 @@ class User(db.Model):
             'updatedAt': self.updated_at.strftime(DATETIME_FORMAT),
             'passwordChangedAt':
                 self.password_changed_at.strftime(DATETIME_FORMAT),
+            # When accounts are created users are logged in automatically, without creating a logged_in timestamp,
+            # so we fall back to created_at if there is no logged_in timestamp.
             'loggedInAt': self.logged_in_at.strftime(DATETIME_FORMAT)
-                if self.logged_in_at else None,
+                if self.logged_in_at else self.created_at.strftime(DATETIME_FORMAT),
             'failedLoginCount': self.failed_login_count,
         }
 


### PR DESCRIPTION
Quick fix for this tech-debt ticket: 
https://trello.com/c/kTZYf8QY/38-newly-created-user-is-not-logged-in-so-has-null-lastloggedin-in-admin

When a user is created they are automatically authenticated when they first set a password.  This means that the "lastLoggedIn" timestamp is null, even if they have done work (e.g. created a brief) that you would think needs a login.  This is confusing for admin users who see users listed who have apparently never logged in.

By falling back to the created_at timestamp we accurately reflect that they were logged in when they first created the account, even if they have never been through the normal log-in flow.