### PR TITLE
Remove frameworkStartDate and frameworkEndDate

### DIFF
--- a/app/supplier_constants.py
+++ b/app/supplier_constants.py
@@ -1,6 +1,7 @@
 # Here we define a set of hardcoded keys that we use when denormalizing data from Supplier/ContactInformation tables
-# into the SupplierFramework.declaration field. These are only used internally by the API - the frontends currently
-# do not need knowledge of them, so there is no reason to centralise them e.g. in utils at this time.
+# into the SupplierFramework.declaration field. These are used only by the API and by the
+# `digitalmarketplace-scripts/scripts/generate-framework-agreement-*-pages`, which generates framework agreement
+# signature pages for successful suppliers to sign. These agreements are populated with some of the details below.
 KEY_DUNS_NUMBER = 'supplierDunsNumber'
 KEY_ORGANISATION_SIZE = 'supplierOrganisationSize'
 KEY_REGISTERED_NAME = 'supplierRegisteredName'

--- a/json_schemas/framework-agreement-details.json
+++ b/json_schemas/framework-agreement-details.json
@@ -19,14 +19,6 @@
       "minLength": 1,
       "type": "string"
     },
-    "frameworkStartDate": {
-      "minLength": 1,
-      "type": "string"
-    },
-    "frameworkEndDate": {
-      "minLength": 1,
-      "type": "string"
-    },
     "frameworkExtensionLength": {
       "minLength": 1,
       "type": "string"


### PR DESCRIPTION
 ## Summary
These two fields can be removed from the frameworkAgreementDetails blob
of data on a framework record as they duplicate information contained at
the top level under frameworkLiveAtUTC and frameworkExpiresAtUTC.

I have already removed these keys from the records across all of our
environments.

 ## Ticket
https://trello.com/c/82u630c9/80