### PR TITLE
set_a_declaration view: add handling of PATCH method 

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -450,19 +450,25 @@ def remove_contact_information_personal_data(supplier_id, contact_id):
 
 @main.route('/suppliers/<int:supplier_id>/frameworks/<framework_slug>/declaration', methods=['PUT'])
 def set_a_declaration(supplier_id, framework_slug):
-    framework = Framework.query.filter(
-        Framework.slug == framework_slug
-    ).first_or_404()
-
     supplier_framework = SupplierFramework.find_by_supplier_and_framework(
         supplier_id, framework_slug
-    ).first()
+    ).options(
+        lazyload('*')
+    ).with_for_update().first()
 
     if supplier_framework is not None:
         status_code = 200 if supplier_framework.declaration else 201
     else:
+        framework = Framework.query.filter(
+            Framework.slug == framework_slug
+        ).options(
+            lazyload('*')
+        ).first_or_404()
+
         supplier = Supplier.query.filter(
             Supplier.supplier_id == supplier_id
+        ).options(
+            lazyload('*')
         ).first_or_404()
 
         supplier_framework = SupplierFramework(

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -658,10 +658,13 @@ def update_supplier_framework(supplier_id, framework_slug):
     json_has_keys(update_json, optional_keys=("onFramework", "prefillDeclarationFromFrameworkSlug",
                                               "applicationCompanyDetailsConfirmed"))
 
+    # fetch and lock SupplierFramework row
     interest_record = SupplierFramework.query.filter(
         SupplierFramework.supplier_id == supplier.supplier_id,
         SupplierFramework.framework_id == framework.id
-    ).first()
+    ).options(
+        lazyload('*')
+    ).with_for_update().first()
 
     if not interest_record:
         abort(404, "supplier_id '{}' has not registered interest in {}".format(supplier_id, framework_slug))

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -486,6 +486,9 @@ def set_a_declaration(supplier_id, framework_slug):
         supplier_framework.declaration = request_data['declaration'] or {}
     elif request_data['declaration']:
         supplier_framework.declaration.update(request_data['declaration'])
+        # FIXME fix json fields to actually run validators on value mutation - until then the following little absurdity
+        # is required, assigning the declaration attr back to itself to ensure validation is performed.
+        supplier_framework.declaration = supplier_framework.declaration
 
     db.session.add(supplier_framework)
     db.session.add(

--- a/default.nix
+++ b/default.nix
@@ -44,7 +44,8 @@ in (with args; {
         ${pythonPackages.python}/bin/python -m venv $VIRTUALENV_ROOT
       fi
       source $VIRTUALENV_ROOT/bin/activate
-      make -C ${(./.)} requirements${pkgs.stdenv.lib.optionalString forDev "-dev"}
+      pip install --upgrade pip==18.0  # some packages are sensitive to "old" pips
+      make -C ${toString (./.)} requirements${pkgs.stdenv.lib.optionalString forDev "-dev"}
     '';
   }).overrideAttrs (if builtins.pathExists localOverridesPath then (import localOverridesPath args) else (x: x));
 })

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -13,7 +13,7 @@ SQLAlchemy-Utils==0.33.3
 sqlalchemy-json==0.2.2
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@45.2.0#egg=digitalmarketplace-utils==45.2.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.8.0#egg=digitalmarketplace-apiclient==19.8.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.14.0#egg=digitalmarketplace-apiclient==19.14.0
 
 # For schema validation
 jsonschema==2.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ SQLAlchemy-Utils==0.33.3
 sqlalchemy-json==0.2.2
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@45.2.0#egg=digitalmarketplace-utils==45.2.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.8.0#egg=digitalmarketplace-apiclient==19.8.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.14.0#egg=digitalmarketplace-apiclient==19.14.0
 
 # For schema validation
 jsonschema==2.5.1
@@ -22,17 +22,18 @@ rfc3987==1.3.4
 strict-rfc3339==0.5
 
 ## The following requirements were added by pip freeze:
-alembic==1.0.5
+alembic==1.0.6
 asn1crypto==0.24.0
-bcrypt==3.1.4
+bcrypt==3.1.6
 boto3==1.7.83
 botocore==1.10.84
-certifi==2018.10.15
+certifi==2018.11.29
 cffi==1.11.5
 chardet==3.0.4
 Click==7.0
 contextlib2==0.5.5
 cryptography==2.3.1
+defusedxml==0.5.0
 docopt==0.4.0
 docutils==0.14
 Flask-Login==0.4.1
@@ -40,7 +41,7 @@ Flask-Script==2.0.6
 Flask-WTF==0.14.2
 fleep==1.0.1
 future==0.17.1
-idna==2.7
+idna==2.8
 Jinja2==2.10
 jmespath==0.9.3
 mailchimp3==2.0.18
@@ -49,16 +50,16 @@ mandrill==1.0.57
 MarkupSafe==1.1.0
 monotonic==1.5
 notifications-python-client==5.2.0
-odfpy==1.3.6
+odfpy==1.4.0
 pycparser==2.19
-PyJWT==1.6.4
+PyJWT==1.7.1
 python-dateutil==2.7.5
 python-editor==1.0.3
 python-json-logger==0.1.10
-pytz==2018.7
-requests==2.20.1
+pytz==2018.9
+requests==2.21.0
 s3transfer==0.1.13
-six==1.11.0
+six==1.12.0
 unicodecsv==0.14.1
 urllib3==1.24.1
 Werkzeug==0.14.1

--- a/tests/main/views/test_suppliers.py
+++ b/tests/main/views/test_suppliers.py
@@ -1229,6 +1229,33 @@ class TestSetSupplierDeclarations(BaseApplicationTest, FixtureMixin):
                 # has_existing_sf
                 True,
                 # existing_declaration
+                {"question": "answer", "turkey": "chestnutmeal"},
+                # method
+                "PUT",
+                # new_declaration
+                {"turkey": None},
+                # expected_status_code
+                200,
+                # expected_result_decl
+                {},
+                # expected_audit_events
+                (
+                    (
+                        # audit_type
+                        "answer_selection_questions",
+                        # object_type
+                        "SupplierFramework",
+                        # data
+                        {"update": {"turkey": None}, "supplierId": 0},
+                        # user
+                        "testing",
+                    ),
+                ),
+            ),
+            (
+                # has_existing_sf
+                True,
+                # existing_declaration
                 {"question": "answer", "Robinson": "Crusoe"},
                 # method
                 "PUT",
@@ -1355,6 +1382,33 @@ class TestSetSupplierDeclarations(BaseApplicationTest, FixtureMixin):
                         "SupplierFramework",
                         # data
                         {"update": {}, "supplierId": 0},
+                        # user
+                        "testing",
+                    ),
+                ),
+            ),
+            (
+                # has_existing_sf
+                True,
+                # existing_declaration
+                {"question": "answer", "turkey": "chestnutmeal"},
+                # method
+                "PATCH",
+                # new_declaration
+                {"turkey": None},
+                # expected_status_code
+                200,
+                # expected_result_decl
+                {"question": "answer"},
+                # expected_audit_events
+                (
+                    (
+                        # audit_type
+                        "update_declaration_answers",
+                        # object_type
+                        "SupplierFramework",
+                        # data
+                        {"update": {"turkey": None}, "supplierId": 0},
                         # user
                         "testing",
                     ),


### PR DESCRIPTION
https://trello.com/c/rMwWZyBv

This PR also safens-up a couple of existing views by taking row locks where appropriate and reduces the amount of unnecessary eager loading that's taking place. Also refactored tests for this view which were previously covering only a subset of its functionality.

This shouldn't go anywhere near merging until https://trello.com/c/X4vuC79J has been dealt with satisfactorily.