### PR TITLE
Use `update_supplier_framework` for updating supplier frameworks

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -468,11 +468,13 @@ def update_supplier_framework(supplier_id, framework_slug):
             prefill_declaration_from_framework_id = None
         interest_record.prefill_declaration_from_framework_id = prefill_declaration_from_framework_id
 
+    # The type of this audit event changed from `supplier_update` to `update_supplier_framework` in early June 2018.
+    # For an accurate date, check the date this commit went live on the stage you're interested in (probably prod).
     audit_event = AuditEvent(
-        audit_type=AuditTypes.supplier_update,
+        audit_type=AuditTypes.update_supplier_framework,
         user=updater_json['updated_by'],
         data={'supplierId': supplier.supplier_id, 'frameworkSlug': framework_slug, 'update': update_json},
-        db_object=supplier
+        db_object=supplier,
     )
 
     try:

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -11,7 +11,7 @@ SQLAlchemy==1.1.4
 SQLAlchemy-Utils==0.30.5
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@35.2.0#egg=digitalmarketplace-utils==35.2.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.0.0#egg=digitalmarketplace-apiclient==15.0.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.2.0#egg=digitalmarketplace-apiclient==15.2.0
 
 # For schema validation
 jsonschema==2.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ SQLAlchemy==1.1.4
 SQLAlchemy-Utils==0.30.5
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@35.2.0#egg=digitalmarketplace-utils==35.2.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.0.0#egg=digitalmarketplace-apiclient==15.0.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.2.0#egg=digitalmarketplace-apiclient==15.2.0
 
 # For schema validation
 jsonschema==2.5.1
@@ -20,13 +20,13 @@ rfc3987==1.3.4
 strict-rfc3339==0.5
 
 ## The following requirements were added by pip freeze:
-alembic==0.9.8
+alembic==0.9.9
 asn1crypto==0.24.0
 backoff==1.0.7
 bcrypt==3.1.4
 boto3==1.4.4
 botocore==1.5.95
-certifi==2018.1.18
+certifi==2018.4.16
 cffi==1.11.5
 chardet==3.0.4
 contextlib2==0.4.0
@@ -51,8 +51,8 @@ monotonic==0.3
 notifications-python-client==4.1.0
 odfpy==1.3.6
 pycparser==2.18
-PyJWT==1.6.0
-python-dateutil==2.7.0
+PyJWT==1.6.1
+python-dateutil==2.7.2
 python-editor==1.0.3
 python-json-logger==0.1.4
 pytz==2015.4

--- a/tests/main/views/test_suppliers.py
+++ b/tests/main/views/test_suppliers.py
@@ -1456,14 +1456,14 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest):
             AuditEvent.object == Supplier.query.filter(
                 Supplier.supplier_id == supplier_id
             ).first(),
-            AuditEvent.type == "supplier_update",
+            AuditEvent.type == "update_supplier_framework",
         ).order_by(AuditEvent.created_at.desc()).first()
 
     @classmethod
     def _assert_and_return_audit_event(cls, supplier_framework):
         # must be performed within an app context
         audit = cls._latest_supplier_update_audit_event(supplier_framework['supplierId'])
-        assert audit.type == "supplier_update"
+        assert audit.type == "update_supplier_framework"
         assert audit.user == "interested@example.com"
         assert audit.data['supplierId'] == supplier_framework['supplierId']
         assert audit.data['frameworkSlug'] == supplier_framework['frameworkSlug']


### PR DESCRIPTION
This is a reopening of [this PR](https://github.com/alphagov/digitalmarketplace-api/pull/774).

We were using the `supplier_update` audit event previously which was
confusing. A new audit event has been created in the api client, which
is being pulled in in this commit.