### PR TITLE
Fix migration 1340

### DIFF
--- a/migrations/versions/1340_set_suppliers_active_flag_not_nullable.py
+++ b/migrations/versions/1340_set_suppliers_active_flag_not_nullable.py
@@ -21,7 +21,7 @@ def upgrade():
     # We want this column to be NOT NULLABLE, so we need to set any NULL
     # values. NULLs are active suppliers (i.e. they have not been made
     # inactive).
-    op.execute("UPDATE suppliers SET active = true WHERE active = NULL")
+    op.execute("UPDATE suppliers SET active = true WHERE active is NULL")
     op.alter_column('suppliers', 'active', nullable=False)
 
 


### PR DESCRIPTION
The last PR had bug where I was using the wrong type of comparison to NULL.

Our preview DB is on version 1330 so I don't think we need to do anything more complicated than fix the bad migration script.