### PR TITLE
Remove personal data methods

### DIFF
--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -6,6 +6,8 @@ from sqlalchemy.orm import lazyload
 from sqlalchemy.exc import DataError, IntegrityError
 from flask import abort, current_app, jsonify, request
 
+from dmutils.config import convert_to_boolean
+
 from .. import main
 from ... import db, encryption
 from ...models import AuditEvent, BuyerEmailDomain, Framework, Service, Supplier, SupplierFramework, User
@@ -118,6 +120,10 @@ def list_users():
             abort(404, "supplier_id '{}' not found".format(supplier_id))
 
         user_query = user_query.filter(User.supplier_id == supplier_id)
+
+    personal_data_removed = request.args.get('personal_data_removed')
+    if personal_data_removed is not None:
+        user_query = user_query.filter(User.personal_data_removed == convert_to_boolean(personal_data_removed))
 
     return paginated_result_response(
         result_name=RESOURCE_NAME,

--- a/app/models/main.py
+++ b/app/models/main.py
@@ -3,16 +3,15 @@
 import re
 from abc import ABCMeta, abstractmethod
 from datetime import datetime
-from six import string_types, iteritems
 from uuid import uuid4
 
 from flask import current_app
 from flask_sqlalchemy import BaseQuery
 
+import sqlalchemy.dialects.postgresql
 from sqlalchemy import Sequence
 from sqlalchemy import asc, desc, exists
 from sqlalchemy import func
-import sqlalchemy.dialects.postgresql
 from sqlalchemy.dialects.postgresql import INTERVAL
 from sqlalchemy.event import listen
 from sqlalchemy.ext.declarative import declared_attr

--- a/app/models/main.py
+++ b/app/models/main.py
@@ -356,7 +356,7 @@ class ContactInformation(db.Model, RemovePersonalDataModelMixin):
             'address1': self.address1,
             'city': self.city,
             'postcode': self.postcode,
-            # 'personalDataRemoved': self.personal_data_removed,
+            'personalDataRemoved': self.personal_data_removed,
             'links': links,
         }
 

--- a/app/models/main.py
+++ b/app/models/main.py
@@ -296,7 +296,7 @@ class Framework(db.Model):
         return '<{}: {} slug={}>'.format(self.__class__.__name__, self.name, self.slug)
 
 
-class ContactInformation(db.Model):
+class ContactInformation(db.Model, RemovePersonalDataModelMixin):
     __tablename__ = 'contact_information'
 
     id = db.Column(db.Integer, primary_key=True)
@@ -360,6 +360,16 @@ class ContactInformation(db.Model):
         }
 
         return filter_null_value_fields(serialized)
+
+    def remove_personal_data(self):
+        self.personal_data_removed = True
+
+        self.contact_name = '<removed>'
+        self.phone_number = '<removed>'
+        self.email = '<removed>'
+        self.address1 = '<removed>'
+        self.city = '<removed>'
+        self.postcode = '<removed>'
 
 
 class Supplier(db.Model):

--- a/app/models/main.py
+++ b/app/models/main.py
@@ -356,6 +356,7 @@ class ContactInformation(db.Model, RemovePersonalDataModelMixin):
             'address1': self.address1,
             'city': self.city,
             'postcode': self.postcode,
+            # 'personalDataRemoved': self.personal_data_removed,
             'links': links,
         }
 
@@ -944,6 +945,7 @@ class User(db.Model, RemovePersonalDataModelMixin):
                 if self.logged_in_at else self.created_at.strftime(DATETIME_FORMAT),
             'failedLoginCount': self.failed_login_count,
             'userResearchOptedIn': self.user_research_opted_in,
+            'personalDataRemoved': self.personal_data_removed,
         }
 
         if self.role == 'supplier':

--- a/example_listings/Supplier.json
+++ b/example_listings/Supplier.json
@@ -9,6 +9,7 @@
       "phoneNumber": "07309404738",
       "address1": "123 Fake Street",
       "city": "London",
+      "personalDataRemoved": false,
       "postcode": "F4 K1E",
       "links": {"self": "http://localhost/suppliers/123456/contact-information/1"}
     },
