### PR TITLE
Allow setting framework close date using the API

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -95,6 +95,7 @@ def update_framework(framework_slug):
         'status': 'status',
         'clarificationQuestionsOpen': 'clarification_questions_open',
         'frameworkAgreementDetails': 'framework_agreement_details',
+        'applicationCloseDate': 'application_close_date',
         'allowDeclarationReuse': 'allow_declaration_reuse',
     }
 

--- a/tests/main/views/test_frameworks.py
+++ b/tests/main/views/test_frameworks.py
@@ -243,6 +243,7 @@ class TestUpdateFramework(BaseApplicationTest, JSONUpdateTestMixin, FixtureMixin
             'status': "standstill",
             'clarificationQuestionsOpen': False,
             'lots': ['saas', 'paas', 'iaas', 'scs'],
+            'applicationCloseDate': '2023-04-11T16:00:00.000000Z',
             'allowDeclarationReuse': True,
         }
 
@@ -250,6 +251,7 @@ class TestUpdateFramework(BaseApplicationTest, JSONUpdateTestMixin, FixtureMixin
             'frameworkAgreementDetails',
             'status',
             'clarificationQuestionsOpen',
+            'applicationCloseDate',
             'allowDeclarationReuse',
         ]
 


### PR DESCRIPTION
This is used by the "Reusing declarations" page both to display the date on the page and to select the most recent declaration to reuse.