### PR TITLE
DOS4 validation schemas

### DIFF
--- a/json_schemas/brief-awards-digital-outcomes-and-specialists-4-digital-outcomes.json
+++ b/json_schemas/brief-awards-digital-outcomes-and-specialists-4-digital-outcomes.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "awardedContractStartDate": {
+      "format": "date",
+      "type": "string"
+    },
+    "awardedContractValue": {
+      "pattern": "^[1-9](?:\\d{1,14})?(?:\\.\\d{2})?$|^0\\.(?!00)\\d{2}$",
+      "type": "string"
+    }
+  },
+  "required": [
+    "awardedContractStartDate",
+    "awardedContractValue"
+  ],
+  "title": "Digital Outcomes and Specialists 4 Digital outcomes Brief Award Schema",
+  "type": "object"
+}

--- a/json_schemas/brief-awards-digital-outcomes-and-specialists-4-digital-specialists.json
+++ b/json_schemas/brief-awards-digital-outcomes-and-specialists-4-digital-specialists.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "awardedContractStartDate": {
+      "format": "date",
+      "type": "string"
+    },
+    "awardedContractValue": {
+      "pattern": "^[1-9](?:\\d{1,14})?(?:\\.\\d{2})?$|^0\\.(?!00)\\d{2}$",
+      "type": "string"
+    }
+  },
+  "required": [
+    "awardedContractStartDate",
+    "awardedContractValue"
+  ],
+  "title": "Digital Outcomes and Specialists 4 Digital specialists Brief Award Schema",
+  "type": "object"
+}

--- a/json_schemas/brief-awards-digital-outcomes-and-specialists-4-user-research-participants.json
+++ b/json_schemas/brief-awards-digital-outcomes-and-specialists-4-user-research-participants.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "awardedContractStartDate": {
+      "format": "date",
+      "type": "string"
+    },
+    "awardedContractValue": {
+      "pattern": "^[1-9](?:\\d{1,14})?(?:\\.\\d{2})?$|^0\\.(?!00)\\d{2}$",
+      "type": "string"
+    }
+  },
+  "required": [
+    "awardedContractStartDate",
+    "awardedContractValue"
+  ],
+  "title": "Digital Outcomes and Specialists 4 User research participants Brief Award Schema",
+  "type": "object"
+}

--- a/json_schemas/brief-responses-digital-outcomes-and-specialists-4-digital-outcomes.json
+++ b/json_schemas/brief-responses-digital-outcomes-and-specialists-4-digital-outcomes.json
@@ -1,0 +1,99 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "availability": {
+      "maxLength": 100,
+      "minLength": 1,
+      "type": "string"
+    },
+    "essentialRequirements": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "evidence": {
+            "minLength": 1,
+            "pattern": "^(?:\\S+\\s+){0,99}\\S+$",
+            "type": "string"
+          }
+        },
+        "required": [
+          "evidence"
+        ],
+        "type": "object"
+      },
+      "minItems": 1,
+      "type": "array"
+    },
+    "essentialRequirementsMet": {
+      "enum": [
+        true
+      ]
+    },
+    "niceToHaveRequirements": {
+      "items": {
+        "additionalProperties": false,
+        "allOf": [
+          {
+            "oneOf": [
+              {
+                "properties": {
+                  "evidence": {
+                    "type": "null"
+                  },
+                  "yesNo": {
+                    "enum": [
+                      false
+                    ]
+                  }
+                }
+              },
+              {
+                "properties": {
+                  "yesNo": {
+                    "enum": [
+                      true
+                    ]
+                  }
+                },
+                "required": [
+                  "yesNo",
+                  "evidence"
+                ]
+              }
+            ]
+          }
+        ],
+        "properties": {
+          "evidence": {
+            "minLength": 1,
+            "pattern": "^(?:\\S+\\s+){0,99}\\S+$",
+            "type": "string"
+          },
+          "yesNo": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "yesNo"
+        ],
+        "type": "object"
+      },
+      "minItems": 0,
+      "type": "array"
+    },
+    "respondToEmailAddress": {
+      "format": "email",
+      "minLength": 1,
+      "type": "string"
+    }
+  },
+  "required": [
+    "availability",
+    "essentialRequirements",
+    "essentialRequirementsMet",
+    "respondToEmailAddress"
+  ],
+  "title": "Digital Outcomes and Specialists 4 Digital outcomes Brief Response Schema",
+  "type": "object"
+}

--- a/json_schemas/brief-responses-digital-outcomes-and-specialists-4-digital-specialists.json
+++ b/json_schemas/brief-responses-digital-outcomes-and-specialists-4-digital-specialists.json
@@ -1,0 +1,104 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "availability": {
+      "maxLength": 100,
+      "minLength": 1,
+      "type": "string"
+    },
+    "dayRate": {
+      "pattern": "^\\d{1,15}(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "essentialRequirements": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "evidence": {
+            "minLength": 1,
+            "pattern": "^(?:\\S+\\s+){0,99}\\S+$",
+            "type": "string"
+          }
+        },
+        "required": [
+          "evidence"
+        ],
+        "type": "object"
+      },
+      "minItems": 1,
+      "type": "array"
+    },
+    "essentialRequirementsMet": {
+      "enum": [
+        true
+      ]
+    },
+    "niceToHaveRequirements": {
+      "items": {
+        "additionalProperties": false,
+        "allOf": [
+          {
+            "oneOf": [
+              {
+                "properties": {
+                  "evidence": {
+                    "type": "null"
+                  },
+                  "yesNo": {
+                    "enum": [
+                      false
+                    ]
+                  }
+                }
+              },
+              {
+                "properties": {
+                  "yesNo": {
+                    "enum": [
+                      true
+                    ]
+                  }
+                },
+                "required": [
+                  "yesNo",
+                  "evidence"
+                ]
+              }
+            ]
+          }
+        ],
+        "properties": {
+          "evidence": {
+            "minLength": 1,
+            "pattern": "^(?:\\S+\\s+){0,99}\\S+$",
+            "type": "string"
+          },
+          "yesNo": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "yesNo"
+        ],
+        "type": "object"
+      },
+      "minItems": 0,
+      "type": "array"
+    },
+    "respondToEmailAddress": {
+      "format": "email",
+      "minLength": 1,
+      "type": "string"
+    }
+  },
+  "required": [
+    "availability",
+    "dayRate",
+    "essentialRequirements",
+    "essentialRequirementsMet",
+    "respondToEmailAddress"
+  ],
+  "title": "Digital Outcomes and Specialists 4 Digital specialists Brief Response Schema",
+  "type": "object"
+}

--- a/json_schemas/brief-responses-digital-outcomes-and-specialists-4-user-research-participants.json
+++ b/json_schemas/brief-responses-digital-outcomes-and-specialists-4-user-research-participants.json
@@ -1,0 +1,99 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "availability": {
+      "maxLength": 100,
+      "minLength": 1,
+      "type": "string"
+    },
+    "essentialRequirements": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "evidence": {
+            "minLength": 1,
+            "pattern": "^(?:\\S+\\s+){0,99}\\S+$",
+            "type": "string"
+          }
+        },
+        "required": [
+          "evidence"
+        ],
+        "type": "object"
+      },
+      "minItems": 1,
+      "type": "array"
+    },
+    "essentialRequirementsMet": {
+      "enum": [
+        true
+      ]
+    },
+    "niceToHaveRequirements": {
+      "items": {
+        "additionalProperties": false,
+        "allOf": [
+          {
+            "oneOf": [
+              {
+                "properties": {
+                  "evidence": {
+                    "type": "null"
+                  },
+                  "yesNo": {
+                    "enum": [
+                      false
+                    ]
+                  }
+                }
+              },
+              {
+                "properties": {
+                  "yesNo": {
+                    "enum": [
+                      true
+                    ]
+                  }
+                },
+                "required": [
+                  "yesNo",
+                  "evidence"
+                ]
+              }
+            ]
+          }
+        ],
+        "properties": {
+          "evidence": {
+            "minLength": 1,
+            "pattern": "^(?:\\S+\\s+){0,99}\\S+$",
+            "type": "string"
+          },
+          "yesNo": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "yesNo"
+        ],
+        "type": "object"
+      },
+      "minItems": 0,
+      "type": "array"
+    },
+    "respondToEmailAddress": {
+      "format": "email",
+      "minLength": 1,
+      "type": "string"
+    }
+  },
+  "required": [
+    "availability",
+    "essentialRequirements",
+    "essentialRequirementsMet",
+    "respondToEmailAddress"
+  ],
+  "title": "Digital Outcomes and Specialists 4 User research participants Brief Response Schema",
+  "type": "object"
+}

