### PR TITLE
Registered postcode can't be longer than 15 characters now

### DIFF
--- a/json_schemas/contact-information.json
+++ b/json_schemas/contact-information.json
@@ -30,6 +30,8 @@
       "type": "boolean"
     },
     "postcode": {
+      "maxLength": 15,
+      "minLength": 1,
       "type": "string"
     },
     "website": {

--- a/tests/main/views/test_suppliers.py
+++ b/tests/main/views/test_suppliers.py
@@ -718,7 +718,7 @@ class TestUpdateContactInformation(BaseApplicationTest, JSONUpdateTestMixin):
             "email": "new-value@example.com",
             "address1": "New address1",
             "city": "New city",
-            "postcode": "New postcode",
+            "postcode": "N3W P05C0",
         })
 
         assert response.status_code == 200
@@ -732,7 +732,7 @@ class TestUpdateContactInformation(BaseApplicationTest, JSONUpdateTestMixin):
         assert contact.email == "new-value@example.com"
         assert contact.address1 == "New address1"
         assert contact.city == "New city"
-        assert contact.postcode == "New postcode"
+        assert contact.postcode == "N3W P05C0"
 
     def test_supplier_json_id_does_not_match_oiginal_id(self):
         response = self.update_request({
@@ -804,7 +804,7 @@ class TestRemoveContactInformationPersonalData(BaseApplicationTest):
             email='test.email@example.com',
             address1='Test address line 1',
             city='Test city',
-            postcode='Test Postcode'
+            postcode='T3S P05C0'
         )
         db.session.add_all([self.supplier, self.contact_information])
         db.session.commit()

--- a/tests/models/test_main.py
+++ b/tests/models/test_main.py
@@ -286,7 +286,7 @@ class TestContactInformation(BaseApplicationTest):
             email='test.email@example.com',
             address1='Test address line 1',
             city='Test city',
-            postcode='Test Postcode'
+            postcode='T3S P05C0'
         )
         db.session.add_all([self.supplier, self.contact_information])
 


### PR DESCRIPTION
This has been done for consistency: labAddressPostcode field
is already validated in such a way. Although there maximum
length is 10 characters. We decided for 15 characters for
supplier registered postcode in the end because some US
postcodes are 13 characters long.

Connected supplier-frontend pull request: alphagov/digitalmarketplace-supplier-frontend#904

Trello ticket: https://trello.com/c/kOGpfxcw/475-supplier-fe-postcode-field-validation-is-more-lax-than-api-and-varies-between-two-forms