### PR TITLE
Outcomes: add direct award non-awarded endpoint

### DIFF
--- a/app/main/views/direct_award.py
+++ b/app/main/views/direct_award.py
@@ -428,10 +428,6 @@ def create_nonawarded_outcome(project_external_id, nonawarded_reason):
     updater_json = validate_and_return_updater_request()
     uniform_now = datetime.datetime.utcnow()
 
-    # an extra guard against incorrect url configuration or unintended call circumstances
-    if nonawarded_reason not in ("cancelled", "none-suitable",):
-        abort(404, f"Unknown nonawarded-reason {nonawarded_reason!r}")
-
     project = db.session.query(DirectAwardProject).filter_by(
         external_id=project_external_id,
     ).first()

--- a/app/main/views/direct_award.py
+++ b/app/main/views/direct_award.py
@@ -428,20 +428,16 @@ def create_nonawarded_outcome(project_external_id, nonawarded_reason):
     updater_json = validate_and_return_updater_request()
     uniform_now = datetime.datetime.utcnow()
 
+    # an extra guard against incorrect url configuration or unintended call circumstances
     if nonawarded_reason not in ("cancelled", "none-suitable",):
-        abort(404, f"Unknown nonawarded_reason {nonawarded_reason!r}")
+        abort(404, f"Unknown nonawarded-reason {nonawarded_reason!r}")
 
-    # Acquire share-lock on project row - what we're trying to assert here is that the "locked" field is true at the
-    # time we create this outcome
     project = db.session.query(DirectAwardProject).filter_by(
         external_id=project_external_id,
-    ).with_for_update(read=True).first()
+    ).first()
 
     if project is None:
         abort(404, f"Project {project_external_id} not found")
-
-    if not project.locked_at:
-        abort(400, f"Project {project_external_id} has not been locked")
 
     if project.outcome is not None:
         abort(410, "Project {} already has a completed outcome: {}".format(
@@ -450,7 +446,7 @@ def create_nonawarded_outcome(project_external_id, nonawarded_reason):
         ))
 
     # TODO? try-loop to assign ids, handling (unlikely) external_id collisions using sub-transaction so we don't lose
-    # our DirectAwardProject row-lock
+    # any row-locks we might have
     outcome = Outcome(
         result=nonawarded_reason,
         direct_award_project=project,

--- a/tests/main/views/test_direct_award.py
+++ b/tests/main/views/test_direct_award.py
@@ -1018,10 +1018,10 @@ class TestDirectAwardOutcomeAward(DirectAwardSetupAndTeardown):
         ),
         (
             # "happy" paths
-            (True, True, True, True, True, None, False, 200, AnySupersetOf({}),),
-            (True, False, True, False, True, None, False, 200, AnySupersetOf({}),),
-            (True, False, True, False, True, "awarded", False, 200, AnySupersetOf({}),),
-            (True, True, True, False, True, "cancelled", False, 200, AnySupersetOf({}),),
+            (True, True, True, True, True, None, False, 200, _anydict,),
+            (True, False, True, False, True, None, False, 200, _anydict,),
+            (True, False, True, False, True, "awarded", False, 200, _anydict,),
+            (True, True, True, False, True, "cancelled", False, 200, _anydict,),
             # "failure" paths
             (
                 True,
@@ -1101,7 +1101,8 @@ class TestDirectAwardOutcomeAward(DirectAwardSetupAndTeardown):
                     "error": AnyStringMatching(r"Project \d+ already has a completed outcome: \d+"),
                 },
             ),
-        )
+        ),
+        ids=(lambda val: "ANYDICT" if val is _anydict else None),
     )
     def test_direct_award_outcome_scenarios(
         self,
@@ -1209,6 +1210,7 @@ class TestDirectAwardOutcomeAward(DirectAwardSetupAndTeardown):
         audit_event_count = AuditEvent.query.count()
         outcome_count = Outcome.query.count()
         chosen_archived_service_id = db.session.query(ArchivedService.id).filter_by(service_id="2000000001").first()[0]
+        outcome_count = Outcome.query.count()
         db.session.commit()
 
         res = self.client.post(
@@ -1252,6 +1254,9 @@ class TestDirectAwardOutcomeAward(DirectAwardSetupAndTeardown):
                     },
                 }
             }
+
+            # only one outcome has been created
+            assert Outcome.query.count() == outcome_count + 1
 
             outcome = db.session.query(Outcome).filter_by(
                 external_id=response_data["outcome"]["id"]

--- a/tests/main/views/test_direct_award.py
+++ b/tests/main/views/test_direct_award.py
@@ -1102,6 +1102,7 @@ class TestDirectAwardOutcomeAward(DirectAwardSetupAndTeardown):
                 },
             ),
         ),
+        # help pytest make its printed representation of the parameter set a little more readable
         ids=(lambda val: "ANYDICT" if val is _anydict else None),
     )
     def test_direct_award_outcome_scenarios(
@@ -1400,6 +1401,7 @@ class TestDirectAwardOutcomeNonAwarded(DirectAwardSetupAndTeardown):
                 ),
             ),
         )),
+        # help pytest make its printed representation of the parameter set a little more readable
         ids=(lambda val: "ANYDICT" if val is _anydict else None),
     )
     def test_direct_award_nonawarded_scenarios(

--- a/tests/main/views/test_direct_award.py
+++ b/tests/main/views/test_direct_award.py
@@ -1,9 +1,10 @@
 import json
 from datetime import datetime
 from freezegun import freeze_time
-from itertools import product
+from itertools import chain, product
 import math
 import random
+import re
 import sys
 from urllib.parse import urljoin
 
@@ -1317,29 +1318,9 @@ class TestDirectAwardOutcomeNonAwarded(DirectAwardSetupAndTeardown):
         (False, True, True, "cancelled", False, 200, _anydict,),
         (True, False, True, "awarded", False, 200, _anydict,),
         (True, True, True, "cancelled", False, 200, _anydict,),
+        (True, False, False, "none-suitable", False, 200, _anydict),
+        (False, False, False, None, False, 200, _anydict),
         # "failure" paths
-        (
-            True,
-            False,
-            False,
-            None,
-            False,
-            400,
-            {
-                "error": AnyStringMatching(r"Project \d+ has not been locked"),
-            },
-        ),
-        (
-            True,
-            False,
-            False,
-            None,
-            False,
-            400,
-            {
-                "error": AnyStringMatching(r"Project \d+ has not been locked"),
-            },
-        ),
         (
             True,
             True,

--- a/tests/main/views/test_outcomes.py
+++ b/tests/main/views/test_outcomes.py
@@ -670,6 +670,7 @@ class TestUpdateOutcome(BaseApplicationTest, FixtureMixin):
                 ),
             ),
         )),
+        # help pytest make its printed representation of the parameter set a little more readable
         ids=(lambda val: "EMPTYDCT" if val == {} else None),
     )
     def test_update_outcome_scenarios(


### PR DESCRIPTION
Trello https://trello.com/c/nhtrO8Qi/78-non-award-flow-back-end-api

This gives us a `POST`able view which will create a non-award `Outcome` and set it to be "completed" in a single call (because no extra information other than the non-awarding `reason` is needed).

URLs are `/direct-award/projects/<int:project_external_id>/none-suitable` and `/direct-award/projects/<int:project_external_id>/cancel`.