### PR TITLE
SupplierFramework: add allow_declaration_reuse

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -672,8 +672,12 @@ def update_supplier_framework(supplier_id, framework_slug):
     updater_json = validate_and_return_updater_request()
     json_has_required_keys(json_payload, ["frameworkInterest"])
     update_json = json_payload["frameworkInterest"]
-    json_has_keys(update_json, optional_keys=("onFramework", "prefillDeclarationFromFrameworkSlug",
-                                              "applicationCompanyDetailsConfirmed"))
+    json_has_keys(update_json, optional_keys=(
+        "allowDeclarationReuse",
+        "applicationCompanyDetailsConfirmed",
+        "onFramework",
+        "prefillDeclarationFromFrameworkSlug",
+    ))
 
     # fetch and lock SupplierFramework row
     interest_record = SupplierFramework.query.filter(
@@ -688,6 +692,9 @@ def update_supplier_framework(supplier_id, framework_slug):
 
     if "onFramework" in update_json:
         interest_record.on_framework = update_json["onFramework"]
+
+    if "allowDeclarationReuse" in update_json:
+        interest_record.allow_declaration_reuse = update_json["allowDeclarationReuse"]
 
     if "prefillDeclarationFromFrameworkSlug" in update_json:
         if update_json["prefillDeclarationFromFrameworkSlug"] is not None:

--- a/app/models/buyer_domains.py
+++ b/app/models/buyer_domains.py
@@ -5,7 +5,7 @@ class BuyerEmailDomain(db.Model):
     __tablename__ = 'buyer_email_domains'
 
     id = db.Column(db.Integer, primary_key=True)
-    domain_name = db.Column(db.String(), nullable=False)
+    domain_name = db.Column(db.String(), nullable=False, unique=True)
 
     def serialize(self):
         return {

--- a/app/models/direct_award.py
+++ b/app/models/direct_award.py
@@ -161,6 +161,9 @@ class DirectAwardSearchResultEntry(db.Model):
         db.UniqueConstraint(
             archived_service_id,
             search_id,
-            name="uq_direct_award_search_result_entries_archived_service_id_search_id",
+            # full desired name uq_direct_award_search_result_entries_archived_service_id_search_id but if
+            # we truncate it ourselves we save ourselves from getting spurious automatic migrations due to
+            # alembic not fully understanding postgres' name limitations.
+            name="uq_direct_award_search_result_entries_archived_service_id_searc",
         ),
     )

--- a/app/models/main.py
+++ b/app/models/main.py
@@ -645,6 +645,7 @@ class SupplierFramework(db.Model):
                 self.prefill_declaration_from_framework and self.prefill_declaration_from_framework.slug
             ),
             "applicationCompanyDetailsConfirmed": self.application_company_details_confirmed,
