### PR TITLE
DirectAwardProject serialization: include completed outcome serialization if present

### DIFF
--- a/app/main/views/direct_award.py
+++ b/app/main/views/direct_award.py
@@ -32,7 +32,7 @@ def get_project_by_id_or_404(project_id: int):
 def list_projects():
     page = get_valid_page_or_1()
 
-    projects = DirectAwardProject.query
+    projects = DirectAwardProject.query.options(db.joinedload(DirectAwardProject.outcome))
 
     includes = request.args.get('include', '').split(',')
 

--- a/app/models/direct_award.py
+++ b/app/models/direct_award.py
@@ -60,7 +60,8 @@ class DirectAwardProject(db.Model):
             "createdAt": self.created_at.strftime(DATETIME_FORMAT),
             "lockedAt": self.locked_at.strftime(DATETIME_FORMAT) if self.locked_at is not None else None,
             "downloadedAt": self.downloaded_at.strftime(DATETIME_FORMAT) if self.downloaded_at is not None else None,
-            "active": self.active
+            "active": self.active,
+            "outcome": self.outcome.serialize() if self.outcome is not None else None,
         }
 
         if with_users:


### PR DESCRIPTION
Trello ... I *think* we meant to include this in one of the cards already in review...?

This just sticks in any completed `Outcome`s, using their existing serialization format. Of course, this works because the `Outcome` serialization only mentions its parent project by id - if it decided to include *it* in its serialization we would end up in recursive craziness. But for now we can hopefully do without having a special cut-down serialization variant?

I include `outcome`s as a `joinedload` in the "list" endpoint as it's more likely to make a performance difference there. In endpoints where we're basically dealing with a single `DirectAwardProject` the extra db hit to fetch that `Outcome` is likely to be unnoticeable.