### PR TITLE
Add outcome model, creation and update views

### DIFF
--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -13,6 +13,18 @@ def add_cache_control(response):
     return response
 
 
-from .views import suppliers, services, users, drafts, audits, frameworks, briefs, brief_responses, agreements,\
-    direct_award, buyer_domains
+from .views import (
+    agreements,
+    audits,
+    brief_responses,
+    briefs,
+    buyer_domains,
+    direct_award,
+    drafts,
+    frameworks,
+    outcomes,
+    services,
+    suppliers,
+    users,
+)
 from .. import errors

--- a/app/main/views/direct_award.py
+++ b/app/main/views/direct_award.py
@@ -25,11 +25,6 @@ from ...utils import (
 
 
 def get_project_by_id_or_404(project_id: int):
-    """During the transitional period, project_id may be either the internal or the public ID of the project."""
-    project = DirectAwardProject.query.filter(DirectAwardProject.id == project_id).first()
-    if project:
-        return project
-
     return DirectAwardProject.query.filter(DirectAwardProject.external_id == project_id).first_or_404()
 
 
@@ -227,7 +222,7 @@ def list_project_services(project_external_id):
     project = get_project_by_id_or_404(project_external_id)
 
     if not project.locked_at:
-        abort(400, 'Project has not been locked: {}'.format(project.id))
+        abort(400, 'Project has not been locked: {}'.format(project.external_id))
 
     # TODO: This should work for _all_ active searches, not just the first (although we currently enforce only one
     # TODO: active search) - SW 21/09/2017
@@ -236,7 +231,7 @@ def list_project_services(project_external_id):
         DirectAwardSearch.active == True  # noqa
     ).first()
     if not search:
