### PR TITLE
Serialize audit events object type and id

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -61,6 +61,7 @@ def create_framework():
             lots=lots
         )
         db.session.add(framework)
+        db.session.flush()
         db.session.add(
             AuditEvent(
                 audit_type=AuditTypes.create_framework,
@@ -178,7 +179,11 @@ WHERE
                 audit_type=AuditTypes.framework_update,
                 db_object=framework,
                 user=updater_json['updated_by'],
-                data={'update': json_payload['frameworks']})
+                data={
+                    'update': json_payload['frameworks'],
+                    'frameworkSlug': framework.slug,
+                },
+            )
         )
         db.session.commit()
     except IntegrityError as e:

--- a/app/models/main.py
+++ b/app/models/main.py
@@ -1196,6 +1196,8 @@ class AuditEvent(db.Model):
             'acknowledged': self.acknowledged,
             'user': self.user,
             'data': self.data,
+            'objectType': self.object_type,
+            'objectId': self.object_id,
             'createdAt': self.created_at.strftime(DATETIME_FORMAT),
             'links': filter_null_value_fields({
                 "self": url_for("main.list_audits"),

--- a/tests/main/views/test_audits.py
+++ b/tests/main/views/test_audits.py
@@ -629,7 +629,11 @@ class TestAuditEvents(BaseTestAuditEvents):
         assert AuditEvent.query.count() == count + 1
 
     def test_should_get_audit_event(self):
-        aid = self.add_audit_event(0)
+        supplier_id = self.setup_dummy_suppliers(1)[0]
+        supplier = Supplier.query.filter(Supplier.supplier_id == supplier_id).first()
+        object_id = supplier.id
+        aid = self.add_audit_event(0, db_object=supplier)
+
         response = self.client.get('/audit-events')
         data = json.loads(response.get_data())
         assert response.status_code == 200
@@ -639,6 +643,8 @@ class TestAuditEvents(BaseTestAuditEvents):
             'acknowledged': False,
             'user': '0',
             'data': {'request': 'data'},
+            'objectType': 'Supplier',
+            'objectId': object_id,
             'id': aid,
             'createdAt': mock.ANY
         }


### PR DESCRIPTION
We weren't returning an audit events object type and id in the API
response. It's useful so we should!