### PR TITLE
Update Docker base image to version v3.3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM digitalmarketplace/base-api:3.2.0
+FROM digitalmarketplace/base-api:3.3.0-20180813T135211Z


### PR DESCRIPTION
This commit updates the base image of this app to the latest version of v3.3.0 of the Digital Marketplace docker image.

v3.3.0 is a rolling release that could theoretically be updated at any time, however initially this app has been tied to a specific build.

Ticket: https://trello.com/c/ldIdPBzy