### PR TITLE
Allow briefs associated with an expired framework to be withdrawn

### DIFF
--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -213,7 +213,7 @@ def update_brief_status(brief_id, action):
     }
     new_brief_status = action_to_status[action]
 
-    if new_brief_status in ['live', 'withdrawn'] and framework_status != 'live':
+    if new_brief_status == 'live' and framework_status != 'live':
         abort(400, "Framework is not live")
 
     if brief.status != new_brief_status:

--- a/tests/main/views/test_briefs.py
+++ b/tests/main/views/test_briefs.py
@@ -814,7 +814,13 @@ class TestUpdateBriefStatus(FrameworkSetupAndTeardown):
         assert data['briefs']['status'] == 'live'
         assert index_brief.called is True
 
-    def test_withdraw_a_brief(self, index_brief):
+    @pytest.mark.parametrize(('framework_status'), ('live', 'expired'))
+    def test_withdraw_a_brief(self, index_brief, framework_status):
+        framework = Framework.query.filter(Framework.slug == 'digital-outcomes-and-specialists').first()
+        framework.status = framework_status
+        db.session.add(framework)
+        db.session.commit()
+
         self.setup_dummy_briefs(1, title='The Title', status='live')
 
         res = self.client.post(


### PR DESCRIPTION
Briefs are still viable for the entire duration of their open period.
This means that a brief can be open even if the framework is expired.