### PR TITLE
Include G11 in service edit config

### DIFF
--- a/config.py
+++ b/config.py
@@ -48,6 +48,9 @@ class Config:
         'g-cloud-10': {
             'services': 'g-cloud-10'
         },
+        'g-cloud-11': {
+            'services': 'g-cloud-11'
+        },
         'digital-outcomes-and-specialists': {
             'briefs': 'briefs-digital-outcomes-and-specialists'
         },


### PR DESCRIPTION
https://trello.com/c/rdHoJl1n/924-g11-service-edits-not-indexed-straight-away-api

When a supplier makes edits to a live service, it needs to be reindexed for it to show up in search results. We updated the overnight job but not the API config that handles ad-hoc edits.