### PR TITLE
Add DOS4 to brief search config

### DIFF
--- a/config.py
+++ b/config.py
@@ -60,6 +60,9 @@ class Config:
         'digital-outcomes-and-specialists-3': {
             'briefs': 'briefs-digital-outcomes-and-specialists'
         },
+        'digital-outcomes-and-specialists-4': {
+            'briefs': 'briefs-digital-outcomes-and-specialists'
+        },
     }
 
 


### PR DESCRIPTION
https://trello.com/c/vzEaS8zD/94-prepare-api-to-update-dos-4-search-index-for-briefs

We almost forgot this for G11, I'm determined to get ahead of the game for DOS4.

If a buyer changes a brief (eg withdraws it, updates the clarification Q&A), it will need reindexing. 

This should be fine to be deployed ahead of DOS4 go-live, as it'll only get called once a DOS4 brief can be created.

Manual entry: https://github.com/alphagov/digitalmarketplace-manual/pull/220