### PR TITLE
Organisation size from supplier

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -159,7 +159,8 @@ class FixtureMixin(object):
                 Supplier(
                     supplier_id=i,
                     name=u'Supplier {}'.format(i),
-                    description=''
+                    description='',
+                    organisation_size='small',
                 )
             )
             db.session.add(

--- a/tests/models/test_main.py
+++ b/tests/models/test_main.py
@@ -883,7 +883,7 @@ class TestBriefResponses(BaseApplicationTest, FixtureMixin):
         supplier_framework = SupplierFramework(
             supplier=self.supplier,
             framework=framework,
-            declaration={'organisationSize': 'small'}
+            declaration={}
         )
         db.session.add(supplier_framework)
         db.session.commit()
@@ -1391,6 +1391,7 @@ class TestSuppliers(BaseApplicationTest, FixtureMixin):
                 },
                 'name': u'Supplier 0',
                 'companyDetailsConfirmed': False,
+                'organisationSize': 'small'
             }
 
     def test_update_from_json(self):


### PR DESCRIPTION
 ## Summary
A supplier's organisation size used to be provided during the framework
application process as a question in the declaration. It is now provided
at the supplier account level and is a feature of a Supplier record.
Therefore, when returning the organisation size in a brief responses, we
no longer need a join to the SupplierFramework table and can instead
pull it directly from the Supplier.

## Ticket
https://trello.com/c/PNPqPL8b/66-brief-responses-still-look-for-supplierorganisationsize-in-the-declaration-rather-than-the-supplier-table