### PR TITLE
Outcome: change serialization of ids

### DIFF
--- a/app/main/views/audits.py
+++ b/app/main/views/audits.py
@@ -29,6 +29,8 @@ AUDIT_OBJECT_TYPES = {
     "frameworks": models.Framework,
     "users": models.User,
     "briefs": models.Brief,
+    "outcomes": models.Outcome,
+    "brief-responses": models.BriefResponse,
 }
 
 AUDIT_OBJECT_ID_FIELDS = {
@@ -37,6 +39,8 @@ AUDIT_OBJECT_ID_FIELDS = {
     "frameworks": models.Framework.slug,
     "users": models.User.id,
     "briefs": models.Brief.id,
+    "outcomes": models.Outcome.external_id,
+    "brief-responses": models.BriefResponse.id,
 }
 
 

--- a/app/main/views/direct_award.py
+++ b/app/main/views/direct_award.py
@@ -32,7 +32,15 @@ def get_project_by_id_or_404(project_id: int):
 def list_projects():
     page = get_valid_page_or_1()
 
-    projects = DirectAwardProject.query.options(db.joinedload(DirectAwardProject.outcome))
+    projects = DirectAwardProject.query.options(
+        db.joinedload(
+            DirectAwardProject.outcome
+        ).joinedload(
+            Outcome.direct_award_archived_service
+        ).load_only(
+            "service_id"
+        )
+    )
 
     includes = request.args.get('include', '').split(',')
 

--- a/app/models/outcomes.py
+++ b/app/models/outcomes.py
@@ -229,12 +229,21 @@ class Outcome(db.Model):
             **(
                 {
                     "resultOfDirectAward": {
-                        "projectId": self.direct_award_project.external_id,
+                        "project": {
+                            "id": self.direct_award_project.external_id,
+                        },
                         **(
                             {
-                                "searchId": self.direct_award_search_id,
-                                "archivedServiceId": self.direct_award_archived_service_id,
-                                "serviceId": self.direct_award_archived_service.service_id,
+                                # heavily abbreviated versions of these objects' serializations
+                                "search": {
+                                    "id": self.direct_award_search_id,
+                                },
+                                "archivedService": {
+                                    "id": self.direct_award_archived_service_id,
+                                    "service": {
+                                        "id": self.direct_award_archived_service.service_id,
+                                    },
+                                },
                             } if self.result == "awarded" else {}
                         ),
                     },
@@ -243,9 +252,15 @@ class Outcome(db.Model):
             **(
                 {
                     "resultOfFurtherCompetition": {
-                        "briefId": self.brief_id,
+                        "brief": {
+                            "id": self.brief_id,
+                        },
                         **(
-                            {"briefResponseId": self.brief_response_id} if self.result == "awarded" else {}
+                            {
+                                "briefResponse": {
+                                    "id": self.brief_response_id,
+                                },
+                            } if self.result == "awarded" else {}
                         )
                     },
                 } if self.brief_id is not None else {}

--- a/tests/main/views/test_direct_award.py
+++ b/tests/main/views/test_direct_award.py
@@ -1248,10 +1248,18 @@ class TestDirectAwardOutcomeAward(DirectAwardSetupAndTeardown):
                         "startDate": None,
                     },
                     "resultOfDirectAward": {
-                        "projectId": project_external_id,
-                        "searchId": active_search_id,
-                        "serviceId": "2000000001",
-                        "archivedServiceId": chosen_archived_service_id,
+                        "project": {
+                            "id": project_external_id,
+                        },
+                        "search": {
+                            "id": active_search_id,
+                        },
+                        "archivedService": {
+                            "id": chosen_archived_service_id,
+                            "service": {
+                                "id": "2000000001",
+                            },
+                        },
                     },
                 }
             }
@@ -1286,7 +1294,7 @@ class TestDirectAwardOutcomeAward(DirectAwardSetupAndTeardown):
             assert audit_event.type == "create_outcome"
             assert audit_event.user == "1"
             assert audit_event.data == {
-                "archivedServiceId": response_data["outcome"]["resultOfDirectAward"]["archivedServiceId"],
+                "archivedServiceId": response_data["outcome"]["resultOfDirectAward"]["archivedService"]["id"],
                 "projectExternalId": project_external_id,
                 "searchId": active_search_id,
                 "result": "awarded",
@@ -1537,7 +1545,9 @@ class TestDirectAwardOutcomeNonAwarded(DirectAwardSetupAndTeardown):
                     "completed": True,
                     "completedAt": AnyStringMatching(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z"),
                     "resultOfDirectAward": {
-                        "projectId": project_external_id,
+                        "project": {
+                            "id": project_external_id,
+                        },
                     },
                 }
             }

--- a/tests/main/views/test_outcomes.py
+++ b/tests/main/views/test_outcomes.py
@@ -845,18 +845,30 @@ class TestUpdateOutcome(BaseApplicationTest, FixtureMixin):
                     ),
                     **({
                         "resultOfFurtherCompetition": {
-                            "briefId": brief_id,
+                            "brief": {
+                                "id": brief_id,
+                            },
                             **({
-                                "briefResponseId": chosen_brief_response_id,
+                                "briefResponse": {
+                                    "id": chosen_brief_response_id,
+                                },
                             } if initial_data.get("result", "awarded") == "awarded" else {}),
                         },
                     } if initial_brief_based else {
                         "resultOfDirectAward": {
-                            "projectId": project_external_id,
+                            "project": {
+                                "id": project_external_id,
+                            },
                             **({
-                                "searchId": search_id,
-                                "serviceId": chosen_archived_service_service_id,
-                                "archivedServiceId": chosen_archived_service_id,
+                                "search": {
+                                    "id": search_id,
+                                },
+                                "archivedService": {
+                                    "id": chosen_archived_service_id,
+                                    "service": {
+                                        "id": chosen_archived_service_service_id,
+                                    },
+                                },
                             } if initial_data.get("result", "awarded") == "awarded" else {})
                         },
                     }),


### PR DESCRIPTION
As discussed, embed ids in their own dictionaries as if we were just returning a very abbreviated version of these objects serializations.  This makes more sense and would mean that future changes to include more details from each object could be backwards compatible.

Also have slipped in a patch here to add `Outcome` and `BriefResponse` to `AUDIT_OBJECT_TYPES` so we're actually able to search by these in `list_audits`.