### PR TITLE
Exclude DOS services from deindexing

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -334,7 +334,6 @@ def update_service_status(service_id, status):
                                            'new_status': status})
 
     if prior_status != status:
-
         # If it's being unpublished, delete it from the search api.
         if prior_status == 'published':
             delete_service_from_index(service)

--- a/app/service_utils.py
+++ b/app/service_utils.py
@@ -146,13 +146,27 @@ def index_service(service):
 
 
 def delete_service_from_index(service):
-    try:
-        search_api_client.delete(index=service.framework.slug,
-                                 service_id=service.service_id)
-    except dmapiclient.HTTPError as e:
+    if (
+        service.framework.status == 'live' and
+        service.framework.framework == 'g-cloud'
+    ):
+        try:
+            search_api_client.delete(
+                index=service.framework.slug,
+                service_id=service.service_id
+            )
+        except dmapiclient.HTTPError as e:
+            current_app.logger.warning(
+                'Failed to remove {} to search index: {}'.format(
+                    service.service_id, e.message))
+    else:
         current_app.logger.warning(
-            'Failed to remove {} to search index: {}'.format(
-                service.service_id, e.message))
+            "Unable to delete {fw_status} {fw_family} service from search index.",
+            extra={
+                "fw_status": service.framework.status,
+                "fw_family": service.framework.framework
+            }
+        )
 
 
 def create_service_from_draft(draft, status):


### PR DESCRIPTION
Trello: https://trello.com/c/8U5bZl2b/778-removing-a-dos-service-shouldnt-try-to-de-index-it-from-elasticsearch

This has been causing some 500s when admins remove services for a DOS supplier, which aren't in Elasticsearch to begin with.