### PR TITLE
Add ability to edit user phoneNumber field

### DIFF
--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -231,6 +231,8 @@ def update_user(user_id):
         user.name = user_update['name']
     if 'emailAddress' in user_update:
         user.email_address = user_update['emailAddress']
+    if 'phoneNumber' in user_update:
+        user.phone_number = user_update['phoneNumber']
     if 'role' in user_update:
         if user.role == 'supplier' and user_update['role'] != user.role:
             user.supplier_id = None

--- a/tests/main/views/test_users.py
+++ b/tests/main/views/test_users.py
@@ -1124,6 +1124,32 @@ class TestUsersUpdate(BaseApplicationTest, JSONUpdateTestMixin, FixtureMixin):
         data = json.loads(response.get_data())['users']
         assert data['emailAddress'] == 'myshinynew@digital.gov.uk'
 
+    def test_can_update_phone_number(self):
+        response = self.client.post(
+            '/users/123',
+            data=json.dumps({
+                "updated_by": "a.user",
+                'users': {
+                    'phoneNumber': '0800666666',
+                }}),
+            content_type='application/json')
+
+        assert response.status_code == 200
+        data = json.loads(response.get_data())['users']
+        assert data['phoneNumber'] == '0800666666'
+
+        response = self.client.post(
+            '/users/auth',
+            data=json.dumps({
+                'authUsers': {
+                    'emailAddress': 'test@digital.gov.uk',
+                    'password': 'my long password'}}),
+            content_type='application/json')
+
+        assert response.status_code == 200
+        data = json.loads(response.get_data())['users']
+        assert data['phoneNumber'] == '0800666666'
+
 
 class TestUsersGet(BaseUserTest, FixtureMixin):
     supplier_id = None


### PR DESCRIPTION
This was missing from the `/users/<user_id>` POST endpoint.