--- a/json_schemas/briefs-digital-outcomes-and-specialists-4-digital-outcomes.json
+++ b/json_schemas/briefs-digital-outcomes-and-specialists-4-digital-outcomes.json
@@ -1,0 +1,222 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "additionalTerms": {
+      "minLength": 0,
+      "pattern": "^$|(^(?:\\S+\\s+){0,99}\\S+$)",
+      "type": "string"
+    },
+    "backgroundInformation": {
+      "minLength": 1,
+      "pattern": "^(?:\\S+\\s+){0,99}\\S+$",
+      "type": "string"
+    },
+    "budgetRange": {
+      "minLength": 0,
+      "pattern": "^$|(^(?:\\S+\\s+){0,99}\\S+$)",
+      "type": "string"
+    },
+    "contractLength": {
+      "maxLength": 100,
+      "minLength": 0,
+      "type": "string"
+    },
+    "culturalFitCriteria": {
+      "items": {
+        "maxLength": 300,
+        "pattern": "^(?:\\S+\\s+){0,29}\\S+$",
+        "type": "string"
+      },
+      "maxItems": 20,
+      "minItems": 1,
+      "type": "array"
+    },
+    "culturalWeighting": {
+      "maximum": 20,
+      "minimum": 5,
+      "type": "integer"
+    },
+    "earlyMarketEngagement": {
+      "minLength": 0,
+      "pattern": "^$|(^(?:\\S+\\s+){0,199}\\S+$)",
+      "type": "string"
+    },
+    "endUsers": {
+      "minLength": 1,
+      "pattern": "^(?:\\S+\\s+){0,99}\\S+$",
+      "type": "string"
+    },
+    "essentialRequirements": {
+      "items": {
+        "maxLength": 300,
+        "pattern": "^(?:\\S+\\s+){0,29}\\S+$",
+        "type": "string"
+      },
+      "maxItems": 20,
+      "minItems": 1,
+      "type": "array"
+    },
+    "evaluationType": {
+      "items": {
+        "enum": [
+          "Case study",
+          "Work history",
+          "Reference",
+          "Presentation"
+        ]
+      },
+      "maxItems": 4,
+      "minItems": 0,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "existingTeam": {
+      "minLength": 1,
+      "pattern": "^(?:\\S+\\s+){0,99}\\S+$",
+      "type": "string"
+    },
+    "location": {
+      "enum": [
+        "Scotland",
+        "North East England",
+        "North West England",
+        "Yorkshire and the Humber",
+        "East Midlands",
+        "West Midlands",
+        "East of England",
+        "Wales",
+        "London",
+        "South East England",
+        "South West England",
+        "Northern Ireland",
+        "Offsite"
+      ]
+    },
+    "niceToHaveRequirements": {
+      "items": {
+        "maxLength": 300,
+        "pattern": "^(?:\\S+\\s+){0,29}\\S+$",
+        "type": "string"
+      },
+      "maxItems": 20,
+      "minItems": 0,
+      "type": "array"
+    },
+    "numberOfSuppliers": {
+      "maximum": 15,
+      "minimum": 3,
+      "type": "integer"
+    },
+    "organisation": {
+      "maxLength": 100,
+      "minLength": 1,
+      "type": "string"
+    },
+    "outcome": {
+      "minLength": 1,
+      "pattern": "^(?:\\S+\\s+){0,99}\\S+$",
+      "type": "string"
+    },
+    "phase": {
+      "enum": [
+        "not_applicable",
+        "not_started",
+        "discovery",
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "priceCriteria": {
+      "enum": [
+        "Fixed price",
+        "Time and materials",
+        "Capped time and materials"
+      ]
+    },
+    "priceWeighting": {
+      "maximum": 85,
+      "minimum": 20,
+      "type": "integer"
+    },
+    "questionAndAnswerSessionDetails": {
+      "minLength": 0,
+      "pattern": "^$|(^(?:\\S+\\s+){0,99}\\S+$)",
+      "type": "string"
+    },
+    "securityClearance": {
+      "minLength": 0,
+      "pattern": "^$|(^(?:\\S+\\s+){0,49}\\S+$)",
+      "type": "string"
+    },
+    "startDate": {
+      "format": "date",
+      "type": "string"
+    },
+    "successCriteria": {
+      "items": {
+        "maxLength": 300,
+        "pattern": "^(?:\\S+\\s+){0,29}\\S+$",
+        "type": "string"
+      },
+      "maxItems": 20,
+      "minItems": 1,
+      "type": "array"
+    },
+    "summary": {
+      "minLength": 1,
+      "pattern": "^(?:\\S+\\s+){0,49}\\S+$",
+      "type": "string"
+    },
+    "technicalWeighting": {
+      "maximum": 75,
+      "minimum": 10,
+      "type": "integer"
+    },
+    "title": {
+      "maxLength": 100,
+      "minLength": 1,
+      "type": "string"
+    },
+    "workAlreadyDone": {
+      "minLength": 0,
+      "pattern": "^$|(^(?:\\S+\\s+){0,99}\\S+$)",
+      "type": "string"
+    },
+    "workingArrangements": {
+      "minLength": 1,
+      "pattern": "^(?:\\S+\\s+){0,99}\\S+$",
+      "type": "string"
+    },
+    "workplaceAddress": {
+      "minLength": 1,
+      "pattern": "^(?:\\S+\\s+){0,99}\\S+$",
+      "type": "string"
+    }
+  },
+  "required": [
+    "backgroundInformation",
+    "culturalFitCriteria",
+    "culturalWeighting",
+    "endUsers",
+    "essentialRequirements",
+    "existingTeam",
+    "location",
+    "numberOfSuppliers",
+    "organisation",
+    "outcome",
+    "phase",
+    "priceCriteria",
+    "priceWeighting",
+    "startDate",
+    "successCriteria",
+    "summary",
+    "technicalWeighting",
+    "title",
+    "workingArrangements",
+    "workplaceAddress"
+  ],
+  "title": "Digital Outcomes and Specialists 4 Digital outcomes Brief Schema",
+  "type": "object"
+}

--- a/json_schemas/briefs-digital-outcomes-and-specialists-4-digital-specialists.json
+++ b/json_schemas/briefs-digital-outcomes-and-specialists-4-digital-specialists.json
@@ -1,0 +1,207 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "additionalTerms": {
+      "minLength": 0,
+      "pattern": "^$|(^(?:\\S+\\s+){0,99}\\S+$)",
+      "type": "string"
+    },
+    "budgetRange": {
+      "minLength": 0,
+      "pattern": "^$|(^(?:\\S+\\s+){0,99}\\S+$)",
+      "type": "string"
+    },
+    "contractLength": {
+      "maxLength": 100,
+      "minLength": 0,
+      "type": "string"
+    },
+    "culturalFitCriteria": {
+      "items": {
+        "maxLength": 300,
+        "pattern": "^(?:\\S+\\s+){0,29}\\S+$",
+        "type": "string"
+      },
+      "maxItems": 20,
+      "minItems": 1,
+      "type": "array"
+    },
+    "culturalWeighting": {
+      "maximum": 20,
+      "minimum": 5,
+      "type": "integer"
+    },
+    "earlyMarketEngagement": {
+      "minLength": 0,
+      "pattern": "^$|(^(?:\\S+\\s+){0,199}\\S+$)",
+      "type": "string"
+    },
+    "essentialRequirements": {
+      "items": {
+        "maxLength": 300,
+        "pattern": "^(?:\\S+\\s+){0,29}\\S+$",
+        "type": "string"
+      },
+      "maxItems": 20,
+      "minItems": 1,
+      "type": "array"
+    },
+    "evaluationType": {
+      "items": {
+        "enum": [
+          "Reference",
+          "Interview",
+          "Scenario or test",
+          "Presentation"
+        ]
+      },
+      "maxItems": 4,
+      "minItems": 0,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "existingTeam": {
+      "minLength": 1,
+      "pattern": "^(?:\\S+\\s+){0,99}\\S+$",
+      "type": "string"
+    },
+    "location": {
+      "enum": [
+        "Scotland",
+        "North East England",
+        "North West England",
+        "Yorkshire and the Humber",
+        "East Midlands",
+        "West Midlands",
+        "East of England",
+        "Wales",
+        "London",
+        "South East England",
+        "South West England",
+        "Northern Ireland",
+        "Offsite"
+      ]
+    },
+    "niceToHaveRequirements": {
+      "items": {
+        "maxLength": 300,
+        "pattern": "^(?:\\S+\\s+){0,29}\\S+$",
+        "type": "string"
+      },
+      "maxItems": 20,
+      "minItems": 0,
+      "type": "array"
+    },
+    "numberOfSuppliers": {
+      "maximum": 15,
+      "minimum": 3,
+      "type": "integer"
+    },
+    "organisation": {
+      "maxLength": 100,
+      "minLength": 1,
+      "type": "string"
+    },
+    "priceWeighting": {
+      "maximum": 85,
+      "minimum": 20,
+      "type": "integer"
+    },
+    "questionAndAnswerSessionDetails": {
+      "minLength": 0,
+      "pattern": "^$|(^(?:\\S+\\s+){0,99}\\S+$)",
+      "type": "string"
+    },
+    "requirementsLength": {
+      "enum": [
+        "1 week",
+        "2 weeks"
+      ]
+    },
+    "securityClearance": {
+      "minLength": 0,
+      "pattern": "^$|(^(?:\\S+\\s+){0,49}\\S+$)",
+      "type": "string"
+    },
+    "specialistRole": {
+      "enum": [
+        "agileCoach",
+        "businessAnalyst",
+        "communicationsManager",
+        "contentDesigner",
+        "securityConsultant",
+        "dataArchitect",
+        "dataEngineer",
+        "dataScientist",
+        "deliveryManager",
+        "designer",
+        "developer",
+        "performanceAnalyst",
+        "portfolioManager",
+        "productManager",
+        "programmeManager",
+        "qualityAssurance",
+        "serviceManager",
+        "technicalArchitect",
+        "userResearcher",
+        "webOperations"
+      ]
+    },
+    "specialistWork": {
+      "minLength": 1,
+      "pattern": "^(?:\\S+\\s+){0,99}\\S+$",
+      "type": "string"
+    },
+    "startDate": {
+      "format": "date",
+      "type": "string"
+    },
+    "summary": {
+      "minLength": 1,
+      "pattern": "^(?:\\S+\\s+){0,49}\\S+$",
+      "type": "string"
+    },
+    "technicalWeighting": {
+      "maximum": 75,
+      "minimum": 10,
+      "type": "integer"
+    },
+    "title": {
+      "maxLength": 100,
+      "minLength": 1,
+      "type": "string"
+    },
+    "workingArrangements": {
+      "minLength": 1,
+      "pattern": "^(?:\\S+\\s+){0,99}\\S+$",
+      "type": "string"
+    },
+    "workplaceAddress": {
+      "minLength": 1,
+      "pattern": "^(?:\\S+\\s+){0,99}\\S+$",
+      "type": "string"
+    }
+  },
+  "required": [
+    "culturalFitCriteria",
+    "culturalWeighting",
+    "essentialRequirements",
+    "existingTeam",
+    "location",
+    "numberOfSuppliers",
+    "organisation",
+    "priceWeighting",
+    "requirementsLength",
+    "specialistRole",
+    "specialistWork",
+    "startDate",
+    "summary",
+    "technicalWeighting",
+    "title",
+    "workingArrangements",
+    "workplaceAddress"
+  ],
+  "title": "Digital Outcomes and Specialists 4 Digital specialists Brief Schema",
+  "type": "object"
+}

