### PR TITLE
Reset failed login count on personal data removal

### DIFF
--- a/app/models/main.py
+++ b/app/models/main.py
@@ -982,6 +982,7 @@ class User(db.Model, RemovePersonalDataModelMixin):
         self.name = '<removed>'
         self.phone_number = '<removed>'
 
+        self.failed_login_count = 0
         self.password = encryption.hashpw(str(uuid4()))
         self.user_research_opted_in = False
 

--- a/tests/main/views/test_users.py
+++ b/tests/main/views/test_users.py
@@ -1310,7 +1310,7 @@ class TestUsersRemovePersonalData(BaseUserTest):
             role=role,
             password='password',
             active=True,
-            failed_login_count=0,
+            failed_login_count=3,
             created_at=now,
             updated_at=now,
             password_changed_at=now,
@@ -1332,6 +1332,7 @@ class TestUsersRemovePersonalData(BaseUserTest):
         assert data['users']['emailAddress'] == '<removed><111>@digital.cabinet-office.gov.uk'
         assert data['users']['userResearchOptedIn'] is False
         assert data['users']['personalDataRemoved'] is True
+        assert data['users']['failedLoginCount'] is 0
 
     @mock.patch('app.models.main.uuid4', return_value='111')
     def test_remove_buyer_user_personal_data(self, uuid4):
@@ -1369,6 +1370,7 @@ class TestUsersRemovePersonalData(BaseUserTest):
         assert data['users']['emailAddress'] == '<removed><111>@digital.cabinet-office.gov.uk'
         assert data['users']['userResearchOptedIn'] is False
         assert data['users']['personalDataRemoved'] is True
+        assert data['users']['failedLoginCount'] is 0
 
     @mock.patch('app.models.main.uuid4', return_value='111')
     def test_remove_supplier_user_personal_data(self, uuid4):
@@ -1410,6 +1412,7 @@ class TestUsersRemovePersonalData(BaseUserTest):
         assert data['users']['emailAddress'] == '<removed>@111.com'
         assert data['users']['userResearchOptedIn'] is False
         assert data['users']['personalDataRemoved'] is True
+        assert data['users']['failedLoginCount'] is 0
 
     @mock.patch('app.models.main.uuid4', return_value='111')
     @pytest.mark.parametrize('role', set(User.ROLES) - {'supplier', 'buyer'})


### PR DESCRIPTION
Otherwise it can lead to misleading messages in the admin

In this case a user cannot be unlocked:

<img width="1416" alt="screen shot 2018-07-18 at 17 08 33" src="https://user-images.githubusercontent.com/3469840/42893804-3cf00b5a-8aad-11e8-8ca4-3620ac00db3e.png">
