### PR TITLE
Remove json schema deprecation warnings

### DIFF
--- a/json_schemas/agreement-details.json
+++ b/json_schemas/agreement-details.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "minProperties": 1,
   "properties": {

--- a/json_schemas/brief-clarification-question.json
+++ b/json_schemas/brief-clarification-question.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Brief clarification question schema",
   "type": "object",
   "properties": {

--- a/json_schemas/buyer-email-domains.json
+++ b/json_schemas/buyer-email-domains.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "properties": {
     "domainName": {

--- a/json_schemas/direct-award-project-update.json
+++ b/json_schemas/direct-award-project-update.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "properties": {
     "stillAssessing": {
       "type": "boolean"

--- a/json_schemas/framework-agreement-details.json
+++ b/json_schemas/framework-agreement-details.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "minProperties": 1,
   "properties": {

--- a/json_schemas/new-supplier.json
+++ b/json_schemas/new-supplier.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "properties": {
     "companiesHouseNumber": {

--- a/json_schemas/outcome-update.json
+++ b/json_schemas/outcome-update.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "properties": {
     "completed": {

--- a/json_schemas/services-g-cloud-4.json
+++ b/json_schemas/services-g-cloud-4.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "properties": {
     "additionalDocumentURLs": {

--- a/json_schemas/services-g-cloud-5.json
+++ b/json_schemas/services-g-cloud-5.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "properties": {
     "additionalDocumentURLs": {

--- a/json_schemas/services-g-cloud-6-iaas.json
+++ b/json_schemas/services-g-cloud-6-iaas.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "properties": {
     "analyticsAvailable": {

--- a/json_schemas/services-g-cloud-6-paas.json
+++ b/json_schemas/services-g-cloud-6-paas.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "properties": {
     "analyticsAvailable": {

--- a/json_schemas/services-g-cloud-6-saas.json
+++ b/json_schemas/services-g-cloud-6-saas.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "properties": {
     "analyticsAvailable": {

--- a/json_schemas/services-g-cloud-6-scs.json
+++ b/json_schemas/services-g-cloud-6-scs.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "properties": {
     "educationPricing": {

--- a/json_schemas/services-update.json
+++ b/json_schemas/services-update.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": true,
   "properties": {
     "updated_by": {

--- a/json_schemas/suppliers.json
+++ b/json_schemas/suppliers.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "properties": {
     "companiesHouseNumber": {

--- a/json_schemas/users-auth.json
+++ b/json_schemas/users-auth.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "properties": {
     "emailAddress": {

--- a/json_schemas/users.json
+++ b/json_schemas/users.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "properties": {
     "emailAddress": {


### PR DESCRIPTION
Following on from @jonodrew's update to Draft 7 schemas (https://github.com/alphagov/digitalmarketplace-api/pull/901), this updates the model validation schemas and service schemas from older frameworks to refer to `/draft-07`, to remove the deprecation warnings.

None of these schemas have the `exclusiveMaximum` breaking change.