### PR TITLE
Use centralised status method

### DIFF
--- a/app/status/views.py
+++ b/app/status/views.py
@@ -1,64 +1,27 @@
-from flask import jsonify, current_app, request
+from flask import request
 from sqlalchemy.exc import SQLAlchemyError
 
 from . import status
 from . import utils
 from ..models import Framework
-from dmutils.status import get_flags
+from dmutils.status import get_app_status, StatusError
 from app import search_api_client
+
+
+def get_db_status():
+    try:
+        return {
+            'frameworks': {f.slug: f.status for f in Framework.query.all()},
+            'db_version': utils.get_db_version(),
+        }
+
+    except SQLAlchemyError:
+        raise StatusError('Error connecting to database')
 
 
 @status.route('/_status')
 def status():
-
-    if 'ignore-dependencies' in request.args:
-        return jsonify(
-            status="ok",
-        ), 200
-
-    version = current_app.config['VERSION']
-    apis = [
-        {
-            'name': 'Search API',
-            'key': 'search_api_status',
-            'status': search_api_client.get_status()
-        },
-    ]  # list for consistency with other apps - a chunk of this should move into utils?
-
-    apis_with_errors = []
-
-    for api in apis:
-        if api['status'] is None or api['status']['status'] != "ok":
-            apis_with_errors.append(api['name'])
-
-    # if no errors found, return as is.  Else, return an error and a message
-    if not apis_with_errors:
-        try:
-            return jsonify(
-                {api['key']: api['status'] for api in apis},
-                status="ok",
-                frameworks={f.slug: f.status for f in Framework.query.all()},
-                version=version,
-                db_version=utils.get_db_version(),
-                flags=get_flags(current_app)
-            )
-        except SQLAlchemyError:
-            current_app.logger.exception('Error connecting to database')
-            return jsonify(
-                status="error",
-                version=version,
-                message="Error connecting to database",
-                flags=get_flags(current_app)
-            ), 500
-
-    message = "Error connecting to {}.".format(
-        ", ".join(apis_with_errors)
-    )
-
-    return jsonify(
-        {api['key']: api['status'] for api in apis},
-        status="error",
-        version=version,
-        message=message,
-        flags=get_flags(current_app)
-    ), 500
+    return get_app_status(data_api_client=None,
+                          search_api_client=search_api_client,
+                          ignore_dependencies='ignore-dependencies' in request.args,
+                          additional_checks=[get_db_status])

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -10,7 +10,7 @@ psycopg2==2.7.3
 SQLAlchemy==1.1.4
 SQLAlchemy-Utils==0.30.5
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@34.1.1#egg=digitalmarketplace-utils==34.1.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@35.2.0#egg=digitalmarketplace-utils==35.2.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.0.0#egg=digitalmarketplace-apiclient==15.0.0
 
 # For schema validation

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ psycopg2==2.7.3
 SQLAlchemy==1.1.4
 SQLAlchemy-Utils==0.30.5
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@34.1.1#egg=digitalmarketplace-utils==34.1.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@35.2.0#egg=digitalmarketplace-utils==35.2.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.0.0#egg=digitalmarketplace-apiclient==15.0.0
 
 # For schema validation

--- a/tests/main/views/test_status.py
+++ b/tests/main/views/test_status.py
@@ -57,4 +57,4 @@ class TestStatus(BaseApplicationTest):
         json_data = json.loads(response.get_data().decode('utf-8'))
 
         assert "{}".format(json_data['status']) == "error"
-        assert json_data.get('search_api_status') is None
+        assert json_data.get('search_api_status') == {'status': 'n/a'}


### PR DESCRIPTION
 ## Summary
The status endpoint for all of the apps is highly redundant across
repositories so I've moved it to dm-utils. We now only need to call this
method from the view stub in each app and pass in a couple of resources
(mainly the current_app and any api clients) to get a consistent status
JSON blob back.

 ## Ticket
https://trello.com/c/BBvu6eUk/383-ensure-healthcheck-endpoint-fails-if-low-disk-space