### PR TITLE
Delete declaration

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -482,13 +482,14 @@ def set_a_declaration(supplier_id, framework_slug):
 @main.route('/suppliers/<int:supplier_id>/frameworks/<framework_slug>/declaration', methods=['POST'])
 def remove_a_declaration(framework_slug, supplier_id):
     """
-    This route will replace unsuccessful applicants' declarations with an empty dict and returns an empty body
+    This route will replace unsuccessful applicants' declarations with an empty dict and returns the updated object,
+    serialized in JSON format
     :param framework_slug: a string describing the framework
     :type framework_slug: string
     :param supplier_id: a way of identifying the supplier whose declaration will be removed
     :type supplier_id: int
-    :return: An empty body and a status code
-    :rtype: Tuple(Dict, int)
+    :return: The serialized SupplierFramework and a status code
+    :rtype: Response
     """
     updater_json = validate_and_return_updater_request()
     supplier_framework = SupplierFramework.find_by_supplier_and_framework(
@@ -512,7 +513,7 @@ def remove_a_declaration(framework_slug, supplier_id):
         error_msg = "Could not remove declaration data from supplier framework: supplier_id {}, framework {}"
         abort(400, error_msg.format(supplier_id, framework_slug))
 
-    return jsonify(), 200
+    return single_result_response("supplierFramework", supplier_framework), 200
 
 
 @main.route('/suppliers/<int:supplier_id>/frameworks/interest', methods=['GET'])

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -498,7 +498,7 @@ def remove_a_declaration(framework_slug, supplier_id):
     supplier_framework.declaration = {}
 
     audit_event = AuditEvent(
-        audit_type=AuditTypes.update_supplier_framework,
+        audit_type=AuditTypes.delete_supplier_framework_declaration,
         db_object=supplier_framework,
         user=updater_json['updated_by'],
         data={}

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -11,7 +11,7 @@ SQLAlchemy==1.1.4
 SQLAlchemy-Utils==0.33.3
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@44.0.1#egg=digitalmarketplace-utils==44.0.1
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.0.0#egg=digitalmarketplace-apiclient==19.4.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.8.0#egg=digitalmarketplace-apiclient==19.8.0
 
 # For schema validation
 jsonschema==2.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ SQLAlchemy==1.1.4
 SQLAlchemy-Utils==0.33.3
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@44.0.1#egg=digitalmarketplace-utils==44.0.1
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.0.0#egg=digitalmarketplace-apiclient==19.4.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.8.0#egg=digitalmarketplace-apiclient==19.8.0
 
 # For schema validation
 jsonschema==2.5.1
@@ -20,15 +20,15 @@ rfc3987==1.3.4
 strict-rfc3339==0.5
 
 ## The following requirements were added by pip freeze:
-alembic==1.0.0
+alembic==1.0.1
 asn1crypto==0.24.0
 bcrypt==3.1.4
 boto3==1.7.83
 botocore==1.10.84
-certifi==2018.8.24
+certifi==2018.10.15
 cffi==1.11.5
 chardet==3.0.4
-click==6.7
+Click==7.0
 contextlib2==0.4.0
 cryptography==2.3
 docopt==0.4.0
@@ -54,11 +54,11 @@ python-dateutil==2.7.3
 python-editor==1.0.3
 python-json-logger==0.1.4
 pytz==2015.4
-requests==2.18.4
+requests==2.20.0
 s3transfer==0.1.13
 six==1.11.0
 unicodecsv==0.14.1
-urllib3==1.22
+urllib3==1.24
 Werkzeug==0.14.1
 workdays==1.4
 WTForms==2.2.1

--- a/tests/main/views/test_suppliers.py
+++ b/tests/main/views/test_suppliers.py
@@ -1935,6 +1935,7 @@ class TestDeleteUnsuccessfulApplicantDeclarations(BaseApplicationTest, FixtureMi
         response = self.client.post("/suppliers/{}/frameworks/{}/declaration".format(
             self.supplier_id, self.framework_slug),
             data=json.dumps(self.updater_json), content_type='application/json')
+        assert len(response.get_json()['supplierFramework']['declaration']) == 0
         assert response.status_code == 200
         assert SupplierFramework.query.first().declaration == {}
 

--- a/tests/main/views/test_suppliers.py
+++ b/tests/main/views/test_suppliers.py
@@ -1914,6 +1914,31 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest):
         }
 
 
+class TestDeleteUnsuccessfulApplicantDeclarations(BaseApplicationTest, FixtureMixin,
+                                                  PutDeclarationAndDetailsAndServicesMixin):
+    def setup(self):
+        """
+        This sets up the class. It creates a dummy framework and a supplier that applied to that framework, with a
+        declaration.
+        :return:
+        :rtype:
+        """
+        super(TestDeleteUnsuccessfulApplicantDeclarations, self).setup()
+        self.supplier_id = self.setup_dummy_suppliers(1)[0]
+        self.framework_slug = 'digital-outcomes-and-specialists'
+        self.set_framework_status('digital-outcomes-and-specialists', 'open')
+        self.updater_json = {'updated_by': 'Joe Bloggs'}
+
+    def test_a_supplier_framework_object_is_returned_with_an_empty_declaration(self):
+        self._register_supplier_with_framework()
+        self._put_declaration("Success!")
+        response = self.client.post("/suppliers/{}/frameworks/{}/declaration".format(
+            self.supplier_id, self.framework_slug),
+            data=json.dumps(self.updater_json), content_type='application/json')
+        assert response.status_code == 200
+        assert SupplierFramework.query.first().declaration == {}
+
+
 class TestSupplierFrameworkVariation(BaseApplicationTest, FixtureMixin):
     def setup(self):
         super(TestSupplierFrameworkVariation, self).setup()

--- a/tests/main/views/test_suppliers.py
+++ b/tests/main/views/test_suppliers.py
@@ -1918,25 +1918,50 @@ class TestDeleteUnsuccessfulApplicantDeclarations(BaseApplicationTest, FixtureMi
                                                   PutDeclarationAndDetailsAndServicesMixin):
     def setup(self):
         """
-        This sets up the class. It creates a dummy framework and a supplier that applied to that framework, with a
-        declaration.
-        :return:
-        :rtype:
+        This sets up the class. Sets up test data for a supplier and their successful application to a framework.
+        :return: an instance of the class
+        :rtype: TestDeleteUnsuccessfulApplicantDeclarations
         """
         super(TestDeleteUnsuccessfulApplicantDeclarations, self).setup()
+
         self.supplier_id = self.setup_dummy_suppliers(1)[0]
         self.framework_slug = 'digital-outcomes-and-specialists'
         self.set_framework_status('digital-outcomes-and-specialists', 'open')
         self.updater_json = {'updated_by': 'Joe Bloggs'}
+        self._register_supplier_with_framework()
 
     def test_a_supplier_framework_object_is_returned_with_an_empty_declaration(self):
-        self._register_supplier_with_framework()
-        self._put_declaration("Success!")
+        self._put_declaration("complete")
         response = self.client.post("/suppliers/{}/frameworks/{}/declaration".format(
             self.supplier_id, self.framework_slug),
             data=json.dumps(self.updater_json), content_type='application/json')
         assert response.status_code == 200
         assert SupplierFramework.query.first().declaration == {}
+
+    @pytest.mark.parametrize('error_class', (DataError, IntegrityError))
+    def test_errors_on_commit(self, error_class):
+        url = '/suppliers/{}/frameworks/{}/declaration'.format(
+            self.supplier_id,
+            self.framework_slug
+        )
+        expected_error_message = (
+            "Could not remove declaration data from supplier framework: supplier_id {}, framework {}"
+        ).format(
+            self.supplier_id,
+            self.framework_slug
+        )
+
+        with mock.patch('app.db.session.commit', side_effect=error_class("Unable to commit", orig=None, params={})):
+            response = self.client.post(
+                url,
+                data=json.dumps({'updated_by': 'test@example.com'}),
+                content_type='application/json'
+            )
+        assert response.status_code == 400
+
+        data = json.loads(response.get_data())
+
+        assert data['error'] == expected_error_message
 
 
 class TestSupplierFrameworkVariation(BaseApplicationTest, FixtureMixin):


### PR DESCRIPTION
This PR enables us to remove supplier declarations from particular frameworks

# Why
It is important that we do this for GDPR, allowing us to remove user's declaration when they ask or after a set period

# What
A new route, `'suppliers/<supplier_id>/frameworks/<framework_slug>'` has been created. POST requests to the endpoint with valid `supplier_id` and `framework_slug` will replace the supplier's declaration with an empty dictionary.

[Ticket](https://trello.com/c/h3VPjiql/209-new-route-for-removing-supplier-declarations)