+            "allowDeclarationReuse": self.allow_declaration_reuse,
         }
         if with_declaration:
             supplier_framework.update({

--- a/app/models/main.py
+++ b/app/models/main.py
@@ -22,6 +22,7 @@ from sqlalchemy.sql.expression import (
     case as sql_case,
     cast as sql_cast,
     select as sql_select,
+    true as sql_true,
     false as sql_false,
     null as sql_null,
     and_ as sql_and,
@@ -519,6 +520,11 @@ class SupplierFramework(db.Model):
         db.ForeignKey('frameworks.id'),
         nullable=True,
     )
+
+    # whether to allow *this* declaration to be reused by *other* SupplierFrameworks
+    # this flag allows us to disable reuse of specific declarations if e.g. they were only
+    # pragmatically allowed on the framework by the framework owner.
+    allow_declaration_reuse = db.Column(db.Boolean, nullable=False, default=True, server_default=sql_true())
 
     # Suppliers must confirm that their details are accurate for every framework application they make.
     # The flag `company_details_confirmed` is set on the Supplier object the first time a supplier confirms their

--- a/default.nix
+++ b/default.nix
@@ -7,12 +7,24 @@ let
     forDev = true;
     localOverridesPath = ./local.nix;
   } // argsOuter;
+  sitePrioNonNix = args.pkgs.writeTextFile {
+    name = "site-prio-non-nix";
+    destination = "/${args.pythonPackages.python.sitePackages}/sitecustomize.py";
+    text = ''
+      import sys
+      first_nix_i = next((i for i, p in enumerate(sys.path) if p.startswith("/nix/")), 1)
+      # after the first nix-provided path in sys.path (presumably the python stdlib itself), re-sort all non-nix
+      # paths to be before the nix paths. this is helped by python's sort being a stable-sort
+      sys.path[first_nix_i+1:] = sorted(sys.path[first_nix_i+1:], key=lambda p: p.startswith("/nix/"))
+    '';
+  };
 in (with args; {
   digitalMarketplaceApiEnv = (pkgs.stdenv.mkDerivation rec {
     name = "digitalmarketplace-api-env";
     shortName = "dm-api";
     buildInputs = [
       pythonPackages.python
+      sitePrioNonNix
       pkgs.glibcLocales
       pkgs.libffi
       pkgs.libyaml

--- a/migrations/versions/1280_tidy_up_latent.py
+++ b/migrations/versions/1280_tidy_up_latent.py
@@ -1,0 +1,26 @@
+"""tidy_up_latent
+
+Tidy up a latent migration not previously picked up by alembic or ignored.
+
+Revision ID: 1280
+Revises: 1270
+Create Date: 2019-06-10 15:51:48.661665
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+
+# revision identifiers, used by Alembic.
+revision = '1280'
+down_revision = '1270'
+
+
+def upgrade():
+    # this field not has a "unique index" instead of a "unique constraint"
+    op.drop_constraint('uq_direct_award_projects_external_id', 'direct_award_projects', type_='unique')
+
+
+def downgrade():
+    op.create_unique_constraint('uq_direct_award_projects_external_id', 'direct_award_projects', ['external_id'])

--- a/migrations/versions/1290_sf_allow_declaration_reuse_add_column.py
+++ b/migrations/versions/1290_sf_allow_declaration_reuse_add_column.py
@@ -1,0 +1,27 @@
+"""sf_allow_declaration_reuse_add_column
+
+create supplier_frameworks.allow_declaration_reuse column as nullable in an initial, small
+transaction. we will backfill it with defaults later to minimize table locking time.
+
+Revision ID: 1290
+Revises: 1280
+Create Date: 2019-06-10 17:00:02.464675
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+
+# revision identifiers, used by Alembic.
+revision = '1290'
+down_revision = '1280'
+
+
+def upgrade():
+    # create column as nullable in an initial, small transaction. we will backfill it with defaults later
+    op.add_column('supplier_frameworks', sa.Column('allow_declaration_reuse', sa.Boolean(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('supplier_frameworks', 'allow_declaration_reuse')

--- a/migrations/versions/1300_sf_allow_declaration_reuse_pop_default.py
+++ b/migrations/versions/1300_sf_allow_declaration_reuse_pop_default.py
@@ -1,0 +1,26 @@
+"""sf_allow_declaration_reuse_pop_default
+
+populate defaults for supplier_frameworks.allow_declaration_reuse
+
+Revision ID: 1300
+Revises: 1290
+Create Date: 2019-06-10 17:09:55.071202
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+
+# revision identifiers, used by Alembic.
+revision = '1300'
+down_revision = '1290'
+
+
+def upgrade():
+    # populate defaults
+    op.execute("UPDATE supplier_frameworks SET allow_declaration_reuse = true")
+
+
+def downgrade():
+    op.execute("UPDATE supplier_frameworks SET allow_declaration_reuse = NULL")

--- a/migrations/versions/1310_sf_allow_declaration_reuse_not_null.py
+++ b/migrations/versions/1310_sf_allow_declaration_reuse_not_null.py
@@ -1,0 +1,36 @@
+"""sf_allow_declaration_reuse_not_null
+
+make supplier_frameworks.allow_declaration_reuse not-null in own transaction to minimize time table is locked
+
+Revision ID: 1310
+Revises: 1300
+Create Date: 2019-06-10 17:20:24.762848
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+
+# revision identifiers, used by Alembic.
+revision = '1310'
+down_revision = '1300'
+
+
+def upgrade():
+    # make column not-null in own transaction to minimize time table is locked
+    op.alter_column(
+        'supplier_frameworks',
+        'allow_declaration_reuse',
+        existing_type=sa.BOOLEAN(),
+        nullable=False,
+    )
+
+
+def downgrade():
+    op.alter_column(
+        'supplier_frameworks',
+        'allow_declaration_reuse',
+        existing_type=sa.BOOLEAN(),
+        nullable=True,
+    )

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,7 +12,7 @@ pytest-cov==2.7.1
 requests-mock==1.6.0
 testfixtures==6.8.2
 
-git+https://github.com/alphagov/digitalmarketplace-test-utils.git@2.3.0#egg=digitalmarketplace-test-utils==2.3.0
+git+https://github.com/alphagov/digitalmarketplace-test-utils.git@2.6.0#egg=digitalmarketplace-test-utils==2.6.0
 
 # For schema generation
 alchemyjsonschema==0.5.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -464,6 +464,17 @@ def live_dos_framework(request, app):
 
 
 @pytest.fixture()
+def live_reusable_dos_framework(request, app):
+    fw = _framework_fixture_inner(request, app, **dict(
+        _dos_framework_defaults,
+        status="live",
+        allow_declaration_reuse=True,
+    ))
+    _add_lots_for_framework(request, app, _dos_framework_defaults["slug"], _dos_framework_lots)
+    return fw
+
+
+@pytest.fixture()
 def expired_dos_framework(request, app):
     fw = _framework_fixture_inner(request, app, **dict(_dos_framework_defaults, status="expired"))
     _add_lots_for_framework(request, app, _dos_framework_defaults["slug"], _dos_framework_lots)
@@ -555,24 +566,26 @@ def live_g8_framework_suppliers_on_framework(
 
 
 @pytest.fixture()
-def open_g8_framework_live_dos_framework_suppliers_on_framework(
+def open_g8_framework_live_reusable_dos_framework_suppliers_on_live_framework(
         request,
         app,
         open_g8_framework,
-        live_dos_framework,
+        live_reusable_dos_framework,
         user_role_supplier,
 ):
-    _supplierframework_fixture_inner(request, app, sf_kwargs={"on_framework": True})
+    _supplierframework_fixture_inner(request, app, sf_kwargs=lambda supplier, framework: {
+        "on_framework": framework.status == "live",
+    })
 
 
 @pytest.fixture()
-def open_g8_framework_live_dos_framework_suppliers_dos_sf(
+def open_g8_framework_live_reusable_dos_framework_suppliers_g8_sf(
         request,
         app,
         open_g8_framework,
-        live_dos_framework,
+        live_reusable_dos_framework,
         user_role_supplier,
 ):
     _supplierframework_fixture_inner(request, app, sf_kwargs=(
-        lambda supplier, framework: None if framework.slug == "g-cloud-8" else {}
+        lambda supplier, framework: None if framework.slug == "digital-outcomes-and-specialists" else {}
     ))

--- a/tests/main/views/test_suppliers.py
+++ b/tests/main/views/test_suppliers.py
@@ -2313,6 +2313,21 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest):
         assert supplier_framework == self._refetch_serialized_sf(supplier_framework)
         assert self._latest_supplier_update_audit_event(supplier_framework["supplierId"]) is None
 
+    def test_setting_allow_declaration_reuse(self, supplier_framework):
+        response = self.supplier_framework_interest(
+            supplier_framework,
+            update={'allowDeclarationReuse': False},
+        )
+        assert response.status_code == 200
+        data = json.loads(response.get_data())
+        assert data['frameworkInterest']['supplierId'] == supplier_framework['supplierId']
+        assert data['frameworkInterest']['frameworkSlug'] == supplier_framework['frameworkSlug']
+        assert data['frameworkInterest']['allowDeclarationReuse'] is False
+
+        assert data['frameworkInterest'] == self._refetch_serialized_sf(data['frameworkInterest'])
+        audit = self._assert_and_return_audit_event(supplier_framework)
+        assert audit.data['update']['allowDeclarationReuse'] is False
+
     def test_multiple_simultaneous_property_updates(
         self,
         open_g8_framework_live_dos_framework_suppliers_on_framework,

--- a/tests/main/views/test_suppliers.py
+++ b/tests/main/views/test_suppliers.py
@@ -1755,73 +1755,71 @@ class TestGetSupplierFrameworks(BaseApplicationTest):
         response = self.client.get('/suppliers/1/frameworks')
         data = json.loads(response.get_data())
         assert response.status_code == 200
-        assert (
-            data ==
-            {
-                'frameworkInterest': [
-                    {
-                        'agreedVariations': {},
-                        'agreementDetails': None,
-                        'agreementId': None,
-                        'agreementPath': None,
-                        'agreementReturned': False,
-                        'agreementReturnedAt': None,
-                        'agreementStatus': None,
-                        'applicationCompanyDetailsConfirmed': False,
-                        'complete_drafts_count': 1,
-                        'countersigned': False,
-                        'countersignedAt': None,
-                        'countersignedDetails': None,
-                        'countersignedPath': None,
-                        'declaration': {},
-                        'drafts_count': 1,
-                        'frameworkFamily': 'g-cloud',
-                        'frameworkFramework': 'g-cloud',
-                        'frameworkSlug': 'g-cloud-6',
-                        'onFramework': False,
-                        'prefillDeclarationFromFrameworkSlug': None,
-                        'services_count': 0,
-                        'supplierId': 1,
-                        'supplierName': 'Supplier 1',
-                    }
-                ]
-            })
+        assert data == {
+            'frameworkInterest': [
+                {
+                    'agreedVariations': {},
+                    'agreementDetails': None,
+                    'agreementId': None,
+                    'agreementPath': None,
+                    'agreementReturned': False,
+                    'agreementReturnedAt': None,
+                    'agreementStatus': None,
+                    'allowDeclarationReuse': True,
+                    'applicationCompanyDetailsConfirmed': False,
+                    'complete_drafts_count': 1,
+                    'countersigned': False,
+                    'countersignedAt': None,
+                    'countersignedDetails': None,
+                    'countersignedPath': None,
+                    'declaration': {},
+                    'drafts_count': 1,
+                    'frameworkFamily': 'g-cloud',
+                    'frameworkFramework': 'g-cloud',
+                    'frameworkSlug': 'g-cloud-6',
+                    'onFramework': False,
+                    'prefillDeclarationFromFrameworkSlug': None,
+                    'services_count': 0,
+                    'supplierId': 1,
+                    'supplierName': 'Supplier 1',
+                }
+            ]
+        }
 
     def test_supplier_with_service(self):
         response = self.client.get('/suppliers/2/frameworks')
         data = json.loads(response.get_data())
         assert response.status_code == 200
-        assert (
-            data ==
-            {
-                'frameworkInterest': [
-                    {
-                        'agreedVariations': {},
-                        'agreementDetails': None,
-                        'agreementId': None,
-                        'agreementPath': None,
-                        'agreementReturned': False,
-                        'agreementReturnedAt': None,
-                        'agreementStatus': None,
-                        'applicationCompanyDetailsConfirmed': False,
-                        'complete_drafts_count': 0,
-                        'countersigned': False,
-                        'countersignedAt': None,
-                        'countersignedDetails': None,
-                        'countersignedPath': None,
-                        'declaration': {},
-                        'drafts_count': 0,
-                        'frameworkFamily': 'g-cloud',
-                        'frameworkFramework': 'g-cloud',
-                        'frameworkSlug': 'g-cloud-6',
-                        'onFramework': False,
-                        'prefillDeclarationFromFrameworkSlug': None,
-                        'services_count': 1,
-                        'supplierId': 2,
-                        'supplierName': 'Supplier 2',
-                    }
-                ]
-            })
+        assert data == {
+            'frameworkInterest': [
+                {
+                    'agreedVariations': {},
+                    'agreementDetails': None,
+                    'agreementId': None,
+                    'agreementPath': None,
+                    'agreementReturned': False,
+                    'agreementReturnedAt': None,
+                    'agreementStatus': None,
+                    'allowDeclarationReuse': True,
+                    'applicationCompanyDetailsConfirmed': False,
+                    'complete_drafts_count': 0,
+                    'countersigned': False,
+                    'countersignedAt': None,
+                    'countersignedDetails': None,
+                    'countersignedPath': None,
+                    'declaration': {},
+                    'drafts_count': 0,
+                    'frameworkFamily': 'g-cloud',
+                    'frameworkFramework': 'g-cloud',
+                    'frameworkSlug': 'g-cloud-6',
+                    'onFramework': False,
+                    'prefillDeclarationFromFrameworkSlug': None,
+                    'services_count': 1,
+                    'supplierId': 2,
+                    'supplierName': 'Supplier 2',
+                }
+            ]
+        }
 
     def test_supplier_with_no_drafts_or_services(self):
         response = self.client.get('/suppliers/3/frameworks')
@@ -1992,6 +1990,7 @@ class TestSupplierFrameworkResponse(BaseApplicationTest):
             'agreementReturned': False,
             'agreementReturnedAt': None,
             'agreementStatus': None,
+            'allowDeclarationReuse': True,
             'applicationCompanyDetailsConfirmed': False,
             'countersigned': False,
             'countersignedAt': None,
@@ -2048,6 +2047,7 @@ class TestSupplierFrameworkResponse(BaseApplicationTest):
             'agreementReturned': True,
             'agreementReturnedAt': '2017-01-01T01:01:01.000000Z',
             'agreementStatus': 'signed',
+            'allowDeclarationReuse': True,
             'applicationCompanyDetailsConfirmed': False,
             'countersigned': False,
             'countersignedAt': None,
@@ -2109,6 +2109,7 @@ class TestSupplierFrameworkResponse(BaseApplicationTest):
             'agreementReturned': True,
             'agreementReturnedAt': '2017-01-01T01:01:01.000000Z',
             'agreementStatus': 'countersigned',
+            'allowDeclarationReuse': True,
             'applicationCompanyDetailsConfirmed': False,
             'countersigned': True,
             'countersignedAt': '2017-02-01T01:01:01.000000Z',

--- a/tests/main/views/test_suppliers.py
+++ b/tests/main/views/test_suppliers.py
@@ -2261,25 +2261,25 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest):
 
     def test_setting_unsetting_prefill_declaration_from_framework_happy_path(
         self,
-        open_g8_framework_live_dos_framework_suppliers_on_framework,
+        open_g8_framework_live_reusable_dos_framework_suppliers_on_live_framework,
     ):
         supplier_framework = SupplierFramework.query.filter(
-            SupplierFramework.framework.has(Framework.slug == "digital-outcomes-and-specialists")
+            SupplierFramework.framework.has(Framework.slug == "g-cloud-8")
         ).order_by(Supplier.id.asc()).first().serialize()
 
         response = self.supplier_framework_interest(
             supplier_framework,
-            update={'prefillDeclarationFromFrameworkSlug': "g-cloud-8"}
+            update={'prefillDeclarationFromFrameworkSlug': "digital-outcomes-and-specialists"}
         )
         assert response.status_code == 200
         data = json.loads(response.get_data())
         assert data['frameworkInterest']['supplierId'] == supplier_framework['supplierId']
         assert data['frameworkInterest']['frameworkSlug'] == supplier_framework['frameworkSlug']
-        assert data['frameworkInterest']['prefillDeclarationFromFrameworkSlug'] == "g-cloud-8"
+        assert data['frameworkInterest']['prefillDeclarationFromFrameworkSlug'] == "digital-outcomes-and-specialists"
 
         assert data['frameworkInterest'] == self._refetch_serialized_sf(data['frameworkInterest'])
         audit = self._assert_and_return_audit_event(supplier_framework)
-        assert audit.data['update']['prefillDeclarationFromFrameworkSlug'] == "g-cloud-8"
+        assert audit.data['update']['prefillDeclarationFromFrameworkSlug'] == "digital-outcomes-and-specialists"
 
         response = self.supplier_framework_interest(
             supplier_framework,
@@ -2297,10 +2297,10 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest):
 
     def test_setting_prefill_declaration_from_framework_invalid_framework_slug(
         self,
-        open_g8_framework_live_dos_framework_suppliers_on_framework,
+        open_g8_framework_live_reusable_dos_framework_suppliers_on_live_framework,
     ):
         supplier_framework = SupplierFramework.query.filter(
-            SupplierFramework.framework.has(Framework.slug == "digital-outcomes-and-specialists")
+            SupplierFramework.framework.has(Framework.slug == "g-cloud-8")
         ).order_by(Supplier.id.asc()).first().serialize()
 
         response = self.supplier_framework_interest(
@@ -2330,16 +2330,16 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest):
 
     def test_multiple_simultaneous_property_updates(
         self,
-        open_g8_framework_live_dos_framework_suppliers_on_framework,
+        open_g8_framework_live_reusable_dos_framework_suppliers_on_live_framework,
     ):
         supplier_framework = SupplierFramework.query.filter(
-            SupplierFramework.framework.has(Framework.slug == "digital-outcomes-and-specialists")
+            SupplierFramework.framework.has(Framework.slug == "g-cloud-8")
         ).order_by(Supplier.id.asc()).first().serialize()
 
         response = self.supplier_framework_interest(
             supplier_framework,
             update={
-                "prefillDeclarationFromFrameworkSlug": "g-cloud-8",
+                "prefillDeclarationFromFrameworkSlug": "digital-outcomes-and-specialists",
                 "onFramework": False,
             },
         )
@@ -2347,13 +2347,13 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest):
         data = json.loads(response.get_data())
         assert data['frameworkInterest']['supplierId'] == supplier_framework['supplierId']
         assert data['frameworkInterest']['frameworkSlug'] == supplier_framework['frameworkSlug']
-        assert data['frameworkInterest']['prefillDeclarationFromFrameworkSlug'] == "g-cloud-8"
+        assert data['frameworkInterest']['prefillDeclarationFromFrameworkSlug'] == "digital-outcomes-and-specialists"
 
         supplier_framework2 = self._refetch_serialized_sf(data['frameworkInterest'])
         assert data['frameworkInterest'] == supplier_framework2
         audit = self._assert_and_return_audit_event(supplier_framework)
         audit_id = audit.id
-        assert audit.data['update']['prefillDeclarationFromFrameworkSlug'] == "g-cloud-8"
+        assert audit.data['update']['prefillDeclarationFromFrameworkSlug'] == "digital-outcomes-and-specialists"
 
         # now we make sure that a single property update failure prevents any db changes
         response2 = self.supplier_framework_interest(
@@ -2371,15 +2371,15 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest):
 
     def test_setting_prefill_declaration_from_framework_supplier_not_on_other_framework(
         self,
-        open_g8_framework_live_dos_framework_suppliers_dos_sf,
+        open_g8_framework_live_reusable_dos_framework_suppliers_g8_sf,
     ):
         supplier_framework = SupplierFramework.query.filter(
-            SupplierFramework.framework.has(Framework.slug == "digital-outcomes-and-specialists")
+            SupplierFramework.framework.has(Framework.slug == "g-cloud-8")
         ).order_by(Supplier.id.asc()).first().serialize()
 
         response = self.supplier_framework_interest(
             supplier_framework,
-            update={'prefillDeclarationFromFrameworkSlug': "g-cloud-8"}
+            update={'prefillDeclarationFromFrameworkSlug': "digital-outcomes-and-specialists"}
         )
         assert response.status_code == 400
 
@@ -2389,22 +2389,22 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest):
 
     def test_setting_prefill_declaration_from_framework_not_allowed(
         self,
-        open_g8_framework_live_dos_framework_suppliers_on_framework,
+        open_g8_framework_live_reusable_dos_framework_suppliers_on_live_framework,
     ):
         supplier_framework = SupplierFramework.query.filter(
-            SupplierFramework.framework.has(Framework.slug == "digital-outcomes-and-specialists")
+            SupplierFramework.framework.has(Framework.slug == "g-cloud-8")
         ).order_by(Supplier.id.asc()).first().serialize()
 
         # disallow declaration reuse of the declaration we'll be attempting to reuse
         SupplierFramework.query.filter(
-            SupplierFramework.framework.has(Framework.slug == "g-cloud-8"),
+            SupplierFramework.framework.has(Framework.slug == "digital-outcomes-and-specialists"),
             SupplierFramework.supplier_id == supplier_framework["supplierId"],
         ).update({SupplierFramework.allow_declaration_reuse: False}, synchronize_session=False)
         db.session.commit()
 
         response = self.supplier_framework_interest(
             supplier_framework,
-            update={'prefillDeclarationFromFrameworkSlug': "g-cloud-8"}
+            update={'prefillDeclarationFromFrameworkSlug': "digital-outcomes-and-specialists"}
         )
         assert response.status_code == 400
 
@@ -2414,7 +2414,7 @@ class TestSupplierFrameworkUpdates(BaseApplicationTest):
 
     def test_set_application_company_details_confirmed_updates_declaration(
         self,
-        open_g8_framework_live_dos_framework_suppliers_on_framework,
+        open_g8_framework_live_reusable_dos_framework_suppliers_on_live_framework,
     ):
         # -------------------------------------------------
         # SETUP


### PR DESCRIPTION
This is to allow https://trello.com/c/V7cUDIRW/, and adds an `allow_declaration_reuse` flag to `SupplierFramework` that should work in the same way as the existing `Framework.allow_declaration_reuse`.

I've also made the endpoint perform some checks that the setting of `prefillDeclarationFromFrameworkSlug` in `update_supplier_framework` doesn't violate these rules. This isn't done in a 100% foolproof way - a request that comes in milliseconds later to change a relevant `allow_declaration_reuse` flag's value will succeed - the "reverse-check" is not implemented. If we cared about that, I really think that's the point at which we'd be better off looking at real db constraints.

The migration adding the column and then back-populating default values is performed in several individual steps to reduce locking time. More information available in commit messages.

Also depends on https://github.com/alphagov/digitalmarketplace-test-utils/pull/24 which I don't want to merge until I'm more sure on the shape of this.