-        abort(400, 'Project does not have a saved search: {}'.format(project.id))
+        abort(400, 'Project does not have a saved search: {}'.format(project.external_id))
 
     paginated_archived_services = search.archived_services.paginate(
         page=page,

--- a/app/main/views/outcomes.py
+++ b/app/main/views/outcomes.py
@@ -1,0 +1,86 @@
+import datetime
+
+from flask import abort
+from dmapiclient.audit import AuditTypes
+
+from .. import main
+from ... import db
+from ...models import AuditEvent, Outcome
+
+from ...utils import (
+    get_json_from_request,
+    json_has_required_keys,
+    single_result_response,
+    validate_and_return_updater_request,
+)
+from ...validation import validate_outcome_json_or_400
+
+
+@main.route("/outcomes/<int:outcome_id>", methods=("GET",))
+def get_outcome(outcome_id):
+    outcome = Outcome.query.filter_by(external_id=outcome_id).first_or_404()
+
+    return single_result_response("outcome", outcome), 200
+
+
+@main.route("/outcomes/<int:outcome_id>", methods=("PUT",))
+def update_outcome(outcome_id):
+    uniform_now = datetime.datetime.utcnow()
+
+    updater_json = validate_and_return_updater_request()
+
+    json_payload = get_json_from_request()
+    json_has_required_keys(json_payload, ["outcome"])
+    outcome_json = json_payload["outcome"]
+
+    validate_outcome_json_or_400(outcome_json)
+
+    # fetch and lock Outcome row so we know writing this back won't overwrite any other updates to it that made
+    # it in in the meantime
+    outcome = db.session.query(Outcome).filter_by(
+        external_id=outcome_id,
+    ).with_for_update().first()
+
+    if not outcome:
+        abort(404, f"Outcome {outcome_id} not found")
+
+    outcome.update_from_json(outcome_json)
+
+    if outcome.completed_at is not None and outcome_json.get("completed") is False:
+        abort(400, f"Can't un-complete outcome")
+    if outcome.completed_at is None and outcome_json.get("completed") is True:
+        # make a cursory check for existing Outcome collisions. we're not actually totally relying on this
+        # to police the constraint - there is a database unique constraint that will do that for us in a transactionally
+        # bulletproof way. we do this check here manually too to be able to give a nicer error message in the 99% case.
+        if outcome.brief and outcome.brief.outcome:
+            abort(400, "Brief {} already has a complete outcome: {}".format(
+                outcome.brief_id,
+                outcome.brief.outcome.external_id,
+            ))
+        if outcome.direct_award_project and outcome.direct_award_project.outcome:
+            abort(400, "Direct award project {} already has a complete outcome: {}".format(
+                outcome.direct_award_project_id,
+                outcome.direct_award_project.outcome.external_id,
+            ))
+
+        outcome.completed_at = uniform_now
+        complete_audit_event = AuditEvent(
+            audit_type=AuditTypes.complete_outcome,
+            user=updater_json['updated_by'],
+            db_object=outcome,
+            data={},
+        )
+        complete_audit_event.created_at = uniform_now
+        db.session.add(complete_audit_event)
+
+    update_audit_event = AuditEvent(
+        audit_type=AuditTypes.update_outcome,
+        user=updater_json['updated_by'],
+        db_object=outcome,
+        data=outcome_json,
+    )
+    update_audit_event.created_at = uniform_now
+    db.session.add(update_audit_event)
+    db.session.commit()
+
+    return single_result_response("outcome", outcome), 200

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,3 +1,4 @@
 from .main import *  # noqa
 from .direct_award import *  # noqa
 from .buyer_domains import *  # noqa
+from .outcomes import * # noqa

--- a/app/models/direct_award.py
+++ b/app/models/direct_award.py
@@ -1,15 +1,21 @@
 from datetime import datetime
 from urllib.parse import urljoin
 
-from sqlalchemy.orm import validates
+from sqlalchemy.orm import validates, foreign, remote
+from sqlalchemy.sql.expression import and_ as sql_and, true as sql_true
 from flask import current_app
 
 from app import db
 from app.utils import random_positive_external_id
 from app.url_utils import force_relative_url
-from app.models import User, ValidationError, ArchivedService
+from app.models import ValidationError
 
 from dmutils.formats import DATETIME_FORMAT
+
+# there is a danger of circular imports here. as such, it is not necessarily "safe" to expect all other models to be
+# present in `models` at import time, but it should be "safe" to reference any of them in this file from within a
+# function or an sqlalchemy expression declared as a lambda
+from app import models
 
 
 class DirectAwardProject(db.Model):
@@ -23,7 +29,29 @@ class DirectAwardProject(db.Model):
     downloaded_at = db.Column(db.DateTime, nullable=True)  # When the project's shortlist was last downloaded
     active = db.Column(db.Boolean, default=True, nullable=False)
 
-    users = db.relationship(User, secondary='direct_award_project_users', order_by=lambda: DirectAwardProjectUser.id)
+    users = db.relationship(
+        lambda: models.User,
+        secondary='direct_award_project_users',
+        order_by=lambda: DirectAwardProjectUser.id
+    )
+    active_search = db.relationship(
+        "DirectAwardSearch",
+        primaryjoin=lambda: (sql_and(
+            foreign(DirectAwardProject.id) == remote(DirectAwardSearch.project_id),
+            remote(DirectAwardSearch.active) == sql_true(),
+        )),
+        viewonly=True,
+        uselist=False,
+    )
+    outcome = db.relationship(
+        "Outcome",
+        primaryjoin=lambda: (sql_and(
+            foreign(DirectAwardProject.id) == remote(models.Outcome.direct_award_project_id),
+            remote(models.Outcome.completed_at).isnot(None),
+        )),
+        viewonly=True,
+        uselist=False,
+    )
 
     def serialize(self, with_users=False):
         data = {
@@ -78,11 +106,11 @@ class DirectAwardSearch(db.Model):
     # in a given state at a specific time. We can still access the live version of the service through the Archived
     # Service, but by storing this we have the flexibility to show either the live state or the state at the time
     # the user ran the search.
-    archived_services = db.relationship(ArchivedService, secondary='direct_award_search_result_entries',
+    archived_services = db.relationship(lambda: models.ArchivedService, secondary='direct_award_search_result_entries',
                                         order_by=lambda: DirectAwardSearchResultEntry.id, lazy='dynamic')
 
-    project = db.relationship(DirectAwardProject)
-    user = db.relationship(User)
+    project = db.relationship(DirectAwardProject, backref="searches")
+    user = db.relationship(lambda: models.User)
 
     __table_args__ = (
         # this may appear tautological (id is a unique column *on its own*, so clearly the combination of id/project_id

--- a/app/models/main.py
+++ b/app/models/main.py
@@ -13,7 +13,7 @@ from sqlalchemy import func
 from sqlalchemy.dialects.postgresql import INTERVAL
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.ext.hybrid import hybrid_property
-from sqlalchemy.orm import validates, backref, mapper
+from sqlalchemy.orm import validates, backref, mapper, foreign, remote
 from sqlalchemy.orm.session import Session
 from sqlalchemy.sql.expression import (
     case as sql_case,
@@ -29,8 +29,8 @@ from sqlalchemy_utils import generic_relationship
 
 from dmutils.dates import get_publishing_dates
 from dmutils.formats import DATETIME_FORMAT
-from .. import db
-from ..models.buyer_domains import BuyerEmailDomain
+
+from app import db
 from app.utils import (
     drop_foreign_fields,
     link,
@@ -39,10 +39,15 @@ from app.utils import (
     strip_whitespace_from_data,
     url_for,
 )
-from ..validation import (
+from app.validation import (
     is_valid_service_id, get_validation_errors, buyer_email_address_has_approved_domain,
     admin_email_address_has_approved_domain
 )
+
+# there is a danger of circular imports here. as such, it is not necessarily "safe" to expect all other models to be
+# present in `models` at import time, but it should be "safe" to reference any of them in this file from within a
+# function or an sqlalchemy expression declared as a lambda
+from app import models
 
 
 class JSON(sqlalchemy.dialects.postgresql.JSON):
@@ -835,7 +840,7 @@ class User(db.Model):
 
     @validates('email_address')
     def validate_email_address(self, key, value):
-        existing_buyer_domains = BuyerEmailDomain.query.all()
+        existing_buyer_domains = models.BuyerEmailDomain.query.all()
         if value:
             if self.role == 'buyer' and not buyer_email_address_has_approved_domain(existing_buyer_domains, value):
                 raise ValidationError("invalid_buyer_domain")
@@ -845,7 +850,7 @@ class User(db.Model):
 
     @validates('role')
     def validate_role(self, key, value):
-        existing_buyer_domains = BuyerEmailDomain.query.all()
+        existing_buyer_domains = models.BuyerEmailDomain.query.all()
         if self.email_address:
             if value == 'buyer' and \
                     not buyer_email_address_has_approved_domain(existing_buyer_domains, self.email_address):
@@ -1317,6 +1322,16 @@ class Brief(db.Model):
         uselist=False,
         lazy='joined',
         viewonly=True
+    )
+
+    outcome = db.relationship(
+        "Outcome",
+        primaryjoin=lambda: (sql_and(
+            foreign(Brief.id) == remote(models.Outcome.brief_id),
+            remote(models.Outcome.completed_at).isnot(None),
+        )),
+        viewonly=True,
+        uselist=False,
     )
 
     @validates('users')

--- a/app/models/main.py
+++ b/app/models/main.py
@@ -1658,6 +1658,12 @@ class BriefResponse(db.Model):
 
     award_details = db.Column(JSON, nullable=True, default={})
 
+    __table_args__ = (
+        # this may appear tautological (id is a unique column *on its own*, so clearly the combination of id/brief_id
+        # is), but is required by postgres to be able to make a compound foreign key to these together
+        db.UniqueConstraint(id, brief_id, name="uq_brief_responses_id_brief_id"),
+    )
+
     brief = db.relationship('Brief', lazy='joined')
     supplier = db.relationship('Supplier', lazy='joined')
 

--- a/app/models/outcomes.py
+++ b/app/models/outcomes.py
@@ -1,0 +1,299 @@
+from sqlalchemy.orm import validates, backref
+from sqlalchemy.sql.expression import (
+    and_ as sql_and,
+    case as sql_case,
+)
+
+from app import db
+from app.utils import random_positive_external_id
+from app.models import ValidationError
+
+from dmutils.formats import DATE_FORMAT, DATETIME_FORMAT
+
+
+class Outcome(db.Model):
+    __tablename__ = "outcomes"
+
+    RESULT_CHOICES = (
+        "awarded",
+        "cancelled",
+        "none-suitable",
+    )
+
+    id = db.Column(db.Integer, primary_key=True)
+    external_id = db.Column(db.BigInteger, nullable=False, default=random_positive_external_id, unique=True)
+    completed_at = db.Column(db.DateTime, nullable=True)
+
+    start_date = db.Column(db.Date, nullable=True)
+    end_date = db.Column(db.Date, nullable=True)
+    awarding_organisation_name = db.Column(db.String, nullable=True)
+    # should be enough scale to represent up to £1b - 1p
+    award_value = db.Column(db.Numeric(11, 2), nullable=True)
+
+    result = db.Column(db.String, nullable=False)
+
+    direct_award_project_id = db.Column(
+        db.Integer,
+        db.ForeignKey('direct_award_projects.id'),
+        nullable=True,
+    )
+    direct_award_search_id = db.Column(
+        db.Integer,
+        db.ForeignKey('direct_award_searches.id'),
+        nullable=True,
+    )
+    direct_award_archived_service_id = db.Column(
+        db.Integer,
+        db.ForeignKey('archived_services.id'),
+        nullable=True,
+    )
+
+    # NOTE though Outcome currently has the *ability* to be associated with a Brief/BriefResponse, at time of
+    # writing this is not yet *used* for reporting brief awards - those are still using their own mechanism, but should
+    # be ported over to this mechanism as soon as time allows.
+    brief_id = db.Column(
+        db.Integer,
+        db.ForeignKey('briefs.id'),
+        nullable=True,
+    )
+    brief_response_id = db.Column(
+        db.Integer,
+        db.ForeignKey('brief_responses.id'),
+        nullable=True,
+    )
+
+    # a concise wrapper to reduce the ugliness of the workaround for https://bitbucket.org/zzzeek/sqlalchemy/issues/3999
+    # (which should no longer be needed once we switch to sqlalchemy 1.2)
+    def c(expression):
+        return db.cast(expression, db.Boolean)
+
+    # The following constraints enforce this general scheme:
+    # All Outcomes must point at either a DirectAwardProject OR a Brief. If the Outcome's "result" is
+    # "awarded", then a DirectAwardProject-based Outcome must also point at the DirectAwardProject's active
+    # search and "winning" archived_service_id or a Brief-based Outcome must also point at the winning
+    # BriefResponse. Only one "completed" Outcome can point at its target (DirectAwardProject or Brief) at once.
+    #
+    # Overlapping compound foreign keys are used to ensure the correctness of the
+    # DirectAwardProject-DirectAwardSearch-ArchivedService and Brief-BriefResponse chains.
+    #
+    # These particular restrictions were chosen to be enforced at a database level because they're all part of an
+    # interrelated system of rules related to cross-table relationships. Contraints which only deal with intra-row
+    # rules can be handled safely (enough) with app-side validation.
+
+    __table_args__ = (
+        db.CheckConstraint(sql_case(
+            (
+                # if awarded, the "null-ness" of direct_award_project_id, direct_award_search_id &
+                # direct_award_archived_service_id must be the same
+                (result == "awarded", sql_and(
+                    (c(direct_award_project_id.is_(None)) == c(direct_award_search_id.is_(None))),
+                    (c(direct_award_project_id.is_(None)) == c(direct_award_archived_service_id.is_(None))),
+                )),
+            ),
+            # if not awarded, we shouldn't have direct_award_search_id or direct_award_archived_service_id set
+            else_=sql_and(c(direct_award_search_id.is_(None)), c(direct_award_archived_service_id.is_(None))),
+        ), name="ck_outcomes_direct_award_keys_nullable"),
+        db.CheckConstraint(sql_case(
+            (
+                # if awarded, the "null-ness" of brief_response_id and brief_id must be the same
+                (result == "awarded", c(brief_response_id.is_(None)) == c(brief_id.is_(None)),),
+            ),
+            # if not awarded, brief_response_id should not be set
+            else_=c(brief_response_id.is_(None)),
+        ), name="ck_outcomes_brief_keys_nullable"),
+        # the "null-ness" of direct_award_project_id and brief_id must *never* be the same
+        db.CheckConstraint(
+            (c(direct_award_project_id.is_(None)) != c(brief_id.is_(None))),
+            name="ck_outcomes_either_brief_xor_direct_award",
+        ),
+        # only one completed award can point at a DirectAwardProject at once
+        db.Index(
+            "idx_outcomes_completed_direct_award_project_unique",
+            direct_award_project_id,
+            postgresql_where=(completed_at.isnot(None)),
+            unique=True,
+        ),
+        # only one completed award can point at a Brief at once
+        db.Index(
+            "idx_outcomes_completed_brief_unique",
+            brief_id,
+            postgresql_where=(completed_at.isnot(None)),
+            unique=True,
+        ),
+        # direct_award_archived_service_id must actually be a result of the given DirectAwardSearch
+        db.ForeignKeyConstraint(
+            (direct_award_archived_service_id, direct_award_search_id,),
+            ("direct_award_search_result_entries.archived_service_id", "direct_award_search_result_entries.search_id",),
+            name="fk_outcomes_da_service_id_da_search_id",
+            deferrable=True,
+            initially="DEFERRED",
+        ),
+        # direct_award_search_id must actually belong the given DirectAwardProject
+        db.ForeignKeyConstraint(
+            (direct_award_search_id, direct_award_project_id,),
+            ("direct_award_searches.id", "direct_award_searches.project_id",),
+            name="fk_outcomes_da_search_id_da_project_id",
+            deferrable=True,
+            initially="DEFERRED",
+        ),
+        # brief_response_id must actually belong to the given Brief
+        db.ForeignKeyConstraint(
+            (brief_response_id, brief_id,),
+            ("brief_responses.id", "brief_responses.brief_id",),
+            name="fk_outcomes_brief_response_id_brief_id",
+            deferrable=True,
+            initially="DEFERRED",
+        ),
+    )
+
+    # let's not leave our de-uglification wrapper hanging around as a method
+    del c
+
+    direct_award_project = db.relationship(
+        "DirectAwardProject",
+        foreign_keys=direct_award_project_id,
+        # named as such to be explicit that this includes incomplete "outcomes"
+        backref="outcomes_all",
+    )
+    direct_award_search = db.relationship(
+        "DirectAwardSearch",
+        foreign_keys=direct_award_search_id,
+        # named as such to be explicit that this includes incomplete "outcomes"
+        backref="outcomes_all",
+    )
+    direct_award_search_result_entry = db.relationship(
+        "DirectAwardSearchResultEntry",
+        foreign_keys=(direct_award_search_id, direct_award_archived_service_id,),
+        uselist=False,
+        # being able to write to this relationship could cause ambiguities with the other relationships that also
+        # use some of their keys
+        viewonly=True,
+        # named as such to be explicit that this includes incomplete "outcomes"
+        backref=backref("outcomes_all", viewonly=True),
+    )
+    direct_award_archived_service = db.relationship(
+        "ArchivedService",
+        foreign_keys=direct_award_archived_service_id,
+        # named as such to be explicit that this includes incomplete "outcomes"
+        backref="outcomes_all",
+    )
+
+    brief_response = db.relationship(
+        "BriefResponse",
+        foreign_keys=brief_response_id,
+        # named as such to be explicit that this includes incomplete "outcomes"
+        backref="outcomes_all",
+    )
+    brief = db.relationship(
+        "Brief",
+        foreign_keys=brief_id,
+        # named as such to be explicit that this includes incomplete "outcomes"
+        backref="outcomes_all",
+    )
+
+    def serialize(self):
+        return {
+            "id": self.external_id,
+            "completed": self.completed_at is not None,
+            "completedAt": self.completed_at.strftime(DATETIME_FORMAT) if self.completed_at is not None else None,
+            "result": self.result,
+            **(
+                {
+                    "resultOfDirectAward": {
+                        "projectId": self.direct_award_project.external_id,
+                        **(
+                            {
+                                "searchId": self.direct_award_search_id,
+                                "archivedServiceId": self.direct_award_archived_service_id,
+                                "serviceId": self.direct_award_archived_service.service_id,
+                            } if self.result == "awarded" else {}
+                        ),
+                    },
+                } if self.direct_award_project_id is not None else {}
+            ),
+            **(
+                {
+                    "resultOfFurtherCompetition": {
+                        "briefId": self.brief_id,
+                        **(
+                            {"briefResponseId": self.brief_response_id} if self.result == "awarded" else {}
+                        )
+                    },
+                } if self.brief_id is not None else {}
+            ),
+            **(
+                {
+                    "award": {
+                        "startDate": self.start_date and self.start_date.strftime(DATE_FORMAT),
+                        "endDate": self.end_date and self.end_date.strftime(DATE_FORMAT),
+                        "awardingOrganisationName": self.awarding_organisation_name,
+                        # don't risk json representing this as a float
+                        "awardValue": str(self.award_value) if self.award_value is not None else None,
+                    },
+                } if self.result == "awarded" else {}
+            ),
+        }
+
+    @validates(
+        "start_date",
+        "end_date",
+        "awarding_organisation_name",
+        "award_value",
+    )
+    def _validates_data_complete_if_completed_at(self, key, value):
+        if key == "award_value":
+            if value is not None and value < 0:
+                raise ValidationError(f"{key} must be greater than or equal to zero, got {value!r}")
+
+        if self.completed_at and self.result == "awarded" and value in (None, "",):
+            raise ValidationError(
+                f"{key} cannot be None or empty if Outcome with result={self.result!r} is 'completed'."
+                f" Received {value!r}"
+            )
+
+        if self.result not in (None, "awarded",) and value is not None:
+            raise ValidationError(
+                f"{key} cannot be set for Outcomes with result={self.result!r}. Attempted to set value {value!r}"
+            )
+
+        return value
+
+    @validates("completed_at", "result")
+    def _validates_completed_at_data_complete_if_set(self, key, value):
+        if key == "result" and value not in self.RESULT_CHOICES:
+            raise ValidationError(f"{value!r} is not a valid choice for field {key!r}")
+
+        result = value if key == "result" else self.result
+        completed_at = value if key == "completed_at" else self.completed_at
+        if result == "awarded" and completed_at is not None:
+            failures = ", ".join(
+                "{}={}".format(fkey, repr(getattr(self, fkey)))
+                for fkey in (
+                    "start_date",
+                    "end_date",
+                    "awarding_organisation_name",
+                    "award_value",
+                )
+                if (getattr(self, fkey) in (None, "",))
+            )
+            if failures:
+                raise ValidationError(
+                    f"Outcome with result={result!r} cannot be 'completed' with None or empty data fields,"
+                    f" but {failures}"
+                )
+        if result not in (None, "awarded",):
+            failures = ", ".join(
+                "{}={}".format(fkey, repr(getattr(self, fkey)))
+                for fkey in (
+                    "start_date",
+                    "end_date",
+                    "awarding_organisation_name",
+                    "award_value",
+                )
+                if getattr(self, fkey) is not None
+            )
+            if failures:
+                raise ValidationError(
+                    f"Outcomes with result={result!r} cannot have award-related data fields set, but {failures}"
+                )
+        return value

--- a/app/validation.py
+++ b/app/validation.py
@@ -80,6 +80,13 @@ def validate_supplier_json_or_400(submitted_json):
         abort(400, "JSON was not a valid format. {}".format(e.message))
 
 
+def validate_outcome_json_or_400(submitted_json):
+    try:
+        get_validator('outcome-update').validate(submitted_json)
+    except ValidationError as e:
+        abort(400, "JSON was not a valid format. {}".format(e.message))
+
+
 def validate_new_supplier_json_or_400(submitted_json):
     try:
         get_validator('new-supplier').validate(submitted_json)

--- a/json_schemas/outcome-update.json
+++ b/json_schemas/outcome-update.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "completed": {
+      "type": "boolean"
+    },
+    "award": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "startDate": {
+          "OneOf": [
+            {
+              "type": "string",
+              "pattern": "\\d{4}-\\d{2}-\\d{2}"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "endDate": {
+          "OneOf": [
+            {
+              "type": "string",
+              "pattern": "\\d{4}-\\d{2}-\\d{2}"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "awardingOrganisationName": {
+          "OneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "awardValue": {
+          "OneOf": [
+            {
+              "type": "string",
+              "pattern": "[\\d.]+"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "title": "Schema to validate outcome updates",
+  "type": "object"
+}

--- a/migrations/versions/1210_add_outcome_model.py
+++ b/migrations/versions/1210_add_outcome_model.py
@@ -1,0 +1,126 @@
+"""Add Outcome model
+
+Revision ID: 1200
+Revises: 1210
+Create Date: 2018-05-10 17:22:50.773017
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+
+# revision identifiers, used by Alembic.
+revision = '1210'
+down_revision = '1200'
+
+
+def upgrade():
+    op.create_unique_constraint('uq_brief_responses_id_brief_id', 'brief_responses', ['id', 'brief_id'])
+    op.create_unique_constraint(
+        'uq_direct_award_search_result_entries_archived_service_id_search_id',
+        'direct_award_search_result_entries',
+        ['archived_service_id', 'search_id'],
+    )
+    op.create_unique_constraint('uq_direct_award_searches_id_project_id', 'direct_award_searches', ['id', 'project_id'])
+    op.create_table('outcomes',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('external_id', sa.BigInteger(), nullable=False),
+        sa.Column('completed_at', sa.DateTime(), nullable=True),
+        sa.Column('start_date', sa.Date(), nullable=True),
+        sa.Column('end_date', sa.Date(), nullable=True),
+        sa.Column('awarding_organisation_name', sa.String(), nullable=True),
+        sa.Column('award_value', sa.Numeric(precision=11, scale=2), nullable=True),
+        sa.Column('result', sa.String(), nullable=False),
+        sa.Column('direct_award_project_id', sa.Integer(), nullable=True),
+        sa.Column('direct_award_search_id', sa.Integer(), nullable=True),
+        sa.Column('direct_award_archived_service_id', sa.Integer(), nullable=True),
+        sa.Column('brief_id', sa.Integer(), nullable=True),
+        sa.Column('brief_response_id', sa.Integer(), nullable=True),
+        sa.CheckConstraint(
+            "CASE WHEN (result = 'awarded') THEN CAST(brief_response_id IS NULL AS BOOLEAN) = CAST(brief_id IS NULL AS BOOLEAN) ELSE CAST(brief_response_id IS NULL AS BOOLEAN) END",
+            name=op.f('ck_outcomes_brief_keys_nullable'),
+        ),
+        sa.CheckConstraint(
+            "CASE WHEN (result = 'awarded') THEN CAST(direct_award_project_id IS NULL AS BOOLEAN) = " \
+            "CAST(direct_award_search_id IS NULL AS BOOLEAN) AND CAST(direct_award_project_id IS NULL AS BOOLEAN) = " \
+            "CAST(direct_award_archived_service_id IS NULL AS BOOLEAN) ELSE " \
+            "CAST(direct_award_search_id IS NULL AS BOOLEAN) " \
+            "AND CAST(direct_award_archived_service_id IS NULL AS BOOLEAN) END",
+            name=op.f('ck_outcomes_direct_award_keys_nullable'),
+        ),
+        sa.CheckConstraint(
+            'CAST(direct_award_project_id IS NULL AS BOOLEAN) != CAST(brief_id IS NULL AS BOOLEAN)', name=op.f('ck_outcomes_either_brief_xor_direct_award'),
+        ),
+        sa.ForeignKeyConstraint(['brief_id'], ['briefs.id'], name=op.f('outcomes_brief_id_fkey')),
+        sa.ForeignKeyConstraint(
+            ['brief_response_id', 'brief_id'],
+            ['brief_responses.id', 'brief_responses.brief_id'],
+            name='fk_outcomes_brief_response_id_brief_id',
+            initially='DEFERRED',
+            deferrable=True,
+        ),
+        sa.ForeignKeyConstraint(
+            ['brief_response_id'],
+            ['brief_responses.id'],
+            name=op.f('outcomes_brief_response_id_fkey'),
+        ),
+        sa.ForeignKeyConstraint(
+            ['direct_award_archived_service_id', 'direct_award_search_id'],
+            ['direct_award_search_result_entries.archived_service_id', 'direct_award_search_result_entries.search_id'],
+            name='fk_outcomes_da_service_id_da_search_id',
+            initially='DEFERRED',
+            deferrable=True,
+        ),
+        sa.ForeignKeyConstraint(
+            ['direct_award_archived_service_id'],
+            ['archived_services.id'],
+            name=op.f('outcomes_direct_award_archived_service_id_fkey'),
+        ),
+        sa.ForeignKeyConstraint(
+            ['direct_award_project_id'],
+            ['direct_award_projects.id'],
+            name=op.f('outcomes_direct_award_project_id_fkey'),
+        ),
+        sa.ForeignKeyConstraint(
+            ['direct_award_search_id', 'direct_award_project_id'],
+            ['direct_award_searches.id', 'direct_award_searches.project_id'],
+            name='fk_outcomes_da_search_id_da_project_id',
+            initially='DEFERRED',
+            deferrable=True,
+        ),
+        sa.ForeignKeyConstraint(
+            ['direct_award_search_id'],
+            ['direct_award_searches.id'],
+            name=op.f('outcomes_direct_award_search_id_fkey'),
+        ),
+        sa.PrimaryKeyConstraint('id', name=op.f('outcomes_pkey')),
+        sa.UniqueConstraint('external_id', name=op.f('uq_outcomes_external_id')),
+    )
+    op.create_index(
+        'idx_outcomes_completed_brief_unique',
+        'outcomes',
+        ['brief_id'],
+        unique=True,
+        postgresql_where=sa.text('completed_at IS NOT NULL'),
+    )
+    op.create_index(
+        'idx_outcomes_completed_direct_award_project_unique',
+        'outcomes',
+        ['direct_award_project_id'],
+        unique=True,
+        postgresql_where=sa.text('completed_at IS NOT NULL'),
+    )
+
+
+def downgrade():
+    op.drop_index('idx_outcomes_completed_direct_award_project_unique', table_name='outcomes')
+    op.drop_index('idx_outcomes_completed_brief_unique', table_name='outcomes')
+    op.drop_table('outcomes')
+    op.drop_constraint('uq_direct_award_searches_id_project_id', 'direct_award_searches', type_='unique')
+    op.drop_constraint(
+        'uq_direct_award_search_result_entries_archived_service_id_search_id',
+        'direct_award_search_result_entries',
+        type_='unique',
+    )
+    op.drop_constraint('uq_brief_responses_id_brief_id', 'brief_responses', type_='unique')

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -11,7 +11,7 @@ SQLAlchemy==1.1.4
 SQLAlchemy-Utils==0.30.5
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@35.2.0#egg=digitalmarketplace-utils==35.2.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.2.0#egg=digitalmarketplace-apiclient==15.2.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@16.1.0#egg=digitalmarketplace-apiclient==16.1.0
 
 # For schema validation
 jsonschema==2.5.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 -r requirements.txt
 
 # For tests
+git+https://github.com/alphagov/digitalmarketplace-test-utils.git@1.4.0#egg=digitalmarketplace-test-utils==1.4.0
 coverage==3.7.1
 flake8-per-file-ignores==0.4.0
 flake8==3.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ SQLAlchemy==1.1.4
 SQLAlchemy-Utils==0.30.5
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@35.2.0#egg=digitalmarketplace-utils==35.2.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.2.0#egg=digitalmarketplace-apiclient==15.2.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@16.1.0#egg=digitalmarketplace-apiclient==16.1.0
 
 # For schema validation
 jsonschema==2.5.1

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -151,6 +151,7 @@ class FixtureMixin(object):
             ))
 
         db.session.commit()
+        return brief
 
     def setup_dummy_suppliers(self, n):
         supplier_ids = []

--- a/tests/main/views/test_direct_award.py
+++ b/tests/main/views/test_direct_award.py
@@ -932,24 +932,3 @@ class TestDirectAwardRecordProjectDownload(DirectAwardSetupAndTeardown):
         assert res.status_code == 200
 
         self._assert_one_audit_event_created_for_only_project(AuditTypes.downloaded_project.value)
-
-
-class TestDirectAwardRoutesAcceptInternalAndExternalIdentifiers(DirectAwardSetupAndTeardown):
-    def setup(self):
-        super(TestDirectAwardRoutesAcceptInternalAndExternalIdentifiers, self).setup()
-        self.project_id, self.project_external_id = self.create_direct_award_project(
-            user_id=self.user_id, project_name=self.direct_award_project_name
-        )
-        self.search_id = self.create_direct_award_project_search(created_by=self.user_id, project_id=self.project_id)
-
-    @pytest.mark.parametrize('route', ['/direct-award/projects/{project_id}',
-                                       '/direct-award/projects/{project_id}/searches',
-                                       '/direct-award/projects/{project_id}/searches/{search_id}'])
-    def test_routes_return_same_result(self, route):
-        internal_id_response = self.client.get(route.format(project_id=self.project_id,
-                                                            search_id=self.search_id))
-        external_id_response = self.client.get(route.format(project_id=self.project_external_id,
-                                                            search_id=self.search_id))
-
-        assert internal_id_response.status_code == external_id_response.status_code == 200
-        assert internal_id_response.get_data(as_text=True) == external_id_response.get_data(as_text=True)

--- a/tests/main/views/test_direct_award.py
+++ b/tests/main/views/test_direct_award.py
@@ -13,8 +13,9 @@ from tests.bases import BaseApplicationTest
 
 from sqlalchemy import desc, BigInteger
 from dmapiclient.audit import AuditTypes
+from dmtestutils.comparisons import RestrictedAny, AnyStringMatching, AnySupersetOf
 
-from app.models import DATETIME_FORMAT, AuditEvent, User, ArchivedService
+from app.models import DATETIME_FORMAT, AuditEvent, User, ArchivedService, Outcome
 from app.models.direct_award import (
     DirectAwardProjectUser,
     DirectAwardSearch,
@@ -932,3 +933,298 @@ class TestDirectAwardRecordProjectDownload(DirectAwardSetupAndTeardown):
         assert res.status_code == 200
 
         self._assert_one_audit_event_created_for_only_project(AuditTypes.downloaded_project.value)
+
+
+class TestDirectAwardOutcomeAward(DirectAwardSetupAndTeardown):
+    def test_nonexistent_project_id(self):
+        res = self.client.post(
+            f"/direct-award/projects/976149527383380/services/2000000001/award",
+            data=json.dumps(self._updated_by_data()),
+            content_type="application/json",
+        )
+        assert res.status_code == 404
+        assert json.loads(res.get_data()) == {
+            "error": "Project 976149527383380 not found",
+        }
+
+    @pytest.mark.parametrize(
+        (
+            "has_active_search",
+            "has_non_active_search",
+            "active_search_has_chosen_sid",
+            "non_active_search_has_chosen_sid",
+            "project_locked",
+            "existing_outcome_result",
+            "existing_outcome_complete",
+            "expected_status_code",
+            "expected_response_data",
+        ),
+        (
+            # "happy" paths
+            (True, True, True, True, True, None, False, 200, AnySupersetOf({}),),
+            (True, False, True, False, True, None, False, 200, AnySupersetOf({}),),
+            (True, False, True, False, True, "awarded", False, 200, AnySupersetOf({}),),
+            (True, True, True, False, True, "cancelled", False, 200, AnySupersetOf({}),),
+            # "failure" paths
+            (
+                True,
+                True,
+                False,
+                True,
+                True,
+                None,
+                False,
+                404,
+                {
+                    "error": AnyStringMatching(r"Service \d+ is not in project \d+\'s active search search results"),
+                },
+            ),
+            (
+                False,
+                True,
+                False,
+                True,
+                True,
+                None,
+                False,
+                404,
+                {
+                    "error": AnyStringMatching(r"Project \d+ doesn't have an active search"),
+                },
+            ),
+            (
+                True,
+                False,
+                True,
+                False,
+                False,
+                None,
+                False,
+                400,
+                {
+                    "error": AnyStringMatching(r"Project \d+ has not been locked"),
+                },
+            ),
+            (
+                True,
+                False,
+                False,
+                False,
+                False,
+                None,
+                False,
+                400,
+                {
+                    "error": AnyStringMatching(r"Project \d+ has not been locked"),
+                },
+            ),
+            (
+                True,
+                True,
+                False,
+                False,
+                True,
+                "cancelled",
+                True,
+                410,
+                {
+                    "error": AnyStringMatching(r"Project \d+ already has a completed outcome: \d+"),
+                },
+            ),
+            (
+                True,
+                False,
+                True,
+                False,
+                True,
+                "awarded",
+                True,
+                410,
+                {
+                    "error": AnyStringMatching(r"Project \d+ already has a completed outcome: \d+"),
+                },
+            ),
+        )
+    )
+    def test_direct_award_outcome_scenarios(
+        self,
+        has_active_search,
+        has_non_active_search,
+        active_search_has_chosen_sid,
+        non_active_search_has_chosen_sid,
+        project_locked,
+        existing_outcome_result,
+        existing_outcome_complete,
+        expected_status_code,
+        expected_response_data,
+    ):
+        """
+        A number of arguments control the background context this test is run in. Clearly, not all of the combinations
+        make sense together and a caller should not expect a test to pass with a nonsensical combination of arguments
+
+        :param has_active_search:                 whether the project should have an active search
+        :param has_non_active_search:             whether the project should have a non-active search
+        :param active_search_has_chosen_sid:      whether the service_id we're going to "choose" should exist in the
+                                                  active search
+        :param non_active_search_has_chosen_sid:  whether the service_id we're going to "choose" should exist in the
+                                                  non-active search
+        :param project_locked:                    whether the project should be marked as "locked"
+        :param existing_outcome_result:           what the "result" field of an existing Outcome for this project
+                                                  should be set to, None for no existing Outcome
+        :param existing_outcome_complete:         whether any existing existing Outcome for this project should
+                                                  be marked as "complete"
+        :param expected_status_code:              numeric status code to expect for this request
+        :param expected_response_data:
+        """
+        self.setup_dummy_suppliers(3)
+        self.setup_dummy_services(3, model=ArchivedService)
+
+        project = DirectAwardProject(
+            name=self.direct_award_project_name,
+            users=[User.query.get(self.user_id)],
+        )
+        db.session.add(project)
+
+        active_search = None
+        if has_active_search:
+            active_search = DirectAwardSearch(
+                project=project,
+                created_by=self.user_id,
+                active=True,
+                search_url="http://nothing.nowhere",
+            )
+            db.session.add(active_search)
+
+        non_active_search = None
+        if has_non_active_search:
+            non_active_search = DirectAwardSearch(
+                project=project,
+                created_by=self.user_id,
+                active=False,
+                search_url="http://nothing.anyhere",
+            )
+            db.session.add(non_active_search)
+
+        archived_service_non_chosen, archived_service_chosen = db.session.query(ArchivedService).filter(
+            ArchivedService.service_id.in_(("2000000000", "2000000001",))
+        ).order_by(ArchivedService.service_id).all()
+
+        if active_search:
+            active_search.archived_services.append(archived_service_non_chosen)
+            if active_search_has_chosen_sid:
+                active_search.archived_services.append(archived_service_chosen)
+        if non_active_search:
+            non_active_search.archived_services.append(archived_service_non_chosen)
+            if non_active_search_has_chosen_sid:
+                non_active_search.archived_services.append(archived_service_chosen)
+
+        existing_outcome = None
+        if existing_outcome_result is not None:
+            # create an "existing" Outcome pointing at this project
+            existing_outcome = Outcome(
+                result=existing_outcome_result,
+                direct_award_project=project,
+                # if this test iteration wants an *awarded* existing_outcome we'll just set it to be awarded to
+                # whichever service makes sense...
+                **({
+                    "direct_award_search": project.active_search,
+                    "direct_award_archived_service": project.active_search.archived_services.order_by(
+                        desc(ArchivedService.service_id)
+                    ).first(),
+                    "start_date": datetime(2020, 3, 3).date(),
+                    "end_date": datetime(2020, 3, 3).date(),
+                    "awarding_organisation_name": "Circumlocution department",
+                    "award_value": 123,
+                } if existing_outcome_result == "awarded" else {})
+            )
+            if existing_outcome_complete:
+                # this has to be set *after* we know all the other fields are set due to the way sa's validators work
+                existing_outcome.completed_at = datetime(2018, 2, 2, 2, 2, 2)
+            db.session.add(existing_outcome)
+
+        # must assign ids before we can lock project
+        db.session.flush()
+        if project_locked:
+            project.locked_at = datetime.now()
+
+        project_external_id = project.external_id
+        active_search_id = active_search and active_search.id
+        audit_event_count = AuditEvent.query.count()
+        outcome_count = Outcome.query.count()
+        chosen_archived_service_id = db.session.query(ArchivedService.id).filter_by(service_id="2000000001").first()[0]
+        db.session.commit()
+
+        res = self.client.post(
+            f"/direct-award/projects/{project.external_id}/services/2000000001/award",
+            data=json.dumps(self._updated_by_data()),
+            content_type="application/json",
+        )
+        assert res.status_code == expected_status_code
+        response_data = json.loads(res.get_data())
+
+        assert response_data == expected_response_data
+
+        # allow these to be re-used in this session, "refreshed"
+        db.session.add(project)
+        if active_search:
+            db.session.add(active_search)
+        db.session.expire_all()
+
+        if res.status_code != 200:
+            # assert no database objects have been created
+            assert Outcome.query.count() == outcome_count
+            assert AuditEvent.query.count() == audit_event_count
+        else:
+            assert response_data == {
+                "outcome": {
+                    "id": RestrictedAny(lambda x: isinstance(x, int) and x > 0),
+                    "result": "awarded",
+                    "completed": False,
+                    "completedAt": None,
+                    "award": {
+                        "awardValue": None,
+                        "awardingOrganisationName": None,
+                        "endDate": None,
+                        "startDate": None,
+                    },
+                    "resultOfDirectAward": {
+                        "projectId": project_external_id,
+                        "searchId": active_search_id,
+                        "serviceId": "2000000001",
+                        "archivedServiceId": chosen_archived_service_id,
+                    },
+                }
+            }
+
+            outcome = db.session.query(Outcome).filter_by(
+                external_id=response_data["outcome"]["id"]
+            ).first()
+
+            # check the modifications actually hit the database correctly
+            assert outcome.direct_award_project is project
+            assert outcome.direct_award_project.active_search is active_search
+            assert outcome.direct_award_search is active_search
+            assert outcome.direct_award_archived_service.id == chosen_archived_service_id
+            assert outcome.direct_award_archived_service.service_id == "2000000001"
+            assert outcome.result == "awarded"
+            assert outcome.completed_at is None
+            assert outcome.start_date is outcome.end_date \
+                is outcome.awarding_organisation_name is outcome.award_value is None
+
+            assert AuditEvent.query.count() == audit_event_count + 1
+            audit_event = db.session.query(AuditEvent).order_by(
+                desc(AuditEvent.created_at),
+                desc(AuditEvent.id),
+            ).first()
+            assert audit_event.object is outcome
+            assert audit_event.acknowledged is False
+            assert audit_event.acknowledged_at is None
+            assert not audit_event.acknowledged_by
+            assert audit_event.type == "create_outcome"
+            assert audit_event.user == "1"
+            assert audit_event.data == {
+                "archivedServiceId": response_data["outcome"]["resultOfDirectAward"]["archivedServiceId"],
+                "projectExternalId": project_external_id,
+                "searchId": active_search_id,
+                "result": "awarded",
+            }

--- a/tests/main/views/test_outcomes.py
+++ b/tests/main/views/test_outcomes.py
@@ -1,0 +1,919 @@
+import datetime
+from itertools import chain, product
+import json
+import re
+
+import pytest
+from sqlalchemy import desc
+
+from dmtestutils.comparisons import AnyStringMatching, AnySupersetOf
+
+from app import db
+from app.models import (
+    ArchivedService,
+    AuditEvent,
+    BriefResponse,
+    DirectAwardProject,
+    DirectAwardSearch,
+    Outcome,
+    User,
+)
+
+from tests.bases import BaseApplicationTest
+
+from ...helpers import FixtureMixin
+
+
+class TestUpdateOutcome(BaseApplicationTest, FixtureMixin):
+    _test_update_outcome_base_scenarios = (
+        (
+            # other_oc_data
+            {},
+            # initial_data
+            {},
+            # put_values
+            {
+                "completed": True,
+                "award": {
+                    "awardingOrganisationName": "Omphalos",
+                    "awardValue": "00314.1500",
+                    "startDate": "2020-10-10",
+                    "endDate": "2020-11-20",
+                },
+            },
+            # expected_status_code
+            200,
+            # expected_response_data
+            {
+                "outcome": AnySupersetOf({
+                    "completed": True,
+                    "award": {
+                        "awardingOrganisationName": "Omphalos",
+                        "awardValue": "314.15",
+                        "startDate": "2020-10-10",
+                        "endDate": "2020-11-20",
+                    },
+                }),
+            },
+        ),
+        (
+            # other_oc_data
+            None,
+            # initial_data
+            {
+                "completed_at": None,
+                "result": "none-suitable",
+            },
+            # put_values
+            {
+                "completed": True,
+            },
+            # expected_status_code
+            200,
+            # expected_response_data
+            {
+                "outcome": AnySupersetOf({
+                    "completed": True,
+                }),
+            },
+        ),
+        (
+            # other_oc_data
+            {
+                "completed_at": None,
+                "result": "cancelled",
+            },
+            # initial_data
+            {
+                "completed_at": None,
+                "result": "none-suitable",
+            },
+            # put_values
+            {
+                "completed": True,
+            },
+            # expected_status_code
+            200,
+            # expected_response_data
+            {
+                "outcome": AnySupersetOf({
+                    "completed": True,
+                }),
+            },
+        ),
+        (
+            # other_oc_data
+            None,
+            # initial_data
+            {},
+            # put_values
+            {
+                "completed": True,
+                "award": {
+                    "awardingOrganisationName": "Omphalos",
+                    "awardValue": "00314.1500",
+                    "startDate": "2020-10-10",
+                    "endDate": "2020-11-20",
+                },
+            },
+            # expected_status_code
+            200,
+            # expected_response_data
+            {
+                "outcome": AnySupersetOf({
+                    "completed": True,
+                    "award": {
+                        "awardingOrganisationName": "Omphalos",
+                        "awardValue": "314.15",
+                        "startDate": "2020-10-10",
+                        "endDate": "2020-11-20",
+                    },
+                }),
+            },
+        ),
+        (
+            # other_oc_data
+            {
+                "completed_at": datetime.datetime(2010, 10, 10, 10, 10, 10),
+                "awarding_organisation_name": "Lambay Freehold",
+                "award_value": 54321,
+                "start_date": datetime.date(2010, 12, 12),
+                "end_date": datetime.date(2011, 12, 12),
+            },
+            # initial_data
+            {},
+            # put_values
+            {
+                "award": {
+                    "awardingOrganisationName": "Omphalos",
+                    "awardValue": "00314.1500",
+                    "startDate": "2020-10-10",
+                    "endDate": "2020-11-20",
+                },
+            },
+            # expected_status_code
+            200,
+            # expected_response_data
+            {
+                "outcome": AnySupersetOf({
+                    "completed": False,
+                    "award": {
+                        "awardingOrganisationName": "Omphalos",
+                        "awardValue": "314.15",
+                        "startDate": "2020-10-10",
+                        "endDate": "2020-11-20",
+                    },
+                }),
+            },
+        ),
+        (
+            # other_oc_data
+            {
+                "awarding_organisation_name": "Lambay Freehold",
+                "award_value": 54321,
+                "start_date": datetime.date(2010, 12, 12),
+                "end_date": datetime.date(2011, 12, 12),
+            },
+            # initial_data
+            {},
+            # put_values
+            {
+                "completed": True,
+                "award": {
+                    "awardingOrganisationName": "Omphalos",
+                    "awardValue": "00314.1500",
+                    "startDate": "2020-10-10",
+                    "endDate": "2020-11-20",
+                },
+            },
+            # expected_status_code
+            200,
+            # expected_response_data
+            {
+                "outcome": AnySupersetOf({
+                    "completed": True,
+                    "award": {
+                        "awardingOrganisationName": "Omphalos",
+                        "awardValue": "314.15",
+                        "startDate": "2020-10-10",
+                        "endDate": "2020-11-20",
+                    },
+                }),
+            },
+        ),
+        (
+            # other_oc_data
+            {},
+            # initial_data
+            {
+                "completed_at": datetime.datetime(2010, 10, 10, 10, 10, 10),
+                "awarding_organisation_name": "Lambay Freehold",
+                "award_value": 54321,
+                "start_date": datetime.date(2010, 12, 12),
+                "end_date": datetime.date(2011, 12, 12),
+            },
+            # put_values
+            {
+                "completed": True,
+                "award": {
+                    "awardingOrganisationName": "Incubator",
+                    "awardValue": "271271.2",
+                    "startDate": "2020-10-10",
+                    "endDate": "2020-11-20",
+                },
+            },
+            # expected_status_code
+            200,
+            # expected_response_data
+            {
+                "outcome": AnySupersetOf({
+                    "award": {
+                        "awardingOrganisationName": "Incubator",
+                        "awardValue": "271271.20",
+                        "startDate": "2020-10-10",
+                        "endDate": "2020-11-20",
+                    },
+                }),
+            },
+        ),
+        (
+            # other_oc_data
+            None,
+            # initial_data
+            {
+                "completed_at": None,
+                "awarding_organisation_name": "Lambay Freehold",
+                "award_value": 54321,
+                "start_date": datetime.date(2010, 12, 12),
+                "end_date": datetime.date(2011, 12, 12),
+            },
+            # put_values
+            {
+                "completed": False,
+                "award": {
+                    "startDate": None,
+                },
+            },
+            # expected_status_code
+            200,
+            # expected_response_data
+            {
+                "outcome": AnySupersetOf({
+                    "completed": False,
+                    "award": {
+                        "awardingOrganisationName": "Lambay Freehold",
+                        "awardValue": "54321.00",
+                        "startDate": None,
+                        "endDate": "2011-12-12",
+                    },
+                }),
+            },
+        ),
+        (
+            # other_oc_data
+            {},
+            # initial_data
+            {
+                "completed_at": None,
+                "awarding_organisation_name": "Lambay Freehold",
+                "award_value": 5432.1,
+                "start_date": datetime.date(2010, 12, 12),
+                "end_date": datetime.date(2011, 12, 12),
+            },
+            # put_values
+            {
+                "completed": True,
+            },
+            # expected_status_code
+            200,
+            # expected_response_data
+            {
+                "outcome": AnySupersetOf({
+                    "completed": True,
+                    "award": {
+                        "awardingOrganisationName": "Lambay Freehold",
+                        "awardValue": "5432.10",
+                        "startDate": "2010-12-12",
+                        "endDate": "2011-12-12",
+                    },
+                }),
+            },
+        ),
+        (
+            # other_oc_data
+            {},
+            # initial_data
+            {
+                "completed_at": None,
+                "result": "none-suitable",
+            },
+            # put_values
+            {
+                "award": {
+                    "awardingOrganisationName": "Talbot de Malahide",
+                },
+            },
+            # expected_status_code
+            400,
+            # expected_response_data
+            {
+                "error": (
+                    "awarding_organisation_name cannot be set for Outcomes with result='none-suitable'."
+                    " Attempted to set value 'Talbot de Malahide'"
+                ),
+            },
+        ),
+        (
+            # other_oc_data
+            {
+                "completed_at": None,
+                "result": "cancelled",
+            },
+            # initial_data
+            {
+                "completed_at": datetime.datetime(2010, 3, 3, 3, 3, 3),
+                "result": "none-suitable",
+            },
+            # put_values
+            {
+                "completed": False,
+            },
+            # expected_status_code
+            400,
+            # expected_response_data
+            {
+                "error": "Can't un-complete outcome",
+            },
+        ),
+        (
+            # other_oc_data
+            {
+                "completed_at": datetime.datetime(2010, 3, 3, 3, 3, 3),
+                "result": "cancelled",
+            },
+            # initial_data
+            {
+                "completed_at": None,
+                "result": "none-suitable",
+            },
+            # put_values
+            {
+                "completed": True,
+            },
+            # expected_status_code
+            400,
+            # expected_response_data
+            {
+                "error": AnyStringMatching(
+                    r".+ \d+ already has a complete outcome: \d+"
+                ),
+            },
+        ),
+        (
+            # other_oc_data
+            None,
+            # initial_data
+            {},
+            # put_values
+            {
+                "result": "cancelled",
+            },
+            # expected_status_code
+            400,
+            # expected_response_data
+            {
+                "error": AnyStringMatching(r".*json was not a valid format.*", flags=re.I),
+            },
+        ),
+        (
+            # other_oc_data
+            {},
+            # initial_data
+            {},
+            # put_values
+            {
+                "resultOfDirectAward": {
+                    "projectId": 321,
+                },
+            },
+            # expected_status_code
+            400,
+            # expected_response_data
+            {
+                "error": AnyStringMatching(r".*json was not a valid format.*", flags=re.I),
+            },
+        ),
+        (
+            # other_oc_data
+            None,
+            # initial_data
+            {},
+            # put_values
+            {
+                "completed": True,
+                # note "award" section flattened here
+                "awardingOrganisationName": "Omphalos",
+                "awardValue": "00314.1500",
+                "startDate": "2020-10-10",
+                "endDate": "2020-11-20",
+            },
+            # expected_status_code
+            400,
+            # expected_response_data
+            {
+                "error": AnyStringMatching(r".*json was not a valid format.*", flags=re.I),
+            },
+        ),
+        (
+            # other_oc_data
+            {
+                "completed_at": datetime.datetime(2010, 10, 10, 10, 10, 10),
+                "awarding_organisation_name": "Lambay Freehold",
+                "award_value": 54321,
+                "start_date": datetime.date(2010, 12, 12),
+                "end_date": datetime.date(2011, 12, 12),
+            },
+            # initial_data
+            {},
+            # put_values
+            {
+                "completed": True,
+                "award": {
+                    "awardingOrganisationName": "Omphalos",
+                    "awardValue": "00314.1500",
+                    "startDate": "2020-10-10",
+                    "endDate": "2020-11-20",
+                },
+            },
+            # expected_status_code
+            400,
+            # expected_response_data
+            {
+                "error": AnyStringMatching(
+                    r".+ \d+ already has a complete outcome: \d+"
+                ),
+            },
+        ),
+        (
+            # other_oc_data
+            {
+                "completed_at": datetime.datetime(2010, 10, 10, 10, 10, 10),
+                "result": "cancelled",
+            },
+            # initial_data
+            {},
+            # put_values
+            {
+                "completed": True,
+                "award": {
+                    "awardingOrganisationName": "Omphalos",
+                    "awardValue": "00314.1500",
+                    "startDate": "2020-10-10",
+                    "endDate": "2020-11-20",
+                },
+            },
+            # expected_status_code
+            400,
+            # expected_response_data
+            {
+                "error": AnyStringMatching(
+                    r".+ \d+ already has a complete outcome: \d+",
+                ),
+            },
+        ),
+        (
+            # other_oc_data
+            {},
+            # initial_data
+            {
+                "completed_at": datetime.datetime(2010, 10, 10, 10, 10, 10),
+                "awarding_organisation_name": "Lambay Freehold",
+                "award_value": 54321,
+                "start_date": datetime.date(2010, 12, 12),
+                "end_date": datetime.date(2011, 12, 12),
+            },
+            # put_values
+            {
+                "completed": False,
+                "award": {
+                    "awardingOrganisationName": "Incubator",
+                    "awardValue": "271271.2",
+                    "startDate": "2020-10-10",
+                    "endDate": "2020-11-20",
+                },
+            },
+            # expected_status_code
+            400,
+            # expected_response_data
+            {
+                "error": "Can't un-complete outcome",
+            },
+        ),
+        (
+            # other_oc_data
+            None,
+            # initial_data
+            {
+                "completed_at": datetime.datetime(2010, 10, 10, 10, 10, 10),
+                "awarding_organisation_name": "Lambay Freehold",
+                "award_value": 54321,
+                "start_date": datetime.date(2010, 12, 12),
+                "end_date": datetime.date(2011, 12, 12),
+            },
+            # put_values
+            {
+                "completed": True,
+                "award": {
+                    "awardingOrganisationName": "",
+                    "awardValue": "271271.2",
+                    "startDate": "2020-10-10",
+                    "endDate": "2020-11-20",
+                },
+            },
+            # expected_status_code
+            400,
+            # expected_response_data
+            {
+                "error": AnyStringMatching(r".*\bawarding_organisation_name\b.*"),
+            },
+        ),
+        (
+            # other_oc_data
+            {},
+            # initial_data
+            {},
+            # put_values
+            {
+                "completed": True,
+                "award": {
+                    "awardingOrganisationName": "Billy Pitt",
+                    "awardValue": "314.15",
+                    "startDate": "2020-10-10",
+                    "endDate": "2020-20-20",
+                },
+            },
+            # expected_status_code
+            400,
+            # expected_response_data
+            {
+                "error": AnyStringMatching(r".*\bendDate\b.*"),
+            },
+        ),
+        (
+            # other_oc_data
+            None,
+            # initial_data
+            {},
+            # put_values
+            {
+                "completed": True,
+                "award": {
+                    "awardingOrganisationName": "Martello",
+                    "awardValue": "Twelve quid",
+                    "startDate": "2020-01-01",
+                    "endDate": "2021-12-21",
+                },
+            },
+            # expected_status_code
+            400,
+            # expected_response_data
+            {
+                "error": AnyStringMatching(r".*\bawardValue\b.*"),
+            },
+        ),
+    )
+
+    @pytest.mark.parametrize(
+        (
+            "other_oc_brief_based",
+            "initial_brief_based",
+            "other_oc_data",
+            "initial_data",
+            "put_values",
+            "expected_status_code",
+            "expected_response_data",
+        ),
+        tuple(chain(
+            (   # we reproduce here the variants in _test_update_outcome_base_scenarios, once for Briefs, once
+                # for Projects
+                (f_t, f_t,) + variant_params
+                for f_t, variant_params in product((False, True,), _test_update_outcome_base_scenarios)
+            ),
+            (   # and also include some with mixed target-types
+                (
+                    # other_oc_brief_based
+                    False,
+                    # initial_brief_based
+                    True,
+                    # other_oc_data
+                    {
+                        "completed_at": datetime.datetime(2007, 7, 7, 7, 7, 7),
+                        "result": "none-suitable",
+                    },
+                    # initial_data
+                    {
+                        "completed_at": None,
+                        "result": "cancelled",
+                    },
+                    # put_values
+                    {
+                        "completed": True,
+                    },
+                    # expected_status_code
+                    200,
+                    # expected_response_data
+                    {
+                        "outcome": AnySupersetOf({
+                            "completed": True,
+                        }),
+                    },
+                ),
+                (
+                    # other_oc_brief_based
+                    True,
+                    # initial_brief_based
+                    False,
+                    # other_oc_data
+                    {
+                        "completed_at": datetime.datetime(2007, 7, 7, 7, 7, 7),
+                        "awarding_organisation_name": "Lambay Freehold",
+                        "award_value": 54321,
+                        "start_date": datetime.date(2010, 12, 12),
+                        "end_date": datetime.date(2011, 12, 12),
+                    },
+                    # initial_data
+                    {},
+                    # put_values
+                    {
+                        "completed": True,
+                        "award": {
+                            "awardingOrganisationName": "Omphalos",
+                            "awardValue": "00314.1500",
+                            "startDate": "2020-10-10",
+                            "endDate": "2020-11-20",
+                        },
+                    },
+                    # expected_status_code
+                    200,
+                    # expected_response_data
+                    {
+                        "outcome": AnySupersetOf({
+                            "completed": True,
+                            "award": {
+                                "awardingOrganisationName": "Omphalos",
+                                "awardValue": "314.15",
+                                "startDate": "2020-10-10",
+                                "endDate": "2020-11-20",
+                            },
+                        }),
+                    },
+                ),
+            ),
+        )),
+        ids=(lambda val: "EMPTYDCT" if val == {} else None),
+    )
+    def test_update_outcome_scenarios(
+        self,
+        other_oc_brief_based,
+        initial_brief_based,
+        other_oc_data,
+        initial_data,
+        put_values,
+        expected_status_code,
+        expected_response_data,
+    ):
+        """
+        A number of arguments control the background context this test is run in and the parameters PUT to the endpoint.
+        Not all of the combinations make sense together and a caller should not expect a test to pass with a nonsensical
+        combination of arguments
+
+        :param other_oc_brief_based:   whether the "other", existing Outcome should be Brief-based as opposed to
+                                       Direct Award-based
+        :param initial_brief_based:    whether the target Outcome should initially be set up to be Brief-based as
+                                       opposed to Direct Award-based
+        :param other_oc_data:          field values to set up the "other" Outcome with, ``None`` for no "other"
+                                       Outcome to be created
+        :param initial_data:           field values to initially set up the target Outcome with
+        :param put_values:             payload dictionary to be PUT to the target endpoint (without the
+                                       ``outcome`` wrapper)
+        :param expected_status_code:
+        :param expected_response_data:
+        """
+        user_id = self.setup_dummy_user(id=1, role='buyer')
+        self.setup_dummy_suppliers(3)
+
+        project = None
+        search = None
+        chosen_archived_service = other_archived_service = None
+        if not (other_oc_brief_based and initial_brief_based):
+            # create required objects for direct award-based Outcome
+            self.setup_dummy_services(3, model=ArchivedService)
+
+            project = DirectAwardProject(
+                name="Lambay Island",
+                users=[User.query.get(user_id)],
+            )
+            db.session.add(project)
+
+            search = DirectAwardSearch(
+                project=project,
+                created_by=user_id,
+                active=True,
+                search_url="http://nothing.nowhere",
+            )
+            db.session.add(search)
+
+            for archived_service in db.session.query(ArchivedService).filter(
+                ArchivedService.service_id.in_(("2000000000", "2000000001",))
+            ).all():
+                search.archived_services.append(archived_service)
+
+            chosen_archived_service, other_archived_service = search.archived_services[:2]
+        # else skip creating these to save time
+
+        brief = None
+        chosen_brief_response = other_brief_response = None
+        if other_oc_brief_based or initial_brief_based:
+            # create required objects for brief-based Outcome
+            brief = self.setup_dummy_brief(status="closed", user_id=user_id, data={})
+            chosen_brief_response, other_brief_response = (BriefResponse(
+                brief=brief,
+                supplier_id=i,
+                submitted_at=datetime.datetime.utcnow(),
+                data={},
+            ) for i in (1, 2,))
+            db.session.add(chosen_brief_response)
+            db.session.add(other_brief_response)
+        # else skip creating these to save time
+
+        other_outcome = None
+        if other_oc_data is not None:
+            # create "other" Outcome for our target one to potentially clash with
+            other_outcome = Outcome(
+                **({"brief": brief} if other_oc_brief_based else {"direct_award_project": project}),
+                **({
+                    "result": other_oc_data.get("result", "awarded"),
+                    **({
+                        "brief_response": other_brief_response,
+                    } if other_oc_brief_based else {
+                        "direct_award_search": search,
+                        "direct_award_archived_service": other_archived_service,
+                    }),
+                } if other_oc_data.get("result", "awarded") == "awarded" else {"result": other_oc_data["result"]}),
+                **{k: v for k, v in (other_oc_data or {}).items() if k not in ("completed_at", "result",)},
+            )
+            if "completed_at" in other_oc_data:
+                other_outcome.completed_at = other_oc_data["completed_at"]
+            db.session.add(other_outcome)
+
+        # create our target Outcome in its initial state
+        outcome = Outcome(
+            **({"brief": brief} if initial_brief_based else {"direct_award_project": project}),
+            **({
+                "result": initial_data.get("result", "awarded"),
+                **({
+                    "brief_response": chosen_brief_response,
+                } if initial_brief_based else {
+                    "direct_award_search": search,
+                    "direct_award_archived_service": chosen_archived_service,
+                }),
+            } if initial_data.get("result", "awarded") == "awarded" else {"result": initial_data["result"]}),
+            **{k: v for k, v in (initial_data or {}).items() if k not in ("completed_at", "result",)},
+        )
+        if "completed_at" in initial_data:
+            # can only set completed_at after other fields have been set
+            outcome.completed_at = initial_data["completed_at"]
+        db.session.add(outcome)
+
+        # must assign ids before we can lock project
+        db.session.flush()
+        if project:
+            project.locked_at = datetime.datetime.now()
+
+        # make a concrete note of these so we don't have to fetch them back from the database after the request,
+        # potentially getting back values which have been inadvertantly changed
+        outcome_external_id = outcome.external_id
+        project_external_id = project and project.external_id
+        search_id = search and search.id
+        chosen_archived_service_id = chosen_archived_service and chosen_archived_service.id
+        chosen_archived_service_service_id = chosen_archived_service and chosen_archived_service.service_id
+        brief_id = brief and brief.id
+        chosen_brief_response_id = chosen_brief_response and chosen_brief_response.id
+        audit_event_count = AuditEvent.query.count()
+        db.session.commit()
+
+        # keep an nice concrete representation for later comparison
+        outcome_serialization_before = outcome.serialize()
+
+        res = self.client.put(
+            f"/outcomes/{outcome.external_id}",
+            data=json.dumps({
+                "updated_by": "lord.talbot@example.com",
+                "outcome": put_values,
+            }),
+            content_type="application/json",
+        )
+        assert res.status_code == expected_status_code
+        response_data = json.loads(res.get_data())
+        assert response_data == expected_response_data
+
+        # allow these to be re-used in this session, "refreshed"
+        db.session.add_all(x for x in (outcome, project, search, chosen_archived_service,) if x is not None)
+        db.session.expire_all()
+
+        if res.status_code != 200:
+            # assert change wasn't made, audit event wasn't added
+            assert outcome.serialize() == outcome_serialization_before
+            assert AuditEvent.query.count() == audit_event_count
+        else:
+            # an additional check of values we should be able to figure out the "correct" values for
+            assert response_data == {
+                "outcome": {
+                    "id": outcome_external_id,
+                    "result": initial_data.get("result", "awarded"),
+                    "completed": (
+                        bool(outcome_serialization_before.get("completedAt"))
+                        or put_values.get("completed") is True
+                    ),
+                    "completedAt": (
+                        outcome_serialization_before.get("completedAt")
+                        or (
+                            AnyStringMatching(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z")
+                            if put_values.get("completed") else None
+                        )
+                    ),
+                    **({
+                        "resultOfFurtherCompetition": {
+                            "briefId": brief_id,
+                            **({
+                                "briefResponseId": chosen_brief_response_id,
+                            } if initial_data.get("result", "awarded") == "awarded" else {}),
+                        },
+                    } if initial_brief_based else {
+                        "resultOfDirectAward": {
+                            "projectId": project_external_id,
+                            **({
+                                "searchId": search_id,
+                                "serviceId": chosen_archived_service_service_id,
+                                "archivedServiceId": chosen_archived_service_id,
+                            } if initial_data.get("result", "awarded") == "awarded" else {})
+                        },
+                    }),
+                    **({"award": AnySupersetOf({})} if initial_data.get("result", "awarded") == "awarded" else {}),
+                }
+            }
+
+            # check changes actually got committed
+            assert response_data == {
+                "outcome": outcome.serialize(),
+            }
+
+            # check audit event(s) were saved
+            expect_complete_audit_event = put_values.get("completed") is True and not initial_data.get("completed_at")
+            n_expected_new_audit_events = 2 if expect_complete_audit_event else 1
+
+            assert AuditEvent.query.count() == audit_event_count + n_expected_new_audit_events
+            # grab those most recent (1 or) 2 audit events from the db, re-sorting them to be in a predictable order -
+            # we don't care whether the complete_outcome or update_outcome comes out of the db first
+            audit_events = sorted(
+                db.session.query(AuditEvent).order_by(
+                    desc(AuditEvent.created_at),
+                    desc(AuditEvent.id),
+                )[:n_expected_new_audit_events],
+                key=lambda ae: ae.type,
+                reverse=True,
+            )
+
+            assert audit_events[0].type == "update_outcome"
+            assert audit_events[0].object is outcome
+            assert audit_events[0].acknowledged is False
+            assert audit_events[0].acknowledged_at is None
+            assert not audit_events[0].acknowledged_by
+            assert audit_events[0].user == "lord.talbot@example.com"
+            assert audit_events[0].data == put_values
+
+            if expect_complete_audit_event:
+                assert audit_events[1].type == "complete_outcome"
+                assert audit_events[1].created_at == audit_events[0].created_at == outcome.completed_at
+                assert audit_events[1].object is outcome
+                assert audit_events[1].acknowledged is False
+                assert audit_events[1].acknowledged_at is None
+                assert not audit_events[1].acknowledged_by
+                assert audit_events[1].user == "lord.talbot@example.com"
+                assert audit_events[1].data == {}
+
+    def test_nonexistent_outcome(self):
+        res = self.client.put(
+            f"/outcomes/314159",
+            data=json.dumps({
+                "updated_by": "lord.talbot@example.com",
+                "outcome": {
+                    "completed": True,
+                },
+            }),
+            content_type="application/json",
+        )
+        assert res.status_code == 404
+        assert json.loads(res.get_data()) == {
+            "error": "Outcome 314159 not found",
+        }


### PR DESCRIPTION
Trello https://trello.com/c/4JtM91iv/67-create-back-end-interface-for-award-flow

Here we add a `ProcessOutcome` model designed to generically represent the "outcome" (whether that be a successful outcome - an "award" - or an unsuccessful outcome) of a particular buying process. The buying process can be either a `DirectAwardProject` or a `Brief`, though in this PR only contains the creation process for a `ProcessOutcome` based on a `DirectAwardProject` and `Brief`s for now are left recording their awards in their own bespoke way. It is *intended* that eventually `Brief`s will be brought into line using `ProcessOutcome`s for this.

A `ProcessOutcome` can, as mentioned, be either an "awarded" or "unawarded" outcome. This is embodied in the `ProcessOutcome`'s `result` field. If the `result` is `awarded`, the `ProcessOutcome` is required to be further linked to the winning (`DirectAwardSearch` and) `ArchivedService` (in the "direct award" case) or winning `BriefResponse` (in the `Brief` case).

A number of database constraints are used to enforce consistency of the data model, chiefly ensuring that only a single `completed` `ProcessOutcome` can be referring to a particular process (be that `DirectAwardProject` or `Brief`) at once. Any number of non-`completed` `ProcessOutcome`s can exist for a process at once, though marking a `ProcessOutcome` as `completed` is intended to be permanent. It is also intended for a `ProcessOutcome`'s `result` or target to be immutable after creation time. The views included here enforce these restrictions.

Ignoring the one straightforward `get_process_outcome` view, there are two main views of interest included here. One (`create_award_process_outcome`) for creating an `awarded` ("successful") `ProcessOutcome` based on a `DirectAwardProject` (once given a "winning" `service_id`) and a general  `update_process_outcome` view. `create_award_process_outcome` creates a mostly empty and non-`completed` `ProcessOutcome` which the client/frontend is expected to then fill out further details of and finally "complete" using the `update_process_outcome` view.

The `@validates` validators added here are as problematic as any others we have - in that they have the undesired side-effect of requiring a particular order of setting interdependent fields because validators are triggered on setattr. i.e. it's not always possible to set all of a new instances field values in the constructor because it's uncertain what order sqlalchemy will set them in. Sometimes they have to be set after the fact and you can see examples of this happening in the tests. However my capacity for Introducing New Stuff was depleted by this point and so I continued following existing patterns.

Depends on https://github.com/alphagov/digitalmarketplace-apiclient/pull/139 though for now is aimed at that PR's specific branch name to make it an easy checkout...

*Not* included in this PR (but to follow soon) is:
 - inclusion of a `processOutcome` key on `DirectAwardProject`s and `Brief`s which have completed outcomes
 - a `DirectAwardProject`-based "unawarded" `ProcessOutcome` creation endpoint. This would presumably also "complete" the `ProcessOutcome` at creation time seeing as there is no additional information to be provided for this outcome type.