### PR TITLE
draft services: ensure `supplierId` is included in audit events

### DIFF
--- a/app/main/views/drafts.py
+++ b/app/main/views/drafts.py
@@ -87,7 +87,8 @@ def copy_draft_service_from_existing_service(service_id):
         user=updater_json['updated_by'],
         data={
             "draftId": draft.id,
-            "serviceId": service_id
+            "serviceId": service_id,
+            "supplierId": draft.supplier_id,
         },
         db_object=draft
     )
@@ -170,7 +171,8 @@ def copy_published_from_framework(framework_slug, lot_slug):
             user=updater_json['updated_by'],
             data={
                 "draftId": draft.id,
-                "serviceId": service.id
+                "serviceId": service.id,
+                "supplierId": supplier_id,
             },
             db_object=draft
         )
@@ -219,7 +221,8 @@ def edit_draft_service(draft_id):
         data={
             "draftId": draft_id,
             "serviceId": draft.service_id,
-            "updateJson": update_json
+            "updateJson": update_json,
+            "supplierId": draft.supplier_id,
         },
         db_object=draft
     )
@@ -313,7 +316,8 @@ def delete_draft_service(draft_id):
         user=updater_json['updated_by'],
         data={
             "draftId": draft_id,
-            "serviceId": draft.service_id
+            "serviceId": draft.service_id,
+            "supplierId": draft.supplier_id,
         },
         db_object=None
     )
@@ -430,6 +434,7 @@ def create_new_draft_service():
             user=updater_json['updated_by'],
             data={
                 "draftId": draft.id,
+                "supplierId": draft.supplier_id,
                 "draftJson": draft_json,
             },
             db_object=draft
@@ -463,7 +468,8 @@ def complete_draft_service(draft_id):
             audit_type=AuditTypes.complete_draft_service,
             user=updater_json['updated_by'],
             data={
-                "draftId": draft.id
+                "draftId": draft.id,
+                "supplierId": draft.supplier_id,
             },
             db_object=draft
         )
@@ -501,7 +507,8 @@ def update_draft_service_status(draft_id):
             user=updater_json['updated_by'],
             data={
                 "draftId": draft.id,
-                "status": new_status
+                "status": new_status,
+                "supplierId": draft.supplier_id,
             },
             db_object=draft
         )
@@ -535,6 +542,7 @@ def copy_draft_service(draft_id):
             data={
                 "draftId": draft_copy.id,
                 "originalDraftId": original_draft.id,
+                "supplierId": draft_copy.supplier_id,
             },
             db_object=draft_copy
         )

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -13,7 +13,7 @@ SQLAlchemy-Utils==0.30.5
 git+https://github.com/alphagov/Flask-FeatureFlags.git@1.0#egg=Flask-FeatureFlags==1.0
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@40.6.1#egg=digitalmarketplace-utils==40.6.1
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@16.5.0#egg=digitalmarketplace-apiclient==16.5.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@18.1.0#egg=digitalmarketplace-apiclient==18.1.0
 
 # For schema validation
 jsonschema==2.5.1

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -12,7 +12,7 @@ SQLAlchemy-Utils==0.30.5
 
 git+https://github.com/alphagov/Flask-FeatureFlags.git@1.0#egg=Flask-FeatureFlags==1.0
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@40.1.0#egg=digitalmarketplace-utils==40.1.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@40.6.1#egg=digitalmarketplace-utils==40.6.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@16.5.0#egg=digitalmarketplace-apiclient==16.5.0
 
 # For schema validation

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ SQLAlchemy-Utils==0.30.5
 
 git+https://github.com/alphagov/Flask-FeatureFlags.git@1.0#egg=Flask-FeatureFlags==1.0
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@40.1.0#egg=digitalmarketplace-utils==40.1.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@40.6.1#egg=digitalmarketplace-utils==40.6.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@16.5.0#egg=digitalmarketplace-apiclient==16.5.0
 
 # For schema validation

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ SQLAlchemy-Utils==0.30.5
 git+https://github.com/alphagov/Flask-FeatureFlags.git@1.0#egg=Flask-FeatureFlags==1.0
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@40.6.1#egg=digitalmarketplace-utils==40.6.1
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@16.5.0#egg=digitalmarketplace-apiclient==16.5.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@18.1.0#egg=digitalmarketplace-apiclient==18.1.0
 
 # For schema validation
 jsonschema==2.5.1

--- a/tests/main/views/test_drafts.py
+++ b/tests/main/views/test_drafts.py
@@ -1571,7 +1571,8 @@ class TestCopyDraft(BaseApplicationTest, JSONUpdateTestMixin):
         assert data['auditEvents'][1]['type'] == 'create_draft_service'
         assert data['auditEvents'][1]['data'] == {
             'draftId': draft_id,
-            'originalDraftId': self.draft_id
+            'originalDraftId': self.draft_id,
+            'supplierId': 1,
         }
 
     def test_should_not_create_draft_with_invalid_data(self):
@@ -1676,6 +1677,7 @@ class TestCompleteDraft(BaseApplicationTest, JSONUpdateTestMixin):
         assert data['auditEvents'][1]['type'] == 'complete_draft_service'
         assert data['auditEvents'][1]['data'] == {
             'draftId': self.draft_id,
+            'supplierId': 1,
         }
 
     def test_should_not_complete_draft_without_updated_by(self):
@@ -2041,7 +2043,9 @@ class TestUpdateDraftStatus(BaseApplicationTest, JSONUpdateTestMixin):
         assert data['auditEvents'][1]['user'] == 'joeblogs'
         assert data['auditEvents'][1]['type'] == 'update_draft_service_status'
         assert data['auditEvents'][1]['data'] == {
-            'draftId': self.draft_id, 'status': 'failed'
+            'draftId': self.draft_id,
+            'status': 'failed',
+            'supplierId': 1,
         }
 
     def test_should_not_update_draft_status_to_invalid_status(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -119,7 +119,7 @@ class TestIndexObject(BaseApplicationTest):
         index_object('g-cloud-9', 'services', 123, {'serialized': 'object'})
 
         current_app.logger.warning.assert_called_once_with(
-            'Failed to add services object with id 123 to g-cloud-9 index: Request failed'
+            'Failed to add services object with id 123 to g-cloud-9 index: Unknown request failure in dmapiclient'
         )
 
 


### PR DESCRIPTION
Trello https://trello.com/c/PhK034pI/215-add-more-information-to-framework-application-audit-events

It remains to be decided how we make this searchable...

(I also slipped in a -utils bump)

(and an -apiclient bump)