### PR TITLE
Use flush, not commit

### DIFF
--- a/app/main/views/direct_award.py
+++ b/app/main/views/direct_award.py
@@ -306,7 +306,7 @@ def lock_project(project_external_id):
     project.locked_at = now
     db.session.add(project)
 
-    db.session.commit()
+    db.session.flush()
 
     audit = AuditEvent(
         audit_type=AuditTypes.lock_project,


### PR DESCRIPTION
 ## Summary
Just flushing the session rather than committing is enough to generate
an id to use for the Audit Event, and we don't create two transactions
that risks possibly locking the search without creating an associated
audit event.