### PR TITLE
Build psycopg2 from source

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -5,7 +5,7 @@ Flask==0.10.1
 Flask-Bcrypt==0.7.1
 Flask-Migrate==2.0.3
 Flask-SQLAlchemy==2.1
-psycopg2==2.7.3
+psycopg2==2.7.3 --no-binary=psycopg2
 SQLAlchemy==1.1.4
 SQLAlchemy-Utils==0.30.5
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ Flask==0.10.1
 Flask-Bcrypt==0.7.1
 Flask-Migrate==2.0.3
 Flask-SQLAlchemy==2.1
-psycopg2==2.7.3
+psycopg2==2.7.3 --no-binary=psycopg2
 SQLAlchemy==1.1.4
 SQLAlchemy-Utils==0.30.5
 


### PR DESCRIPTION
## Summary
When pip installing psycopg2, we need to build it from source rather
than use a pre-compiled binary/wheel so that it gets linked against the
correct libssl.

https://github.com/unbit/uwsgi/issues/1569