### PR TITLE
auth failures: don't bother keeping IP information in audit log, instead rely on trace/span ids

### DIFF
--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -68,9 +68,9 @@ def auth_user():
 
         audit_data = {
             'email_address': json_payload['emailAddress'].lower(),
-            'client_ip': request.environ.get('HTTP_X_REAL_IP', request.remote_addr),  # HTTP_X_REAL_IP added by nginx
             'failed_login_count': user.failed_login_count,
             'request_id': request.trace_id,
+            'span_id': request.span_id,
         }
 
         audit = AuditEvent(

--- a/tests/main/views/test_users.py
+++ b/tests/main/views/test_users.py
@@ -73,9 +73,9 @@ class TestUsersAuth(BaseUserTest):
         assert failed_login_audit[0].user == email_address
         assert failed_login_audit[0].data == {
             'email_address': email_address,
-            'client_ip': client_ip,
             'failed_login_count': failed_login_count,
             'request_id': mock.ANY,
+            'span_id': mock.ANY,
         }
 
     def test_should_validate_credentials(self):


### PR DESCRIPTION
https://trello.com/c/9KsjF8Ns

The way the APIs are served these days, it'll be hard to get a single useful IP for a client from the API process. it's probably much better to rely on our regular logs and instead make the association as strong as possible by adding the request's span id as well as trace id.