### PR TITLE
Pyup ignore sqlalchemy updates

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -3,12 +3,12 @@
 
 Flask==1.0.2
 Flask-Bcrypt==0.7.1
-Flask-Migrate==2.0.3
-Flask-SQLAlchemy==2.1
+Flask-Migrate==2.0.3 # pyup: ignore
+Flask-SQLAlchemy==2.1 # pyup: ignore
 itsdangerous==0.24 # pyup: ignore
 --no-binary=psycopg2
 psycopg2==2.7.7
-SQLAlchemy==1.2.18
+SQLAlchemy==1.2.18 # pyup: ignore
 SQLAlchemy-Utils==0.33.11
 sqlalchemy-json==0.2.3
 
@@ -16,6 +16,6 @@ git+https://github.com/alphagov/digitalmarketplace-utils.git@46.1.2#egg=digitalm
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.14.0#egg=digitalmarketplace-apiclient==19.14.0
 
 # For schema validation
-jsonschema==3.0.0
-rfc3987==1.3.4
+jsonschema==3.0.1
+rfc3987==1.3.8
 strict-rfc3339==0.5

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,16 +1,16 @@
 -r requirements.txt
 
 # For tests
-coverage==4.5.2
-coveralls==1.5.1
-flake8==3.7.5
+coverage==4.5.3
+coveralls==1.6.0
+flake8==3.7.7
 freezegun==0.3.11
 hypothesis==3.82.1
 mock==2.0.0
-pytest==4.2.1
+pytest==4.3.0
 pytest-cov==2.6.1
 requests-mock==1.5.2
-testfixtures==6.3.0
+testfixtures==6.6.0
 
 git+https://github.com/alphagov/digitalmarketplace-test-utils.git@2.3.0#egg=digitalmarketplace-test-utils==2.3.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,12 +4,12 @@
 
 Flask==1.0.2
 Flask-Bcrypt==0.7.1
-Flask-Migrate==2.0.3
-Flask-SQLAlchemy==2.1
+Flask-Migrate==2.0.3 # pyup: ignore
+Flask-SQLAlchemy==2.1 # pyup: ignore
 itsdangerous==0.24 # pyup: ignore
 --no-binary=psycopg2
 psycopg2==2.7.7
-SQLAlchemy==1.2.18
+SQLAlchemy==1.2.18 # pyup: ignore
 SQLAlchemy-Utils==0.33.11
 sqlalchemy-json==0.2.3
 
@@ -17,19 +17,19 @@ git+https://github.com/alphagov/digitalmarketplace-utils.git@46.1.2#egg=digitalm
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.14.0#egg=digitalmarketplace-apiclient==19.14.0
 
 # For schema validation
-jsonschema==3.0.0
-rfc3987==1.3.4
+jsonschema==3.0.1
+rfc3987==1.3.8
 strict-rfc3339==0.5
 
 ## The following requirements were added by pip freeze:
-alembic==1.0.7
+alembic==1.0.8
 asn1crypto==0.24.0
-attrs==18.2.0
+attrs==19.1.0
 bcrypt==3.1.6
 boto3==1.7.83
 botocore==1.10.84
-certifi==2018.11.29
-cffi==1.12.1
+certifi==2019.3.9
+cffi==1.12.2
 chardet==3.0.4
 Click==7.0
 contextlib2==0.5.5


### PR DESCRIPTION
Hopefully avoids the mess that https://github.com/alphagov/digitalmarketplace-api/pull/909 would have created.

- Updates `jsonschema` and `rfc3987`
- Pyup-ignored the other app dependencies, which wrought havoc with the database
- Bumps the test dependencies, which were all fine