### PR TITLE
[WIP] Freeze requirements to bump urllib3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,20 +22,20 @@ rfc3987==1.3.8
 strict-rfc3339==0.7
 
 ## The following requirements were added by pip freeze:
-alembic==1.0.9
+alembic==1.0.10
 asn1crypto==0.24.0
 attrs==19.1.0
 bcrypt==3.1.6
 blinker==1.4
-boto3==1.9.130
-botocore==1.12.130
+boto3==1.9.139
+botocore==1.12.139
 certifi==2019.3.9
-cffi==1.12.2
+cffi==1.12.3
 chardet==3.0.4
 Click==7.0
 contextlib2==0.5.5
 cryptography==2.3.1
-defusedxml==0.5.0
+defusedxml==0.6.0
 docopt==0.6.2
 docutils==0.14
 Flask-Login==0.4.1
@@ -57,7 +57,7 @@ odfpy==1.4.0
 prometheus-client==0.2.0
 pycparser==2.19
 PyJWT==1.7.1
-pyrsistent==0.14.11
+pyrsistent==0.15.1
 python-dateutil==2.8.0
 python-editor==1.0.4
 python-json-logger==0.1.11
@@ -66,7 +66,7 @@ requests==2.21.0
 s3transfer==0.2.0
 six==1.12.0
 unicodecsv==0.14.1
-urllib3==1.24.1
+urllib3==1.24.2
 Werkzeug==0.14.1
 workdays==1.4
 WTForms==2.2.1


### PR DESCRIPTION
Trello: https://trello.com/c/twYGdLUB/744-vulnerability-fix-weekly-tracking

`urllib3==1.24.2` required to fix https://app.snyk.io/vuln/SNYK-PYTHON-URLLIB3-174464

Other bumps introduced via `make freeze-requirements`.