### PR TITLE
Revert "digitalmarketplace-utils dependency: bump to v41.2.0"

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -12,7 +12,7 @@ SQLAlchemy-Utils==0.30.5
 
 git+https://github.com/alphagov/Flask-FeatureFlags.git@1.0#egg=Flask-FeatureFlags==1.0
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@41.2.0#egg=digitalmarketplace-utils==41.2.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@40.9.0#egg=digitalmarketplace-utils==40.9.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.0.0#egg=digitalmarketplace-apiclient==19.0.0
 
 # For schema validation

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ SQLAlchemy-Utils==0.30.5
 
 git+https://github.com/alphagov/Flask-FeatureFlags.git@1.0#egg=Flask-FeatureFlags==1.0
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@41.2.0#egg=digitalmarketplace-utils==41.2.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@40.9.0#egg=digitalmarketplace-utils==40.9.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.0.0#egg=digitalmarketplace-apiclient==19.0.0
 
 # For schema validation
@@ -31,7 +31,7 @@ certifi==2018.4.16
 cffi==1.11.5
 chardet==3.0.4
 contextlib2==0.4.0
-cryptography==2.3
+cryptography==1.9
 docopt==0.4.0
 docutils==0.14
 Flask-Login==0.4.1


### PR DESCRIPTION
This reverts commit e929254af78e45beda7e038b4a8c36aa4b4c1a3b.

This utils bump is currently causing undiagnosed FT failures on other apps on preview. Better get this out of production.