### PR TITLE
Test BriefResponse API stub

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,7 +13,7 @@ pytest-cov==2.6.0
 requests-mock==1.5.2
 testfixtures==6.3.0
 
-git+https://github.com/alphagov/digitalmarketplace-test-utils.git@2.1.1#egg=digitalmarketplace-test-utils==2.1.1
+git+https://github.com/alphagov/digitalmarketplace-test-utils.git@2.2.0#egg=digitalmarketplace-test-utils==2.2.0
 
 # For schema generation
 alchemyjsonschema==0.5.0

--- a/tests/models/test_main.py
+++ b/tests/models/test_main.py
@@ -20,7 +20,7 @@ from tests.bases import BaseApplicationTest
 from tests.helpers import FixtureMixin
 
 from dmtestutils.api_model_stubs import (
-    BriefStub, FrameworkStub, FrameworkAgreementStub, LotStub, SupplierStub, SupplierFrameworkStub
+    BriefStub, BriefResponseStub, FrameworkStub, FrameworkAgreementStub, LotStub, SupplierStub, SupplierFrameworkStub
 )
 
 
@@ -672,7 +672,7 @@ class TestBriefs(BaseApplicationTest, FixtureMixin):
         brief_stub = BriefStub(
             framework_slug=self.framework.slug, status='open', lot=self.lot, clarification_questions_closed=True,
         )
-        assert sorted(brief.serialize(with_users=True).keys()) == sorted(brief_stub.response().keys())
+        assert sorted(brief.serialize().keys()) == sorted(brief_stub.response().keys())
 
 
 class TestBriefStatuses(BaseApplicationTest, FixtureMixin):
@@ -1572,6 +1572,25 @@ class TestBriefResponses(BaseApplicationTest, FixtureMixin):
             brief_response.awarded_at = None
 
         assert 'Cannot remove or change award datestamp on previously awarded Brief Response' in e.value.message
+
+    def test_brief_response_serialize_keys_match_api_stub_keys(self):
+        # Ensures our dmtestutils.api_model_stubs are kept up to date
+        brief_response = BriefResponse(
+            data={
+                'availability': '02/01/2018',
+                'essentialRequirements': [],
+                'essentialRequirementsMet': True,
+                'niceToHaveRequirements': [],
+                'respondToEmailAddress': 'davidbowie@example.com'
+            },
+            brief=self.brief, supplier=self.supplier, submitted_at=datetime(2016, 9, 28)
+        )
+        db.session.add(brief_response)
+        db.session.commit()
+
+        with mock.patch('app.models.main.url_for') as url_for:
+            url_for.side_effect = lambda *args, **kwargs: (args, kwargs)
+            assert sorted(brief_response.serialize().keys()) == sorted(BriefResponseStub().response().keys())
 
 
 class TestBriefClarificationQuestion(BaseApplicationTest):

--- a/tests/models/test_main.py
+++ b/tests/models/test_main.py
@@ -673,6 +673,10 @@ class TestBriefs(BaseApplicationTest, FixtureMixin):
             framework_slug=self.framework.slug, status='open', lot=self.lot, clarification_questions_closed=True,
         )
         assert sorted(brief.serialize().keys()) == sorted(brief_stub.response().keys())
+        assert (
+            sorted(brief.serialize(with_users=True, with_clarification_questions=True).keys()) ==
+            sorted(brief_stub.single_result_response()['briefs'].keys())
+        )
 
 
 class TestBriefStatuses(BaseApplicationTest, FixtureMixin):


### PR DESCRIPTION
See https://github.com/alphagov/digitalmarketplace-test-utils/pull/19

Also updates the test for BriefStub to handle `with_users` and `with_clarification_questions`.