### PR TITLE
bump docker base image to 4.5.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM digitalmarketplace/base-api:4.4.4
+FROM digitalmarketplace/base-api:4.5.4


### PR DESCRIPTION
https://trello.com/c/PyDaRXEj

To get us https://github.com/alphagov/digitalmarketplace-docker-base/pull/56