### PR TITLE
Test API stubs

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,7 +13,7 @@ pytest-cov==2.6.0
 requests-mock==1.5.2
 testfixtures==6.3.0
 
-git+https://github.com/alphagov/digitalmarketplace-test-utils.git@1.4.0#egg=digitalmarketplace-test-utils==1.4.0
+git+https://github.com/alphagov/digitalmarketplace-test-utils.git@2.1.1#egg=digitalmarketplace-test-utils==2.1.1
 
 # For schema generation
 alchemyjsonschema==0.5.0

--- a/tests/main/views/test_audits.py
+++ b/tests/main/views/test_audits.py
@@ -15,6 +15,8 @@ from app.models import Supplier, Service
 from tests.bases import BaseApplicationTest
 from tests.helpers import FixtureMixin
 
+from dmtestutils.api_model_stubs import AuditEventStub
+
 
 class BaseTestAuditEvents(BaseApplicationTest, FixtureMixin):
     @staticmethod
@@ -1034,6 +1036,12 @@ class TestAuditEvents(BaseTestAuditEvents):
         assert res.status_code == 200
         assert len(new_data['auditEvents']) == 1
         assert new_data['auditEvents'][0]['id'] == data['auditEvents'][1]['id']
+
+    def test_audit_event_serialize_keys_match_api_stub_keys(self):
+        # Ensures our dmtestutils.api_model_stubs are kept up to date
+        audit_event_id = self.add_audit_event(type=AuditTypes.update_service)
+        audit_event = AuditEvent.query.get(audit_event_id)
+        assert sorted(audit_event.serialize().keys()) == sorted(AuditEventStub().response().keys())
 
 
 class TestCreateAuditEvent(BaseApplicationTest, FixtureMixin):


### PR DESCRIPTION
Trello: https://trello.com/c/FYPvix7N/270-update-api-stubs-in-dm-utils

Basic tests for the API stubs added to `dmtestutils` (see https://github.com/alphagov/digitalmarketplace-test-utils/pull/16)

On the `Supplier` serialization tests I've removed `otherCompanyRegistrationNumber` from the serialized payload, as this won't realistically be included alongside a `companiesHouseNumber`.