### PR TITLE
Make audit events searchable by supplier

### DIFF
--- a/app/main/views/audits.py
+++ b/app/main/views/audits.py
@@ -87,6 +87,12 @@ def list_audits():
             AuditEvent.user == user
         )
 
+    data_supplier_id = request.args.get('data-supplier-id')
+    if data_supplier_id:
+        audits = audits.filter(
+            AuditEvent.data['supplierId'] == data_supplier_id
+        )
+
     acknowledged = request.args.get('acknowledged', None)
     if acknowledged and acknowledged != 'all':
         if is_valid_acknowledged_state(acknowledged):

--- a/app/models/main.py
+++ b/app/models/main.py
@@ -12,7 +12,7 @@ import sqlalchemy.dialects.postgresql
 from sqlalchemy import Sequence
 from sqlalchemy import asc, desc, exists
 from sqlalchemy import func
-from sqlalchemy.dialects.postgresql import INTERVAL
+from sqlalchemy.dialects.postgresql import INTERVAL, JSONB
 from sqlalchemy.event import listen
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.ext.hybrid import hybrid_property
@@ -1278,7 +1278,7 @@ class AuditEvent(db.Model):
     type = db.Column(db.String, index=True, nullable=False)
     created_at = db.Column(db.DateTime, index=True, nullable=False, default=datetime.utcnow)
     user = db.Column(db.String)
-    data = db.Column(JSON, nullable=False)
+    data = db.Column(JSONB, nullable=False)
 
     object_type = db.Column(db.String)
     object_id = db.Column(db.BigInteger)
@@ -1942,6 +1942,11 @@ db.Index(
     AuditEvent.created_at,
 )
 
+db.Index(
+    'idx_audit_events_data_supplier_id',
+    AuditEvent.data['supplierId'],
+    postgresql_where=AuditEvent.data['supplierId'] != sql_null()
+)
 
 # DEPRECATED - remove in a migration once service update admin app feature has been updated
 db.Index(

--- a/migrations/versions/1260_add_index_on_audit_event_data.py
+++ b/migrations/versions/1260_add_index_on_audit_event_data.py
@@ -1,0 +1,26 @@
+"""Add an index to audit events data blob to make it easier to search by supplier id. The data needed to be converted
+to JSONB from JSON for the index to work. It's a partial index - so only indexing rows that have the 'supplierId' field
+in their data blob. It's also an expression index, so only indexing the 'supplierId' field rather than all of the data.
+
+Revision ID: 1260
+Revises: 1250
+Create Date: 2018-08-13 11:54:17.725685
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+
+# revision identifiers, used by Alembic.
+revision = '1260'
+down_revision = '1250'
+
+
+def upgrade():
+    op.alter_column('audit_events', 'data', type_=JSONB, postgresql_using='data::text::jsonb')
+    op.create_index('idx_audit_events_data_supplier_id', 'audit_events', [sa.text("(data -> 'supplierId')")], unique=False, postgresql_where=sa.text("(data -> 'supplierId') IS NOT NULL"))
+
+
+def downgrade():
+    op.drop_index('idx_audit_events_data_supplier_id', table_name='audit_events')


### PR DESCRIPTION
For [this trello ticket.](https://trello.com/c/AdtcNmBR)
See [this associated PR on the apiclient.
](https://github.com/alphagov/digitalmarketplace-apiclient/pull/154)
### Add index to audit event data  …
To improve the searchability of audit events, `supplierId` has been added
to draft brief audit events as a top level key in the audit event data.
To make this searchable in an effective way, this adds an index on it.

To do this, audit event data needed to be converted to jsonb. A partial
expression index is then added. Partial because it only indexes rows
that have the `supplierId` field in the data, and an expression index as
it only indexes the `supplierId` field instead of the whole data blob.

### Allow searching of audit events by supplier id  …
This adds a parameter to the `list_audits` view that allows passing in a
supplier id to search for in the data of audit events.