### PR TITLE
digitalmarketplace-apiclient dependency: bump to 17.4.0

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -11,7 +11,7 @@ SQLAlchemy==1.1.4
 SQLAlchemy-Utils==0.30.5
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@39.3.0#egg=digitalmarketplace-utils==39.3.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@16.5.0#egg=digitalmarketplace-apiclient==16.5.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@17.4.0#egg=digitalmarketplace-apiclient==17.4.0
 
 # For schema validation
 jsonschema==2.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ SQLAlchemy==1.1.4
 SQLAlchemy-Utils==0.30.5
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@39.3.0#egg=digitalmarketplace-utils==39.3.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@16.5.0#egg=digitalmarketplace-apiclient==16.5.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@17.4.0#egg=digitalmarketplace-apiclient==17.4.0
 
 # For schema validation
 jsonschema==2.5.1


### PR DESCRIPTION
This should bring `childSpanId` logging.