@@ -19,6 +20,7 @@
       "phoneNumber": "020 7918 9200",
       "address1": "4 Don Hill",
       "city": "London",
+      "personalDataRemoved": false,
       "postcode": "EC1A D0N"
     }
   ],

--- a/json_schemas/contact-information.json
+++ b/json_schemas/contact-information.json
@@ -26,6 +26,9 @@
     "phoneNumber": {
       "type": "string"
     },
+    "personalDataRemoved": {
+      "type": "boolean"
+    },
     "postcode": {
       "type": "string"
     },

--- a/migrations/versions/1220_add_personal_data_removed_flag_to_users_and_contact_information.py
+++ b/migrations/versions/1220_add_personal_data_removed_flag_to_users_and_contact_information.py
@@ -1,0 +1,27 @@
+"""Add 'obfuscated' flag to User and ContactInformation models
+
+Revision ID: 1220
+Revises: 1210
+Create Date: 2018-05-01 09:47:36.085886
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '1220'
+down_revision = '1210'
+
+
+def upgrade():
+    op.add_column('users', sa.Column('personal_data_removed', sa.Boolean(), nullable=False,  server_default=sa.false()))
+    op.add_column(
+        'contact_information',
+        sa.Column('personal_data_removed', sa.Boolean(), nullable=False, server_default=sa.false())
+    )
+
+
+def downgrade():
+    op.drop_column('contact_information', 'personal_data_removed')
+    op.drop_column('users', 'personal_data_removed')
+

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -50,9 +50,11 @@ def fixture_params(fixture_name, params):
 
 class FixtureMixin(object):
 
+    default_buyer_domain = 'digital.gov.uk'
+
     def setup_default_buyer_domain(self):
-        if BuyerEmailDomain.query.filter(BuyerEmailDomain.domain_name == 'digital.gov.uk').count() == 0:
-            db.session.add(BuyerEmailDomain(domain_name='digital.gov.uk'))
+        if BuyerEmailDomain.query.filter(BuyerEmailDomain.domain_name == self.default_buyer_domain).count() == 0:
+            db.session.add(BuyerEmailDomain(domain_name=self.default_buyer_domain))
             db.session.commit()
 
     def setup_dummy_user(self, id=123, role='buyer'):

--- a/tests/main/views/test_briefs.py
+++ b/tests/main/views/test_briefs.py
@@ -447,6 +447,7 @@ class TestGetBrief(FrameworkSetupAndTeardown):
                         'role': 'buyer',
                         'active': True,
                         'userResearchOptedIn': False,
+                        'personalDataRemoved': False,
                     }
                 ],
                 "clarificationQuestions": [],

--- a/tests/models/test_main.py
+++ b/tests/models/test_main.py
@@ -1636,6 +1636,7 @@ class TestSuppliers(BaseApplicationTest, FixtureMixin):
                         'address1': '7 Gem Lane',
                         'city': 'Cantelot',
                         'postcode': 'SW1A 1AA',
+                        'personalDataRemoved': False,
                     }
                 ],
                 'description': u'',
@@ -1693,6 +1694,7 @@ class TestSuppliers(BaseApplicationTest, FixtureMixin):
                         'address1': '7 Gem Lane',
                         'city': 'Cantelot',
                         'postcode': 'SW1A 1AA',
+                        'personalDataRemoved': False,
                     }
                 ],
                 'description': 'All your parcel wrapping needs catered for',


### PR DESCRIPTION
** Requires https://github.com/alphagov/digitalmarketplace-apiclient/pull/142 **


https://trello.com/c/gsDnUsC3/208-delete-users-code-that-takes-the-user-and-strips-all-the-personal-data-out

We need a mechanism to remove personal data from the `users` and `contact_information` tables.

This PR:
* Creates a base class that adds a `personal_data_removed` flag
  * If this flag is set the object is made effectively read only by a listener that denies new changes
* Adds this base class to `User` and `ContactInformation`
* Adds methods to remove data to `User` and `ContactInformation`
* Adds views to trigger those methods and audit the action
* Adds tests for the new model methods and
* Adds tests for the new views 