### PR TITLE
Update to JSON Draft 7

### DIFF
--- a/app/validation.py
+++ b/app/validation.py
@@ -295,12 +295,12 @@ def _translate_json_schema_error(key, validator, validator_value, message):
         'minLength': 'answer_required',
         'minItems': 'answer_required',
         'minimum': 'not_a_number',
+        'exclusiveMaximum': 'not_a_number',
         'maximum': 'not_a_number',
         'maxItems': 'max_items_limit',
         'maxLength': 'under_character_limit',
         'format': 'invalid_format',
     }
-
     if validator in validator_type_to_error:
         return validator_type_to_error[validator]
 

--- a/json_schemas/brief-awards-digital-outcomes-and-specialists-2-digital-outcomes.json
+++ b/json_schemas/brief-awards-digital-outcomes-and-specialists-2-digital-outcomes.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "properties": {
     "awardedContractStartDate": {

--- a/json_schemas/brief-awards-digital-outcomes-and-specialists-2-digital-specialists.json
+++ b/json_schemas/brief-awards-digital-outcomes-and-specialists-2-digital-specialists.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "properties": {
     "awardedContractStartDate": {

--- a/json_schemas/brief-awards-digital-outcomes-and-specialists-2-user-research-participants.json
+++ b/json_schemas/brief-awards-digital-outcomes-and-specialists-2-user-research-participants.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "properties": {
     "awardedContractStartDate": {

--- a/json_schemas/brief-awards-digital-outcomes-and-specialists-3-digital-outcomes.json
+++ b/json_schemas/brief-awards-digital-outcomes-and-specialists-3-digital-outcomes.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "properties": {
     "awardedContractStartDate": {

--- a/json_schemas/brief-awards-digital-outcomes-and-specialists-3-digital-specialists.json
+++ b/json_schemas/brief-awards-digital-outcomes-and-specialists-3-digital-specialists.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "properties": {
     "awardedContractStartDate": {

--- a/json_schemas/brief-awards-digital-outcomes-and-specialists-3-user-research-participants.json
+++ b/json_schemas/brief-awards-digital-outcomes-and-specialists-3-user-research-participants.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "properties": {
     "awardedContractStartDate": {

--- a/json_schemas/brief-awards-digital-outcomes-and-specialists-digital-outcomes.json
+++ b/json_schemas/brief-awards-digital-outcomes-and-specialists-digital-outcomes.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "properties": {
     "awardedContractStartDate": {

--- a/json_schemas/brief-awards-digital-outcomes-and-specialists-digital-specialists.json
+++ b/json_schemas/brief-awards-digital-outcomes-and-specialists-digital-specialists.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "properties": {
     "awardedContractStartDate": {

--- a/json_schemas/brief-awards-digital-outcomes-and-specialists-user-research-participants.json
+++ b/json_schemas/brief-awards-digital-outcomes-and-specialists-user-research-participants.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "properties": {
     "awardedContractStartDate": {

--- a/json_schemas/brief-responses-digital-outcomes-and-specialists-2-digital-outcomes.json
+++ b/json_schemas/brief-responses-digital-outcomes-and-specialists-2-digital-outcomes.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "properties": {
     "availability": {

--- a/json_schemas/brief-responses-digital-outcomes-and-specialists-2-digital-specialists.json
+++ b/json_schemas/brief-responses-digital-outcomes-and-specialists-2-digital-specialists.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "properties": {
     "availability": {

--- a/json_schemas/brief-responses-digital-outcomes-and-specialists-2-user-research-participants.json
+++ b/json_schemas/brief-responses-digital-outcomes-and-specialists-2-user-research-participants.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "properties": {
     "availability": {

--- a/json_schemas/brief-responses-digital-outcomes-and-specialists-3-digital-outcomes.json
+++ b/json_schemas/brief-responses-digital-outcomes-and-specialists-3-digital-outcomes.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "properties": {
     "availability": {

--- a/json_schemas/brief-responses-digital-outcomes-and-specialists-3-digital-specialists.json
+++ b/json_schemas/brief-responses-digital-outcomes-and-specialists-3-digital-specialists.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "properties": {
     "availability": {

--- a/json_schemas/brief-responses-digital-outcomes-and-specialists-3-user-research-participants.json
+++ b/json_schemas/brief-responses-digital-outcomes-and-specialists-3-user-research-participants.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "properties": {
     "availability": {

--- a/json_schemas/brief-responses-digital-outcomes-and-specialists-digital-outcomes.json
+++ b/json_schemas/brief-responses-digital-outcomes-and-specialists-digital-outcomes.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "properties": {
     "availability": {

--- a/json_schemas/brief-responses-digital-outcomes-and-specialists-digital-specialists.json
+++ b/json_schemas/brief-responses-digital-outcomes-and-specialists-digital-specialists.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "properties": {
     "availability": {

--- a/json_schemas/brief-responses-digital-outcomes-and-specialists-user-research-participants.json
+++ b/json_schemas/brief-responses-digital-outcomes-and-specialists-user-research-participants.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "properties": {
     "availability": {

--- a/json_schemas/briefs-digital-outcomes-and-specialists-2-digital-outcomes.json
+++ b/json_schemas/briefs-digital-outcomes-and-specialists-2-digital-outcomes.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "properties": {
     "additionalTerms": {
@@ -33,7 +33,6 @@
       "type": "array"
     },
     "culturalWeighting": {
-      "exclusiveMaximum": false,
       "maximum": 20,
       "minimum": 5,
       "type": "integer"
@@ -105,7 +104,6 @@
       "type": "array"
     },
     "numberOfSuppliers": {
-      "exclusiveMaximum": false,
       "maximum": 15,
       "minimum": 3,
       "type": "integer"
@@ -138,7 +136,6 @@
       ]
     },
     "priceWeighting": {
-      "exclusiveMaximum": false,
       "maximum": 85,
       "minimum": 20,
       "type": "integer"
@@ -173,7 +170,6 @@
       "type": "string"
     },
     "technicalWeighting": {
-      "exclusiveMaximum": false,
       "maximum": 75,
       "minimum": 10,
       "type": "integer"

--- a/json_schemas/briefs-digital-outcomes-and-specialists-2-digital-specialists.json
+++ b/json_schemas/briefs-digital-outcomes-and-specialists-2-digital-specialists.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "properties": {
     "additionalTerms": {
@@ -28,7 +28,6 @@
       "type": "array"
     },
     "culturalWeighting": {
-      "exclusiveMaximum": false,
       "maximum": 20,
       "minimum": 5,
       "type": "integer"
@@ -95,7 +94,6 @@
       "type": "array"
     },
     "numberOfSuppliers": {
-      "exclusiveMaximum": false,
       "maximum": 15,
       "minimum": 3,
       "type": "integer"
@@ -106,7 +104,6 @@
       "type": "string"
     },
     "priceWeighting": {
-      "exclusiveMaximum": false,
       "maximum": 85,
       "minimum": 20,
       "type": "integer"
@@ -163,7 +160,6 @@
       "type": "string"
     },
     "technicalWeighting": {
-      "exclusiveMaximum": false,
       "maximum": 75,
       "minimum": 10,
       "type": "integer"

--- a/json_schemas/briefs-digital-outcomes-and-specialists-2-user-research-participants.json
+++ b/json_schemas/briefs-digital-outcomes-and-specialists-2-user-research-participants.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "properties": {
     "accessRestrictions": {
@@ -18,7 +18,6 @@
       "type": "string"
     },
     "culturalWeighting": {
-      "exclusiveMaximum": false,
       "maximum": 70,
       "minimum": 10,
       "type": "integer"
@@ -79,7 +78,6 @@
       "type": "array"
     },
     "numberOfSuppliers": {
-      "exclusiveMaximum": false,
       "maximum": 15,
       "minimum": 3,
       "type": "integer"
@@ -105,7 +103,6 @@
       "type": "string"
     },
     "priceWeighting": {
-      "exclusiveMaximum": false,
       "maximum": 80,
       "minimum": 20,
       "type": "integer"
@@ -168,7 +165,6 @@
       "type": "string"
     },
     "technicalWeighting": {
-      "exclusiveMaximum": false,
       "maximum": 70,
       "minimum": 10,
       "type": "integer"

--- a/json_schemas/briefs-digital-outcomes-and-specialists-3-digital-outcomes.json
+++ b/json_schemas/briefs-digital-outcomes-and-specialists-3-digital-outcomes.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "properties": {
     "additionalTerms": {
@@ -33,7 +33,6 @@
       "type": "array"
     },
     "culturalWeighting": {
-      "exclusiveMaximum": false,
       "maximum": 20,
       "minimum": 5,
       "type": "integer"
@@ -105,7 +104,6 @@
       "type": "array"
     },
     "numberOfSuppliers": {
-      "exclusiveMaximum": false,
       "maximum": 15,
       "minimum": 3,
       "type": "integer"
@@ -138,7 +136,6 @@
       ]
     },
     "priceWeighting": {
-      "exclusiveMaximum": false,
       "maximum": 85,
       "minimum": 20,
       "type": "integer"
@@ -173,7 +170,6 @@
       "type": "string"
     },
     "technicalWeighting": {
-      "exclusiveMaximum": false,
       "maximum": 75,
       "minimum": 10,
       "type": "integer"

--- a/json_schemas/briefs-digital-outcomes-and-specialists-3-digital-specialists.json
+++ b/json_schemas/briefs-digital-outcomes-and-specialists-3-digital-specialists.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "properties": {
     "additionalTerms": {
@@ -28,7 +28,6 @@
       "type": "array"
     },
     "culturalWeighting": {
-      "exclusiveMaximum": false,
       "maximum": 20,
       "minimum": 5,
       "type": "integer"
@@ -95,7 +94,6 @@
       "type": "array"
     },
     "numberOfSuppliers": {
-      "exclusiveMaximum": false,
       "maximum": 15,
       "minimum": 3,
       "type": "integer"
@@ -106,7 +104,6 @@
       "type": "string"
     },
     "priceWeighting": {
-      "exclusiveMaximum": false,
       "maximum": 85,
       "minimum": 20,
       "type": "integer"
@@ -166,7 +163,6 @@
       "type": "string"
     },
     "technicalWeighting": {
-      "exclusiveMaximum": false,
       "maximum": 75,
       "minimum": 10,
       "type": "integer"

--- a/json_schemas/briefs-digital-outcomes-and-specialists-3-user-research-participants.json
+++ b/json_schemas/briefs-digital-outcomes-and-specialists-3-user-research-participants.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "properties": {
     "accessRestrictions": {
@@ -18,7 +18,6 @@
       "type": "string"
     },
     "culturalWeighting": {
-      "exclusiveMaximum": false,
       "maximum": 70,
       "minimum": 10,
       "type": "integer"
@@ -79,7 +78,6 @@
       "type": "array"
     },
     "numberOfSuppliers": {
-      "exclusiveMaximum": false,
       "maximum": 15,
       "minimum": 3,
       "type": "integer"
@@ -105,7 +103,6 @@
       "type": "string"
     },
     "priceWeighting": {
-      "exclusiveMaximum": false,
       "maximum": 80,
       "minimum": 20,
       "type": "integer"
@@ -168,7 +165,6 @@
       "type": "string"
     },
     "technicalWeighting": {
-      "exclusiveMaximum": false,
       "maximum": 70,
       "minimum": 10,
       "type": "integer"

--- a/json_schemas/briefs-digital-outcomes-and-specialists-digital-outcomes.json
+++ b/json_schemas/briefs-digital-outcomes-and-specialists-digital-outcomes.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "properties": {
     "additionalTerms": {
@@ -33,7 +33,6 @@
       "type": "array"
     },
     "culturalWeighting": {
-      "exclusiveMaximum": false,
       "maximum": 20,
       "minimum": 5,
       "type": "integer"
@@ -105,7 +104,6 @@
       "type": "array"
     },
     "numberOfSuppliers": {
-      "exclusiveMaximum": false,
       "maximum": 15,
       "minimum": 3,
       "type": "integer"
@@ -138,7 +136,6 @@
       ]
     },
     "priceWeighting": {
-      "exclusiveMaximum": false,
       "maximum": 85,
       "minimum": 20,
       "type": "integer"
@@ -174,7 +171,6 @@
       "type": "string"
     },
     "technicalWeighting": {
-      "exclusiveMaximum": false,
       "maximum": 75,
       "minimum": 10,
       "type": "integer"

--- a/json_schemas/briefs-digital-outcomes-and-specialists-digital-specialists.json
+++ b/json_schemas/briefs-digital-outcomes-and-specialists-digital-specialists.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "properties": {
     "additionalTerms": {
@@ -28,7 +28,6 @@
       "type": "array"
     },
     "culturalWeighting": {
-      "exclusiveMaximum": false,
       "maximum": 20,
       "minimum": 5,
       "type": "integer"
@@ -95,7 +94,6 @@
       "type": "array"
     },
     "numberOfSuppliers": {
-      "exclusiveMaximum": false,
       "maximum": 15,
       "minimum": 3,
       "type": "integer"
@@ -106,7 +104,6 @@
       "type": "string"
     },
     "priceWeighting": {
-      "exclusiveMaximum": false,
       "maximum": 85,
       "minimum": 20,
       "type": "integer"
@@ -164,7 +161,6 @@
       "type": "string"
     },
     "technicalWeighting": {
-      "exclusiveMaximum": false,
       "maximum": 75,
       "minimum": 10,
       "type": "integer"

--- a/json_schemas/briefs-digital-outcomes-and-specialists-user-research-participants.json
+++ b/json_schemas/briefs-digital-outcomes-and-specialists-user-research-participants.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "properties": {
     "accessRestrictions": {
@@ -18,7 +18,6 @@
       "type": "string"
     },
     "culturalWeighting": {
-      "exclusiveMaximum": false,
       "maximum": 70,
       "minimum": 10,
       "type": "integer"
@@ -79,7 +78,6 @@
       "type": "array"
     },
     "numberOfSuppliers": {
-      "exclusiveMaximum": false,
       "maximum": 15,
       "minimum": 3,
       "type": "integer"
@@ -105,7 +103,6 @@
       "type": "string"
     },
     "priceWeighting": {
-      "exclusiveMaximum": false,
       "maximum": 80,
       "minimum": 20,
       "type": "integer"
@@ -168,7 +165,6 @@
       "type": "string"
     },
     "technicalWeighting": {
-      "exclusiveMaximum": false,
       "maximum": 70,
       "minimum": 10,
       "type": "integer"

--- a/json_schemas/services-digital-outcomes-and-specialists-2-digital-outcomes.json
+++ b/json_schemas/services-digital-outcomes-and-specialists-2-digital-outcomes.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "anyOf": [
     {

--- a/json_schemas/services-digital-outcomes-and-specialists-2-digital-specialists.json
+++ b/json_schemas/services-digital-outcomes-and-specialists-2-digital-specialists.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "anyOf": [
     {

--- a/json_schemas/services-digital-outcomes-and-specialists-2-user-research-participants.json
+++ b/json_schemas/services-digital-outcomes-and-specialists-2-user-research-participants.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "properties": {
     "anonymousRecruitment": {

--- a/json_schemas/services-digital-outcomes-and-specialists-2-user-research-studios.json
+++ b/json_schemas/services-digital-outcomes-and-specialists-2-user-research-studios.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "properties": {
     "labAccessibility": {

--- a/json_schemas/services-digital-outcomes-and-specialists-3-digital-outcomes.json
+++ b/json_schemas/services-digital-outcomes-and-specialists-3-digital-outcomes.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "anyOf": [
     {

--- a/json_schemas/services-digital-outcomes-and-specialists-3-digital-specialists.json
+++ b/json_schemas/services-digital-outcomes-and-specialists-3-digital-specialists.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "anyOf": [
     {

--- a/json_schemas/services-digital-outcomes-and-specialists-3-user-research-participants.json
+++ b/json_schemas/services-digital-outcomes-and-specialists-3-user-research-participants.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "properties": {
     "anonymousRecruitment": {

--- a/json_schemas/services-digital-outcomes-and-specialists-3-user-research-studios.json
+++ b/json_schemas/services-digital-outcomes-and-specialists-3-user-research-studios.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "properties": {
     "labAccessibility": {

--- a/json_schemas/services-digital-outcomes-and-specialists-digital-outcomes.json
+++ b/json_schemas/services-digital-outcomes-and-specialists-digital-outcomes.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "anyOf": [
     {

--- a/json_schemas/services-digital-outcomes-and-specialists-digital-specialists.json
+++ b/json_schemas/services-digital-outcomes-and-specialists-digital-specialists.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "anyOf": [
     {

--- a/json_schemas/services-digital-outcomes-and-specialists-user-research-participants.json
+++ b/json_schemas/services-digital-outcomes-and-specialists-user-research-participants.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "properties": {
     "anonymousRecruitment": {

--- a/json_schemas/services-digital-outcomes-and-specialists-user-research-studios.json
+++ b/json_schemas/services-digital-outcomes-and-specialists-user-research-studios.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "properties": {
     "labAccessibility": {

--- a/json_schemas/services-g-cloud-10-cloud-hosting.json
+++ b/json_schemas/services-g-cloud-10-cloud-hosting.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "allOf": [
     {

--- a/json_schemas/services-g-cloud-10-cloud-software.json
+++ b/json_schemas/services-g-cloud-10-cloud-software.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "allOf": [
     {

--- a/json_schemas/services-g-cloud-10-cloud-support.json
+++ b/json_schemas/services-g-cloud-10-cloud-support.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "allOf": [
     {

--- a/json_schemas/services-g-cloud-11-cloud-hosting.json
+++ b/json_schemas/services-g-cloud-11-cloud-hosting.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "allOf": [
     {
@@ -641,6 +641,35 @@
       "oneOf": [
         {
           "properties": {
+            "documentation": {
+              "enum": [
+                false
+              ]
+            },
+            "documentationAccessibility": {
+              "type": "null"
+            }
+          }
+        },
+        {
+          "properties": {
+            "documentation": {
+              "enum": [
+                true
+              ]
+            }
+          },
+          "required": [
+            "documentation",
+            "documentationAccessibility"
+          ]
+        }
+      ]
+    },
+    {
+      "oneOf": [
+        {
+          "properties": {
             "documentationFormats": {
               "items": {
                 "enum": [
@@ -672,6 +701,37 @@
           "required": [
             "documentationFormats",
             "documentationFormatsOther"
+          ]
+        }
+      ]
+    },
+    {
+      "oneOf": [
+        {
+          "properties": {
+            "documentationAccessibility": {
+              "enum": [
+                "wcag_a",
+                "wcag_aa",
+                "wcag_aaa"
+              ]
+            },
+            "documentationAccessibilityDescription": {
+              "type": "null"
+            }
+          }
+        },
+        {
+          "properties": {
+            "documentationAccessibility": {
+              "enum": [
+                "none_or_not_sure"
+              ]
+            }
+          },
+          "required": [
+            "documentationAccessibility",
+            "documentationAccessibilityDescription"
           ]
         }
       ]
@@ -2006,6 +2066,35 @@
       "oneOf": [
         {
           "properties": {
+            "energyEfficientDatacentres": {
+              "enum": [
+                false
+              ]
+            },
+            "energyEfficientDatacentresDescription": {
+              "type": "null"
+            }
+          }
+        },
+        {
+          "properties": {
+            "energyEfficientDatacentres": {
+              "enum": [
+                true
+              ]
+            }
+          },
+          "required": [
+            "energyEfficientDatacentres",
+            "energyEfficientDatacentresDescription"
+          ]
+        }
+      ]
+    },
+    {
+      "oneOf": [
+        {
+          "properties": {
             "freeVersionDescription": {
               "type": "null"
             },
@@ -2377,6 +2466,20 @@
     "documentation": {
       "type": "boolean"
     },
+    "documentationAccessibility": {
+      "enum": [
+        "wcag_aaa",
+        "wcag_aa",
+        "wcag_a",
+        "none_or_not_sure"
+      ]
+    },
+    "documentationAccessibilityDescription": {
+      "maxLength": 2000,
+      "minLength": 1,
+      "pattern": "^(?:\\S+\\s+){0,199}\\S+$",
+      "type": "string"
+    },
     "documentationFormats": {
       "items": {
         "enum": [
@@ -2442,6 +2545,12 @@
     },
     "energyEfficientDatacentres": {
       "type": "boolean"
+    },
+    "energyEfficientDatacentresDescription": {
+      "maxLength": 2000,
+      "minLength": 1,
+      "pattern": "^(?:\\S+\\s+){0,199}\\S+$",
+      "type": "string"
     },
     "equipmentDisposalApproach": {
       "enum": [

--- a/json_schemas/services-g-cloud-11-cloud-software.json
+++ b/json_schemas/services-g-cloud-11-cloud-software.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "allOf": [
     {
@@ -393,6 +393,93 @@
       "oneOf": [
         {
           "properties": {
+            "serviceInterface": {
+              "enum": [
+                false
+              ]
+            },
+            "serviceInterfaceDescription": {
+              "type": "null"
+            }
+          }
+        },
+        {
+          "properties": {
+            "serviceInterface": {
+              "enum": [
+                true
+              ]
+            }
+          },
+          "required": [
+            "serviceInterface",
+            "serviceInterfaceDescription"
+          ]
+        }
+      ]
+    },
+    {
+      "oneOf": [
+        {
+          "properties": {
+            "serviceInterface": {
+              "enum": [
+                false
+              ]
+            },
+            "serviceInterfaceAccessibility": {
+              "type": "null"
+            }
+          }
+        },
+        {
+          "properties": {
+            "serviceInterface": {
+              "enum": [
+                true
+              ]
+            }
+          },
+          "required": [
+            "serviceInterface",
+            "serviceInterfaceAccessibility"
+          ]
+        }
+      ]
+    },
+    {
+      "oneOf": [
+        {
+          "properties": {
+            "serviceInterface": {
+              "enum": [
+                false
+              ]
+            },
+            "serviceInterfaceTesting": {
+              "type": "null"
+            }
+          }
+        },
+        {
+          "properties": {
+            "serviceInterface": {
+              "enum": [
+                true
+              ]
+            }
+          },
+          "required": [
+            "serviceInterface",
+            "serviceInterfaceTesting"
+          ]
+        }
+      ]
+    },
+    {
+      "oneOf": [
+        {
+          "properties": {
             "serviceInterfaceAccessibility": {
               "enum": [
                 "wcag_a",
@@ -598,6 +685,35 @@
       "oneOf": [
         {
           "properties": {
+            "documentation": {
+              "enum": [
+                false
+              ]
+            },
+            "documentationAccessibility": {
+              "type": "null"
+            }
+          }
+        },
+        {
+          "properties": {
+            "documentation": {
+              "enum": [
+                true
+              ]
+            }
+          },
+          "required": [
+            "documentation",
+            "documentationAccessibility"
+          ]
+        }
+      ]
+    },
+    {
+      "oneOf": [
+        {
+          "properties": {
             "documentationFormats": {
               "items": {
                 "enum": [
@@ -629,6 +745,37 @@
           "required": [
             "documentationFormats",
             "documentationFormatsOther"
+          ]
+        }
+      ]
+    },
+    {
+      "oneOf": [
+        {
+          "properties": {
+            "documentationAccessibility": {
+              "enum": [
+                "wcag_a",
+                "wcag_aa",
+                "wcag_aaa"
+              ]
+            },
+            "documentationAccessibilityDescription": {
+              "type": "null"
+            }
+          }
+        },
+        {
+          "properties": {
+            "documentationAccessibility": {
+              "enum": [
+                "none_or_not_sure"
+              ]
+            }
+          },
+          "required": [
+            "documentationAccessibility",
+            "documentationAccessibilityDescription"
           ]
         }
       ]
@@ -801,6 +948,7 @@
             "publicSectorNetworksTypes": {
               "items": {
                 "enum": [
+                  "hscn",
                   "janet",
                   "n3",
                   "other",
@@ -818,6 +966,7 @@
               "not": {
                 "items": {
                   "enum": [
+                    "hscn",
                     "janet",
                     "n3",
                     "other",
@@ -1921,12 +2070,18 @@
       "uniqueItems": true
     },
     "cloudDeploymentModel": {
-      "enum": [
-        "public",
-        "private",
-        "community",
-        "hybrid"
-      ]
+      "items": {
+        "enum": [
+          "public",
+          "private",
+          "community",
+          "hybrid"
+        ]
+      },
+      "maxItems": 4,
+      "minItems": 1,
+      "type": "array",
+      "uniqueItems": true
     },
     "configurationAndChangeManagementProcesses": {
       "maxLength": 1000,
@@ -2087,6 +2242,20 @@
     },
     "documentation": {
       "type": "boolean"
+    },
+    "documentationAccessibility": {
+      "enum": [
+        "wcag_aaa",
+        "wcag_aa",
+        "wcag_a",
+        "none_or_not_sure"
+      ]
+    },
+    "documentationAccessibilityDescription": {
+      "maxLength": 2000,
+      "minLength": 1,
+      "pattern": "^(?:\\S+\\s+){0,199}\\S+$",
+      "type": "string"
     },
     "documentationFormats": {
       "items": {
@@ -2438,10 +2607,11 @@
           "n3",
           "janet",
           "swan",
+          "hscn",
           "other"
         ]
       },
-      "maxItems": 6,
+      "maxItems": 7,
       "minItems": 1,
       "type": "array",
       "uniqueItems": true
@@ -2801,6 +2971,9 @@
       "minItems": 1,
       "type": "array"
     },
+    "serviceInterface": {
+      "type": "boolean"
+    },
     "serviceInterfaceAccessibility": {
       "enum": [
         "wcag_aaa",
@@ -2810,6 +2983,12 @@
       ]
     },
     "serviceInterfaceAccessibilityDescription": {
+      "maxLength": 1000,
+      "minLength": 1,
+      "pattern": "^(?:\\S+\\s+){0,99}\\S+$",
+      "type": "string"
+    },
+    "serviceInterfaceDescription": {
       "maxLength": 1000,
       "minLength": 1,
       "pattern": "^(?:\\S+\\s+){0,99}\\S+$",
@@ -3078,8 +3257,7 @@
     "serviceConstraints",
     "serviceDescription",
     "serviceFeatures",
-    "serviceInterfaceAccessibility",
-    "serviceInterfaceTesting",
+    "serviceInterface",
     "serviceName",
     "staffSecurityClearanceChecks",
     "standardsCSASTAR",

--- a/json_schemas/services-g-cloud-11-cloud-support.json
+++ b/json_schemas/services-g-cloud-11-cloud-support.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "allOf": [
     {

--- a/json_schemas/services-g-cloud-7-iaas.json
+++ b/json_schemas/services-g-cloud-7-iaas.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "properties": {
     "analyticsAvailable": {
@@ -933,8 +933,7 @@
           ]
         },
         "value": {
-          "exclusiveMaximum": true,
-          "maximum": 100,
+          "exclusiveMaximum": 100,
           "minimum": 0,
           "type": "number"
         }

--- a/json_schemas/services-g-cloud-7-paas.json
+++ b/json_schemas/services-g-cloud-7-paas.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "properties": {
     "analyticsAvailable": {
@@ -933,8 +933,7 @@
           ]
         },
         "value": {
-          "exclusiveMaximum": true,
-          "maximum": 100,
+          "exclusiveMaximum": 100,
           "minimum": 0,
           "type": "number"
         }

--- a/json_schemas/services-g-cloud-7-saas.json
+++ b/json_schemas/services-g-cloud-7-saas.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "properties": {
     "analyticsAvailable": {
@@ -717,8 +717,7 @@
           ]
         },
         "value": {
-          "exclusiveMaximum": true,
-          "maximum": 100,
+          "exclusiveMaximum": 100,
           "minimum": 0,
           "type": "number"
         }

--- a/json_schemas/services-g-cloud-7-scs.json
+++ b/json_schemas/services-g-cloud-7-scs.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "properties": {
     "educationPricing": {

--- a/json_schemas/services-g-cloud-8-iaas.json
+++ b/json_schemas/services-g-cloud-8-iaas.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "properties": {
     "analyticsAvailable": {
@@ -929,8 +929,7 @@
           ]
         },
         "value": {
-          "exclusiveMaximum": true,
-          "maximum": 100,
+          "exclusiveMaximum": 100,
           "minimum": 0,
           "type": "number"
         }

--- a/json_schemas/services-g-cloud-8-paas.json
+++ b/json_schemas/services-g-cloud-8-paas.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "properties": {
     "analyticsAvailable": {
@@ -929,8 +929,7 @@
           ]
         },
         "value": {
-          "exclusiveMaximum": true,
-          "maximum": 100,
+          "exclusiveMaximum": 100,
           "minimum": 0,
           "type": "number"
         }

--- a/json_schemas/services-g-cloud-8-saas.json
+++ b/json_schemas/services-g-cloud-8-saas.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "properties": {
     "analyticsAvailable": {
@@ -713,8 +713,7 @@
           ]
         },
         "value": {
-          "exclusiveMaximum": true,
-          "maximum": 100,
+          "exclusiveMaximum": 100,
           "minimum": 0,
           "type": "number"
         }

--- a/json_schemas/services-g-cloud-8-scs.json
+++ b/json_schemas/services-g-cloud-8-scs.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "properties": {
     "educationPricing": {

--- a/json_schemas/services-g-cloud-9-cloud-hosting.json
+++ b/json_schemas/services-g-cloud-9-cloud-hosting.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "allOf": [
     {

--- a/json_schemas/services-g-cloud-9-cloud-software.json
+++ b/json_schemas/services-g-cloud-9-cloud-software.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "allOf": [
     {

--- a/json_schemas/services-g-cloud-9-cloud-support.json
+++ b/json_schemas/services-g-cloud-9-cloud-support.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "allOf": [
     {

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -16,6 +16,6 @@ git+https://github.com/alphagov/digitalmarketplace-utils.git@46.1.2#egg=digitalm
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.14.0#egg=digitalmarketplace-apiclient==19.14.0
 
 # For schema validation
-jsonschema==2.5.1
+jsonschema==3.0.0
 rfc3987==1.3.4
 strict-rfc3339==0.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,13 +17,14 @@ git+https://github.com/alphagov/digitalmarketplace-utils.git@46.1.2#egg=digitalm
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.14.0#egg=digitalmarketplace-apiclient==19.14.0
 
 # For schema validation
-jsonschema==2.5.1
+jsonschema==3.0.0
 rfc3987==1.3.4
 strict-rfc3339==0.5
 
 ## The following requirements were added by pip freeze:
 alembic==1.0.7
 asn1crypto==0.24.0
+attrs==18.2.0
 bcrypt==3.1.6
 boto3==1.7.83
 botocore==1.10.84
@@ -44,15 +45,16 @@ future==0.17.1
 govuk-country-register==0.2.2
 idna==2.8
 Jinja2==2.10
-jmespath==0.9.3
+jmespath==0.9.4
 mailchimp3==3.0.6
 Mako==1.0.7
-MarkupSafe==1.1.0
+MarkupSafe==1.1.1
 monotonic==1.5
 notifications-python-client==5.3.0
 odfpy==1.4.0
 pycparser==2.19
 PyJWT==1.7.1
+pyrsistent==0.14.11
 python-dateutil==2.8.0
 python-editor==1.0.4
 python-json-logger==0.1.10


### PR DESCRIPTION
This PR is to update the JSON schemas we use to Draft 7. The meat of the PR is new schemas generated by an updated script in frameworks.

The only important change is that where previously an integer value might have `exclusiveMaximum: false` if the value was inclusive, or `exclusiveMaximum: true` if it was exclusive. Having a boolean added extra complexity, so in the new standard we just use `exclusiveMaximum` as the maximum if it's needed. `maximum` is always inclusive.

The final change updates the validator error translator to include `exclusiveMaximum`