### PR TITLE
supplier audit events: add supplierId to most events

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -168,7 +168,10 @@ def create_supplier():
                 audit_type=AuditTypes.create_supplier,
                 db_object=supplier,
                 user="no logged-in user",
-                data={'update': request_data}
+                data={
+                    "update": request_data,
+                    "supplierId": supplier.supplier_id,
+                },
             )
         )
         db.session.commit()
@@ -208,7 +211,11 @@ def update_supplier(supplier_id):
             audit_type=AuditTypes.supplier_update,
             db_object=supplier,
             user=updater_json['updated_by'],
-            data={'update': request_data['suppliers']})
+            data={
+                "update": request_data["suppliers"],
+                "supplierId": supplier.supplier_id,
+            },
+        )
     )
 
     try:
@@ -249,7 +256,11 @@ def update_contact_information(supplier_id, contact_id):
             audit_type=AuditTypes.contact_update,
             db_object=contact.supplier,
             user=updater_json['updated_by'],
-            data={'update': request_data['contactInformation']})
+            data={
+                "update": request_data["contactInformation"],
+                "supplierId": contact.supplier.supplier_id,
+            },
+        )
     )
 
     try:
@@ -296,7 +307,11 @@ def set_a_declaration(supplier_id, framework_slug):
             audit_type=AuditTypes.answer_selection_questions,
             db_object=supplier_framework,
             user=updater_json['updated_by'],
-            data={'update': request_data['declaration']})
+            data={
+                "update": request_data["declaration"],
+                "supplierId": supplier_id,
+            },
+        )
     )
 
     try:

--- a/tests/main/views/test_suppliers.py
+++ b/tests/main/views/test_suppliers.py
@@ -446,6 +446,7 @@ class TestUpdateSupplier(BaseApplicationTest, JSONUpdateTestMixin):
         assert audit.user == "supplier@user.dmdev"
         assert audit.data == {
             'update': {'name': "Name"},
+            'supplierId': supplier.supplier_id,
         }
 
     def test_update_response_matches_payload_plus_defaults(self):
@@ -689,6 +690,7 @@ class TestUpdateContactInformation(BaseApplicationTest, JSONUpdateTestMixin):
         assert audit.user == "supplier@user.dmdev"
         assert audit.data == {
             'update': {'city': "New City"},
+            'supplierId': contact.supplier.supplier_id,
         }
 
     def test_update_response_matches_payload(self):
@@ -892,7 +894,10 @@ class TestPostSupplier(BaseApplicationTest, JSONTestMixin):
         ).first()
         assert audit.type == "create_supplier"
         assert audit.user == "no logged-in user"
-        assert audit.data == {'update': payload}
+        assert audit.data == {
+            'update': payload,
+            'supplierId': supplier.supplier_id,
+        }
 
     def test_when_supplier_has_missing_contact_information(self):
         payload = load_example_listing("new-supplier")


### PR DESCRIPTION
this is the externally visible id, which is used in most parts of the api. far more handy than the internal id most the time.

A result of trying to track down a second line situation and finding this lacking: https://trello.com/c/11syiJPd/260-overzealous-notify-failure-causes-503-rather-than-graceful-handling