### PR TITLE
Re-add migration to drop registration_date column from suppliers

### DIFF
--- a/migrations/versions/1100_drop_registration_date_column.py
+++ b/migrations/versions/1100_drop_registration_date_column.py
@@ -1,0 +1,23 @@
+"""Drop registration date column
+
+Revision ID: 1100
+Revises: 1090
+Create Date: 2018-03-05 13:36:36.395640
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision = '1100'
+down_revision = '1090'
+
+
+def upgrade():
+    op.drop_column('suppliers', 'registration_date')
+
+
+def downgrade():
+    op.add_column('suppliers', sa.Column('registration_date', postgresql.TIMESTAMP(), autoincrement=False, nullable=True))


### PR DESCRIPTION
This should work OK now that the code has been released beforehand.

(This migration has previously been approved).