--- a/json_schemas/briefs-digital-outcomes-and-specialists-4-user-research-participants.json
+++ b/json_schemas/briefs-digital-outcomes-and-specialists-4-user-research-participants.json
@@ -1,0 +1,198 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "accessRestrictions": {
+      "minLength": 0,
+      "pattern": "^$|(^(?:\\S+\\s+){0,99}\\S+$)",
+      "type": "string"
+    },
+    "additionalTerms": {
+      "minLength": 0,
+      "pattern": "^$|(^(?:\\S+\\s+){0,99}\\S+$)",
+      "type": "string"
+    },
+    "budgetRange": {
+      "minLength": 0,
+      "pattern": "^$|(^(?:\\S+\\s+){0,99}\\S+$)",
+      "type": "string"
+    },
+    "culturalWeighting": {
+      "maximum": 70,
+      "minimum": 10,
+      "type": "integer"
+    },
+    "earlyMarketEngagement": {
+      "minLength": 0,
+      "pattern": "^$|(^(?:\\S+\\s+){0,199}\\S+$)",
+      "type": "string"
+    },
+    "essentialRequirements": {
+      "items": {
+        "maxLength": 300,
+        "pattern": "^(?:\\S+\\s+){0,29}\\S+$",
+        "type": "string"
+      },
+      "maxItems": 20,
+      "minItems": 1,
+      "type": "array"
+    },
+    "evaluationType": {
+      "items": {
+        "enum": [
+          "Case study",
+          "Reference",
+          "Interview"
+        ]
+      },
+      "maxItems": 3,
+      "minItems": 0,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "location": {
+      "enum": [
+        "Scotland",
+        "North East England",
+        "North West England",
+        "Yorkshire and the Humber",
+        "East Midlands",
+        "West Midlands",
+        "East of England",
+        "Wales",
+        "London",
+        "South East England",
+        "South West England",
+        "Northern Ireland",
+        "International (outside the UK)"
+      ]
+    },
+    "niceToHaveRequirements": {
+      "items": {
+        "maxLength": 300,
+        "pattern": "^(?:\\S+\\s+){0,29}\\S+$",
+        "type": "string"
+      },
+      "maxItems": 20,
+      "minItems": 0,
+      "type": "array"
+    },
+    "numberOfSuppliers": {
+      "maximum": 15,
+      "minimum": 3,
+      "type": "integer"
+    },
+    "organisation": {
+      "maxLength": 100,
+      "minLength": 1,
+      "type": "string"
+    },
+    "participantAccessibilityNeeds": {
+      "minLength": 0,
+      "pattern": "^$|(^(?:\\S+\\s+){0,99}\\S+$)",
+      "type": "string"
+    },
+    "participantSpecification": {
+      "minLength": 1,
+      "pattern": "^(?:\\S+\\s+){0,199}\\S+$",
+      "type": "string"
+    },
+    "participantsPerRound": {
+      "minLength": 1,
+      "pattern": "^(?:\\S+\\s+){0,99}\\S+$",
+      "type": "string"
+    },
+    "priceWeighting": {
+      "maximum": 80,
+      "minimum": 20,
+      "type": "integer"
+    },
+    "questionAndAnswerSessionDetails": {
+      "minLength": 0,
+      "pattern": "^$|(^(?:\\S+\\s+){0,99}\\S+$)",
+      "type": "string"
+    },
+    "researchAddress": {
+      "minLength": 1,
+      "pattern": "^(?:\\S+\\s+){0,99}\\S+$",
+      "type": "string"
+    },
+    "researchDates": {
+      "maxLength": 100,
+      "minLength": 1,
+      "type": "string"
+    },
+    "researchFrequency": {
+      "minLength": 1,
+      "pattern": "^(?:\\S+\\s+){0,99}\\S+$",
+      "type": "string"
+    },
+    "researchOutOfHours": {
+      "items": {
+        "enum": [
+          "Weekday evenings",
+          "Weekends"
+        ]
+      },
+      "maxItems": 2,
+      "minItems": 0,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "researchPlan": {
+      "minLength": 0,
+      "pattern": "^$|(^(?:\\S+\\s+){0,99}\\S+$)",
+      "type": "string"
+    },
+    "researchRounds": {
+      "maxLength": 100,
+      "minLength": 1,
+      "type": "string"
+    },
+    "successCriteria": {
+      "items": {
+        "maxLength": 300,
+        "pattern": "^(?:\\S+\\s+){0,29}\\S+$",
+        "type": "string"
+      },
+      "maxItems": 20,
+      "minItems": 1,
+      "type": "array"
+    },
+    "summary": {
+      "minLength": 1,
+      "pattern": "^(?:\\S+\\s+){0,49}\\S+$",
+      "type": "string"
+    },
+    "technicalWeighting": {
+      "maximum": 70,
+      "minimum": 10,
+      "type": "integer"
+    },
+    "title": {
+      "maxLength": 100,
+      "minLength": 1,
+      "type": "string"
+    }
+  },
+  "required": [
+    "culturalWeighting",
+    "essentialRequirements",
+    "location",
+    "numberOfSuppliers",
+    "organisation",
+    "participantSpecification",
+    "participantsPerRound",
+    "priceWeighting",
+    "researchAddress",
+    "researchDates",
+    "researchFrequency",
+    "researchRounds",
+    "successCriteria",
+    "summary",
+    "technicalWeighting",
+    "title"
+  ],
+  "title": "Digital Outcomes and Specialists 4 User research participants Brief Schema",
+  "type": "object"
+}

