### PR TITLE
Return only a count of created drafts when copying all

### DIFF
--- a/app/main/views/drafts.py
+++ b/app/main/views/drafts.py
@@ -108,7 +108,7 @@ def copy_published_from_framework(framework_slug, lot_slug):
     Copy all published services from a given framework/lot to a different framework's drafts.
     :param framework_slug: The slug for the framework to create the new drafts in.
     :param lot: The slug for the lot to copy services from/create drafts forself.
-    :return: The serialized drafts.
+    :return: The count of created drafts.
     """
     updater_json = validate_and_return_updater_request()
     json_payload = get_json_from_request()
@@ -181,7 +181,11 @@ def copy_published_from_framework(framework_slug, lot_slug):
         db.session.rollback()
         abort(400, format(e))
 
-    return list_result_response(RESOURCE_NAME, [draft_service[0] for draft_service in drafts_services]), 201
+    return jsonify({
+        RESOURCE_NAME: {
+            'draftsCreatedCount': len(drafts_services)
+        }
+    }), 201
 
 
 @main.route('/draft-services/<int:draft_id>', methods=['POST'])

--- a/app/main/views/drafts.py
+++ b/app/main/views/drafts.py
@@ -141,6 +141,8 @@ def copy_published_from_framework(framework_slug, lot_slug):
         ),
         Service.status == 'published',
         Service.copied_to_following_framework == False,  # NOQA
+    ).with_for_update(
+        of=Service
     ).order_by(
         # Descending order so created drafts id's are sequential in reverse alphabetical order. Helps with ordering
         # in the frontend (most recent id first).

--- a/tests/main/views/test_drafts.py
+++ b/tests/main/views/test_drafts.py
@@ -371,7 +371,7 @@ class TestCopyPublishedFromFramework(DraftsHelpersMixin):
         assert res.status_code == 201
 
         data = json.loads(res.get_data(as_text=True))
-        serialized_drafts = data['services']
+        drafts_count = data['services']['draftsCreatedCount']
 
         db_drafts = DraftService.query.filter(
             DraftService.supplier_id == 1,
@@ -379,13 +379,13 @@ class TestCopyPublishedFromFramework(DraftsHelpersMixin):
             DraftService.lot_id == 2,
         ).all()
 
-        assert len(serialized_drafts) == 5
+        assert drafts_count == 5
         assert len(db_drafts) == 5
-        assert all(service['status'] == 'not-submitted' for service in serialized_drafts)
-        assert all(service['frameworkSlug'] == 'g-cloud-7' for service in serialized_drafts)
-        assert all('serviceId' not in service for service in serialized_drafts)
-        for service, serialized_draft, db_draft in zip(services, serialized_drafts, db_drafts):
-            assert service.data['serviceName'] == serialized_draft['serviceName'] == db_draft.data['serviceName']
+        assert all(draft_service.status == 'not-submitted' for draft_service in db_drafts)
+        assert all(draft_service.framework.slug == 'g-cloud-7' for draft_service in db_drafts)
+        assert all(draft_service.service_id is None for draft_service in db_drafts)
+        for service, db_draft in zip(services, db_drafts):
+            assert service.data['serviceName'] == db_draft.data['serviceName']
 
     def test_should_400_if_no_source_framework_slug(self):
         res = self.post_to_copy_published_from_framework(source_framework_slug=None)
@@ -440,14 +440,19 @@ class TestCopyPublishedFromFramework(DraftsHelpersMixin):
         res = self.post_to_copy_published_from_framework()
         assert res.status_code == 201
 
-        drafts = json.loads(res.get_data(as_text=True))['services']
+        data = json.loads(res.get_data(as_text=True))
+        drafts_count = data['services']['draftsCreatedCount']
 
-        assert len(drafts) == 4
-        assert all(draft['frameworkSlug'] == 'g-cloud-7' for draft in drafts)
-        assert all(draft['lotSlug'] == 'paas' for draft in drafts)
-        assert all(draft['status'] == 'not-submitted' for draft in drafts)
-        for service, draft in zip(services, drafts):
-            assert service.data['serviceName'] == draft['serviceName']
+        db_drafts = DraftService.query.filter(
+            DraftService.supplier_id == 1,
+        ).all()
+
+        assert drafts_count == 4
+        assert all(draft.framework.slug == 'g-cloud-7' for draft in db_drafts)
+        assert all(draft.lot.slug == 'paas' for draft in db_drafts)
+        assert all(draft.status == 'not-submitted' for draft in db_drafts)
+        for service, draft in zip(services, db_drafts):
+            assert service.data['serviceName'] == draft.data['serviceName']
 
     def test_should_only_copy_published_services_from_correct_supplier(self):
         self.setup_additional_dummy_suppliers(1, 'A')
@@ -457,10 +462,14 @@ class TestCopyPublishedFromFramework(DraftsHelpersMixin):
         res = self.post_to_copy_published_from_framework()
         assert res.status_code == 201
 
-        drafts = json.loads(res.get_data(as_text=True))['services']
+        data = json.loads(res.get_data(as_text=True))
+        drafts_count = data['services']['draftsCreatedCount']
 
-        assert len(drafts) == 3
-        assert all(draft['supplierId'] == 1 for draft in drafts)
+        db_drafts = DraftService.query.all()
+
+        assert drafts_count == 3
+        assert len(db_drafts) == 3
+        assert all(draft.supplier_id == 1 for draft in db_drafts)
 
     def test_should_create_drafts_in_reverse_alphabetical_order_by_service_name(self):
         for service_id, char in enumerate('SERVICE'):
@@ -473,9 +482,13 @@ class TestCopyPublishedFromFramework(DraftsHelpersMixin):
         res = self.post_to_copy_published_from_framework()
         assert res.status_code == 201
 
-        drafts = json.loads(res.get_data(as_text=True))['services']
+        db_drafts = DraftService.query.filter(
+            DraftService.supplier_id == 1,
+        ).order_by(
+            DraftService.id
+        ).all()
 
-        assert [draft['serviceName'] for draft in drafts] == \
+        assert [draft.data['serviceName'] for draft in db_drafts] == \
             ['V service', 'S service', 'R service', 'I service', 'E service', 'E service', 'C service']
 
     def test_should_only_copy_questions_specified(self):
@@ -494,10 +507,12 @@ class TestCopyPublishedFromFramework(DraftsHelpersMixin):
         res = self.post_to_copy_published_from_framework(override_questions_to_copy=questions_to_copy)
         assert res.status_code == 201
 
-        drafts = json.loads(res.get_data(as_text=True))['services']
+        db_drafts = DraftService.query.filter(
+            DraftService.supplier_id == 1,
+        ).all()
 
-        assert all(question in draft for draft in drafts for question in questions_to_copy)
-        assert all(question not in draft for draft in drafts for question in questions_to_drop)
+        assert all(question in draft.data for draft in db_drafts for question in questions_to_copy)
+        assert all(question not in draft.data for draft in db_drafts for question in questions_to_drop)
 
     def test_should_mark_source_services_as_copied(self):
         self.setup_dummy_services(5, supplier_id=1, lot_id=2)

--- a/tests/main/views/test_drafts.py
+++ b/tests/main/views/test_drafts.py
@@ -569,6 +569,19 @@ class TestCopyPublishedFromFramework(DraftsHelpersMixin):
 
         assert "Could not commit" in json.loads(res.get_data())['error']
 
+    def test_uses_with_for_update_for_isolation(self):
+        filter_mock = mock.Mock()
+        filter_mock.with_for_update.return_value = Service.query
+        query_patch = mock.patch('app.main.views.drafts.Service.query')
+        query = query_patch.start()
+        query.filter.return_value = filter_mock
+
+        self.post_to_copy_published_from_framework()
+
+        query_patch.stop()
+
+        filter_mock.with_for_update.assert_called_once_with(of=Service)
+
 
 class TestDraftServices(DraftsHelpersMixin):
     def test_reject_list_drafts_no_supplier_id(self):


### PR DESCRIPTION
### Return only a count of created drafts when copying all
When a supplier has a large number of services which are all copied to
drafts in one go, the response was quite large and slow. The highest
number of services we've seen in one lot is 280. Serializing them all
and sending them in the responses is unnecessary. All the supplier
frontend was doing was counting the number of serialized drafts, so we
can just send that instead.

### Use `with_for_update` when copying all services to drafts
Copying all services can take a little while, and there's a risk that a
user might mash the button a bit and send multiple requests. If we lock
the services for update when we select them it will prevent multiple
requests copying all the services multiple times.