### PR TITLE
Copy services between frameworks

### DIFF
--- a/app/main/views/drafts.py
+++ b/app/main/views/drafts.py
@@ -2,12 +2,12 @@ from dmapiclient.audit import AuditTypes
 from flask import jsonify, abort, request, current_app
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import lazyload
-from sqlalchemy import asc
+from sqlalchemy import asc, desc
 
 from .. import main
 from ... import db
 from ...validation import is_valid_service_id_or_400
-from ...models import Service, DraftService, Supplier, AuditEvent, Framework
+from ...models import Service, DraftService, Supplier, AuditEvent, Framework, Lot
 from ...utils import (
     get_int_or_400,
     get_json_from_request,
@@ -100,6 +100,88 @@ def copy_draft_service_from_existing_service(service_id):
         abort(400, format(e))
 
     return single_result_response(RESOURCE_NAME, draft), 201
+
+
+@main.route('/draft-services/<framework_slug>/<lot_slug>/copy-published-from-framework', methods=['POST'])
+def copy_published_from_framework(framework_slug, lot_slug):
+    """
+    Copy all published services from a given framework/lot to a different framework's drafts.
+    :param framework_slug: The slug for the framework to create the new drafts in.
+    :param lot: The slug for the lot to copy services from/create drafts forself.
+    :return: The serialized drafts.
+    """
+    updater_json = validate_and_return_updater_request()
+    json_payload = get_json_from_request()
+
+    supplier_id = get_int_or_400(json_payload, 'supplierId')
+    source_framework_slug = json_payload.get('sourceFrameworkSlug')
+    questions_to_copy = json_payload.get('questionsToCopy')
+
+    if not source_framework_slug:
+        abort(400, "Required data missing: 'source_framework_slug'")
+    if not questions_to_copy:
+        abort(400, "Required data missing: 'questions_to_copy'")
+    if not isinstance(questions_to_copy, list):
+        abort(400, "Data error: 'questions_to_copy' must be a list")
+
+    target_framework = Framework.query.filter(
+        Framework.slug == framework_slug
+    ).first_or_404()
+
+    if target_framework.status != 'open':
+        abort(400, "Target framework is not open")
+
+    source_services = Service.query.filter(
+        Service.supplier_id == supplier_id,
+        Service.framework.has(
+            Framework.slug == source_framework_slug
+        ),
+        Service.lot.has(
+            Lot.slug == lot_slug
+        ),
+        Service.status == 'published',
+        Service.copied_to_following_framework == False,  # NOQA
+    ).order_by(
+        # Descending order so created drafts id's are sequential in reverse alphabetical order. Helps with ordering
+        # in the frontend (most recent id first).
+        desc(Service.data['serviceName'].astext)
+    ).all()
+
+    drafts_services = []
+    for service in source_services:
+        draft = DraftService.from_service(
+            service,
+            questions_to_copy,
+            target_framework_id=target_framework.id,
+        )
+        drafts_services.append((draft, service))
+
+        service.copied_to_following_framework = True
+        db.session.add(draft, service)
+
+    # Flush so the new drafts are assigned an ID, which is used below in the audit events.
+    db.session.flush()
+
+    for draft, service in drafts_services:
+        audit = AuditEvent(
+            audit_type=AuditTypes.create_draft_service,
+            user=updater_json['updated_by'],
+            data={
+                "draftId": draft.id,
+                "serviceId": service.id
+            },
+            db_object=draft
+        )
+
+        db.session.add(audit)
+
+    try:
+        db.session.commit()
+    except IntegrityError as e:
+        db.session.rollback()
+        abort(400, format(e))
+
+    return list_result_response(RESOURCE_NAME, [draft_service[0] for draft_service in drafts_services]), 201
 
 
 @main.route('/draft-services/<int:draft_id>', methods=['POST'])

--- a/app/models/main.py
+++ b/app/models/main.py
@@ -890,6 +890,8 @@ class ServiceTableMixin(object):
     updated_at = db.Column(db.DateTime, index=False, nullable=False,
                            default=datetime.utcnow, onupdate=datetime.utcnow)
 
+    copied_to_following_framework = db.Column(db.Boolean, nullable=False, server_default=sql_false())
+
     @declared_attr
     def supplier_id(cls):
         return db.Column(db.BigInteger, db.ForeignKey('suppliers.supplier_id'),
@@ -944,7 +946,7 @@ class ServiceTableMixin(object):
             'supplierId', 'supplierName',
             'frameworkSlug', 'frameworkFramework', 'frameworkName', 'frameworkStatus',
             'lot', 'lotSlug', 'lotName',
-            'updatedAt', 'createdAt', 'links'
+            'updatedAt', 'createdAt', 'links', 'copiedToFollowingFramework'
         ])
 
         data = strip_whitespace_from_data(data)
