### PR TITLE
Add a view that exports suppliers related to a framework

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -127,9 +127,16 @@ def export_suppliers_for_framework(framework_slug):
                 supplier.supplier_id in suppliers_with_a_complete_service and
                 company_details_confirmed
         ) else 'no_application'
-        application_result = 'no result'
+        application_result = ''
         framework_agreement = False
         variations_agreed = ''
+
+        if framework.status != 'open':
+            if sf.on_framework is None:
+                application_result = 'no result'
+            else:
+                application_result = 'pass' if sf.on_framework else 'fail'
+            framework_agreement = bool(getattr(sf.current_framework_agreement, 'signed_agreement_returned_at', None))
 
         supplier_rows.append({
             "supplier_id": supplier.supplier_id,

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -116,8 +116,21 @@ def export_suppliers_for_framework(framework_slug):
 
     supplier_rows = []
 
+    suppliers_with_a_complete_service = frozenset(framework.get_supplier_ids_for_completed_service())
+
     for sf, supplier, ci in suppliers_and_framework:
         declaration_status = sf.declaration.get('status') if sf.declaration else 'unstarted'
+        # For G10 we need to check the suppliers company detatils have been confirmed
+        company_details_confirmed = supplier.company_details_confirmed
+        application_status = 'application' if (
+                declaration_status == 'complete' and
+                supplier.supplier_id in suppliers_with_a_complete_service and
+                company_details_confirmed
+        ) else 'no_application'
+        application_result = 'no result'
+        framework_agreement = False
+        variations_agreed = ''
+
         supplier_rows.append({
             "supplier_id": supplier.supplier_id,
             "supplier_name": supplier.name,
@@ -125,12 +138,12 @@ def export_suppliers_for_framework(framework_slug):
             "duns_number": supplier.duns_number,
             "registered_name": supplier.registered_name,
             "companies_house_number": supplier.companies_house_number,
-            # TODO: framework application status
-            'application_result': 'no result',
-            'application_status': 'no_application',
+            # TODO: framework application result, framework agreement, variations agreed
+            'application_result': application_result,
+            'application_status': application_status,
             'declaration_status': declaration_status,
-            'framework_agreement': False,
-            'variations_agreed': '',
+            'framework_agreement': framework_agreement,
+            'variations_agreed': variations_agreed,
             # TODO: service counts for each lot
             "published_services_count": {
                 "digital-outcomes": 0,

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -193,7 +193,7 @@ def export_suppliers_for_framework(framework_slug):
             }
         })
 
-    return jsonify(suppliers=[supplier for supplier in supplier_rows]), 200
+    return jsonify(suppliers=supplier_rows), 200
 
 
 @main.route('/suppliers/<int:supplier_id>', methods=['GET'])

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -137,6 +137,7 @@ def export_suppliers_for_framework(framework_slug):
             else:
                 application_result = 'pass' if sf.on_framework else 'fail'
             framework_agreement = bool(getattr(sf.current_framework_agreement, 'signed_agreement_returned_at', None))
+            variations_agreed = ', '.join(sf.agreed_variations.keys()) if sf.agreed_variations else ''
 
         supplier_rows.append({
             "supplier_id": supplier.supplier_id,

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -117,6 +117,7 @@ def export_suppliers_for_framework(framework_slug):
     supplier_rows = []
 
     for sf, supplier, ci in suppliers_and_framework:
+        declaration_status = sf.declaration.get('status') if sf.declaration else 'unstarted'
         supplier_rows.append({
             "supplier_id": supplier.supplier_id,
             "supplier_name": supplier.name,
@@ -127,7 +128,7 @@ def export_suppliers_for_framework(framework_slug):
             # TODO: framework application status
             'application_result': 'no result',
             'application_status': 'no_application',
-            'declaration_status': 'unstarted',
+            'declaration_status': declaration_status,
             'framework_agreement': False,
             'variations_agreed': '',
             # TODO: service counts for each lot

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -148,9 +148,9 @@ def export_suppliers_for_framework(framework_slug):
         # For G10 we need to check the suppliers company detatils have been confirmed
         company_details_confirmed = supplier.company_details_confirmed
         application_status = 'application' if (
-                declaration_status == 'complete' and
-                supplier.supplier_id in suppliers_with_a_complete_service and
-                company_details_confirmed
+            declaration_status == 'complete' and
+            supplier.supplier_id in suppliers_with_a_complete_service and
+            company_details_confirmed
         ) else 'no_application'
         application_result = ''
         framework_agreement = False
@@ -171,13 +171,11 @@ def export_suppliers_for_framework(framework_slug):
             "duns_number": supplier.duns_number,
             "registered_name": supplier.registered_name,
             "companies_house_number": supplier.companies_house_number,
-            # TODO: framework application result, framework agreement, variations agreed
             'application_result': application_result,
             'application_status': application_status,
             'declaration_status': declaration_status,
             'framework_agreement': framework_agreement,
             'variations_agreed': variations_agreed,
-            # TODO: service counts for each lot
             "published_services_count": {
                 lot_slugs_by_id[lot_id]: service_counts_by_lot_by_supplier.get(
                     supplier.supplier_id, {}

--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -339,7 +339,7 @@ def export_users_for_framework(framework_slug):
             'published_service_count': supplier_id_published_service_count.get(sf.supplier_id, 0)
         })
 
-    return jsonify(users=[user for user in user_rows]), 200
+    return jsonify(users=user_rows), 200
 
 
 @main.route("/users/check-buyer-email", methods=["GET"])

--- a/tests/bases.py
+++ b/tests/bases.py
@@ -72,6 +72,13 @@ class BaseApplicationTest(object):
                 db.engine.execute(table.delete())
         FrameworkLot.query.filter(FrameworkLot.framework_id >= 100).delete()
         Framework.query.filter(Framework.id >= 100).delete()
+
+        # Remove any framework variation details
+        frameworks = db.session.query(Framework).filter(Framework.framework_agreement_details is not None)
+        for framework in frameworks.all():
+            framework.framework_agreement_details = None
+            db.session.add(framework)
+
         db.session.commit()
         db.get_engine(self.app).dispose()
         self.app_context.pop()

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -172,7 +172,7 @@ class FixtureMixin(object):
                     supplier_id=i,
                     contact_name=u'Contact for Supplier {}'.format(i),
                     email=u'{}@contact.com'.format(i),
-                    postcode=u'CN1A 1AA',
+                    postcode=u'SW1A 1AA',
                     address1='7 Gem Lane',
                     city='Cantelot'
                 )

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -159,9 +159,12 @@ class FixtureMixin(object):
             db.session.add(
                 Supplier(
                     supplier_id=i,
+                    registered_name='Registered Supplier Name {}'.format(i),
                     name=u'Supplier {}'.format(i),
                     description='',
                     organisation_size='small',
+                    duns_number='{}'.format(100000000 + i),
+                    registration_country='country:GB',
                 )
             )
             db.session.add(
@@ -169,7 +172,9 @@ class FixtureMixin(object):
                     supplier_id=i,
                     contact_name=u'Contact for Supplier {}'.format(i),
                     email=u'{}@contact.com'.format(i),
-                    postcode=u'SW1A 1AA'
+                    postcode=u'CN1A 1AA',
+                    address1='7 Gem Lane',
+                    city='Cantelot'
                 )
             )
             supplier_ids.append(i)

--- a/tests/main/views/test_suppliers.py
+++ b/tests/main/views/test_suppliers.py
@@ -2205,3 +2205,25 @@ class TestSuppliersExport(BaseApplicationTest, FixtureMixin):
             self._return_suppliers_export_after_setting_framework_status(status='live').get_data()
         )["suppliers"]
         assert data[0]['variations_agreed'] == '1'
+
+    def test_published_service_count_with_different_statuses(self):
+        self._setup_supplier_on_framework()
+        self._post_company_details_confirmed()
+        self._put_complete_declaration()
+        self._post_complete_draft_service()
+        self._post_framework_application_result(True)
+        self.set_framework_status(self.framework_slug, 'open')
+
+        self.setup_dummy_service('10000000002', 1, frameworkSlug=self.framework_slug, lot_id=5)
+        self.setup_dummy_service('10000000003', 1, frameworkSlug=self.framework_slug, lot_id=5)
+        self.setup_dummy_service('10000000004', 1, frameworkSlug=self.framework_slug, lot_id=5)
+        self.setup_dummy_service('10000000005', 1, frameworkSlug=self.framework_slug, lot_id=5, status='enabled')
+        self.setup_dummy_service('10000000006', 1, frameworkSlug=self.framework_slug, lot_id=5, status='disabled')
+
+        data = json.loads(self._return_suppliers_export_after_setting_framework_status().get_data())["suppliers"]
+        assert data[0]["published_services_count"] == {
+            "digital-outcomes": 3,
+            "digital-specialists": 0,
+            "user-research-studios": 0,
+            "user-research-participants": 0,
+        }

--- a/tests/main/views/test_suppliers.py
+++ b/tests/main/views/test_suppliers.py
@@ -2182,7 +2182,7 @@ class TestSuppliersExport(BaseApplicationTest, FixtureMixin):
         self._post_complete_draft_service()
         self._post_framework_application_result(False)
         data = json.loads(self._return_suppliers_export_after_setting_framework_status().get_data())["suppliers"]
-        assert data[0]['framework_agreement'] == False
+        assert data[0]['framework_agreement'] is False
         assert data[0]['application_result'] == 'fail'
 
     def test_response_agreed_contract_variation(self):

--- a/tests/main/views/test_suppliers.py
+++ b/tests/main/views/test_suppliers.py
@@ -1932,3 +1932,97 @@ class TestSupplierFrameworkVariation(BaseApplicationTest, FixtureMixin):
         assert audit_events[1].data["update"] == {
             "agreedUserId": 2,
         }
+
+
+class TestSuppliersExport(BaseApplicationTest, FixtureMixin):
+
+    framework_slug = None
+    updater_json = None
+
+    def setup(self):
+        super(TestSuppliersExport, self).setup()
+        self.setup_default_buyer_domain()
+        self.framework_slug = 'digital-outcomes-and-specialists'
+        self.set_framework_status(self.framework_slug, 'open')
+        self.updater_json = {'updated_by': 'Paula'}
+
+    def _set_framework_status(self, status='pending'):
+        self.set_framework_status(self.framework_slug, status)
+
+    def _return_suppliers_export(self):
+        response = self.client.get('/suppliers/export/{}'.format(self.framework_slug))
+        assert response.status_code == 200
+        return response
+
+    def _return_suppliers_export_after_setting_framework_status(self, status='pending'):
+        self._set_framework_status(status)
+        return self._return_suppliers_export()
+
+    def _register_supplier_with_framework(self):
+        response = self.client.put(
+            '/suppliers/{}/frameworks/{}'.format(self.supplier_id, self.framework_slug),
+            data=json.dumps(self.updater_json),
+            content_type='application/json')
+        assert response.status_code == 201
+
+    def _setup_supplier_on_framework(self, post_supplier=True, register_supplier_with_framework=True):
+        if post_supplier:
+            # set the supplier_id to the id of the last supplier created
+            self.supplier_id = self.setup_dummy_suppliers(2)[-1]
+        if register_supplier_with_framework:
+            self._register_supplier_with_framework()
+
+    def test_get_response_when_no_suppliers(self):
+        data = json.loads(self._return_suppliers_export_after_setting_framework_status().get_data())["suppliers"]
+        assert data == []
+
+    def test_400_response_if_bad_framework_name(self):
+        self._setup_supplier_on_framework()
+        response = self.client.get('/suppliers/export/{}'.format('cyber-outcomes-and-cyber-specialists'))
+        assert response.status_code == 400
+
+    def test_400_response_if_framework_is_coming(self):
+        self._setup_supplier_on_framework()
+        self._set_framework_status('coming')
+        response = self.client.get('/suppliers/export/{}'.format(self.framework_slug))
+        assert response.status_code == 400
+
+    def test_get_response_when_not_registered_with_framework(self):
+        self._setup_supplier_on_framework(register_supplier_with_framework=False)
+        data = json.loads(self._return_suppliers_export_after_setting_framework_status().get_data())["suppliers"]
+        assert data == []
+
+    def test_response_unstarted_declaration_no_drafts(self):
+        self._setup_supplier_on_framework()
+        data = json.loads(self._return_suppliers_export_after_setting_framework_status().get_data())["suppliers"]
+
+        assert data == [
+            {
+                'supplier_id': 1,
+                'application_result': 'no result',
+                'application_status': 'no_application',
+                'declaration_status': 'unstarted',
+                'framework_agreement': False,
+                'supplier_name': "Supplier 1",
+                'supplier_organisation_size': "small",
+                'duns_number': "100000001",
+                'registered_name': 'Registered Supplier Name 1',
+                'companies_house_number': None,
+                "published_services_count": {
+                    "digital-outcomes": 0,
+                    "digital-specialists": 0,
+                    "user-research-studios": 0,
+                    "user-research-participants": 0,
+                },
+                "contact_information": {
+                    'contact_name': 'Contact for Supplier 1',
+                    'contact_email': '1@contact.com',
+                    'contact_phone_number': None,
+                    'address_first_line': '7 Gem Lane',
+                    'address_city': 'Cantelot',
+                    'address_postcode': 'CN1A 1AA',
+                    'address_country': 'country:GB',
+                },
+                'variations_agreed': '',
+            }
+        ]

--- a/tests/main/views/test_suppliers.py
+++ b/tests/main/views/test_suppliers.py
@@ -2122,7 +2122,7 @@ class TestSuppliersExport(BaseApplicationTest, FixtureMixin):
                     'contact_phone_number': None,
                     'address_first_line': '7 Gem Lane',
                     'address_city': 'Cantelot',
-                    'address_postcode': 'CN1A 1AA',
+                    'address_postcode': 'SW1A 1AA',
                     'address_country': 'country:GB',
                 },
                 'variations_agreed': '',

--- a/tests/models/test_main.py
+++ b/tests/models/test_main.py
@@ -1467,7 +1467,7 @@ class TestSuppliers(BaseApplicationTest, FixtureMixin):
                         },
                         'address1': '7 Gem Lane',
                         'city': 'Cantelot',
-                        'postcode': 'CN1A 1AA',
+                        'postcode': 'SW1A 1AA',
                     }
                 ],
                 'description': u'',
