### PR TITLE
Add a log for successful account deactivation

### DIFF
--- a/app/callbacks/views/notify.py
+++ b/app/callbacks/views/notify.py
@@ -38,6 +38,11 @@ def notify_callback():
 
             db.session.commit()
 
+            current_app.logger.info(
+                "User account disabled for {hashed_email} after Notify reported permanent delivery "
+                "failure.".format(hashed_email=hash_string(notify_data['to']))
+            )
+
     elif notify_data['status'] == 'technical-failure':
         current_app.logger.warning("Notify failed to deliver {reference} to {hashed_email}".format(
             reference=notify_data['reference'],

--- a/tests/callbacks/views/test_notify.py
+++ b/tests/callbacks/views/test_notify.py
@@ -35,15 +35,16 @@ class TestNotifyCallback(BaseApplicationTest):
         response = self.client.get('/callbacks')
         assert response.status_code == 200
 
-    def test_user_account_deactivated_on_permanent_delivery_failure(self, user_role_supplier):
+    def test_user_account_deactivated_with_log_on_permanent_delivery_failure(self, user_role_supplier):
         notify_data = self.notify_data(to='test+1@digital.gov.uk')
 
         user = User.query.filter(User.email_address == 'test+1@digital.gov.uk').first()
         assert user.active is True
 
-        response = self.client.post('/callbacks/notify',
-                                    data=json.dumps(notify_data),
-                                    content_type='application/json')
+        with logcapture.LogCapture(names=('app',), level=logging.INFO) as logs:
+            response = self.client.post('/callbacks/notify',
+                                        data=json.dumps(notify_data),
+                                        content_type='application/json')
 
         assert response.status_code == 200
 
@@ -54,6 +55,9 @@ class TestNotifyCallback(BaseApplicationTest):
         assert len(audit_events) == 1
         assert audit_events[0].data['user'] == {'active': False}
         assert audit_events[0].data['notify_callback_data'] == notify_data
+
+        assert logs.records[0].msg == "User account disabled for -htpNCrT2nn2dCuqWsXwBZDgkP-WQQCYAfPgSw7Rb4A= after " \
+                                      "Notify reported permanent delivery failure."
 
     def test_no_audit_event_if_already_inactive_on_permanent_delivery_failure(self):
         notify_data = self.notify_data()


### PR DESCRIPTION
 ## Summary
Log successful account deactivation after a Notify callback with
permanent failure.