### PR TITLE
G11 validation schema updates

### DIFF
--- a/json_schemas/services-g-cloud-11-cloud-hosting.json
+++ b/json_schemas/services-g-cloud-11-cloud-hosting.json
@@ -1584,7 +1584,6 @@
                   "dedicated_link",
                   "government_network",
                   "identity_federation",
-                  "other",
                   "public_key",
                   "two_factor",
                   "username_or_password"
@@ -1605,7 +1604,6 @@
                     "dedicated_link",
                     "government_network",
                     "identity_federation",
-                    "other",
                     "public_key",
                     "two_factor",
                     "username_or_password"

--- a/json_schemas/services-g-cloud-11-cloud-software.json
+++ b/json_schemas/services-g-cloud-11-cloud-software.json
@@ -951,7 +951,6 @@
                   "hscn",
                   "janet",
                   "n3",
-                  "other",
                   "pnn",
                   "psn",
                   "swan"
@@ -969,7 +968,6 @@
                     "hscn",
                     "janet",
                     "n3",
-                    "other",
                     "pnn",
                     "psn",
                     "swan"
@@ -1407,7 +1405,6 @@
                   "dedicated_link",
                   "government_network",
                   "identity_federation",
-                  "other",
                   "public_key",
                   "two_factor",
                   "username_or_password"
@@ -1428,7 +1425,6 @@
                     "dedicated_link",
                     "government_network",
                     "identity_federation",
-                    "other",
                     "public_key",
                     "two_factor",
                     "username_or_password"


### PR DESCRIPTION
Trello: https://trello.com/c/5CzbmwiW/407-bug-fixes-for-the-supplier-declaration-journey

Changes to some of the service questions in https://github.com/alphagov/digitalmarketplace-frameworks/pull/553 required a refresh of the validation schemas:

- `managementAccessAuthentication` now requires `managementAccessAuthenticationDescription` if the answer is 'other'
- `publicSectorNetworksTypes` now requires `publicSectorNetworksOther` if the answer is 'other'



