### PR TITLE
427-put-metrics-on-api

### DIFF
--- a/app/metrics.py
+++ b/app/metrics.py
@@ -1,0 +1,9 @@
+from flask import Blueprint
+from dmutils.metrics import DMGDSMetrics
+
+
+metrics = Blueprint('metrics', __name__)
+
+gds_metrics = DMGDSMetrics()
+
+metrics.add_url_rule(gds_metrics.metrics_path, 'metrics', gds_metrics.metrics_endpoint)

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -1,6 +1,9 @@
 # Run `make freeze-requirements` to update requirements.txt
 # with package version changes made in requirements-app.txt
 
+git+https://github.com/alphagov/digitalmarketplace-utils.git@47.2.0#egg=digitalmarketplace-utils==47.2.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.15.1#egg=digitalmarketplace-apiclient==19.15.1
+
 Flask==1.0.2
 Flask-Bcrypt==0.7.1
 Flask-Migrate==2.0.3 # pyup: ignore
@@ -11,9 +14,6 @@ psycopg2==2.7.7
 SQLAlchemy==1.2.18 # pyup: ignore
 SQLAlchemy-Utils==0.33.11
 sqlalchemy-json==0.2.3
-
-git+https://github.com/alphagov/digitalmarketplace-utils.git@46.3.1#egg=digitalmarketplace-utils==46.3.1
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.15.1#egg=digitalmarketplace-apiclient==19.15.1
 
 # For schema validation
 jsonschema==3.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,9 @@
 # Run `make freeze-requirements` to update requirements.txt
 # with package version changes made in requirements-app.txt
 
+git+https://github.com/alphagov/digitalmarketplace-utils.git@47.2.0#egg=digitalmarketplace-utils==47.2.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.15.1#egg=digitalmarketplace-apiclient==19.15.1
+
 Flask==1.0.2
 Flask-Bcrypt==0.7.1
 Flask-Migrate==2.0.3 # pyup: ignore
@@ -13,9 +16,6 @@ SQLAlchemy==1.2.18 # pyup: ignore
 SQLAlchemy-Utils==0.33.11
 sqlalchemy-json==0.2.3
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@46.3.1#egg=digitalmarketplace-utils==46.3.1
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.15.1#egg=digitalmarketplace-apiclient==19.15.1
-
 # For schema validation
 jsonschema==3.0.1
 rfc3987==1.3.8
@@ -26,8 +26,9 @@ alembic==1.0.8
 asn1crypto==0.24.0
 attrs==19.1.0
 bcrypt==3.1.6
-boto3==1.9.116
-botocore==1.12.116
+blinker==1.4
+boto3==1.9.124
+botocore==1.12.124
 certifi==2019.3.9
 cffi==1.12.2
 chardet==3.0.4
@@ -42,16 +43,18 @@ Flask-Script==2.0.6
 Flask-WTF==0.14.2
 fleep==1.0.1
 future==0.17.1
+gds-metrics==0.2.0
 govuk-country-register==0.3.0
 idna==2.8
 Jinja2==2.10
 jmespath==0.9.4
 mailchimp3==3.0.6
-Mako==1.0.7
+Mako==1.0.8
 MarkupSafe==1.1.1
 monotonic==1.5
 notifications-python-client==5.3.0
 odfpy==1.4.0
+prometheus-client==0.2.0
 pycparser==2.19
 PyJWT==1.7.1
 pyrsistent==0.14.11

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,8 @@ from app.main.views.frameworks import FRAMEWORK_UPDATE_WHITELISTED_ATTRIBUTES_MA
 @pytest.fixture(autouse=True, scope='session')
 def db_migration(request):
     print("Doing db setup")
+    app_env_var_mock = mock.patch.dict('gds_metrics.os.environ', {'PROMETHEUS_METRICS_PATH': '/_metrics'})
+    app_env_var_mock.start()
     app = create_app('test')
     Migrate(app, db)
     Manager(db, MigrateCommand)
@@ -45,6 +47,7 @@ def db_migration(request):
             for enum in insp.get_enums():
                 db.Enum(name=enum['name']).drop(db.engine)
             db.get_engine(app).dispose()
+            app_env_var_mock.stop()
     request.addfinalizer(teardown)
 
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,57 @@
+import re
+
+from tests.bases import BaseApplicationTest
+
+
+def load_prometheus_metrics(response_bytes):
+    return dict(re.findall(rb"(\w+{.+?}) (\d+)", response_bytes))
+
+
+class TestMetrics(BaseApplicationTest):
+
+    def test_metrics_page_accessible(self):
+        metrics_response = self.client.get('/_metrics')
+
+        assert metrics_response.status_code == 200
+
+    def test_metrics_page_contents(self):
+        metrics_response = self.client.get('/_metrics')
+        results = load_prometheus_metrics(metrics_response.data)
+        assert (
+            b'http_server_requests_total{code="200",host="127.0.0.1:5000",method="GET",path="/_metrics"}'
+        ) in results
+
+
+class TestMetricsPageRegistersPageViews(BaseApplicationTest):
+
+    def test_metrics_page_registers_page_views(self):
+        expected_metric_name = (
+            b'http_server_requests_total{code="200",host="127.0.0.1:5000",method="GET",path="/users"}'
+        )
+
+        res = self.client.get('/users')
+        assert res.status_code == 200
+
+        metrics_response = self.client.get('/_metrics')
+        results = load_prometheus_metrics(metrics_response.data)
+        assert expected_metric_name in results
+
+    def test_metrics_page_registers_multiple_page_views(self):
+        expected_metric_name = (
+            b'http_server_requests_total{code="200",host="127.0.0.1:5000",method="GET",path="/users"}'
+        )
+
+        initial_metrics_response = self.client.get('/_metrics')
+        initial_results = load_prometheus_metrics(initial_metrics_response.data)
+        initial_metric_value = int(initial_results.get(expected_metric_name, 0))
+
+        for _ in range(3):
+            res = self.client.get('/users')
+            assert res.status_code == 200
+
+        metrics_response = self.client.get('/_metrics')
+        results = load_prometheus_metrics(metrics_response.data)
+        metric_value = int(results.get(expected_metric_name, 0))
+
+        assert expected_metric_name in results
+        assert metric_value - initial_metric_value == 3


### PR DESCRIPTION
https://trello.com/c/wGJZQFxO/427-put-metrics-on-api

Use metrics from utils on API.

Adds metrics capabilities.
Requires a push to digitalmarketplace-aws to update manifest that API is pushed with. Needs env var `PROMETHEUS_METRICS_PATH` and explicitly assigned /_metrics route that we can then whitelist.