### PR TITLE
AuditEvent: add partial index for data['draftId']

### DIFF
--- a/app/main/views/audits.py
+++ b/app/main/views/audits.py
@@ -87,20 +87,25 @@ def list_audits():
             AuditEvent.user == user
         )
 
-    data_supplier_id = request.args.get('data-supplier-id')
+    # note in the following that even though the supplier and draft ids *are* integers, we're doing the searches as
+    # strings because of the postgres static type system's awkwardness with json types. we first let args.get normalize
+    # them into actual integers though
+
+    data_supplier_id = request.args.get('data-supplier-id', type=int)
     if data_supplier_id:
-        #  This filter relies on index `idx_audit_events_data_supplier_id`. See `app..models.main` for its definition.
+        # This filter relies on index `idx_audit_events_data_supplier_id`. See `app..models.main` for its definition.
         audits = audits.filter(
             func.coalesce(
-                AuditEvent.__table__.c.data['supplierId'].astext,
-                AuditEvent.__table__.c.data['supplier_id'].astext,
-            ) == data_supplier_id
+                AuditEvent.data['supplierId'].astext,
+                AuditEvent.data['supplier_id'].astext,
+            ) == str(data_supplier_id)
         )
 
-    data_draft_service_id = request.args.get('data-draft-service-id')
+    data_draft_service_id = request.args.get('data-draft-service-id', type=int)
     if data_draft_service_id:
+        # This filter relies on index `idx_audit_events_data_draft_id`. See `app..models.main` for its definition.
         audits = audits.filter(
-            AuditEvent.data['draftId'].astext == data_draft_service_id
+            AuditEvent.data['draftId'].astext == str(data_draft_service_id)
         )
 
     acknowledged = request.args.get('acknowledged', None)

--- a/app/models/main.py
+++ b/app/models/main.py
@@ -1953,8 +1953,12 @@ db.Index(
 #  have been used, hence the need for the coalesce. Audits all now use `supplierId` consistantly.
 db.Index(
     'idx_audit_events_data_supplier_id',
-    func.coalesce(AuditEvent.data['supplierId'], AuditEvent.data['supplier_id']),
-    postgresql_where=func.coalesce(AuditEvent.data['supplierId'], AuditEvent.data['supplier_id']) != sql_null()
+    func.coalesce(AuditEvent.data['supplierId'].astext, AuditEvent.data['supplier_id'].astext),
+    postgresql_where=func.coalesce(
+        AuditEvent.data['supplierId'].astext,
+        AuditEvent.data['supplier_id'].astext,
+    ) != sql_null()
+)
 
 # Index for searching audit events by the draft id included in the data blob.
 db.Index(

--- a/app/models/main.py
+++ b/app/models/main.py
@@ -1955,6 +1955,12 @@ db.Index(
     'idx_audit_events_data_supplier_id',
     func.coalesce(AuditEvent.data['supplierId'], AuditEvent.data['supplier_id']),
     postgresql_where=func.coalesce(AuditEvent.data['supplierId'], AuditEvent.data['supplier_id']) != sql_null()
+
+# Index for searching audit events by the draft id included in the data blob.
+db.Index(
+    'idx_audit_events_data_draft_id',
+    AuditEvent.data['draftId'].astext,
+    postgresql_where=AuditEvent.data['draftId'].astext != sql_null()
 )
 
 # DEPRECATED - remove in a migration once service update admin app feature has been updated

--- a/migrations/versions/1390_auditevent_add_data_draftid_partial_index.py
+++ b/migrations/versions/1390_auditevent_add_data_draftid_partial_index.py
@@ -1,0 +1,29 @@
+"""AuditEvent: add data['draftId'] partial index
+
+Revision ID: 1390
+Revises: 1380
+Create Date: 2019-08-06 10:24:00.359631
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+
+# revision identifiers, used by Alembic.
+revision = '1390'
+down_revision = '1380'
+
+
+def upgrade():
+    op.create_index(
+        'idx_audit_events_data_draft_id',
+        'audit_events',
+        [sa.text("(data ->> 'draftId')")],
+        unique=False,
+        postgresql_where=sa.text("(data ->> 'draftId') IS NOT NULL"),
+    )
+
+
+def downgrade():
+    op.drop_index('idx_audit_events_data_draft_id', table_name='audit_events')


### PR DESCRIPTION
Similar to that for `supplierId`/`supplier_id`, but simpler because we only use one key for `draftId`.

Also some tidying up of the queries used in the `list_audits` view.

