### PR TITLE
Ensure services from all lots are counted in the export

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -122,7 +122,7 @@ def export_suppliers_for_framework(framework_slug):
                 Service.supplier_id,
                 Service.lot_id,
             ).all(),
-            key = lambda row: row[0],
+            key=lambda row: row[0],
         )
     }
 

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -115,11 +115,14 @@ def export_suppliers_for_framework(framework_slug):
             ).filter(
                 Service.status == 'published',
                 Service.framework_id == framework.id
+            ).order_by(
+                Service.supplier_id,
+                Service.lot_id,
             ).group_by(
                 Service.supplier_id,
                 Service.lot_id,
             ).all(),
-            key=lambda row: row[0],
+            key = lambda row: row[0],
         )
     }
 

--- a/tests/main/views/test_suppliers.py
+++ b/tests/main/views/test_suppliers.py
@@ -2318,11 +2318,12 @@ class TestSuppliersExport(BaseApplicationTest, FixtureMixin):
         self.setup_dummy_service('10000000004', 1, frameworkSlug=self.framework_slug, lot_id=5)
         self.setup_dummy_service('10000000005', 1, frameworkSlug=self.framework_slug, lot_id=5, status='enabled')
         self.setup_dummy_service('10000000006', 1, frameworkSlug=self.framework_slug, lot_id=5, status='disabled')
+        self.setup_dummy_service('10000000007', 1, frameworkSlug=self.framework_slug, lot_id=6)
 
         data = json.loads(self._return_suppliers_export_after_setting_framework_status().get_data())["suppliers"]
         assert data[0]["published_services_count"] == {
             "digital-outcomes": 3,
-            "digital-specialists": 0,
+            "digital-specialists": 1,
             "user-research-studios": 0,
             "user-research-participants": 0,
         }


### PR DESCRIPTION
Bug in the supplier export CSV, noticed by @samuelhwilliams. 

The `groupby` on the query was only returning the first lot that the supplier had services on (not sure why). The fix is not very elegant and is probably less efficient, but the data now looks right - added a test to check.  