### PR TITLE
bumping utils and client to latest versions

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -1,8 +1,8 @@
 # Run `make freeze-requirements` to update requirements.txt
 # with package version changes made in requirements-app.txt
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@47.2.0#egg=digitalmarketplace-utils==47.2.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.15.1#egg=digitalmarketplace-apiclient==19.15.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@48.4.0#egg=digitalmarketplace-utils==48.4.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@20.2.0#egg=digitalmarketplace-apiclient==20.2.0
 
 Flask==1.0.3
 Flask-Bcrypt==0.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,8 @@
 # Run `make freeze-requirements` to update requirements.txt
 # with package version changes made in requirements-app.txt
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@47.2.0#egg=digitalmarketplace-utils==47.2.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.15.1#egg=digitalmarketplace-apiclient==19.15.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@48.4.0#egg=digitalmarketplace-utils==48.4.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@20.2.0#egg=digitalmarketplace-apiclient==20.2.0
 
 Flask==1.0.3
 Flask-Bcrypt==0.7.1
@@ -22,13 +22,13 @@ rfc3987==1.3.8
 strict-rfc3339==0.7
 
 ## The following requirements were added by pip freeze:
-alembic==1.0.10
+alembic==1.0.11
 asn1crypto==0.24.0
 attrs==19.1.0
-bcrypt==3.1.6
+bcrypt==3.1.7
 blinker==1.4
-boto3==1.9.169
-botocore==1.12.169
+boto3==1.9.198
+botocore==1.12.198
 certifi==2019.6.16
 cffi==1.12.3
 chardet==3.0.4
@@ -49,7 +49,7 @@ idna==2.8
 Jinja2==2.10.1
 jmespath==0.9.4
 mailchimp3==3.0.6
-Mako==1.0.12
+Mako==1.0.14
 MarkupSafe==1.1.1
 monotonic==1.5
 notifications-python-client==5.3.0
@@ -57,7 +57,7 @@ odfpy==1.4.0
 prometheus-client==0.2.0
 pycparser==2.19
 PyJWT==1.7.1
-pyrsistent==0.15.2
+pyrsistent==0.15.4
 python-dateutil==2.8.0
 python-editor==1.0.4
 python-json-logger==0.1.11
@@ -67,6 +67,6 @@ s3transfer==0.2.1
 six==1.12.0
 unicodecsv==0.14.1
 urllib3==1.25.3
-Werkzeug==0.14.1
+Werkzeug==0.15.5
 workdays==1.4
 WTForms==2.2.1


### PR DESCRIPTION
trello: https://trello.com/c/YjIgCnFp/657-watch-out-for-bumps-to-werkzeug

It will upgrade Werkzeug 0.15.x