### PR TITLE
Create endpoint for transitioning DOS frameworks

### DIFF
--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -3,6 +3,7 @@ import datetime
 from flask import jsonify, abort, request
 from sqlalchemy import func, orm, case
 from sqlalchemy.exc import IntegrityError, DataError
+from sqlalchemy.orm import lazyload
 from dmapiclient.audit import AuditTypes
 from dmutils.config import convert_to_boolean
 
@@ -16,6 +17,7 @@ from ...models import (
     Supplier,
     SupplierFramework,
     User,
+    Brief,
 )
 from ...utils import (
     get_json_from_request,
@@ -330,3 +332,107 @@ def get_framework_interest(framework_slug):
     supplier_ids = [supplier_framework.supplier_id for supplier_framework in supplier_frameworks]
 
     return jsonify(interestedSuppliers=supplier_ids), 200
+
+
+@main.route('/frameworks/transition-dos/<string:framework_slug>', methods=['POST'])
+def transition_dos_framework(framework_slug):
+    updater_json = validate_and_return_updater_request()
+    json_payload = get_json_from_request()
+    json_has_required_keys(json_payload, ['expiringFramework'])
+
+    going_live_framework = Framework.query.filter(
+        Framework.slug == framework_slug
+    ).with_for_update(
+        of=Framework,
+    ).options(
+        lazyload(Framework.lots)
+    ).first_or_404()
+    expiring_framework = Framework.query.filter(
+        Framework.slug == json_payload['expiringFramework']
+    ).with_for_update(
+        of=Framework,
+    ).options(
+        lazyload(Framework.lots)
+    ).first_or_404()
+
+    if going_live_framework.id <= expiring_framework.id:
+        abort(400, f"'going_live_framework' ID ('{going_live_framework.id}') must greater than"
+              f"'expiring_framework' ID ('{expiring_framework.id}')")
+
+    if any(f.framework != 'digital-outcomes-and-specialists' for f in (going_live_framework, expiring_framework)):
+        abort(400, f"'going_live_framework' family: '{going_live_framework.framework}' and 'expiring_framework' family:"
+              f" '{expiring_framework.framework}' must both be 'digital-outcomes-and-specialists'")
+
+    if going_live_framework.status != 'standstill' or expiring_framework.status != 'live':
+        abort(400, f"'going_live_framework' status ({going_live_framework.status}) must be 'standstill', and "
+              f"'expiring_framework' status ({expiring_framework.status}) must be 'live'")
+
+    expiring_framework_draft_briefs = Brief.query.filter(
+        Brief.status == 'draft',
+        Brief.framework_id == expiring_framework.id,
+    ).with_for_update(
+        of=Brief,
+    ).all()
+
+    for brief in expiring_framework_draft_briefs:
+        brief.framework_id = going_live_framework.id
+        db.session.add(brief)
+        db.session.flush()
+
+        audit = AuditEvent(
+            audit_type=AuditTypes.update_brief_framework_id,
+            user=updater_json['updated_by'],
+            data={
+                'briefId': brief.id,
+                'previousFrameworkId': expiring_framework.id,
+                'newFrameworkId': going_live_framework.id,
+            },
+            db_object=brief,
+        )
+
+        db.session.add(audit)
+
+    going_live_framework.status = 'live'
+    going_live_framework.framework_live_at_utc = datetime.datetime.utcnow()
+    expiring_framework.status = 'expired'
+    expiring_framework.framework_expires_at_utc = datetime.datetime.utcnow()
+
+    db.session.add_all((going_live_framework, going_live_framework))
+
+    db.session.add(
+        AuditEvent(
+            audit_type=AuditTypes.framework_update,
+            db_object=expiring_framework,
+            user=updater_json['updated_by'],
+            data={
+                "update": {
+                    "status": "expired",
+                    "framework_expires_at_utc set": "framework status set to 'expired'"
+                },
+                "frameworkSlug": expiring_framework.slug,
+            },
+        )
+    )
+
+    db.session.add(
+        AuditEvent(
+            audit_type=AuditTypes.framework_update,
+            db_object=going_live_framework,
+            user=updater_json['updated_by'],
+            data={
+                "update": {
+                    "status": "live",
+                    "framework_live_at_utc set": "framework status set to 'live'"
+                },
+                "frameworkSlug": going_live_framework.slug,
+            },
+        )
+    )
+
+    try:
+        db.session.commit()
+    except IntegrityError as error:
+        db.session.rollback()
+        abort(400, format_framework_integrity_error_message(error, {}))
+
+    return single_result_response(RESOURCE_NAME, going_live_framework), 200

--- a/app/main/views/frameworks.py
+++ b/app/main/views/frameworks.py
@@ -336,6 +336,17 @@ def get_framework_interest(framework_slug):
 
 @main.route('/frameworks/transition-dos/<string:framework_slug>', methods=['POST'])
 def transition_dos_framework(framework_slug):
+    """When we transition from one DOS framework to another, there is no overlap period. One framework is expired at the
+    same time the other is made live. A buyer publishes a requirement, and it will either be on one framework or the
+    other. Suppliers are able to apply to an opportunity even if the framework it was published on is expired, as long
+    as the brief is still open (within 1 or 2 weeks of its publication date).
+
+    The issue is that a brief is tied to a framework at the point it is created (as a draft). If a framework is expired,
+    any drafts that belong to it are no longer editable/publishable. We don't want a buyer to lose a draft.
+
+    This endpoint will update the framework statuses, move the draft briefs belonging to that framework to the incoming
+    framework, and create audit events for it all, in a transactionally safe way.
+    """
     updater_json = validate_and_return_updater_request()
     json_payload = get_json_from_request()
     json_has_required_keys(json_payload, ['expiringFramework'])

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -270,25 +270,42 @@ class FixtureMixin(object):
         )
         db.session.commit()
 
