### PR TITLE
Drop registration date column

### DIFF
--- a/app/models/main.py
+++ b/app/models/main.py
@@ -316,7 +316,6 @@ class Supplier(db.Model):
     registered_name = db.Column(db.String, index=False, unique=False, nullable=True)
     registration_country = db.Column(db.String, index=False, unique=False, nullable=True)
     other_company_registration_number = db.Column(db.String, index=False, unique=False, nullable=True)
-    registration_date = db.Column(db.DateTime, index=False, unique=False, nullable=True)
     vat_number = db.Column(db.String, index=False, unique=False, nullable=True)
     organisation_size = db.Column(db.String, index=False, unique=False, nullable=True)
     trading_status = db.Column(db.String, index=False, unique=False, nullable=True)

--- a/migrations/versions/1100_drop_registration_date_column.py
+++ b/migrations/versions/1100_drop_registration_date_column.py
@@ -1,0 +1,23 @@
+"""Drop registration date column
+
+Revision ID: 1100
+Revises: 1090
+Create Date: 2018-03-05 13:36:36.395640
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision = '1100'
+down_revision = '1090'
+
+
+def upgrade():
+    op.drop_column('suppliers', 'registration_date')
+
+
+def downgrade():
+    op.add_column('suppliers', sa.Column('registration_date', postgresql.TIMESTAMP(), autoincrement=False, nullable=True))


### PR DESCRIPTION
## Summary
After merging https://github.com/alphagov/digitalmarketplace-api/pull/752 and the apiclient/supplier-fe PRs, we will have no code which uses a company's registration date, so let's drop the column altogether.

## Note
Please only review the 2nd commit of this PR as the first commit is from the aforementioned other API PR.

This PR **must not** be merged and released in the same pipeline as https://github.com/alphagov/digitalmarketplace-api/pull/752

## Ticket
https://trello.com/c/M2jPJ3kZ/58-purge-registration-date-from-logic-and-data