### PR TITLE
556-include-other-registration-number-in-official-supplier-details-csv

### DIFF
--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -200,6 +200,7 @@ def export_suppliers_for_framework(framework_slug):
             "duns_number": supplier.duns_number,
             "registered_name": supplier.registered_name,
             "companies_house_number": supplier.companies_house_number,
+            "other_company_registration_number": supplier.other_company_registration_number,
             'application_result': application_result,
             'application_status': application_status,
             'declaration_status': declaration_status,

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -170,6 +170,7 @@ class FixtureMixin(object):
                     organisation_size='small',
                     duns_number='{}'.format(100000000 + i),
                     registration_country='country:GB',
+                    companies_house_number='{}'.format(12345670 + i),
                     other_company_registration_number='555-222-111'
                 )
             )

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -170,6 +170,7 @@ class FixtureMixin(object):
                     organisation_size='small',
                     duns_number='{}'.format(100000000 + i),
                     registration_country='country:GB',
+                    other_company_registration_number='555-222-111'
                 )
             )
             db.session.add(

--- a/tests/main/views/test_suppliers.py
+++ b/tests/main/views/test_suppliers.py
@@ -2901,7 +2901,7 @@ class TestSuppliersExport(BaseApplicationTest, FixtureMixin, PutDeclarationAndDe
                 'supplier_organisation_size': "small",
                 'duns_number': "100000001",
                 'registered_name': 'Registered Supplier Name 1',
-                'companies_house_number': None,
+                'companies_house_number': '12345671',
                 'other_company_registration_number': '555-222-111',
                 "published_services_count": {
                     "digital-outcomes": 0,

--- a/tests/main/views/test_suppliers.py
+++ b/tests/main/views/test_suppliers.py
@@ -2902,6 +2902,7 @@ class TestSuppliersExport(BaseApplicationTest, FixtureMixin, PutDeclarationAndDe
                 'duns_number': "100000001",
                 'registered_name': 'Registered Supplier Name 1',
                 'companies_house_number': None,
+                'other_company_registration_number': '555-222-111',
                 "published_services_count": {
                     "digital-outcomes": 0,
                     "digital-specialists": 0,

--- a/tests/models/test_main.py
+++ b/tests/models/test_main.py
@@ -1770,6 +1770,7 @@ class TestSuppliers(BaseApplicationTest, FixtureMixin):
                 'organisationSize': 'small',
                 'dunsNumber': '100000000',
                 'registeredName': 'Registered Supplier Name 0',
+                'companiesHouseNumber': '12345670',
                 'otherCompanyRegistrationNumber': '555-222-111',
                 'registrationCountry': 'country:GB'
             }

--- a/tests/models/test_main.py
+++ b/tests/models/test_main.py
@@ -1770,6 +1770,7 @@ class TestSuppliers(BaseApplicationTest, FixtureMixin):
                 'organisationSize': 'small',
                 'dunsNumber': '100000000',
                 'registeredName': 'Registered Supplier Name 0',
+                'otherCompanyRegistrationNumber': '555-222-111',
                 'registrationCountry': 'country:GB'
             }
 


### PR DESCRIPTION
556-include-other-registration-number-in-official-supplier-details-csv

https://trello.com/c/schDS1vB/556-include-other-registration-number-in-official-supplier-details-csv

* Add other_company_registration_number to supplier export output
* Add other_company_registration_number to base `dummy_suppliers` test method
* Add other_company_registration_number to test for supplier export output
* Add otherCompanyRegistrationNumber to test for serialization of new supplier (After addition to base `dummy_suppliers` test method)