### PR TITLE
Load supplier frameworks lazily

### DIFF
--- a/app/main/views/agreements.py
+++ b/app/main/views/agreements.py
@@ -31,7 +31,7 @@ def create_framework_agreement():
 
     supplier_framework = SupplierFramework.find_by_supplier_and_framework(
         update_json['supplierId'], update_json['frameworkSlug']
-    )
+    ).first()
 
     if not supplier_framework or not supplier_framework.on_framework:
         abort(

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -2,6 +2,7 @@ from datetime import datetime
 
 from flask import jsonify, abort, request, current_app
 from sqlalchemy.exc import IntegrityError, DataError
+from sqlalchemy.orm import lazyload
 from dmapiclient.audit import AuditTypes
 from dmutils.formats import DATETIME_FORMAT
 
@@ -268,7 +269,8 @@ def set_a_declaration(supplier_id, framework_slug):
 
     supplier_framework = SupplierFramework.find_by_supplier_and_framework(
         supplier_id, framework_slug
-    )
+    ).first()
+
     if supplier_framework is not None:
         status_code = 200 if supplier_framework.declaration else 201
     else:
@@ -347,7 +349,10 @@ def get_supplier_frameworks_info(supplier_id):
 def get_supplier_framework_info(supplier_id, framework_slug):
     supplier_framework = SupplierFramework.find_by_supplier_and_framework(
         supplier_id, framework_slug
-    )
+    ).options(
+        lazyload('*')
+    ).first()
+
     if supplier_framework is None:
         abort(404)
 

--- a/app/models/main.py
+++ b/app/models/main.py
@@ -486,17 +486,13 @@ class SupplierFramework(db.Model):
         return value
 
     @staticmethod
-    def find_by_framework(framework_slug):
+    def find_by_supplier_and_framework(supplier_id, framework_slug):
         return SupplierFramework.query.filter(
             SupplierFramework.framework.has(
-                Framework.slug == framework_slug)
+                Framework.slug == framework_slug
+            ),
+            SupplierFramework.supplier_id == supplier_id,
         )
-
-    @staticmethod
-    def find_by_supplier_and_framework(supplier_id, framework_slug):
-        return SupplierFramework.find_by_framework(framework_slug).filter(
-            SupplierFramework.supplier_id == supplier_id
-        ).first()
 
     @staticmethod
     def get_service_counts(supplier_id):

--- a/tests/main/views/test_suppliers.py
+++ b/tests/main/views/test_suppliers.py
@@ -817,9 +817,9 @@ class TestSetSupplierDeclarations(BaseApplicationTest, FixtureMixin, JSONUpdateT
                 content_type='application/json')
 
             assert response.status_code == 201
-            answers = SupplierFramework \
-                .find_by_supplier_and_framework(0, 'test-open')
-            assert answers.declaration['question'] == 'answer'
+            answer = SupplierFramework \
+                .find_by_supplier_and_framework(0, 'test-open').first()
+            assert answer.declaration['question'] == 'answer'
 
     def test_add_null_declaration_should_result_in_dict(self):
         response = self.client.put(
@@ -831,9 +831,9 @@ class TestSetSupplierDeclarations(BaseApplicationTest, FixtureMixin, JSONUpdateT
             content_type='application/json')
 
         assert response.status_code == 201
-        answers = SupplierFramework \
-            .find_by_supplier_and_framework(0, 'test-open')
-        assert isinstance(answers.declaration, dict)
+        answer = SupplierFramework \
+            .find_by_supplier_and_framework(0, 'test-open').first()
+        assert isinstance(answer.declaration, dict)
 
     def test_update_existing_declaration(self):
         framework_id = Framework.query.filter(
@@ -857,7 +857,7 @@ class TestSetSupplierDeclarations(BaseApplicationTest, FixtureMixin, JSONUpdateT
 
         assert response.status_code == 200
         supplier_framework = SupplierFramework \
-            .find_by_supplier_and_framework(0, 'test-open')
+            .find_by_supplier_and_framework(0, 'test-open').first()
         assert supplier_framework.declaration['question'] == 'answer2'
 
 
@@ -1248,7 +1248,7 @@ class TestSupplierFrameworkResponse(BaseApplicationTest):
     def test_get_supplier_framework_does_not_return_draft_framework_agreement(self, supplier_framework):
         supplier_framework_object = SupplierFramework.find_by_supplier_and_framework(
             supplier_framework['supplierId'], supplier_framework['frameworkSlug']
-        )
+        ).first()
 
         framework_agreement = FrameworkAgreement(
             supplier_framework=supplier_framework_object,
@@ -1295,7 +1295,7 @@ class TestSupplierFrameworkResponse(BaseApplicationTest):
     def test_get_supplier_framework_returns_signed_framework_agreement(self, supplier_framework):
         supplier_framework_object = SupplierFramework.find_by_supplier_and_framework(
             supplier_framework['supplierId'], supplier_framework['frameworkSlug']
-        )
+        ).first()
 
         framework_agreement = FrameworkAgreement(
             supplier_framework=supplier_framework_object,
@@ -1349,7 +1349,7 @@ class TestSupplierFrameworkResponse(BaseApplicationTest):
     def test_get_supplier_framework_returns_countersigned_framework_agreement(self, supplier_framework, supplier):
         supplier_framework_object = SupplierFramework.find_by_supplier_and_framework(
             supplier_framework['supplierId'], supplier_framework['frameworkSlug']
-        )
+        ).first()
 
         framework_agreement = FrameworkAgreement(
             supplier_framework=supplier_framework_object,


### PR DESCRIPTION
This is a straw man really, not sure if there are issues with doing this here.

When getting supplier frameworks we use a fully joined query. When under
a lot of load, especially for suppliers editing draft services, the
supplier framework gets called a lot. Looking at sequence diagrams, the
request for the supplier frameworks is by far the longest request from
the api. See below for a couple of examples, taken from requests around 
the time the supplier frontend started to struggle in load tests.

Anecdotally on my machine this change has halved the request time. How that
stands up when making requests over the network I don't know.

<img width="662" alt="screen shot 2018-04-04 at 09 49 50" src="https://user-images.githubusercontent.com/13836290/38297945-cde9b916-37ed-11e8-93ef-6566850fe066.png">

<img width="661" alt="screen shot 2018-04-04 at 09 50 48" src="https://user-images.githubusercontent.com/13836290/38297947-cfa08d02-37ed-11e8-8126-ddb6c0abf940.png">
