### PR TITLE
Add DOS3 to framework to search index mapping

### DIFF
--- a/config.py
+++ b/config.py
@@ -56,6 +56,9 @@ class Config:
         'digital-outcomes-and-specialists-2': {
             'briefs': 'briefs-digital-outcomes-and-specialists'
         },
+        'digital-outcomes-and-specialists-3': {
+            'briefs': 'briefs-digital-outcomes-and-specialists'
+        },
     }
 
 


### PR DESCRIPTION
There are no breaking changes between the DOS2 and DOS3 search mappings,
and we index all DOS briefs to the same index so no need to map to a new
index.