### PR TITLE
Update copied_to_following_framework flag if supplied

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -144,8 +144,11 @@ def update_service(service_id):
     update_details = validate_and_return_updater_request()
     update = validate_and_return_service_request(service_id)
 
-    updated_service = update_and_validate_service(service, update)
+    # Check for an update to the copied_to_following_framework flag on the service object
+    if 'copiedToFollowingFramework' in update and isinstance(update['copiedToFollowingFramework'], bool):
+        service.copied_to_following_framework = update['copiedToFollowingFramework']
 
+    updated_service = update_and_validate_service(service, update)
     audit_type = (
         AuditTypes.update_service_admin if request.args.get('user-role') == 'admin' else AuditTypes.update_service
     )

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -145,7 +145,9 @@ def update_service(service_id):
     update = validate_and_return_service_request(service_id)
 
     # Check for an update to the copied_to_following_framework flag on the service object
-    if 'copiedToFollowingFramework' in update and isinstance(update['copiedToFollowingFramework'], bool):
+    if 'copiedToFollowingFramework' in update:
+        if not isinstance(update['copiedToFollowingFramework'], bool):
+            abort(400, "Invalid value for 'copiedToFollowingFramework' supplied")
         service.copied_to_following_framework = update['copiedToFollowingFramework']
 
     updated_service = update_and_validate_service(service, update)

--- a/tests/main/views/test_services.py
+++ b/tests/main/views/test_services.py
@@ -799,8 +799,11 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin, FixtureMixin):
     @mock.patch('app.main.views.services.index_service', autospec=True)
     def test_dont_set_copied_to_following_framework_flag_if_not_boolean(self, index_service, copy_flag):
         response = self._post_service_update({'copiedToFollowingFramework': copy_flag})
-        assert response.status_code == 200
-        assert index_service.called is True  # There may be other service data updates to index
+        assert response.status_code == 400
+        assert "Invalid value for 'copiedToFollowingFramework' supplied" in "{}".format(
+            json.loads(response.get_data())['error']
+        )
+        assert index_service.called is False
 
         response = self.client.get('/services/{}'.format(self.service_id))
         data = json.loads(response.get_data())


### PR DESCRIPTION
Trello: https://trello.com/c/u0QnZn8y/459-deleting-a-copied-draft-service-should-reset-the-source-service-flag

Currently a call to `update_service` can only update the service `data` itself, not the `copied_to_following_framework` flag. This PR checks for the flag in the request payload and sets the flag if necessary.

To keep changes minimal, the service is still archived and re-indexed via the helper function, as per any other service update. 