### PR TITLE
Strengthen duns validation 💪

### DIFF
--- a/json_schemas/new-supplier.json
+++ b/json_schemas/new-supplier.json
@@ -19,7 +19,9 @@
     },
     "dunsNumber": {
       "pattern": "^[0-9]+$",
-      "type": "string"
+      "type": "string",
+      "maxLength": 9,
+      "minLength": 9
     },
     "name": {
       "type": "string"

--- a/tests/main/views/test_suppliers.py
+++ b/tests/main/views/test_suppliers.py
@@ -563,7 +563,7 @@ class TestUpdateSupplier(BaseApplicationTest, JSONUpdateTestMixin, PutDeclaratio
             "name": "New Name",
             "description": "New Description",
             "companiesHouseNumber": "AA123456",
-            "dunsNumber": "010101",
+            "dunsNumber": "010101010",
             "otherCompanyRegistrationNumber": "A11",
             "registeredName": "New Name Inc.",
             "registrationCountry": "country:GT",
@@ -581,7 +581,7 @@ class TestUpdateSupplier(BaseApplicationTest, JSONUpdateTestMixin, PutDeclaratio
 
         assert supplier.name == 'New Name'
         assert supplier.description == "New Description"
-        assert supplier.duns_number == "010101"
+        assert supplier.duns_number == "010101010"
         assert supplier.companies_house_number == "AA123456"
         assert supplier.other_company_registration_number == "A11"
         assert supplier.registered_name == "New Name Inc."

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -40,6 +40,16 @@ def test_supplier_fails_with_bad_companies_house_number():
     assert len(errs) == 1
 
 
+@pytest.mark.parametrize(
+    'duns', ['12345678', '1234567890']
+)
+def test_supplier_fails_with_bad_duns(duns):
+    data = load_example_listing("new-supplier")
+    data["dunsNumber"] = duns
+    errs = get_validation_errors("new-supplier", data)
+    assert len(errs) == 1
+
+
 def test_for_valid_date():
     cases = [
         ("2010-01-01", True),

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -43,7 +43,7 @@ def test_supplier_fails_with_bad_companies_house_number():
 @pytest.mark.parametrize(
     'duns', ['12345678', '1234567890']
 )
-def test_supplier_fails_with_bad_duns(duns):
+def test_new_supplier_fails_with_bad_duns(duns):
     data = load_example_listing("new-supplier")
     data["dunsNumber"] = duns
     errs = get_validation_errors("new-supplier", data)


### PR DESCRIPTION
The API now validates that DUNS numbers are the right length, as well as the right kind of characters. I've written a test for both of the validators that validate supplier JSON. [Ticket](https://trello.com/c/AtOz5X7I/414-duns-number-validation-in-the-api-is-weak-sept-17)