### PR TITLE
Allow G10 services to be reindexed after editing

### DIFF
--- a/config.py
+++ b/config.py
@@ -47,6 +47,9 @@ class Config:
         'g-cloud-9': {
             'services': 'g-cloud-9'
         },
+        'g-cloud-10': {
+            'services': 'g-cloud-10'
+        },
         'digital-outcomes-and-specialists': {
             'briefs': 'briefs-digital-outcomes-and-specialists'
         },


### PR DESCRIPTION
Trello: https://trello.com/c/pIDrRdP2/363-failed-to-find-index-name-for-framework-g-cloud-10-with-object-type-services-application-error

Kibana is showing application errors when trying to reindex G10 services after they've been edited in the admin. This commit adds G10 to the `DM_FRAMEWORK_TO_ES_INDEX` map in the config.