-    def setup_dos_2_framework(self, status='open', clarifications=True):
-        db.session.add(
-            Framework(
-                id=101,
-                slug=u'digital-outcomes-and-specialists-2',
-                name=u'Digital Outcomes and Specialists 2',
-                framework=u'digital-outcomes-and-specialists',
-                status=status,
-                clarification_questions_open=clarifications,
-                lots=[Lot.query.filter(Lot.slug == 'digital-outcomes').first(),
-                      Lot.query.filter(Lot.slug == 'digital-specialists').first(),
-                      Lot.query.filter(Lot.slug == 'user-research-participants').first(),
-                      Lot.query.filter(Lot.slug == 'user-research-studios').first(),
-                      ],
-                has_direct_award=False,
-                has_further_competition=True,
-            )
+    def setup_dummy_framework(
+        self, slug, framework_family, name='New Framework', id=None, status='open', clarifications=False, lots=None,
+        has_direct_award=True, has_further_competition=False,
+    ):
+        if lots is None:
+            if framework_family.startswith('g-cloud'):
+                lots = [
+                    Lot.query.filter(Lot.slug == 'cloud-hosting').first(),
+                    Lot.query.filter(Lot.slug == 'cloud-software').first(),
+                    Lot.query.filter(Lot.slug == 'cloud-support').first(),
+                ]
+            elif framework_family.startswith('digital-outcomes-and-specialists'):
+                lots = [
+                    Lot.query.filter(Lot.slug == 'digital-outcomes').first(),
+                    Lot.query.filter(Lot.slug == 'digital-specialists').first(),
+                    Lot.query.filter(Lot.slug == 'user-research-participants').first(),
+                    Lot.query.filter(Lot.slug == 'user-research-studios').first(),
+                ]
+            else:
+                lots = []
+
+        framework = Framework(
+            id=id,
+            slug=slug,
+            name=name,
+            framework=framework_family,
+            status=status,
+            clarification_questions_open=clarifications,
+            lots=lots,
+            has_direct_award=has_direct_award,
+            has_further_competition=has_further_competition,
         )
+        db.session.add(framework)
         db.session.commit()
+
+        return framework.id
 
     def set_framework_status(self, slug, status):
         Framework.query.filter_by(slug=slug).update({'status': status})

--- a/tests/main/views/test_drafts.py
+++ b/tests/main/views/test_drafts.py
@@ -1800,7 +1800,12 @@ class TestDOSServices(BaseApplicationTest, FixtureMixin):
         assert data['error'] == "'digital-specialists' service already exists for supplier '1'"
 
     def test_allow_multiple_drafts_for_one_service_lots_on_different_frameworks(self):
-        self.setup_dos_2_framework()
+        self.setup_dummy_framework(
+            slug='digital-outcomes-and-specialists-2',
+            framework_family='digital-outcomes-and-specialists',
+            name='Digital Outcomes and Specialists 2',
+            id=101,
+        )
         self._post_dos_draft()
 
         dos_2_draft = self.create_draft_json.copy()

--- a/tests/main/views/test_frameworks.py
+++ b/tests/main/views/test_frameworks.py
@@ -1309,10 +1309,9 @@ class TestTransitionDosFramework(BaseApplicationTest, FixtureMixin):
         audit_events = AuditEvent.query.all()
         assert all(audit.created_at == audit_events[0].created_at for audit in audit_events)
 
-
     def test_integrity_errors_are_handled_and_changes_rolled_back(self):
         self._setup_for_succesful_call()
-        
+
         with mock.patch("app.main.views.frameworks.db.session.commit") as commit_mock:
             commit_mock.side_effect = IntegrityError("Could not commit", orig=None, params={})
             response = self.client.post(

--- a/tests/main/views/test_frameworks.py
+++ b/tests/main/views/test_frameworks.py
@@ -1,14 +1,14 @@
 import datetime
+import mock
+import pytest
 
 from flask import json
 from freezegun import freeze_time
-import mock
 from sqlalchemy.exc import IntegrityError
 
 from tests.bases import BaseApplicationTest, JSONUpdateTestMixin
-from app.models import db, Framework, SupplierFramework, DraftService, User, FrameworkLot, AuditEvent
+from app.models import db, Framework, SupplierFramework, DraftService, User, FrameworkLot, AuditEvent, Brief
 from tests.helpers import FixtureMixin
-
 from app.main.views.frameworks import FRAMEWORK_UPDATE_WHITELISTED_ATTRIBUTES_MAP
 
 
@@ -1110,3 +1110,221 @@ class TestGetFrameworkInterest(BaseApplicationTest, FixtureMixin):
         response = self.client.get('/frameworks/biscuits-for-gov/interest')
 
         assert response.status_code == 404
+
+
+class TestTransitionDosFramework(BaseApplicationTest, FixtureMixin):
+    def test_400s_if_invalid_updater_json(self):
+        response = self.client.post(
+            "/frameworks/transition-dos/sausage-cloud-6",
+            data=json.dumps({"not-updated": "correctly"}),
+            content_type="application/json"
+        )
+        data = response.get_data(as_text=True)
+
+        assert response.status_code == 400
+        assert json.loads(data)['error'] == "JSON validation error: 'updated_by' is a required property"
+
+    def test_400s_if_expiring_framework_not_in_request_body(self):
+        response = self.client.post(
+            "/frameworks/transition-dos/sausage-cloud-6",
+            data=json.dumps({"updated_by": "🤖"}),
+            content_type="application/json"
+        )
+        data = response.get_data(as_text=True)
+
+        assert response.status_code == 400
+        assert json.loads(data)['error'] == "Invalid JSON must have 'expiringFramework' keys"
+
+    def test_400s_if_going_live_framework_is_older_than_expiring_framework(self):
+        dos_2_id = self.setup_dummy_framework(
+            slug="digital-outcomes-and-specialists-2", framework_family="digital-outcomes-and-specialists", id=101,
+        )
+
+        response = self.client.post(
+            "/frameworks/transition-dos/digital-outcomes-and-specialists",
+            data=json.dumps({
+                "updated_by": "🤖",
+                "expiringFramework": "digital-outcomes-and-specialists-2",
+            }),
+            content_type="application/json"
+        )
+        data = response.get_data(as_text=True)
+
+        assert response.status_code == 400
+        assert json.loads(data)['error'] == \
+            f"'going_live_framework' ID ('5') must greater than'expiring_framework' ID ('{dos_2_id}')"
+
+    @pytest.mark.parametrize(
+        ("going_live_slug", "going_live_family", "expiring_slug", "expiring_family"),
+        (
+            ("g-cloud-10", "g-cloud", "digital-outcomes-and-specialists", "digital-outcomes-and-specialists",),
+            ("digital-outcomes-and-specialists-2", "digital-outcomes-and-specialists", "g-cloud-10", "g-cloud",)
+        )
+    )
+    def test_400s_if_either_framework_has_wrong_family(
+        self, going_live_slug, going_live_family, expiring_slug, expiring_family,
+    ):
+        self.setup_dummy_framework(
+            slug="g-cloud-10", framework_family="g-cloud", lots=[], id=101,
+        )
+        self.setup_dummy_framework(
+            slug="digital-outcomes-and-specialists-2", framework_family="digital-outcomes-and-specialists", id=102,
+        )
+
+        response = self.client.post(
+            f"/frameworks/transition-dos/{going_live_slug}",
+            data=json.dumps({
+                "updated_by": "🤖",
+                "expiringFramework": f"{expiring_slug}",
+            }),
+            content_type="application/json"
+        )
+        data = response.get_data(as_text=True)
+
+        assert response.status_code == 400
+        assert json.loads(data)['error'] == f"'going_live_framework' family: '{going_live_family}' and " \
+            f"'expiring_framework' family: '{expiring_family}' must both be 'digital-outcomes-and-specialists'"
+
+    @pytest.mark.parametrize('status', ('coming', 'open', 'pending', 'live', 'expired'))
+    def test_400s_if_going_live_framework_status_is_not_standstill(self, status):
+        self.setup_dummy_framework(
+            slug="digital-outcomes-and-specialists-2", framework_family="digital-outcomes-and-specialists",
+            status='live', id=101,
+        )
+        self.setup_dummy_framework(
+            slug="digital-outcomes-and-specialists-3", framework_family="digital-outcomes-and-specialists",
+            status=status, id=102,
+        )
+
+        response = self.client.post(
+            "/frameworks/transition-dos/digital-outcomes-and-specialists-3",
+            data=json.dumps({
+                "updated_by": "🤖",
+                "expiringFramework": "digital-outcomes-and-specialists-2",
+            }),
+            content_type="application/json"
+        )
+        data = response.get_data(as_text=True)
+
+        assert response.status_code == 400
+        assert json.loads(data)['error'] == f"'going_live_framework' status ({status}) must be 'standstill', and " \
+            "'expiring_framework' status (live) must be 'live'"
+
+    def test_success_does_all_the_right_things(self):
+        # Remove all audit events to make assertions easier later
+        AuditEvent.query.delete()
+        self.setup_dummy_framework(
+            slug="digital-outcomes-and-specialists-2", framework_family="digital-outcomes-and-specialists",
+            status='live', id=101,
+        )
+        self.setup_dummy_framework(
+            slug="digital-outcomes-and-specialists-3", framework_family="digital-outcomes-and-specialists",
+            status='standstill', id=102,
+        )
+        self.setup_dummy_user()
+        for status in ("draft", "live", "withdrawn", "closed", "draft", "cancelled", "unsuccessful"):
+            self.setup_dummy_brief(
+                status=status,
+                framework_slug="digital-outcomes-and-specialists-2",
+                data={"some": "data"},
+                user_id=123,
+            )
+
+        # keep track of brief ids for assertions later
+        draft_brief_ids = {
+            brief.id for brief in Brief.query.filter(Brief.framework_id == 101).all() if brief.status == 'draft'
+        }
+        assert len(draft_brief_ids) == 2
+
+        not_draft_brief_ids = {
+            brief.id for brief in Brief.query.filter(Brief.framework_id == 101).all() if brief.status != 'draft'
+        }
+        assert len(not_draft_brief_ids) == 5
+
+        with freeze_time('2018-09-03 17:09:56.999999'):
+            response = self.client.post(
+                "/frameworks/transition-dos/digital-outcomes-and-specialists-3",
+                data=json.dumps({
+                    "updated_by": "🤖",
+                    "expiringFramework": "digital-outcomes-and-specialists-2",
+                }),
+                content_type="application/json"
+            )
+
+        assert response.status_code == 200
+
+        # Assert that the correct briefs were transferred to the new live framework
+        expired_framework_briefs = Brief.query.filter(Brief.framework_id == 101).all()
+        new_live_framework_briefs = Brief.query.filter(Brief.framework_id == 102).all()
+
+        assert all(brief.status == "draft" for brief in new_live_framework_briefs)
+        assert {brief.id for brief in new_live_framework_briefs} == draft_brief_ids
+
+        assert all(brief.status != "draft" for brief in expired_framework_briefs)
+        assert {brief.id for brief in expired_framework_briefs} == not_draft_brief_ids
+
+        # Assert audit events were created for the brief changes
+        brief_audits = AuditEvent.query.filter(AuditEvent.type == "update_brief_framework_id").all()
+        assert len(brief_audits) == 2
+        assert all(
+            (audit.data["previousFrameworkId"], audit.data["newFrameworkId"]) == (101, 102) for audit in brief_audits
+        )
+        assert {audit.data["briefId"] for audit in brief_audits} == draft_brief_ids
+
+        # Assert the frameworks statuses were correctly changed and timestamps set
+        expired_framework = Framework.query.get(101)
+        new_live_framework = Framework.query.get(102)
+        assert expired_framework.status == "expired"
+        assert expired_framework.framework_expires_at_utc == datetime.datetime(2018, 9, 3, 17, 9, 56, 999999)
+        assert new_live_framework.status == "live"
+        assert new_live_framework.framework_live_at_utc == datetime.datetime(2018, 9, 3, 17, 9, 56, 999999)
+
+        # Assert audit events for the framework updates were created
+        framework_audits = AuditEvent.query.filter(AuditEvent.type == "framework_update").all()
+        assert len(framework_audits) == 2
+        assert {(audit.data["update"]["status"], audit.data["frameworkSlug"]) for audit in framework_audits} == \
+            {("expired", "digital-outcomes-and-specialists-2"), ("live", "digital-outcomes-and-specialists-3")}
+
+        # Assert the endpoint returns the new live framework to us
+        assert json.loads(response.get_data(as_text=True))["frameworks"]["slug"] == "digital-outcomes-and-specialists-3"
+
+    def test_integrity_errors_are_handled_and_changes_rolled_back(self):
+        self.setup_dummy_framework(
+            slug="digital-outcomes-and-specialists-2", framework_family="digital-outcomes-and-specialists",
+            status='live', id=101,
+        )
+        self.setup_dummy_framework(
+            slug="digital-outcomes-and-specialists-3", framework_family="digital-outcomes-and-specialists",
+            status='standstill', id=102,
+        )
+        self.setup_dummy_user()
+        for status in ("draft", "live", "withdrawn", "closed", "draft", "cancelled", "unsuccessful"):
+            self.setup_dummy_brief(
+                status=status,
+                framework_slug="digital-outcomes-and-specialists-2",
+                data={"some": "data"},
+                user_id=123,
+            )
+        with mock.patch("app.main.views.frameworks.db.session.commit") as commit_mock:
+            commit_mock.side_effect = IntegrityError("Could not commit", orig=None, params={})
+            response = self.client.post(
+                "/frameworks/transition-dos/digital-outcomes-and-specialists-3",
+                data=json.dumps({
+                    "updated_by": "🤖",
+                    "expiringFramework": "digital-outcomes-and-specialists-2",
+                }),
+                content_type="application/json"
+            )
+        data = response.get_data(as_text=True)
+
+        assert response.status_code == 400
+        assert "Could not commit" in json.loads(data)["error"]
+
+        expiring_framework_briefs = Brief.query.filter(Brief.framework_id == 101).all()
+        going_live_framework_briefs = Brief.query.filter(Brief.framework_id == 102).all()
+
+        assert len(expiring_framework_briefs) == 7
+        assert not going_live_framework_briefs
+
+        assert Framework.query.get(101).status == "live"
+        assert Framework.query.get(102).status == "standstill"

--- a/tests/models/test_main.py
+++ b/tests/models/test_main.py
@@ -2128,10 +2128,13 @@ class TestFrameworkSupplierIdsMany(BaseApplicationTest, FixtureMixin):
     """Test multiple suppliers, multiple services."""
 
     def test_multiple_services(self):
-        self.setup_dos_2_framework()
+        framework_id = self.setup_dummy_framework(
+            slug='digital-outcomes-and-specialists-2',
+            framework_family='digital-outcomes-and-specialists',
+        )
         lot = Lot.query.first()
         self.fl_query = {
-            'framework_id': 101,
+            'framework_id': framework_id,
             'lot_id': lot.id
         }
         fl = FrameworkLot(**self.fl_query)
@@ -2164,7 +2167,7 @@ class TestFrameworkSupplierIdsMany(BaseApplicationTest, FixtureMixin):
                 db.session.add(ds)
                 db.session.commit()
         # Assert that only those suppliers whose service_status list contains failed and/ or submitted are returned.
-        framework = Framework.query.filter(Framework.id == 101).first()
+        framework = Framework.query.filter(Framework.id == framework_id).first()
         assert sorted(framework.get_supplier_ids_for_completed_service()) == [0, 2, 4]
 
 


### PR DESCRIPTION
For [this trello ticket.](https://trello.com/c/qGsP2FS0)

When we transition from one DOS framework to another, there is no
overlap period. One framework is expired at the same time the other 
is made live. A buyer publishes a requirement, and it will either be
on one framework or the other. Suppliers are able to apply to an
opportunity even if the framework it was published on is expired, as
long as the brief is still open (within 1 or 2 weeks of its publication
date).

The issue is that a brief is tied to a framework at the point it is
created (as a draft). If a framework is expired, any drafts that belong
to it are no longer editable/publishable. We don't want a buyer to lose
a draft.

This endpoint will update the framework statuses, move the draft briefs
belonging to that framework to the incoming framework, and create audit
events for it all, in a transactionally safe way.