### PR TITLE
Update validation on tradingStatus

### DIFF
--- a/app/models/main.py
+++ b/app/models/main.py
@@ -281,6 +281,14 @@ class Supplier(db.Model):
     __tablename__ = 'suppliers'
 
     ORGANISATION_SIZES = (None, 'micro', 'small', 'medium', 'large')
+    TRADING_STATUSES = (None,
+                        "limited company (LTD)",
+                        "limited liability company (LLC)",
+                        "public limited company (PLC)",
+                        "limited liability partnership (LLP)",
+                        "sole trader",
+                        "public body",
+                        "other")
 
     # Companies House numbers consist of 8 numbers, or 2 letters followed by 6 numbers
     COMPANIES_HOUSE_NUMBER_REGEX = re.compile('^([0-9]{2}|[A-Za-z]{2})[0-9]{6}$')
@@ -304,6 +312,13 @@ class Supplier(db.Model):
     vat_number = db.Column(db.String, index=False, unique=False, nullable=True)
     organisation_size = db.Column(db.String, index=False, unique=False, nullable=True)
     trading_status = db.Column(db.String, index=False, unique=False, nullable=True)
+
+    @validates('trading_status')
+    def validates_trading_status(self, key, value):
+        if value not in self.TRADING_STATUSES:
+            raise ValidationError("Invalid trading status '{}'".format(value))
+
+        return value
 
     @validates('organisation_size')
     def validates_org_size(self, key, value):

--- a/json_schemas/suppliers.json
+++ b/json_schemas/suppliers.json
@@ -50,14 +50,7 @@
       "type": "string"
     },
     "tradingStatus": {
-      "oneOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
+      "type": "string"
     },
     "vatNumber": {
       "type": "string"

--- a/tests/main/views/test_frameworks.py
+++ b/tests/main/views/test_frameworks.py
@@ -387,7 +387,7 @@ class TestUpdateFrameworkPending(BaseApplicationTest):
         supplier_constants.KEY_VAT_NUMBER: "123456789",
         supplier_constants.KEY_DUNS_NUMBER: "987654321",
         supplier_constants.KEY_TRADING_NAME: "Sam's Sweaters",
-        supplier_constants.KEY_TRADING_STATUS: "limited company",
+        supplier_constants.KEY_TRADING_STATUS: "limited company (LTD)",
         supplier_constants.KEY_REGISTERED_NAME: "Sam's Sweaters",
         supplier_constants.KEY_ORGANISATION_SIZE: "small",
         supplier_constants.KEY_REGISTRATION_DATE: "2018-01-01T12:00:00",

--- a/tests/main/views/test_suppliers.py
+++ b/tests/main/views/test_suppliers.py
@@ -2,6 +2,7 @@ from datetime import datetime
 
 from flask import json
 from freezegun import freeze_time
+import pytest
 
 from app import db
 from app.models import Supplier, ContactInformation, AuditEvent, \
@@ -474,7 +475,7 @@ class TestUpdateSupplier(BaseApplicationTest, JSONUpdateTestMixin):
             "registrationDate": "1969-07-20",
             "vatNumber": "12312312",
             "organisationSize": "micro",
-            "tradingStatus": "Sole trader",
+            "tradingStatus": "sole trader",
         })
 
         assert response.status_code == 200
@@ -493,7 +494,7 @@ class TestUpdateSupplier(BaseApplicationTest, JSONUpdateTestMixin):
         assert supplier.registration_date == datetime(1969, 7, 20, 0, 0)
         assert supplier.vat_number == "12312312"
         assert supplier.organisation_size == "micro"
-        assert supplier.trading_status == "Sole trader"
+        assert supplier.trading_status == "sole trader"
 
     def test_supplier_json_id_does_not_match_original_id(self):
         response = self.update_request({
@@ -560,6 +561,16 @@ class TestUpdateSupplier(BaseApplicationTest, JSONUpdateTestMixin):
         response = self.update_request({"organisationSize": "tiny"})
         assert response.status_code == 400
         assert "Invalid organisation size" in response.get_data(as_text=True)
+
+    def test_update_with_bad_trading_status(self):
+        response = self.update_request({"tradingStatus": "invalid"})
+        assert response.status_code == 400
+        assert "Invalid trading status" in response.get_data(as_text=True)
+
+    @pytest.mark.parametrize('trading_status', filter(lambda x: x, Supplier.TRADING_STATUSES))
+    def test_update_succeeds_with_valid_trading_status(self, trading_status):
+        response = self.update_request({"tradingStatus": trading_status})
+        assert response.status_code == 200
 
 
 class TestUpdateContactInformation(BaseApplicationTest, JSONUpdateTestMixin):

--- a/tests/models/test_main.py
+++ b/tests/models/test_main.py
@@ -1339,7 +1339,7 @@ class TestSuppliers(BaseApplicationTest, FixtureMixin):
             "registrationDate": "1973-08-10",
             "vatNumber": "321321321",
             "organisationSize": "medium",
-            "tradingStatus": "Sticky",
+            "tradingStatus": "sole trader",
         }
         self.supplier.update_from_json(update_data)
 
@@ -1390,7 +1390,7 @@ class TestSuppliers(BaseApplicationTest, FixtureMixin):
         assert self.supplier.registration_date == datetime(1973, 8, 10, 0, 0)
         assert self.supplier.vat_number == "321321321"
         assert self.supplier.organisation_size == "medium"
-        assert self.supplier.trading_status == "Sticky"
+        assert self.supplier.trading_status == "sole trader"
 
         # Check that serialization of a supplier with all details added looks as it should
         with mock.patch('app.models.main.url_for') as url_for:
@@ -1421,7 +1421,7 @@ class TestSuppliers(BaseApplicationTest, FixtureMixin):
                 'registeredName': 'Tape and String Inc.',
                 'registrationCountry': 'Wales',
                 'registrationDate': '1973-08-10',
-                'tradingStatus': 'Sticky',
+                'tradingStatus': 'sole trader',
                 'vatNumber': '321321321',
             }
 


### PR DESCRIPTION
## Summary
We now have a more limited set of options that are suitable for suppliers to set as their trading status, and we no longer allow free text entries, so we will allow only an enum of choices as valid entries.

This PR should be merged before the other two (data migration in scripts and new page in suppler-fe).

## Ticket
https://trello.com/c/Wvvtb1yW/52-new-editable-page-trading-status