### PR TITLE
Fix Flask 0.12 deprecation warnings

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,6 +1,6 @@
 from functools import wraps
 from flask import Flask
-from flask.ext.sqlalchemy import SQLAlchemy
+from flask_sqlalchemy import SQLAlchemy
 import json
 from sqlalchemy import MetaData
 

--- a/app/encryption.py
+++ b/app/encryption.py
@@ -1,5 +1,4 @@
-from flask.ext.bcrypt import generate_password_hash, \
-    check_password_hash
+from flask_bcrypt import generate_password_hash, check_password_hash
 
 
 def authenticate_user(password, user):

--- a/application.py
+++ b/application.py
@@ -5,7 +5,7 @@ from __future__ import print_function
 import os
 
 from dmutils import init_manager
-from flask.ext.migrate import Migrate, MigrateCommand
+from flask_migrate import Migrate, MigrateCommand
 
 from app import create_app, db
 

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -8,7 +8,7 @@ Flask-SQLAlchemy==2.1
 --no-binary=psycopg2
 psycopg2==2.7.3
 SQLAlchemy==1.1.4
-SQLAlchemy-Utils==0.30.5
+SQLAlchemy-Utils==0.33.3
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@43.0.0#egg=digitalmarketplace-utils==43.0.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.0.0#egg=digitalmarketplace-apiclient==19.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ Flask-SQLAlchemy==2.1
 --no-binary=psycopg2
 psycopg2==2.7.3
 SQLAlchemy==1.1.4
-SQLAlchemy-Utils==0.30.5
+SQLAlchemy-Utils==0.33.3
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@43.0.0#egg=digitalmarketplace-utils==43.0.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.0.0#egg=digitalmarketplace-apiclient==19.0.0
@@ -25,7 +25,7 @@ asn1crypto==0.24.0
 bcrypt==3.1.4
 boto3==1.4.8
 botocore==1.8.50
-certifi==2018.8.13
+certifi==2018.8.24
 cffi==1.11.5
 chardet==3.0.4
 click==6.7

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ import mock
 import pytest
 from alembic.command import upgrade
 from alembic.config import Config
-from flask.ext.migrate import Migrate, MigrateCommand
+from flask_migrate import Migrate, MigrateCommand
 from flask.ext.script import Manager
 from sqlalchemy import inspect
 


### PR DESCRIPTION
Following the upgrade to Flask 0.12 we were getting the following:
```
Importing flask.ext.sqlalchemy is deprecated, use flask_sqlalchemy instead. 
Importing flask.ext.babel is deprecated, use flask_babel instead.
Importing flask.ext.bcrypt is deprecated, use flask_bcrypt instead.
Importing flask.ext.migrate is deprecated, use flask_migrate instead.
```

- Simple enough to fix the `flask_sqlalchemy`, `flask_bcrypt` and `flask_migrate` imports
- `flask_babel` fix required upgrading SQLAlchemy-Utils to latest version v0.33.3 (see Changelog https://github.com/kvesteri/sqlalchemy-utils/blob/master/CHANGES.rst)