### PR TITLE
Remove trailing commas

### DIFF
--- a/tests/models/test_main.py
+++ b/tests/models/test_main.py
@@ -944,7 +944,7 @@ class TestBriefResponses(BaseApplicationTest, FixtureMixin):
             submitted_at=datetime.utcnow(),
             award_details={'pending': True},
         )
-        brief_response.award_details = {'confirmed': 'details'},
+        brief_response.award_details = {'confirmed': 'details'}
         brief_response.awarded_at = datetime(2016, 1, 1)
         db.session.add(brief_response)
         db.session.commit()
@@ -1105,13 +1105,13 @@ class TestBriefResponses(BaseApplicationTest, FixtureMixin):
             data={}, brief=brief, supplier=self.supplier, submitted_at=datetime.utcnow(),
             award_details={'pending': True},
         )
-        brief_response1.award_details = {'confirmed': 'details'},
+        brief_response1.award_details = {'confirmed': 'details'}
         brief_response1.awarded_at = timestamp
         brief_response2 = BriefResponse(
             data={}, brief=brief, supplier=self.supplier, submitted_at=datetime.utcnow(),
             award_details={'pending': True},
         )
-        brief_response2.award_details = {'confirmed': 'details'},
+        brief_response2.award_details = {'confirmed': 'details'}
         brief_response2.awarded_at = timestamp
         db.session.add_all([brief_response1, brief_response2])
         with pytest.raises(IntegrityError) as exc:


### PR DESCRIPTION
These set the values as a tuple instead of as a dictionary when
the trailing comma is there e.g.
`({'confirmed': 'details'},)`