### PR TITLE
Create an 'update project' endpoint

### DIFF
--- a/app/models/direct_award.py
+++ b/app/models/direct_award.py
@@ -27,6 +27,7 @@ class DirectAwardProject(db.Model):
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
     locked_at = db.Column(db.DateTime, nullable=True)  # When the project's active search/es are final and cannot change
     downloaded_at = db.Column(db.DateTime, nullable=True)  # When the project's shortlist was last downloaded
+    still_assessing_at = db.Column(db.DateTime, nullable=True)
     active = db.Column(db.Boolean, default=True, nullable=False)
 
     users = db.relationship(
@@ -60,6 +61,10 @@ class DirectAwardProject(db.Model):
             "createdAt": self.created_at.strftime(DATETIME_FORMAT),
             "lockedAt": self.locked_at.strftime(DATETIME_FORMAT) if self.locked_at is not None else None,
             "downloadedAt": self.downloaded_at.strftime(DATETIME_FORMAT) if self.downloaded_at is not None else None,
+            "stillAssessingAt": (
+                self.still_assessing_at.strftime(DATETIME_FORMAT)
+                if self.still_assessing_at is not None else None
+            ),
             "active": self.active,
             "outcome": self.outcome.serialize() if self.outcome is not None else None,
         }

--- a/app/validation.py
+++ b/app/validation.py
@@ -87,6 +87,13 @@ def validate_outcome_json_or_400(submitted_json):
         abort(400, "JSON was not a valid format. {}".format(e.message))
 
 
+def validate_direct_award_project_json_or_400(submitted_json):
+    try:
+        get_validator('direct-award-project-update').validate(submitted_json)
+    except ValidationError as e:
+        abort(400, "JSON was not a valid format. {}".format(e.message))
+
+
 def validate_new_supplier_json_or_400(submitted_json):
     try:
         get_validator('new-supplier').validate(submitted_json)

--- a/json_schemas/direct-award-project-update.json
+++ b/json_schemas/direct-award-project-update.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "properties": {
+    "stillAssessing": {
+      "type": "boolean"
+    }
+  }
+}

--- a/migrations/versions/1230_add_still_assessing_at_field_to_direct_.py
+++ b/migrations/versions/1230_add_still_assessing_at_field_to_direct_.py
@@ -1,0 +1,22 @@
+"""add still assessing at field to direct award project
+
+Revision ID: 1230
+Revises: 1220
+Create Date: 2018-06-22 11:38:57.559198
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '1230'
+down_revision = '1220'
+
+
+def upgrade():
+    op.add_column('direct_award_projects', sa.Column('still_assessing_at', sa.DateTime(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('direct_award_projects', 'still_assessing_at')

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -11,7 +11,7 @@ SQLAlchemy==1.1.4
 SQLAlchemy-Utils==0.30.5
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@39.3.0#egg=digitalmarketplace-utils==39.3.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@16.1.0#egg=digitalmarketplace-apiclient==16.1.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@16.5.0#egg=digitalmarketplace-apiclient==16.5.0
 
 # For schema validation
 jsonschema==2.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ SQLAlchemy==1.1.4
 SQLAlchemy-Utils==0.30.5
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@39.3.0#egg=digitalmarketplace-utils==39.3.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@16.1.0#egg=digitalmarketplace-apiclient==16.1.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@16.5.0#egg=digitalmarketplace-apiclient==16.5.0
 
 # For schema validation
 jsonschema==2.5.1

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -7,7 +7,9 @@ from datetime import datetime, timedelta
 import pytest
 
 from app import db
-from app.models import Framework, User, Lot, Brief, Supplier, ContactInformation, Service, BriefClarificationQuestion
+from app.models import (
+    DATETIME_FORMAT, Framework, User, Lot, Brief, Supplier, ContactInformation, Service, BriefClarificationQuestion
+)
 from app.models.direct_award import DirectAwardProject, DirectAwardProjectUser, DirectAwardSearch
 from app.models.buyer_domains import BuyerEmailDomain
 
@@ -39,6 +41,7 @@ COMPLETE_DIGITAL_SPECIALISTS_BRIEF = {
 
 DIRECT_AWARD_PROJECT_NAME = 'My Direct Award Project'
 DIRECT_AWARD_FROZEN_TIME = '2017-01-01T00:00:00.000000Z'
+DIRECT_AWARD_FROZEN_TIME_DATETIME = datetime.strptime(DIRECT_AWARD_FROZEN_TIME, DATETIME_FORMAT)
 DIRECT_AWARD_SEARCH_BASE = 'https://search-api.digitalmarketplace.service.gov.uk/'
 DIRECT_AWARD_SEARCH_RELATIVE_URL = 'g-cloud/services/search?q=hosting'
 DIRECT_AWARD_SEARCH_URL = DIRECT_AWARD_SEARCH_BASE + DIRECT_AWARD_SEARCH_RELATIVE_URL


### PR DESCRIPTION
This PR adds the endpoint `PATCH /direct-award/projects/<id>`.

Currently the only column that can be updated is `stillAssessingAt`;
this was added for the buyer-frontend ticket [#110][ticket].

[ticket]: https://trello.com/c/5Lrp1lOK