### PR TITLE
Add suppliers 'active' flag

### DIFF
--- a/app/models/main.py
+++ b/app/models/main.py
@@ -409,6 +409,9 @@ class Supplier(db.Model):
     # SupplierFramework.application_company_details_confirmed
     company_details_confirmed = db.Column(db.Boolean, index=False, default=False, nullable=False)
 
+    # This flag indicates if a supplier is no longer providing any services.
+    active = db.Column(db.Boolean, default=True, server_default=sql_true(), nullable=False)
+
     @validates('trading_status')
     def validates_trading_status(self, key, value):
         if value not in self.TRADING_STATUSES:

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -37,7 +37,7 @@ def run_migrations_offline():
 
     """
     url = config.get_main_option("sqlalchemy.url")
-    context.configure(url=url)
+    context.configure(url=url, transaction_per_migration=True)
 
     with context.begin_transaction():
         context.run_migrations()
@@ -57,7 +57,8 @@ def run_migrations_online():
     connection = engine.connect()
     context.configure(
                 connection=connection,
-                target_metadata=target_metadata
+                target_metadata=target_metadata,
+                transaction_per_migration=True,
                 )
 
     try:

--- a/migrations/versions/1330_add_suppliers_active_flag.py
+++ b/migrations/versions/1330_add_suppliers_active_flag.py
@@ -1,0 +1,29 @@
+"""add suppliers active flag
+
+Adds a new column to the suppliers table, 'active', that indicates whether a
+supplier is currently valid.
+
+Revision ID: 1330
+Revises: 1320
+Create Date: 2019-06-26 11:14:56.085586
+
+"""
+from alembic import context, op
+import sqlalchemy as sa
+
+
+
+# revision identifiers, used by Alembic.
+revision = '1330'
+down_revision = '1320'
+
+
+def upgrade():
+    # We want this column to be DEFAULT true, but creating a column
+    # with defaults is a slow operation, so we split it up a bit.
+    op.add_column('suppliers', sa.Column('active', sa.Boolean(), nullable=True))
+    op.alter_column('suppliers', 'active', server_default=sa.text('true'))
+
+
+def downgrade():
+    op.drop_column('suppliers', 'active')

--- a/migrations/versions/1340_set_suppliers_active_flag_not_nullable.py
+++ b/migrations/versions/1340_set_suppliers_active_flag_not_nullable.py
@@ -1,0 +1,29 @@
+"""set suppliers active flag NOT NULLABLE
+
+Ensure that all suppliers are either active or inactive.
+
+Revision ID: 1340
+Revises: 1330
+Create Date: 2019-06-26 11:53:56.085586
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+
+# revision identifiers, used by Alembic.
+revision = '1340'
+down_revision = '1330'
+
+
+def upgrade():
+    # We want this column to be NOT NULLABLE, so we need to set any NULL
+    # values. NULLs are active suppliers (i.e. they have not been made
+    # inactive).
+    op.execute("UPDATE suppliers SET active = true WHERE active = NULL")
+    op.alter_column('suppliers', 'active', nullable=False)
+
+
+def downgrade():
+    op.alter_column('suppliers', 'active', nullable=True)


### PR DESCRIPTION
https://trello.com/c/t85UtxUa/560-inactive-suppliers

We want to be able to indicate in the database whether a supplier is inactive (i.e. they have stopped existing, have merged with another supplier). This commit adds a simple boolean flag to the supplier table.  (@agalamatis actually wrote it, I'm just commiting it :P).

The migration is a bit involved, thanks @risicle for taking me through it. You can see the SQL that will be produced below:

```
$ ./application.py db upgrade 1320:1330 --sql
-- Running upgrade 1320 -> 1330

ALTER TABLE suppliers ADD COLUMN active BOOLEAN;

ALTER TABLE suppliers ALTER COLUMN active SET DEFAULT true;

UPDATE suppliers SET active = true WHERE active = NULL;

ALTER TABLE suppliers ALTER COLUMN active SET NOT NULL;

UPDATE alembic_version SET version_num='1330' WHERE alembic_version.version_num = '1320';

COMMIT;
```