### PR TITLE
New admin user role for CCS Data Controller

### DIFF
--- a/app/models/main.py
+++ b/app/models/main.py
@@ -839,12 +839,12 @@ class User(db.Model, RemovePersonalDataModelMixin):
     __tablename__ = 'users'
 
     ADMIN_ROLES = [
-        'admin',  # a general admin user, with permission to do most (but not all) admin actions.
-        'admin-ccs-category',  # generally restricted to read-only access to admin views.
-        'admin-ccs-sourcing',  # can perform admin actions involving supplier acceptance.
-        'admin-manager',  # can add, edit and disable other types of admin user
-        'admin-framework-manager',  # can perform admin actions involving framework applications
-        'admin-ccs-data-controller',  # can view and edit supplier company registration details
+        'admin',                        # can view and suspend supplier and buyer user accounts
+        'admin-ccs-category',           # can view, edit and suspend supplier services
+        'admin-ccs-sourcing',           # can view framework applications and countersign agreements
+        'admin-manager',                # can add, edit and disable other types of admin user
+        'admin-framework-manager',      # can perform admin actions involving framework applications
+        'admin-ccs-data-controller',    # can view and edit supplier company registration details
     ]
 
     ROLES = ADMIN_ROLES + [

--- a/app/models/main.py
+++ b/app/models/main.py
@@ -844,6 +844,7 @@ class User(db.Model, RemovePersonalDataModelMixin):
         'admin-ccs-sourcing',  # can perform admin actions involving supplier acceptance.
         'admin-manager',  # can add, edit and disable other types of admin user
         'admin-framework-manager',  # can perform admin actions involving framework applications
+        'admin-ccs-data-controller',  # can view and edit supplier company registration details
     ]
 
     ROLES = ADMIN_ROLES + [

--- a/json_schemas/model_schemas/users.json
+++ b/json_schemas/model_schemas/users.json
@@ -51,6 +51,7 @@
                 "admin-ccs-sourcing",
                 "admin-manager",
                 "admin-framework-manager",
+                "admin-ccs-data-controller",
                 "buyer",
                 "supplier"
             ]

--- a/json_schemas/users.json
+++ b/json_schemas/users.json
@@ -32,7 +32,8 @@
         "admin-ccs-category",
         "admin-ccs-sourcing",
         "admin-manager",
-        "admin-framework-manager"
+        "admin-framework-manager",
+        "admin-ccs-data-controller"
       ]
     },
     "supplierId": {

--- a/migrations/versions/1270_add_ccs_admin_data_controller_role.py
+++ b/migrations/versions/1270_add_ccs_admin_data_controller_role.py
@@ -1,0 +1,24 @@
+"""Add CCS admin data controller role
+
+Revision ID: 1270
+Revises: 1260
+Create Date: 2018-11-22 14:51:03.013362
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '1270'
+down_revision = '1260'
+
+
+def upgrade():
+    op.execute("COMMIT")  # See: http://stackoverflow.com/a/30910417/15720
+    op.execute("ALTER TYPE user_roles_enum ADD VALUE IF NOT EXISTS 'admin-ccs-data-controller' AFTER 'admin-framework-manager';")
+
+
+def downgrade():
+    # Cannot remove user role value
+    pass

--- a/tests/main/views/test_users.py
+++ b/tests/main/views/test_users.py
@@ -374,6 +374,21 @@ class TestUsersPost(BaseApplicationTest, JSONTestMixin, FixtureMixin):
         data = json.loads(response.get_data())["users"]
         assert data["emailAddress"] == "joeblogs+framework+manager@digital.cabinet-office.gov.uk"
 
+    def test_can_post_an_admin_data_controller_user(self):
+        response = self.client.post(
+            '/users',
+            data=json.dumps({
+                'users': {
+                    'emailAddress': 'joeblogs+ccs+data+controller@digital.cabinet-office.gov.uk',
+                    'password': '1234567890',
+                    'role': 'admin-ccs-data-controller',
+                    'name': 'joe bloggs'}}),
+            content_type='application/json')
+
+        assert response.status_code == 201
+        data = json.loads(response.get_data())["users"]
+        assert data["emailAddress"] == "joeblogs+ccs+data+controller@digital.cabinet-office.gov.uk"
+
     # The admin-ccs role is no longer in use
     def test_can_not_post_an_admin_ccs_user(self):
         response = self.client.post(


### PR DESCRIPTION
Trello: https://trello.com/c/tZJCxC87/249-new-admin-search-box-for-suppliers

The DOS3 Admin mission identified a need for a new CCS admin role, 'data controller'. Users with this role will have new permissions in the Admin FE to edit a limited subset of supplier details: name, companies house registration number, registered name, registered address, and DUNS number (this must still be a unique value). 

The role will also have the following permissions, currently available to the CCS Category role:
- search for suppliers
- view framework agreements for a supplier
- view a list of users for a supplier 
- download 'Official supplier details' CSV

Note that the `ENUM` migration is copied from 1050 and 1060 (adding framework manager and admin manager roles). 