### PR TITLE
Ignore copiedFromServiceId during service validation

### DIFF
--- a/app/service_utils.py
+++ b/app/service_utils.py
@@ -82,8 +82,14 @@ def validate_service_data(service, enforce_required=True, required_fields=None):
 
 
 def get_service_validation_errors(service, enforce_required=True, required_fields=None):
+    # TODO: remove this when draft.data['copiedFromServiceId'] is converted to a foreign key field
+    data_to_validate = service.data.copy()
+    if 'copiedFromServiceId' in data_to_validate:
+        data_to_validate.pop('copiedFromServiceId')
+
     return get_validation_errors(
-        _get_validator_name(service), service.data,
+        _get_validator_name(service),
+        data_to_validate,
         enforce_required=enforce_required,
         required_fields=required_fields
     )

--- a/tests/main/views/test_drafts.py
+++ b/tests/main/views/test_drafts.py
@@ -983,6 +983,25 @@ class TestDraftServices(DraftsHelpersMixin):
         assert 'serviceName' not in updated_draft
         assert 'serviceBenefits' not in updated_draft
 
+    def test_update_draft_should_ignore_copiedfromserviceid_field(self):
+        draft_id = self.create_draft_service()['id']
+
+        res = self.client.get('/draft-services/{}'.format(draft_id))
+        submitted_draft = json.loads(res.get_data())['services']
+        submitted_draft['copiedFromServiceId'] = "123456789"
+
+        draft_update_json = self.updater_json.copy()
+        draft_update_json['services'] = submitted_draft
+
+        res2 = self.client.post(
+            '/draft-services/{}'.format(draft_id),
+            data=json.dumps(draft_update_json),
+            content_type='application/json')
+        updated_draft = json.loads(res2.get_data())['services']
+
+        assert res2.status_code == 200
+        assert 'copiedFromServiceId' in updated_draft
+
     def test_update_draft_catches_db_integrity_error(self):
         draft_id = self.create_draft_service()['id']
         draft_update_json = self.updater_json.copy()


### PR DESCRIPTION
Fixes a bug encountered while testing https://github.com/alphagov/digitalmarketplace-api/pull/934.

The `copiedFromServiceId` flag is not in the service validation schemas, and `additionalProperties` are not allowed, so its presence was causing an error during service updates.

Adds a temporary fix to ignore the field during validation (with the appropriate TODO to remove later). 