### PR TITLE
Reset copiedtoFollowingFramework flag on service when draft is deleted

### DIFF
--- a/app/main/views/drafts.py
+++ b/app/main/views/drafts.py
@@ -77,6 +77,8 @@ def copy_draft_service_from_existing_service(service_id):
     )
 
     if target_framework_id != service.framework.id:
+        # TODO: convert data['copiedFromServiceId'] to a foreign key field on the model, linking the new draft with the
+        # source service. That way if the draft is deleted, the relationship to the source service will also be removed.
         service.copied_to_following_framework = True
         draft.data['copiedFromServiceId'] = service_id
 
@@ -316,6 +318,7 @@ def delete_draft_service(draft_id):
     # a service is copied, it's removed from the list of available services to copy from.
     # Resetting the .copied_to_following_framework flag on the source when the copy is deleted allows
     # the user to try again with a fresh copy.
+    # TODO: remove this when draft.data['copiedFromServiceId'] is converted to a foreign key field
     source_service, source_service_audit = None, None
     if 'copiedFromServiceId' in draft.data:
         source_service_id = draft.data['copiedFromServiceId']

--- a/app/main/views/drafts.py
+++ b/app/main/views/drafts.py
@@ -332,11 +332,11 @@ def delete_draft_service(draft_id):
                 audit_type=AuditTypes.update_service,
                 user=updater_json['updated_by'],
                 data={
-                    "serviceId": draft.service_id,
-                    "supplierId": draft.supplier_id,
+                    "serviceId": source_service.service_id,
+                    "supplierId": source_service.supplier_id,
                     "copiedToFollowingFramework": False
                 },
-                db_object=None
+                db_object=source_service
             )
 
     audit = AuditEvent(

--- a/app/main/views/drafts.py
+++ b/app/main/views/drafts.py
@@ -78,6 +78,7 @@ def copy_draft_service_from_existing_service(service_id):
 
     if target_framework_id != service.framework.id:
         service.copied_to_following_framework = True
+        draft.data['copiedFromServiceId'] = service_id
 
     db.session.add(draft, service)
     db.session.flush()


### PR DESCRIPTION
Trello: https://trello.com/c/n7cCL1ZM/411-if-a-user-copies-a-service-from-the-previous-framework-then-deletes-that-service-they-will-not-be-able-to-copy-it-again

- When a draft service (the 'copy') is created, add in the ID of the source service to the copy's `data` blob
- If the copy is deleted, look up the source service and reset the `copiedToFollowingFramework` flag.
