### PR TITLE
Include supplier organisation size in User serialization

### DIFF
--- a/app/models/main.py
+++ b/app/models/main.py
@@ -867,6 +867,8 @@ class User(db.Model):
                 "supplierId": self.supplier.supplier_id,
                 "name": self.supplier.name
             }
+            if self.supplier.organisation_size:
+                supplier['organisationSize'] = self.supplier.organisation_size
             user['supplier'] = supplier
 
         return user

--- a/tests/models/test_main.py
+++ b/tests/models/test_main.py
@@ -63,6 +63,29 @@ class TestUser(BaseApplicationTest, FixtureMixin):
         assert user.logged_in_at is None
         assert user.serialize()['loggedInAt'] == "2018-01-09T00:00:00.000000Z"
 
+    def test_supplier_user_serializes_extra_supplier_fields(self):
+        now = datetime.utcnow()
+        supplier = Supplier(name="Joe Bananas", organisation_size="micro", supplier_id=1234)
+        db.session.add(supplier)
+        db.session.commit()
+        user = User(
+            email_address='supplier@example.com',
+            name='name',
+            role='supplier',
+            password='password',
+            active=True,
+            failed_login_count=0,
+            created_at=now,
+            updated_at=now,
+            password_changed_at=now,
+        )
+        user.supplier = supplier
+
+        serialized_user = user.serialize()
+        assert serialized_user['supplier']['supplierId'] == 1234
+        assert serialized_user['supplier']['name'] == "Joe Bananas"
+        assert serialized_user['supplier']['organisationSize'] == "micro"
+
     def test_buyer_user_requires_valid_email_domain(self):
         with pytest.raises(ValidationError) as exc:
             self.setup_default_buyer_domain()


### PR DESCRIPTION
Trello: https://trello.com/c/PZyZdMtG/337-custom-dimension-to-capture-size-of-supplier

We now have data in the Supplier `organisation_size` field for around 50% of suppliers (hopefully the active 50%). This PR includes that data in the serialized `/users` response if it's present.

The upcoming changes to the dm-utils `User` object (not to be confused with the API `User` model) will be able to cope with the key not being present in the response (see https://github.com/alphagov/digitalmarketplace-utils/pull/364).

