### PR TITLE
tracing: bump digitalmarketplace-apiclient dependency to 15.0.0

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -11,7 +11,7 @@ SQLAlchemy==1.1.4
 SQLAlchemy-Utils==0.30.5
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@34.1.1#egg=digitalmarketplace-utils==34.1.1
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@14.5.0#egg=digitalmarketplace-apiclient==14.5.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.0.0#egg=digitalmarketplace-apiclient==15.0.0
 
 # For schema validation
 jsonschema==2.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ SQLAlchemy==1.1.4
 SQLAlchemy-Utils==0.30.5
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@34.1.1#egg=digitalmarketplace-utils==34.1.1
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@14.5.0#egg=digitalmarketplace-apiclient==14.5.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.0.0#egg=digitalmarketplace-apiclient==15.0.0
 
 # For schema validation
 jsonschema==2.5.1
@@ -52,7 +52,7 @@ notifications-python-client==4.1.0
 odfpy==1.3.6
 pycparser==2.18
 PyJWT==1.6.0
-python-dateutil==2.6.1
+python-dateutil==2.7.0
 python-editor==1.0.3
 python-json-logger==0.1.4
 pytz==2015.4


### PR DESCRIPTION
This should bring in support for zipkin span ids

https://trello.com/c/exuNFb7A/357-zipkin-headers-pt2-api-client
https://trello.com/b/ioXxSA1U/tech-debt