@@ -972,7 +974,8 @@ class ServiceTableMixin(object):
             'lotName': self.lot.name,
             'updatedAt': self.updated_at.strftime(DATETIME_FORMAT),
             'createdAt': self.created_at.strftime(DATETIME_FORMAT),
-            'status': self.status
+            'status': self.status,
+            'copiedToFollowingFramework': self.copied_to_following_framework,
         })
 
         data['links'] = link(

--- a/migrations/versions/1130_add_copied_to_following_framework_column.py
+++ b/migrations/versions/1130_add_copied_to_following_framework_column.py
@@ -1,0 +1,27 @@
+"""add_copied_to_following_framework_column
+
+Revision ID: 1130
+Revises: 1120
+Create Date: 2018-04-06 11:52:17.825501
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+
+# revision identifiers, used by Alembic.
+revision = '1130'
+down_revision = '1120'
+
+
+def upgrade():
+    op.add_column('archived_services', sa.Column('copied_to_following_framework', sa.Boolean(), server_default=sa.text('false'), nullable=False))
+    op.add_column('draft_services', sa.Column('copied_to_following_framework', sa.Boolean(), server_default=sa.text('false'), nullable=False))
+    op.add_column('services', sa.Column('copied_to_following_framework', sa.Boolean(), server_default=sa.text('false'), nullable=False))
+
+
+def downgrade():
+    op.drop_column('services', 'copied_to_following_framework')
+    op.drop_column('draft_services', 'copied_to_following_framework')
+    op.drop_column('archived_services', 'copied_to_following_framework')

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -217,8 +217,8 @@ class FixtureMixin(object):
         db.session.commit()
         return service.id
 
-    def setup_dummy_services(self, n, supplier_id=None, framework_id=1,
-                             start_id=0, lot_id=1, model=Service):
+    def setup_dummy_services(self, n, supplier_id=None, framework_id=1, data=None,
+                             start_id=0, lot_id=1, model=Service, status='published'):
         for i in range(start_id, start_id + n):
             self.setup_dummy_service(
                 service_id=str(2000000000 + start_id + i),
@@ -226,6 +226,8 @@ class FixtureMixin(object):
                 framework_id=framework_id,
                 lot_id=lot_id,
                 model=model,
+                status=status,
+                data=data,
             )
 
     def setup_dummy_services_including_unpublished(self, n):

--- a/tests/models/test_main.py
+++ b/tests/models/test_main.py
@@ -1614,6 +1614,102 @@ class TestServices(BaseApplicationTest, FixtureMixin):
         assert service.data == {'foo': 'bar', 'serviceName': 'Service 1000000000'}
 
 
+class TestDraftService(BaseApplicationTest, FixtureMixin):
+    def setup(self):
+        super().setup()
+
+        self.setup_dummy_suppliers(1)
+        self.setup_dummy_service(
+            service_id='1000000000',
+            supplier_id=0,
+            status='published',
+            framework_id=2)
+
+    def test_from_service(self):
+        service = Service.query.filter(Service.service_id == '1000000000').first()
+        draft_service = DraftService.from_service(service)
+
+        db.session.add(draft_service)
+        db.session.commit()
+
+        assert draft_service.framework_id == service.framework_id
+        assert draft_service.lot == service.lot
+        assert draft_service.service_id == service.service_id
+        assert draft_service.supplier == service.supplier
+        assert draft_service.data == service.data
+        assert draft_service.status == service.status
+
+    def test_from_service_with_target_framework_id_and_questions(self):
+        service = Service.query.filter(Service.service_id == '1000000000').first()
+        service.data.update(
+            questionOne='Question one',
+            questionTwo='Question two',
+            questionThree='Question three'
+        )
+
+        draft_service = DraftService.from_service(
+            service,
+            questions_to_copy=['serviceName', 'questionOne', 'questionThree'],
+            target_framework_id=3,
+        )
+
+        db.session.add(draft_service)
+        db.session.commit()
+
+        assert draft_service.framework_id == 3
+        assert draft_service.lot == service.lot
+        assert draft_service.service_id is None
+        assert draft_service.supplier == service.supplier
+        assert draft_service.status == 'not-submitted'
+        assert draft_service.data == {
+            'serviceName': 'Service 1000000000',
+            'questionOne': 'Question one',
+            'questionThree': 'Question three',
+        }
+
+    @pytest.mark.parametrize(
+        ['questions_to_copy', 'should_raise'],
+        (
+            (None, True),
+            ({'questions': 'to_copy'}, True),
+            ('Questions', True),
+            (1, True),
+            (['question1', 'question2'], False),
+            (('question1', 'question2'), False),
+            ({'question1', 'question2'}, False),
+        )
+    )
+    def test_from_service_questions_to_copy_must_be_a_set_or_list_or_tuple_if_target_framework_id(
+        self, questions_to_copy, should_raise
+    ):
+        service = Service.query.filter(Service.service_id == '1000000000').first()
+
+        if should_raise:
+            with pytest.raises(TypeError) as e:
+                DraftService.from_service(
+                    service,
+                    questions_to_copy=questions_to_copy,
+                    target_framework_id=3
+                )
+            assert "'questions_to_copy' must be a list, set or tuple" in str(e.value)
+        else:
+            assert DraftService.from_service(
+                service,
+                questions_to_copy=questions_to_copy,
+                target_framework_id=3
+            )
+
+    def test_from_service_copies_status_if_target_framework_id_is_the_same(self):
+        service = Service.query.filter(Service.service_id == '1000000000').first()
+        draft_service = DraftService.from_service(
+            service,
+            questions_to_copy=['serviceName'],
+            target_framework_id=service.framework_id,
+        )
+
+        assert draft_service.status == service.status
+
+
 class TestSupplierFrameworks(BaseApplicationTest, FixtureMixin):
     def test_nulls_are_stripped_from_declaration(self):
         supplier_framework = SupplierFramework()

--- a/tests/models/test_main.py
+++ b/tests/models/test_main.py
@@ -1668,7 +1668,7 @@ class TestDraftService(BaseApplicationTest, FixtureMixin):
         }
 
     @pytest.mark.parametrize(
-        ['questions_to_copy', 'should_raise'],
+        ('questions_to_copy', 'should_raise'),
         (
             (None, True),
             ({'questions': 'to_copy'}, True),


### PR DESCRIPTION
For this trello ticket: https://trello.com/c/Nbv7N4lf

### Add 'copied_to_following_framework' column to services
We need to keep track of whether a service has been copied to a
following framework during applications. Adding this column will allow
this.

### Add copied_to_following_framework to service models
This new column will allow us to tell if a service has been copied to a
new framework. It needs to be dropped from the data when validated so it
doesn't prevent validation.

### Allow copying of draft services to new frameworks
This allows the existing `copy_draft_service_from_existing_service`
endpoint to copy existing services to different frameworks.

This endpoint doesn't appear to be currently used anywhere, however I've
maintained it's default behaviour so this isn't a breaking change to the
API.

### Add endpoint for copying multiple services
Some suppliers may have hundreds of services on a lot. To save on api
calls, this endpoint allows us to bulk copy services to drafts.
