### PR TITLE
DOS4 service validation schemas

### DIFF
--- a/json_schemas/services-digital-outcomes-and-specialists-4-digital-outcomes.json
+++ b/json_schemas/services-digital-outcomes-and-specialists-4-digital-outcomes.json
@@ -53,13 +53,19 @@
   ],
   "properties": {
     "accessibleApplicationsOutcomes": {
-      "type": "boolean"
+      "enum": [
+        true
+      ]
     },
     "bespokeSystemInformation": {
-      "type": "boolean"
+      "enum": [
+        true
+      ]
     },
     "dataProtocols": {
-      "type": "boolean"
+      "enum": [
+        true
+      ]
     },
     "deliveryTypes": {
       "items": {
@@ -80,7 +86,9 @@
       "uniqueItems": true
     },
     "helpGovernmentImproveServices": {
-      "type": "boolean"
+      "enum": [
+        true
+      ]
     },
     "locations": {
       "items": {
@@ -106,7 +114,9 @@
       "uniqueItems": true
     },
     "openStandardsPrinciples": {
-      "type": "boolean"
+      "enum": [
+        true
+      ]
     },
     "performanceAnalysisTypes": {
       "items": {

--- a/json_schemas/services-digital-outcomes-and-specialists-4-digital-specialists.json
+++ b/json_schemas/services-digital-outcomes-and-specialists-4-digital-specialists.json
@@ -440,7 +440,9 @@
   },
   "properties": {
     "accessibleApplicationsSpecialists": {
-      "type": "boolean"
+      "enum": [
+        true
+      ]
     },
     "agileCoachLocations": {
       "items": {
@@ -474,7 +476,9 @@
       "type": "string"
     },
     "bespokeSystemInformation": {
-      "type": "boolean"
+      "enum": [
+        true
+      ]
     },
     "businessAnalystLocations": {
       "items": {
@@ -632,7 +636,9 @@
       "type": "string"
     },
     "dataProtocols": {
-      "type": "boolean"
+      "enum": [
+        true
+      ]
     },
     "dataScientistLocations": {
       "items": {
@@ -759,10 +765,14 @@
       "type": "string"
     },
     "helpGovernmentImproveServices": {
-      "type": "boolean"
+      "enum": [
+        true
+      ]
     },
     "openStandardsPrinciples": {
-      "type": "boolean"
+      "enum": [
+        true
+      ]
     },
     "performanceAnalystLocations": {
       "items": {


### PR DESCRIPTION
Commits the new DOS4 service schemas, generated by https://github.com/alphagov/digitalmarketplace-frameworks/pull/573

The questions below now must be answered `True` in order to validate, i.e. the supplier can't submit their service if they don't meet these criteria. 