### PR TITLE
Allow clearing other reg number

### DIFF
--- a/json_schemas/suppliers.json
+++ b/json_schemas/suppliers.json
@@ -38,7 +38,14 @@
       "type": "string"
     },
     "otherCompanyRegistrationNumber": {
-      "type": "string"
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "registeredName": {
       "type": "string"

--- a/tests/main/views/test_suppliers.py
+++ b/tests/main/views/test_suppliers.py
@@ -569,6 +569,10 @@ class TestUpdateSupplier(BaseApplicationTest, JSONUpdateTestMixin):
         assert response.status_code == 400
         assert "Invalid trading status" in response.get_data(as_text=True)
 
+    def test_update_succeeds_with_null_other_company_registration_number(self):
+        response = self.update_request({"otherCompanyRegistrationNumber": None})
+        assert response.status_code == 200
+
     @pytest.mark.parametrize('trading_status', filter(lambda x: x, Supplier.TRADING_STATUSES))
     def test_update_succeeds_with_valid_trading_status(self, trading_status):
         response = self.update_request({"tradingStatus": trading_status})


### PR DESCRIPTION
## Summary
We want to allow suppliers to update some of their company details until
they click a big green 'confirm details are correct' button. This means
that a supplier might provide an 'other company registration number'
incorrectly and then want to change it to a Companies House number,
meaning we need to let them post an update which clears out their other
company registration number.

They can also provide a VAT number and then decide they shouldn't have,
but when a supplier declares they haven't registered for VAT we store
the value "Not VAT registered" in the column rather than leaving it
blank, so we don't need to worry about allowing null updates there.

## Related PRs
* https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/833

## Ticket
https://trello.com/c/NaNjMOHc/61-confirm-supplier-details-2-frontend-logic-changes