### PR TITLE
SupplierFramework.allow_declaration_reuse: add missed migration setting server_default

### DIFF
--- a/migrations/versions/1320_sf_allow_declaration_reuse_sv_def.py
+++ b/migrations/versions/1320_sf_allow_declaration_reuse_sv_def.py
@@ -1,0 +1,33 @@
+"""sf_allow_declaration_reuse_sv_def
+
+
+
+Revision ID: 1320
+Revises: 1310
+Create Date: 2019-06-17 16:07:25.688384
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+
+# revision identifiers, used by Alembic.
+revision = '1320'
+down_revision = '1310'
+
+
+def upgrade():
+    op.alter_column(
+        'supplier_frameworks',
+        'allow_declaration_reuse',
+        server_default='true',
+    )
+
+
+def downgrade():
+    op.alter_column(
+        'supplier_frameworks',
+        'allow_declaration_reuse',
+        server_default=None,
+    )


### PR DESCRIPTION
https://trello.com/c/V7cUDIRW/

Oops. Forgot to set the `server_default` of this new field to `true`.

Add migration to fix that.