--- a/json_schemas/services-digital-outcomes-and-specialists-4-digital-outcomes.json
+++ b/json_schemas/services-digital-outcomes-and-specialists-4-digital-outcomes.json
@@ -1,0 +1,256 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "anyOf": [
+    {
+      "required": [
+        "deliveryTypes"
+      ],
+      "title": "capability"
+    },
+    {
+      "required": [
+        "performanceAnalysisTypes"
+      ],
+      "title": "capability"
+    },
+    {
+      "required": [
+        "securityTypes"
+      ],
+      "title": "capability"
+    },
+    {
+      "required": [
+        "softwareDevelopmentTypes"
+      ],
+      "title": "capability"
+    },
+    {
+      "required": [
+        "supportAndOperationsTypes"
+      ],
+      "title": "capability"
+    },
+    {
+      "required": [
+        "testingAndAuditingTypes"
+      ],
+      "title": "capability"
+    },
+    {
+      "required": [
+        "userExperienceAndDesignTypes"
+      ],
+      "title": "capability"
+    },
+    {
+      "required": [
+        "userResearchTypes"
+      ],
+      "title": "capability"
+    }
+  ],
+  "properties": {
+    "accessibleApplicationsOutcomes": {
+      "type": "boolean"
+    },
+    "bespokeSystemInformation": {
+      "type": "boolean"
+    },
+    "dataProtocols": {
+      "type": "boolean"
+    },
+    "deliveryTypes": {
+      "items": {
+        "enum": [
+          "Agile coaching",
+          "Agile delivery",
+          "Business analysis",
+          "Digital communication and engagement",
+          "Product management",
+          "Programme management",
+          "Project management",
+          "Service management"
+        ]
+      },
+      "maxItems": 8,
+      "minItems": 1,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "helpGovernmentImproveServices": {
+      "type": "boolean"
+    },
+    "locations": {
+      "items": {
+        "enum": [
+          "Offsite",
+          "Scotland",
+          "North East England",
+          "North West England",
+          "Yorkshire and the Humber",
+          "East Midlands",
+          "West Midlands",
+          "East of England",
+          "Wales",
+          "London",
+          "South East England",
+          "South West England",
+          "Northern Ireland"
+        ]
+      },
+      "maxItems": 13,
+      "minItems": 1,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "openStandardsPrinciples": {
+      "type": "boolean"
+    },
+    "performanceAnalysisTypes": {
+      "items": {
+        "enum": [
+          "A/B and multivariate testing",
+          "Data analysis",
+          "Data cleansing",
+          "Data visualisation",
+          "Performance frameworks",
+          "Performance reporting",
+          "Statistical modelling",
+          "Web analytics"
+        ]
+      },
+      "maxItems": 8,
+      "minItems": 1,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "securityTypes": {
+      "items": {
+        "enum": [
+          "CESG information assurance certification",
+          "Firewall audit",
+          "Incident response and forensics",
+          "Infrastructure review",
+          "IT health check",
+          "Risk management",
+          "Security policy",
+          "Threat modelling",
+          "Vulnerability and penetration testing"
+        ]
+      },
+      "maxItems": 9,
+      "minItems": 1,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "softwareDevelopmentTypes": {
+      "items": {
+        "enum": [
+          "API development",
+          "Cloud-based service development",
+          "Content management system",
+          "Customer relationship management",
+          "Database development",
+          "Desktop application development",
+          "Front-end web application development",
+          "Game development",
+          "Geographic information systems (GIS) development",
+          "Machine learning",
+          "Mainframe",
+          "Message queues",
+          "Mobile application development",
+          "Search",
+          "Systems integration",
+          "Web application development"
+        ]
+      },
+      "maxItems": 16,
+      "minItems": 1,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "supportAndOperationsTypes": {
+      "items": {
+        "enum": [
+          "Customer support",
+          "Firewall management",
+          "Hosting",
+          "Incident management",
+          "Monitoring",
+          "Network administration",
+          "Service desk",
+          "Systems administration",
+          "Tooling"
+        ]
+      },
+      "maxItems": 9,
+      "minItems": 1,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "testingAndAuditingTypes": {
+      "items": {
+        "enum": [
+          "Accessibility testing",
+          "Application testing",
+          "Data auditing",
+          "Load and performance testing",
+          "Process auditing",
+          "Software auditing",
+          "System auditing"
+        ]
+      },
+      "maxItems": 7,
+      "minItems": 1,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "userExperienceAndDesignTypes": {
+      "items": {
+        "enum": [
+          "Accessibility",
+          "Animation",
+          "Brand development",
+          "Content design and copywriting",
+          "Cross-platform design",
+          "Information architecture",
+          "Interaction design",
+          "Prototyping",
+          "Service design",
+          "User experience and design strategy"
+        ]
+      },
+      "maxItems": 10,
+      "minItems": 1,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "userResearchTypes": {
+      "items": {
+        "enum": [
+          "Creating personas",
+          "Quantitative research",
+          "Usability testing",
+          "User journey mapping",
+          "User needs and insights"
+        ]
+      },
+      "maxItems": 5,
+      "minItems": 1,
+      "type": "array",
+      "uniqueItems": true
+    }
+  },
+  "required": [
+    "accessibleApplicationsOutcomes",
+    "bespokeSystemInformation",
+    "dataProtocols",
+    "helpGovernmentImproveServices",
+    "locations",
+    "openStandardsPrinciples"
+  ],
+  "title": "Digital Outcomes and Specialists 4 Digital outcomes Service Schema",
+  "type": "object"
+}

--- a/json_schemas/services-digital-outcomes-and-specialists-4-digital-specialists.json
+++ b/json_schemas/services-digital-outcomes-and-specialists-4-digital-specialists.json
@@ -1,0 +1,1086 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "anyOf": [
+    {
+      "required": [
+        "agileCoachLocations",
+        "agileCoachPriceMax",
+        "agileCoachPriceMin"
+      ],
+      "title": "specialist"
+    },
+    {
+      "required": [
+        "businessAnalystLocations",
+        "businessAnalystPriceMax",
+        "businessAnalystPriceMin"
+      ],
+      "title": "specialist"
+    },
+    {
+      "required": [
+        "communicationsManagerLocations",
+        "communicationsManagerPriceMax",
+        "communicationsManagerPriceMin"
+      ],
+      "title": "specialist"
+    },
+    {
+      "required": [
+        "accessibleApplicationsSpecialists",
+        "contentDesignerLocations",
+        "contentDesignerPriceMax",
+        "contentDesignerPriceMin"
+      ],
+      "title": "specialist"
+    },
+    {
+      "required": [
+        "dataArchitectLocations",
+        "dataArchitectPriceMax",
+        "dataArchitectPriceMin"
+      ],
+      "title": "specialist"
+    },
+    {
+      "required": [
+        "dataEngineerLocations",
+        "dataEngineerPriceMax",
+        "dataEngineerPriceMin"
+      ],
+      "title": "specialist"
+    },
+    {
+      "required": [
+        "dataScientistLocations",
+        "dataScientistPriceMax",
+        "dataScientistPriceMin"
+      ],
+      "title": "specialist"
+    },
+    {
+      "required": [
+        "deliveryManagerLocations",
+        "deliveryManagerPriceMax",
+        "deliveryManagerPriceMin"
+      ],
+      "title": "specialist"
+    },
+    {
+      "required": [
+        "accessibleApplicationsSpecialists",
+        "designerLocations",
+        "designerPriceMax",
+        "designerPriceMin"
+      ],
+      "title": "specialist"
+    },
+    {
+      "required": [
+        "accessibleApplicationsSpecialists",
+        "developerLocations",
+        "developerPriceMax",
+        "developerPriceMin"
+      ],
+      "title": "specialist"
+    },
+    {
+      "required": [
+        "performanceAnalystLocations",
+        "performanceAnalystPriceMax",
+        "performanceAnalystPriceMin"
+      ],
+      "title": "specialist"
+    },
+    {
+      "required": [
+        "portfolioManagerLocations",
+        "portfolioManagerPriceMax",
+        "portfolioManagerPriceMin"
+      ],
+      "title": "specialist"
+    },
+    {
+      "required": [
+        "productManagerLocations",
+        "productManagerPriceMax",
+        "productManagerPriceMin"
+      ],
+      "title": "specialist"
+    },
+    {
+      "required": [
+        "programmeManagerLocations",
+        "programmeManagerPriceMax",
+        "programmeManagerPriceMin"
+      ],
+      "title": "specialist"
+    },
+    {
+      "required": [
+        "accessibleApplicationsSpecialists",
+        "qualityAssuranceLocations",
+        "qualityAssurancePriceMax",
+        "qualityAssurancePriceMin"
+      ],
+      "title": "specialist"
+    },
+    {
+      "required": [
+        "securityConsultantLocations",
+        "securityConsultantPriceMax",
+        "securityConsultantPriceMin"
+      ],
+      "title": "specialist"
+    },
+    {
+      "required": [
+        "accessibleApplicationsSpecialists",
+        "serviceManagerLocations",
+        "serviceManagerPriceMax",
+        "serviceManagerPriceMin"
+      ],
+      "title": "specialist"
+    },
+    {
+      "required": [
+        "accessibleApplicationsSpecialists",
+        "technicalArchitectLocations",
+        "technicalArchitectPriceMax",
+        "technicalArchitectPriceMin"
+      ],
+      "title": "specialist"
+    },
+    {
+      "required": [
+        "userResearcherLocations",
+        "userResearcherPriceMax",
+        "userResearcherPriceMin"
+      ],
+      "title": "specialist"
+    },
+    {
+      "required": [
+        "accessibleApplicationsSpecialists",
+        "webOperationsLocations",
+        "webOperationsPriceMax",
+        "webOperationsPriceMin"
+      ],
+      "title": "specialist"
+    }
+  ],
+  "dependencies": {
+    "accessibleApplicationsSpecialists": [
+      "webOperationsLocations",
+      "webOperationsPriceMax",
+      "webOperationsPriceMin"
+    ],
+    "agileCoachLocations": [
+      "agileCoachPriceMax",
+      "agileCoachPriceMin"
+    ],
+    "agileCoachPriceMax": [
+      "agileCoachLocations",
+      "agileCoachPriceMin"
+    ],
+    "agileCoachPriceMin": [
+      "agileCoachLocations",
+      "agileCoachPriceMax"
+    ],
+    "businessAnalystLocations": [
+      "businessAnalystPriceMax",
+      "businessAnalystPriceMin"
+    ],
+    "businessAnalystPriceMax": [
+      "businessAnalystLocations",
+      "businessAnalystPriceMin"
+    ],
+    "businessAnalystPriceMin": [
+      "businessAnalystLocations",
+      "businessAnalystPriceMax"
+    ],
+    "communicationsManagerLocations": [
+      "communicationsManagerPriceMax",
+      "communicationsManagerPriceMin"
+    ],
+    "communicationsManagerPriceMax": [
+      "communicationsManagerLocations",
+      "communicationsManagerPriceMin"
+    ],
+    "communicationsManagerPriceMin": [
+      "communicationsManagerLocations",
+      "communicationsManagerPriceMax"
+    ],
+    "contentDesignerLocations": [
+      "accessibleApplicationsSpecialists",
+      "contentDesignerPriceMax",
+      "contentDesignerPriceMin"
+    ],
+    "contentDesignerPriceMax": [
+      "accessibleApplicationsSpecialists",
+      "contentDesignerLocations",
+      "contentDesignerPriceMin"
+    ],
+    "contentDesignerPriceMin": [
+      "accessibleApplicationsSpecialists",
+      "contentDesignerLocations",
+      "contentDesignerPriceMax"
+    ],
+    "dataArchitectLocations": [
+      "dataArchitectPriceMax",
+      "dataArchitectPriceMin"
+    ],
+    "dataArchitectPriceMax": [
+      "dataArchitectLocations",
+      "dataArchitectPriceMin"
+    ],
+    "dataArchitectPriceMin": [
+      "dataArchitectLocations",
+      "dataArchitectPriceMax"
+    ],
+    "dataEngineerLocations": [
+      "dataEngineerPriceMax",
+      "dataEngineerPriceMin"
+    ],
+    "dataEngineerPriceMax": [
+      "dataEngineerLocations",
+      "dataEngineerPriceMin"
+    ],
+    "dataEngineerPriceMin": [
+      "dataEngineerLocations",
+      "dataEngineerPriceMax"
+    ],
+    "dataScientistLocations": [
+      "dataScientistPriceMax",
+      "dataScientistPriceMin"
+    ],
+    "dataScientistPriceMax": [
+      "dataScientistLocations",
+      "dataScientistPriceMin"
+    ],
+    "dataScientistPriceMin": [
+      "dataScientistLocations",
+      "dataScientistPriceMax"
+    ],
+    "deliveryManagerLocations": [
+      "deliveryManagerPriceMax",
+      "deliveryManagerPriceMin"
+    ],
+    "deliveryManagerPriceMax": [
+      "deliveryManagerLocations",
+      "deliveryManagerPriceMin"
+    ],
+    "deliveryManagerPriceMin": [
+      "deliveryManagerLocations",
+      "deliveryManagerPriceMax"
+    ],
+    "designerLocations": [
+      "accessibleApplicationsSpecialists",
+      "designerPriceMax",
+      "designerPriceMin"
+    ],
+    "designerPriceMax": [
+      "accessibleApplicationsSpecialists",
+      "designerLocations",
+      "designerPriceMin"
+    ],
+    "designerPriceMin": [
+      "accessibleApplicationsSpecialists",
+      "designerLocations",
+      "designerPriceMax"
+    ],
+    "developerLocations": [
+      "accessibleApplicationsSpecialists",
+      "developerPriceMax",
+      "developerPriceMin"
+    ],
+    "developerPriceMax": [
+      "accessibleApplicationsSpecialists",
+      "developerLocations",
+      "developerPriceMin"
+    ],
+    "developerPriceMin": [
+      "accessibleApplicationsSpecialists",
+      "developerLocations",
+      "developerPriceMax"
+    ],
+    "performanceAnalystLocations": [
+      "performanceAnalystPriceMax",
+      "performanceAnalystPriceMin"
+    ],
+    "performanceAnalystPriceMax": [
+      "performanceAnalystLocations",
+      "performanceAnalystPriceMin"
+    ],
+    "performanceAnalystPriceMin": [
+      "performanceAnalystLocations",
+      "performanceAnalystPriceMax"
+    ],
+    "portfolioManagerLocations": [
+      "portfolioManagerPriceMax",
+      "portfolioManagerPriceMin"
+    ],
+    "portfolioManagerPriceMax": [
+      "portfolioManagerLocations",
+      "portfolioManagerPriceMin"
+    ],
+    "portfolioManagerPriceMin": [
+      "portfolioManagerLocations",
+      "portfolioManagerPriceMax"
+    ],
+    "productManagerLocations": [
+      "productManagerPriceMax",
+      "productManagerPriceMin"
+    ],
+    "productManagerPriceMax": [
+      "productManagerLocations",
+      "productManagerPriceMin"
+    ],
+    "productManagerPriceMin": [
+      "productManagerLocations",
+      "productManagerPriceMax"
+    ],
+    "programmeManagerLocations": [
+      "programmeManagerPriceMax",
+      "programmeManagerPriceMin"
+    ],
+    "programmeManagerPriceMax": [
+      "programmeManagerLocations",
+      "programmeManagerPriceMin"
+    ],
+    "programmeManagerPriceMin": [
+      "programmeManagerLocations",
+      "programmeManagerPriceMax"
+    ],
+    "qualityAssuranceLocations": [
+      "accessibleApplicationsSpecialists",
+      "qualityAssurancePriceMax",
+      "qualityAssurancePriceMin"
+    ],
+    "qualityAssurancePriceMax": [
+      "accessibleApplicationsSpecialists",
+      "qualityAssuranceLocations",
+      "qualityAssurancePriceMin"
+    ],
+    "qualityAssurancePriceMin": [
+      "accessibleApplicationsSpecialists",
+      "qualityAssuranceLocations",
+      "qualityAssurancePriceMax"
+    ],
+    "securityConsultantLocations": [
+      "securityConsultantPriceMax",
+      "securityConsultantPriceMin"
+    ],
+    "securityConsultantPriceMax": [
+      "securityConsultantLocations",
+      "securityConsultantPriceMin"
+    ],
+    "securityConsultantPriceMin": [
+      "securityConsultantLocations",
+      "securityConsultantPriceMax"
+    ],
+    "serviceManagerLocations": [
+      "accessibleApplicationsSpecialists",
+      "serviceManagerPriceMax",
+      "serviceManagerPriceMin"
+    ],
+    "serviceManagerPriceMax": [
+      "accessibleApplicationsSpecialists",
+      "serviceManagerLocations",
+      "serviceManagerPriceMin"
+    ],
+    "serviceManagerPriceMin": [
+      "accessibleApplicationsSpecialists",
+      "serviceManagerLocations",
+      "serviceManagerPriceMax"
+    ],
+    "technicalArchitectLocations": [
+      "accessibleApplicationsSpecialists",
+      "technicalArchitectPriceMax",
+      "technicalArchitectPriceMin"
+    ],
+    "technicalArchitectPriceMax": [
+      "accessibleApplicationsSpecialists",
+      "technicalArchitectLocations",
+      "technicalArchitectPriceMin"
+    ],
+    "technicalArchitectPriceMin": [
+      "accessibleApplicationsSpecialists",
+      "technicalArchitectLocations",
+      "technicalArchitectPriceMax"
+    ],
+    "userResearcherLocations": [
+      "userResearcherPriceMax",
+      "userResearcherPriceMin"
+    ],
+    "userResearcherPriceMax": [
+      "userResearcherLocations",
+      "userResearcherPriceMin"
+    ],
+    "userResearcherPriceMin": [
+      "userResearcherLocations",
+      "userResearcherPriceMax"
+    ],
+    "webOperationsLocations": [
+      "accessibleApplicationsSpecialists",
+      "webOperationsPriceMax",
+      "webOperationsPriceMin"
+    ],
+    "webOperationsPriceMax": [
+      "accessibleApplicationsSpecialists",
+      "webOperationsLocations",
+      "webOperationsPriceMin"
+    ],
+    "webOperationsPriceMin": [
+      "accessibleApplicationsSpecialists",
+      "webOperationsLocations",
+      "webOperationsPriceMax"
+    ]
+  },
+  "properties": {
+    "accessibleApplicationsSpecialists": {
+      "type": "boolean"
+    },
+    "agileCoachLocations": {
+      "items": {
+        "enum": [
+          "Offsite",
+          "Scotland",
+          "North East England",
+          "North West England",
+          "Yorkshire and the Humber",
+          "East Midlands",
+          "West Midlands",
+          "East of England",
+          "Wales",
+          "London",
+          "South East England",
+          "South West England",
+          "Northern Ireland"
+        ]
+      },
+      "maxItems": 13,
+      "minItems": 1,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "agileCoachPriceMax": {
+      "pattern": "^\\d{1,15}(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "agileCoachPriceMin": {
+      "pattern": "^\\d{1,15}(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "bespokeSystemInformation": {
+      "type": "boolean"
+    },
+    "businessAnalystLocations": {
+      "items": {
+        "enum": [
+          "Offsite",
+          "Scotland",
+          "North East England",
+          "North West England",
+          "Yorkshire and the Humber",
+          "East Midlands",
+          "West Midlands",
+          "East of England",
+          "Wales",
+          "London",
+          "South East England",
+          "South West England",
+          "Northern Ireland"
+        ]
+      },
+      "maxItems": 13,
+      "minItems": 1,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "businessAnalystPriceMax": {
+      "pattern": "^\\d{1,15}(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "businessAnalystPriceMin": {
+      "pattern": "^\\d{1,15}(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "communicationsManagerLocations": {
+      "items": {
+        "enum": [
+          "Offsite",
+          "Scotland",
+          "North East England",
+          "North West England",
+          "Yorkshire and the Humber",
+          "East Midlands",
+          "West Midlands",
+          "East of England",
+          "Wales",
+          "London",
+          "South East England",
+          "South West England",
+          "Northern Ireland"
+        ]
+      },
+      "maxItems": 13,
+      "minItems": 1,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "communicationsManagerPriceMax": {
+      "pattern": "^\\d{1,15}(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "communicationsManagerPriceMin": {
+      "pattern": "^\\d{1,15}(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "contentDesignerLocations": {
+      "items": {
+        "enum": [
+          "Offsite",
+          "Scotland",
+          "North East England",
+          "North West England",
+          "Yorkshire and the Humber",
+          "East Midlands",
+          "West Midlands",
+          "East of England",
+          "Wales",
+          "London",
+          "South East England",
+          "South West England",
+          "Northern Ireland"
+        ]
+      },
+      "maxItems": 13,
+      "minItems": 1,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "contentDesignerPriceMax": {
+      "pattern": "^\\d{1,15}(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "contentDesignerPriceMin": {
+      "pattern": "^\\d{1,15}(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "dataArchitectLocations": {
+      "items": {
+        "enum": [
+          "Offsite",
+          "Scotland",
+          "North East England",
+          "North West England",
+          "Yorkshire and the Humber",
+          "East Midlands",
+          "West Midlands",
+          "East of England",
+          "Wales",
+          "London",
+          "South East England",
+          "South West England",
+          "Northern Ireland"
+        ]
+      },
+      "maxItems": 13,
+      "minItems": 1,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "dataArchitectPriceMax": {
+      "pattern": "^\\d{1,15}(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "dataArchitectPriceMin": {
+      "pattern": "^\\d{1,15}(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "dataEngineerLocations": {
+      "items": {
+        "enum": [
+          "Offsite",
+          "Scotland",
+          "North East England",
+          "North West England",
+          "Yorkshire and the Humber",
+          "East Midlands",
+          "West Midlands",
+          "East of England",
+          "Wales",
+          "London",
+          "South East England",
+          "South West England",
+          "Northern Ireland"
+        ]
+      },
+      "maxItems": 13,
+      "minItems": 1,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "dataEngineerPriceMax": {
+      "pattern": "^\\d{1,15}(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "dataEngineerPriceMin": {
+      "pattern": "^\\d{1,15}(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "dataProtocols": {
+      "type": "boolean"
+    },
+    "dataScientistLocations": {
+      "items": {
+        "enum": [
+          "Offsite",
+          "Scotland",
+          "North East England",
+          "North West England",
+          "Yorkshire and the Humber",
+          "East Midlands",
+          "West Midlands",
+          "East of England",
+          "Wales",
+          "London",
+          "South East England",
+          "South West England",
+          "Northern Ireland"
+        ]
+      },
+      "maxItems": 13,
+      "minItems": 1,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "dataScientistPriceMax": {
+      "pattern": "^\\d{1,15}(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "dataScientistPriceMin": {
+      "pattern": "^\\d{1,15}(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "deliveryManagerLocations": {
+      "items": {
+        "enum": [
+          "Offsite",
+          "Scotland",
+          "North East England",
+          "North West England",
+          "Yorkshire and the Humber",
+          "East Midlands",
+          "West Midlands",
+          "East of England",
+          "Wales",
+          "London",
+          "South East England",
+          "South West England",
+          "Northern Ireland"
+        ]
+      },
+      "maxItems": 13,
+      "minItems": 1,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "deliveryManagerPriceMax": {
+      "pattern": "^\\d{1,15}(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "deliveryManagerPriceMin": {
+      "pattern": "^\\d{1,15}(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "designerLocations": {
+      "items": {
+        "enum": [
+          "Offsite",
+          "Scotland",
+          "North East England",
+          "North West England",
+          "Yorkshire and the Humber",
+          "East Midlands",
+          "West Midlands",
+          "East of England",
+          "Wales",
+          "London",
+          "South East England",
+          "South West England",
+          "Northern Ireland"
+        ]
+      },
+      "maxItems": 13,
+      "minItems": 1,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "designerPriceMax": {
+      "pattern": "^\\d{1,15}(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "designerPriceMin": {
+      "pattern": "^\\d{1,15}(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "developerLocations": {
+      "items": {
+        "enum": [
+          "Offsite",
+          "Scotland",
+          "North East England",
+          "North West England",
+          "Yorkshire and the Humber",
+          "East Midlands",
+          "West Midlands",
+          "East of England",
+          "Wales",
+          "London",
+          "South East England",
+          "South West England",
+          "Northern Ireland"
+        ]
+      },
+      "maxItems": 13,
+      "minItems": 1,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "developerPriceMax": {
+      "pattern": "^\\d{1,15}(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "developerPriceMin": {
+      "pattern": "^\\d{1,15}(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "helpGovernmentImproveServices": {
+      "type": "boolean"
+    },
+    "openStandardsPrinciples": {
+      "type": "boolean"
+    },
+    "performanceAnalystLocations": {
+      "items": {
+        "enum": [
+          "Offsite",
+          "Scotland",
+          "North East England",
+          "North West England",
+          "Yorkshire and the Humber",
+          "East Midlands",
+          "West Midlands",
+          "East of England",
+          "Wales",
+          "London",
+          "South East England",
+          "South West England",
+          "Northern Ireland"
+        ]
+      },
+      "maxItems": 13,
+      "minItems": 1,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "performanceAnalystPriceMax": {
+      "pattern": "^\\d{1,15}(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "performanceAnalystPriceMin": {
+      "pattern": "^\\d{1,15}(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "portfolioManagerLocations": {
+      "items": {
+        "enum": [
+          "Offsite",
+          "Scotland",
+          "North East England",
+          "North West England",
+          "Yorkshire and the Humber",
+          "East Midlands",
+          "West Midlands",
+          "East of England",
+          "Wales",
+          "London",
+          "South East England",
+          "South West England",
+          "Northern Ireland"
+        ]
+      },
+      "maxItems": 13,
+      "minItems": 1,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "portfolioManagerPriceMax": {
+      "pattern": "^\\d{1,15}(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "portfolioManagerPriceMin": {
+      "pattern": "^\\d{1,15}(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "productManagerLocations": {
+      "items": {
+        "enum": [
+          "Offsite",
+          "Scotland",
+          "North East England",
+          "North West England",
+          "Yorkshire and the Humber",
+          "East Midlands",
+          "West Midlands",
+          "East of England",
+          "Wales",
+          "London",
+          "South East England",
+          "South West England",
+          "Northern Ireland"
+        ]
+      },
+      "maxItems": 13,
+      "minItems": 1,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "productManagerPriceMax": {
+      "pattern": "^\\d{1,15}(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "productManagerPriceMin": {
+      "pattern": "^\\d{1,15}(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "programmeManagerLocations": {
+      "items": {
+        "enum": [
+          "Offsite",
+          "Scotland",
+          "North East England",
+          "North West England",
+          "Yorkshire and the Humber",
+          "East Midlands",
+          "West Midlands",
+          "East of England",
+          "Wales",
+          "London",
+          "South East England",
+          "South West England",
+          "Northern Ireland"
+        ]
+      },
+      "maxItems": 13,
+      "minItems": 1,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "programmeManagerPriceMax": {
+      "pattern": "^\\d{1,15}(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "programmeManagerPriceMin": {
+      "pattern": "^\\d{1,15}(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "qualityAssuranceLocations": {
+      "items": {
+        "enum": [
+          "Offsite",
+          "Scotland",
+          "North East England",
+          "North West England",
+          "Yorkshire and the Humber",
+          "East Midlands",
+          "West Midlands",
+          "East of England",
+          "Wales",
+          "London",
+          "South East England",
+          "South West England",
+          "Northern Ireland"
+        ]
+      },
+      "maxItems": 13,
+      "minItems": 1,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "qualityAssurancePriceMax": {
+      "pattern": "^\\d{1,15}(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "qualityAssurancePriceMin": {
+      "pattern": "^\\d{1,15}(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "securityConsultantLocations": {
+      "items": {
+        "enum": [
+          "Offsite",
+          "Scotland",
+          "North East England",
+          "North West England",
+          "Yorkshire and the Humber",
+          "East Midlands",
+          "West Midlands",
+          "East of England",
+          "Wales",
+          "London",
+          "South East England",
+          "South West England",
+          "Northern Ireland"
+        ]
+      },
+      "maxItems": 13,
+      "minItems": 1,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "securityConsultantPriceMax": {
+      "pattern": "^\\d{1,15}(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "securityConsultantPriceMin": {
+      "pattern": "^\\d{1,15}(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "serviceManagerLocations": {
+      "items": {
+        "enum": [
+          "Offsite",
+          "Scotland",
+          "North East England",
+          "North West England",
+          "Yorkshire and the Humber",
+          "East Midlands",
+          "West Midlands",
+          "East of England",
+          "Wales",
+          "London",
+          "South East England",
+          "South West England",
+          "Northern Ireland"
+        ]
+      },
+      "maxItems": 13,
+      "minItems": 1,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "serviceManagerPriceMax": {
+      "pattern": "^\\d{1,15}(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "serviceManagerPriceMin": {
+      "pattern": "^\\d{1,15}(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "technicalArchitectLocations": {
+      "items": {
+        "enum": [
+          "Offsite",
+          "Scotland",
+          "North East England",
+          "North West England",
+          "Yorkshire and the Humber",
+          "East Midlands",
+          "West Midlands",
+          "East of England",
+          "Wales",
+          "London",
+          "South East England",
+          "South West England",
+          "Northern Ireland"
+        ]
+      },
+      "maxItems": 13,
+      "minItems": 1,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "technicalArchitectPriceMax": {
+      "pattern": "^\\d{1,15}(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "technicalArchitectPriceMin": {
+      "pattern": "^\\d{1,15}(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "userResearcherLocations": {
+      "items": {
+        "enum": [
+          "Offsite",
+          "Scotland",
+          "North East England",
+          "North West England",
+          "Yorkshire and the Humber",
+          "East Midlands",
+          "West Midlands",
+          "East of England",
+          "Wales",
+          "London",
+          "South East England",
+          "South West England",
+          "Northern Ireland"
+        ]
+      },
+      "maxItems": 13,
+      "minItems": 1,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "userResearcherPriceMax": {
+      "pattern": "^\\d{1,15}(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "userResearcherPriceMin": {
+      "pattern": "^\\d{1,15}(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "webOperationsLocations": {
+      "items": {
+        "enum": [
+          "Offsite",
+          "Scotland",
+          "North East England",
+          "North West England",
+          "Yorkshire and the Humber",
+          "East Midlands",
+          "West Midlands",
+          "East of England",
+          "Wales",
+          "London",
+          "South East England",
+          "South West England",
+          "Northern Ireland"
+        ]
+      },
+      "maxItems": 13,
+      "minItems": 1,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "webOperationsPriceMax": {
+      "pattern": "^\\d{1,15}(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "webOperationsPriceMin": {
+      "pattern": "^\\d{1,15}(?:\\.\\d{1,5})?$",
+      "type": "string"
+    }
+  },
+  "required": [
+    "bespokeSystemInformation",
+    "dataProtocols",
+    "helpGovernmentImproveServices",
+    "openStandardsPrinciples"
+  ],
+  "title": "Digital Outcomes and Specialists 4 Digital specialists Service Schema",
+  "type": "object"
+}

--- a/json_schemas/services-digital-outcomes-and-specialists-4-user-research-participants.json
+++ b/json_schemas/services-digital-outcomes-and-specialists-4-user-research-participants.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "anonymousRecruitment": {
+      "type": "boolean"
+    },
+    "locations": {
+      "items": {
+        "enum": [
+          "Scotland",
+          "North East England",
+          "North West England",
+          "Yorkshire and the Humber",
+          "East Midlands",
+          "West Midlands",
+          "East of England",
+          "Wales",
+          "London",
+          "South East England",
+          "South West England",
+          "Northern Ireland",
+          "International (outside the UK)"
+        ]
+      },
+      "maxItems": 13,
+      "minItems": 1,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "manageIncentives": {
+      "type": "boolean"
+    },
+    "recruitFromList": {
+      "type": "boolean"
+    },
+    "recruitMethods": {
+      "items": {
+        "enum": [
+          "Entirely offline",
+          "Initial recruitment offline, but then contact them online",
+          "Entirely online"
+        ]
+      },
+      "maxItems": 3,
+      "minItems": 1,
+      "type": "array",
+      "uniqueItems": true
+    }
+  },
+  "required": [
+    "anonymousRecruitment",
+    "locations",
+    "manageIncentives",
+    "recruitFromList",
+    "recruitMethods"
+  ],
+  "title": "Digital Outcomes and Specialists 4 User research participants Service Schema",
+  "type": "object"
+}

--- a/json_schemas/services-digital-outcomes-and-specialists-4-user-research-studios.json
+++ b/json_schemas/services-digital-outcomes-and-specialists-4-user-research-studios.json
@@ -1,0 +1,157 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "labAccessibility": {
+      "maxLength": 500,
+      "minLength": 1,
+      "pattern": "^(?:\\S+\\s+){0,49}\\S+$",
+      "type": "string"
+    },
+    "labAddressBuilding": {
+      "maxLength": 200,
+      "minLength": 1,
+      "pattern": "^(?:\\S+\\s+){0,19}\\S+$",
+      "type": "string"
+    },
+    "labAddressPostcode": {
+      "maxLength": 10,
+      "minLength": 1,
+      "type": "string"
+    },
+    "labAddressTown": {
+      "maxLength": 200,
+      "minLength": 1,
+      "pattern": "^(?:\\S+\\s+){0,19}\\S+$",
+      "type": "string"
+    },
+    "labBabyChanging": {
+      "type": "boolean"
+    },
+    "labCarPark": {
+      "maxLength": 500,
+      "minLength": 1,
+      "pattern": "^(?:\\S+\\s+){0,49}\\S+$",
+      "type": "string"
+    },
+    "labDesktopStreaming": {
+      "enum": [
+        "Yes \u2013 included as standard",
+        "Yes \u2013 for an additional cost",
+        "No"
+      ]
+    },
+    "labDeviceStreaming": {
+      "enum": [
+        "Yes \u2013 included as standard",
+        "Yes \u2013 for an additional cost",
+        "No"
+      ]
+    },
+    "labEyeTracking": {
+      "enum": [
+        "Yes \u2013 included as standard",
+        "Yes \u2013 for an additional cost",
+        "No"
+      ]
+    },
+    "labHosting": {
+      "enum": [
+        "Yes \u2013 included as standard",
+        "Yes \u2013 for an additional cost",
+        "No"
+      ]
+    },
+    "labPriceMin": {
+      "pattern": "^\\d{1,15}(?:\\.\\d{1,5})?$",
+      "type": "string"
+    },
+    "labPublicTransport": {
+      "maxLength": 500,
+      "minLength": 1,
+      "pattern": "^(?:\\S+\\s+){0,49}\\S+$",
+      "type": "string"
+    },
+    "labSize": {
+      "maxLength": 100,
+      "minLength": 1,
+      "type": "string"
+    },
+    "labStreaming": {
+      "enum": [
+        "Yes \u2013 included as standard",
+        "Yes \u2013 for an additional cost",
+        "No"
+      ]
+    },
+    "labTechAssistance": {
+      "enum": [
+        "Yes \u2013 included as standard",
+        "Yes \u2013 for an additional cost",
+        "No"
+      ]
+    },
+    "labTimeMin": {
+      "enum": [
+        "1 hour",
+        "2 hours",
+        "3 hours",
+        "4 hours",
+        "5 hours",
+        "6 hours",
+        "7 hours",
+        "8 hours"
+      ]
+    },
+    "labToilets": {
+      "type": "boolean"
+    },
+    "labViewingArea": {
+      "enum": [
+        "Yes \u2013 included as standard",
+        "Yes \u2013 for an additional cost",
+        "No"
+      ]
+    },
+    "labWaitingArea": {
+      "enum": [
+        "Yes \u2013 included as standard",
+        "Yes \u2013 for an additional cost",
+        "No"
+      ]
+    },
+    "labWiFi": {
+      "type": "boolean"
+    },
+    "serviceName": {
+      "maxLength": 100,
+      "minLength": 1,
+      "type": "string"
+    }
+  },
+  "required": [
+    "labAccessibility",
+    "labAddressBuilding",
+    "labAddressPostcode",
+    "labAddressTown",
+    "labBabyChanging",
+    "labCarPark",
+    "labDesktopStreaming",
+    "labDeviceStreaming",
+    "labEyeTracking",
+    "labHosting",
+    "labPriceMin",
+    "labPublicTransport",
+    "labSize",
+    "labStreaming",
+    "labTechAssistance",
+    "labTimeMin",
+    "labToilets",
+    "labViewingArea",
+    "labWaitingArea",
+    "labWiFi",
+    "serviceName"
+  ],
+  "title": "Digital Outcomes and Specialists 4 User research studios Service Schema",
+  "type": "object"
+}


### PR DESCRIPTION
Trello: https://trello.com/c/kTVN6PlQ/532-clone-dos4-content

See https://alphagov.github.io/digitalmarketplace-manual/content-and-frameworks/adding-frameworks.html#id3 for how these were generated.

- The four DOS lots each have a service schema (used in applications)
- Three of the DOS lots (i.e. not `user-research-studios`) also have schemas for briefs, brief-responses and brief awards.