### PR TITLE
Outcomes: add list_outcomes view & tests 

### DIFF
--- a/app/models/main.py
+++ b/app/models/main.py
@@ -1759,7 +1759,7 @@ class BriefResponse(db.Model):
         db.UniqueConstraint(id, brief_id, name="uq_brief_responses_id_brief_id"),
     )
 
-    brief = db.relationship('Brief', lazy='joined')
+    brief = db.relationship('Brief', lazy='joined', backref=backref("brief_responses", lazy="select"))
     supplier = db.relationship('Supplier', lazy='joined')
 
     @validates('data')

--- a/config.py
+++ b/config.py
@@ -26,6 +26,7 @@ class Config:
     DM_API_BRIEF_RESPONSES_PAGE_SIZE = 100
     DM_API_BUYER_DOMAINS_PAGE_SIZE = 100
     DM_API_PROJECTS_PAGE_SIZE = 100
+    DM_API_OUTCOMES_PAGE_SIZE = 100
 
     DM_ALLOWED_ADMIN_DOMAINS = ['digital.cabinet-office.gov.uk', 'crowncommercial.gov.uk', 'user.marketplace.team',
                                 'notifications.service.gov.uk']


### PR DESCRIPTION
https://trello.com/c/t2N1EqPk

Fairly straightforward. I've made sure to include the listing of brief-based outcomes in the tests here in the spirit of "sooner or later we'll convert the brief awards to `Outcome` and be able to use these views for both".

Also managed to tidy up some temporary ugly fixes we no longer need.