### PR TITLE
Add notifications.service.gov.uk to allowed domains for non-Production envs

### DIFF
--- a/config.py
+++ b/config.py
@@ -31,7 +31,7 @@ class Config:
     DM_API_BUYER_DOMAINS_PAGE_SIZE = 100
     DM_API_PROJECTS_PAGE_SIZE = 100
 
-    DM_ALLOWED_ADMIN_DOMAINS = ['digital.cabinet-office.gov.uk', 'crowncommercial.gov.uk', 'user.marketplace.team']
+    DM_ALLOWED_ADMIN_DOMAINS = ['digital.cabinet-office.gov.uk', 'crowncommercial.gov.uk', 'user.marketplace.team', 'notifications.service.gov.uk']
 
     SQLALCHEMY_COMMIT_ON_TEARDOWN = False
     SQLALCHEMY_DATABASE_URI = 'postgresql://localhost/digitalmarketplace'


### PR DESCRIPTION
The test email address for Notify, used by our functional tests to invite an admin user, is at this domain.