### PR TITLE
Add audit event for creation of supplier

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -11,7 +11,7 @@ SQLAlchemy==1.1.4
 SQLAlchemy-Utils==0.30.5
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@34.1.1#egg=digitalmarketplace-utils==34.1.1
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@14.0.0#egg=digitalmarketplace-apiclient==14.0.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@14.5.0#egg=digitalmarketplace-apiclient==14.5.0
 
 # For schema validation
 jsonschema==2.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ SQLAlchemy==1.1.4
 SQLAlchemy-Utils==0.30.5
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@34.1.1#egg=digitalmarketplace-utils==34.1.1
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@14.0.0#egg=digitalmarketplace-apiclient==14.0.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@14.5.0#egg=digitalmarketplace-apiclient==14.5.0
 
 # For schema validation
 jsonschema==2.5.1

--- a/tests/main/views/test_suppliers.py
+++ b/tests/main/views/test_suppliers.py
@@ -439,10 +439,10 @@ class TestUpdateSupplier(BaseApplicationTest, JSONUpdateTestMixin):
         ).first()
 
         audit = AuditEvent.query.filter(
-            AuditEvent.object == supplier
+            AuditEvent.object == supplier,
+            AuditEvent.type == "supplier_update"
         ).first()
 
-        assert audit.type == "supplier_update"
         assert audit.user == "supplier@user.dmdev"
         assert audit.data == {
             'update': {'name': "Name"},
@@ -674,10 +674,10 @@ class TestUpdateContactInformation(BaseApplicationTest, JSONUpdateTestMixin):
         ).first()
 
         audit = AuditEvent.query.filter(
-            AuditEvent.object == contact.supplier
+            AuditEvent.object == contact.supplier,
+            AuditEvent.type == "contact_update"
         ).first()
 
-        assert audit.type == "contact_update"
         assert audit.user == "supplier@user.dmdev"
         assert audit.data == {
             'update': {'city': "New City"},
@@ -869,11 +869,22 @@ class TestPostSupplier(BaseApplicationTest, JSONTestMixin):
 
     def test_add_a_new_supplier(self):
         payload = load_example_listing("new-supplier")
+
         response = self.post_supplier(payload)
+
         assert response.status_code == 201
-        assert Supplier.query.filter(
+
+        supplier = Supplier.query.filter(
             Supplier.name == payload['name']
-        ).first() is not None
+        ).first()
+        assert supplier is not None
+
+        audit = AuditEvent.query.filter(
+            AuditEvent.object == supplier
+        ).first()
+        assert audit.type == "create_supplier"
+        assert audit.user == "no logged-in user"
+        assert audit.data == {'update': payload}
 
     def test_when_supplier_has_missing_contact_information(self):
         payload = load_example_listing("new-supplier")


### PR DESCRIPTION
https://trello.com/c/0Q9fOz46/234-creating-a-supplier-is-not-audited-there-is-no-createsupplier-audit-event

We were not doing this previously and wanted to add coverage
of it to match that we store audit events for all other DB
actions.

Note, unlike most other actions, we do not have a logged in user
at this point so who did the action is unknown.