### PR TITLE
Add audit event for failed login

### DIFF
--- a/tests/bases.py
+++ b/tests/bases.py
@@ -51,7 +51,8 @@ class BaseApplicationTest(object):
         self.app = create_app('test')
         self.app.wsgi_app = WSGIApplicationWithEnvironment(
             self.app.wsgi_app,
-            HTTP_AUTHORIZATION='Bearer {}'.format(self.app.config['DM_API_AUTH_TOKENS'])
+            HTTP_AUTHORIZATION='Bearer {}'.format(self.app.config['DM_API_AUTH_TOKENS']),
+            REMOTE_ADDR='127.0.0.1',
         )
         self.app.test_client_class = TestClient
         self.client = self.app.test_client()


### PR DESCRIPTION
 ## Summary
We have an audit event type defined for `user_auth_failed` but this
doesn't seem to have been added to the appropriate API endpoint. We've
had a support query come in that we are unable to properly investigate
due to being unable to tie up login attempts with requests. This now
adds an audit event on failed login which will store the email address
of the account, the client IP making the request, the hashed password
and the number of failed login attempts currently on the account (after
adding one for the current requests).

 ## Ticket
https://trello.com/c/iSAzWgQk/466