### PR TITLE
Pin itsdangerous to version 0.24

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -5,6 +5,7 @@ Flask==1.0.2
 Flask-Bcrypt==0.7.1
 Flask-Migrate==2.0.3
 Flask-SQLAlchemy==2.1
+itsdangerous==0.24
 --no-binary=psycopg2
 psycopg2==2.7.3
 SQLAlchemy==1.1.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ Flask==1.0.2
 Flask-Bcrypt==0.7.1
 Flask-Migrate==2.0.3
 Flask-SQLAlchemy==2.1
+itsdangerous==0.24
 --no-binary=psycopg2
 psycopg2==2.7.3
 SQLAlchemy==1.1.4
@@ -36,9 +37,8 @@ docutils==0.14
 Flask-Login==0.4.1
 Flask-Script==2.0.6
 Flask-WTF==0.14.2
-future==0.16.0
+future==0.17.0
 idna==2.7
-itsdangerous==0.24
 Jinja2==2.10
 jmespath==0.9.3
 mailchimp3==2.0.11
@@ -50,7 +50,7 @@ notifications-python-client==4.1.0
 odfpy==1.3.6
 pycparser==2.19
 PyJWT==1.6.4
-python-dateutil==2.7.3
+python-dateutil==2.7.5
 python-editor==1.0.3
 python-json-logger==0.1.4
 pytz==2015.4


### PR DESCRIPTION
Pallets recently released and then pulled version 1.0.0 of the library itsdangerous, which is a requirement of Flask. See [this Trello card](https://trello.com/b/NnlGJoWD) for details.

We've decided that this time we want to wait a bit before commiting to the new version, so this commit pins this app to the old 0.24 version