### PR TITLE
Allow null trading status

### DIFF
--- a/json_schemas/suppliers.json
+++ b/json_schemas/suppliers.json
@@ -50,7 +50,14 @@
       "type": "string"
     },
     "tradingStatus": {
-      "type": "string"
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "vatNumber": {
       "type": "string"


### PR DESCRIPTION
Allow trading status to be empty so that we can perform the data migration in https://github.com/alphagov/digitalmarketplace-scripts/pull/198

After the migration has been completed, we will re-apply the validation to prevent submission of null trading status.

## Ticket
https://trello.com/c/Wvvtb1yW/52-new-editable-page-trading-status