### PR TITLE
Include registered supplier name in prefix search

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -4,6 +4,7 @@ from flask import jsonify, abort, request, current_app
 from itertools import groupby
 from sqlalchemy import func
 from sqlalchemy.exc import IntegrityError, DataError
+from sqlalchemy.sql.expression import or_ as sql_or
 from sqlalchemy.orm import lazyload
 from dmapiclient.audit import AuditTypes
 from dmutils.formats import DATETIME_FORMAT
@@ -86,7 +87,12 @@ def list_suppliers():
         else:
             # case insensitive LIKE comparison for matching supplier names
             suppliers = suppliers.filter(
-                Supplier.name.ilike(prefix + '%'))
+                sql_or(
+                    Supplier.name.ilike(prefix + '%'),
+                    Supplier.registered_name.ilike(prefix + '%'),
+                )
+
+            )
 
     suppliers = suppliers.distinct(Supplier.name, Supplier.supplier_id)
 

--- a/tests/main/views/test_suppliers.py
+++ b/tests/main/views/test_suppliers.py
@@ -102,6 +102,34 @@ class TestListSuppliers(BaseApplicationTest, FixtureMixin):
         assert data['suppliers'][0]['id'] == 999
         assert u"999 Supplier" == data['suppliers'][0]['name']
 
+    def test_query_string_prefix_matches_name_and_registered_name(self):
+        db.session.add(
+            Supplier(
+                supplier_id=1004,
+                name='X suppliers',
+                registered_name='Y suppliers 1004 Ltd',
+                description=''
+            )
+        )
+        db.session.add(
+            Supplier(
+                supplier_id=1005,
+                name='Y suppliers',
+                registered_name='X suppliers 1004 Ltd',
+                description=''
+            )
+        )
+        db.session.commit()
+        response = self.client.get('/suppliers?prefix=X')
+
+        data = json.loads(response.get_data())
+        assert response.status_code == 200
+        assert len(data['suppliers']) == 2
+        assert data['suppliers'][0]['id'] == 1004
+        assert data['suppliers'][1]['id'] == 1005
+        assert data['suppliers'][0]['name'] == 'X suppliers'
+        assert data['suppliers'][1]['name'] == 'Y suppliers'
+
     def test_query_string_prefix_returns_paginated_page_one(self):
         response = self.client.get('/suppliers?prefix=s')
         data = json.loads(response.get_data())


### PR DESCRIPTION
Trello: https://trello.com/c/aSOduJAQ/319-admin-search-for-registered-name-as-well-as-supplier-name

Filters by either `Supplier.name` or `Supplier.registered_name`, given a query string prefix. 