### PR TITLE
digitalmarketplace-utils dependency: bump to 43.0.0, remove featureflags references, fix error handlers for flask 0.12

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -5,7 +5,7 @@ import json
 from sqlalchemy import MetaData
 
 import dmapiclient
-from dmutils import init_app, flask_featureflags
+from dmutils import init_app
 
 from config import configs
 
@@ -17,7 +17,6 @@ db = SQLAlchemy(metadata=MetaData(naming_convention={
     "pk": "%(table_name)s_pkey",
 }))
 search_api_client = dmapiclient.SearchAPIClient()
-feature_flags = flask_featureflags.FeatureFlag()
 
 
 def create_app(config_name):
@@ -28,7 +27,6 @@ def create_app(config_name):
         application,
         configs[config_name],
         db=db,
-        feature_flags=feature_flags,
         search_api_client=search_api_client
     )
 

--- a/app/errors.py
+++ b/app/errors.py
@@ -1,4 +1,5 @@
 from flask import jsonify
+from werkzeug.exceptions import default_exceptions
 
 from .main import main
 from .callbacks import callbacks
@@ -25,5 +26,6 @@ def generic_error_handler(e):
 
 
 for code in range(400, 599):
-    main.app_errorhandler(code)(generic_error_handler)
-    callbacks.app_errorhandler(code)(generic_error_handler)
+    if code in default_exceptions:  # flask complains if we attempt to register a handler for status code its unaware of
+        main.app_errorhandler(code)(generic_error_handler)
+        callbacks.app_errorhandler(code)(generic_error_handler)

--- a/config.py
+++ b/config.py
@@ -20,9 +20,6 @@ class Config:
     DM_LOG_PATH = None
     DM_APP_NAME = 'api'
 
-    # Feature Flags
-    RAISE_ERROR_ON_MISSING_FEATURES = True
-
     DM_API_SERVICES_PAGE_SIZE = 100
     DM_API_SUPPLIERS_PAGE_SIZE = 100
     DM_API_BRIEFS_PAGE_SIZE = 100

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -1,7 +1,7 @@
 # Run `make freeze-requirements` to update requirements.txt
 # with package version changes made in requirements-app.txt
 
-Flask==0.10.1
+Flask==0.12.4
 Flask-Bcrypt==0.7.1
 Flask-Migrate==2.0.3
 Flask-SQLAlchemy==2.1
@@ -10,9 +10,7 @@ psycopg2==2.7.3
 SQLAlchemy==1.1.4
 SQLAlchemy-Utils==0.30.5
 
-git+https://github.com/alphagov/Flask-FeatureFlags.git@1.0#egg=Flask-FeatureFlags==1.0
-
-git+https://github.com/alphagov/digitalmarketplace-utils.git@41.2.1#egg=digitalmarketplace-utils==41.2.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@43.0.0#egg=digitalmarketplace-utils==43.0.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.0.0#egg=digitalmarketplace-apiclient==19.0.0
 
 # For schema validation

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # Run `make freeze-requirements` to update requirements.txt
 # with package version changes made in requirements-app.txt
 
-Flask==0.10.1
+Flask==0.12.4
 Flask-Bcrypt==0.7.1
 Flask-Migrate==2.0.3
 Flask-SQLAlchemy==2.1
@@ -11,9 +11,7 @@ psycopg2==2.7.3
 SQLAlchemy==1.1.4
 SQLAlchemy-Utils==0.30.5
 
-git+https://github.com/alphagov/Flask-FeatureFlags.git@1.0#egg=Flask-FeatureFlags==1.0
-
-git+https://github.com/alphagov/digitalmarketplace-utils.git@41.2.1#egg=digitalmarketplace-utils==41.2.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@43.0.0#egg=digitalmarketplace-utils==43.0.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.0.0#egg=digitalmarketplace-apiclient==19.0.0
 
 # For schema validation
@@ -27,9 +25,10 @@ asn1crypto==0.24.0
 bcrypt==3.1.4
 boto3==1.4.8
 botocore==1.8.50
-certifi==2018.4.16
+certifi==2018.8.13
 cffi==1.11.5
 chardet==3.0.4
+click==6.7
 contextlib2==0.4.0
 cryptography==2.3
 docopt==0.4.0


### PR DESCRIPTION
Trello https://trello.com/c/ZH9trgjH/419-snyk-alert-for-flask-010x-vulnerability

https://github.com/alphagov/digitalmarketplace-utils/pull/447

Only thing that stands out about this app is the changes I had to make to `generic_error_handler` to accommodate flask 0.12.