@@ -1524,7 +1524,7 @@ class TestSuppliers(BaseApplicationTest, FixtureMixin):
                         },
                         'address1': '7 Gem Lane',
                         'city': 'Cantelot',
-                        'postcode': 'CN1A 1AA',
+                        'postcode': 'SW1A 1AA',
                     }
                 ],
                 'description': 'All your parcel wrapping needs catered for',

--- a/tests/models/test_main.py
+++ b/tests/models/test_main.py
@@ -1465,7 +1465,9 @@ class TestSuppliers(BaseApplicationTest, FixtureMixin):
                                 {'contact_id': self.contact_id, 'supplier_id': 0}
                             )
                         },
-                        'postcode': u'SW1A 1AA',
+                        'address1': '7 Gem Lane',
+                        'city': 'Cantelot',
+                        'postcode': 'CN1A 1AA',
                     }
                 ],
                 'description': u'',
@@ -1475,7 +1477,10 @@ class TestSuppliers(BaseApplicationTest, FixtureMixin):
                 },
                 'name': u'Supplier 0',
                 'companyDetailsConfirmed': False,
-                'organisationSize': 'small'
+                'organisationSize': 'small',
+                'dunsNumber': '100000000',
+                'registeredName': 'Registered Supplier Name 0',
+                'registrationCountry': 'country:GB'
             }
 
     def test_update_from_json(self):
@@ -1517,7 +1522,9 @@ class TestSuppliers(BaseApplicationTest, FixtureMixin):
                                 {'contact_id': self.contact_id, 'supplier_id': 0}
                             )
                         },
-                        'postcode': u'SW1A 1AA',
+                        'address1': '7 Gem Lane',
+                        'city': 'Cantelot',
+                        'postcode': 'CN1A 1AA',
                     }
                 ],
                 'description': 'All your parcel wrapping needs catered for',


### PR DESCRIPTION
Trello: https://trello.com/c/gVkJo8Zj/70-update-framework-manager-user-download-list-to-include-additional-fields

- New API view to export supplier data for a particular framework
- Service counts for each lot
- TODO: Squash commits

See also: 
- API Client: https://github.com/alphagov/digitalmarketplace-apiclient/pull/140/files
- Admin FE: https://github.com/alphagov/digitalmarketplace-admin-frontend/pull/392