### PR TITLE
update_service view: handle `wait-for-index` query argument

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -2,6 +2,7 @@ from dmapiclient.audit import AuditTypes
 from flask import jsonify, abort, request, current_app
 from sqlalchemy import asc
 
+from dmutils.config import convert_to_boolean
 from dmutils.errors.api import ValidationError
 
 from .. import main
@@ -156,7 +157,7 @@ def update_service(service_id):
     )
 
     commit_and_archive_service(updated_service, update_details, audit_type)
-    index_service(updated_service)
+    index_service(updated_service, wait_for_response=convert_to_boolean(request.args.get("wait-for-index", "true")))
 
     return jsonify(message="done"), 200
 

--- a/app/service_utils.py
+++ b/app/service_utils.py
@@ -136,7 +136,7 @@ def commit_and_archive_service(updated_service, update_details,
         abort(400, format(e))
 
 
-def index_service(service):
+def index_service(service, wait_for_response=True):
     if (
         service.framework.status == 'live' and
         service.framework.framework == 'g-cloud' and
@@ -148,6 +148,7 @@ def index_service(service):
             doc_type='services',
             object_id=service.service_id,
             serialized_object=service.serialize(),
+            wait_for_response=wait_for_response,
         )
 
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -210,7 +210,7 @@ def get_request_page_questions():
     return json_payload.get('page_questions', [])
 
 
-def index_object(framework, doc_type, object_id, serialized_object):
+def index_object(framework, doc_type, object_id, serialized_object, wait_for_response=True):
     try:
         index_name = current_app.config['DM_FRAMEWORK_TO_ES_INDEX'][framework][doc_type]
 
@@ -220,6 +220,7 @@ def index_object(framework, doc_type, object_id, serialized_object):
                 object_id=object_id,
                 serialized_object=serialized_object,
                 doc_type=doc_type,
+                client_wait_for_response=wait_for_response,
             )
         except dmapiclient.HTTPError as e:
             current_app.logger.warning(

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -2,7 +2,7 @@
 # with package version changes made in requirements-app.txt
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@48.4.0#egg=digitalmarketplace-utils==48.4.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.0.0#egg=digitalmarketplace-apiclient==21.0.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.2.0#egg=digitalmarketplace-apiclient==21.2.0
 
 Flask==1.0.4 # pyup: >=1.0.0,<1.1.0
 Flask-Bcrypt==0.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 # with package version changes made in requirements-app.txt
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@48.4.0#egg=digitalmarketplace-utils==48.4.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.0.0#egg=digitalmarketplace-apiclient==21.0.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.2.0#egg=digitalmarketplace-apiclient==21.2.0
 
 Flask==1.0.4 # pyup: >=1.0.0,<1.1.0
 Flask-Bcrypt==0.7.1

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -75,18 +75,22 @@ class TestKeyFilterJSON(object):
 
 @mock.patch('app.utils.search_api_client', autospec=True)
 class TestIndexObject(BaseApplicationTest):
-    def test_calls_the_search_api_index_method_correctly(self, search_api_client):
+    @pytest.mark.parametrize("wait_for_response", (False, True,))
+    def test_calls_the_search_api_index_method_correctly(self, search_api_client, wait_for_response):
         for framework, doc_type_to_index_mapping in current_app.config['DM_FRAMEWORK_TO_ES_INDEX'].items():
             for doc_type, index_name in doc_type_to_index_mapping.items():
 
-                index_object(framework, doc_type, 123, {'serialized': 'object'})
+                index_object(framework, doc_type, 123, {'serialized': 'object'}, wait_for_response=wait_for_response)
 
-                search_api_client.index.assert_called_once_with(
-                    index_name=index_name,
-                    object_id=123,
-                    serialized_object={'serialized': 'object'},
-                    doc_type=doc_type,
-                )
+                assert search_api_client.index.mock_calls == [
+                    mock.call(
+                        index_name=index_name,
+                        object_id=123,
+                        serialized_object={'serialized': 'object'},
+                        doc_type=doc_type,
+                        client_wait_for_response=wait_for_response,
+                    )
+                ]
                 search_api_client.reset_mock()
 
     @mock.patch('app.utils.current_app')


### PR DESCRIPTION
https://trello.com/c/LABe8BKA

Depends on https://github.com/alphagov/digitalmarketplace-apiclient/pull/222

With this argument set as `false`, the request should trigger an reindexing request corresponding to the service update but not wait for its result. though of course it has the same danger any async request has in that overuse can cause a large number of requests to be sent to the target (in this case the search api) in a very short amount of time. hopefully the `update_service` view itself is slow enough to cause this to be throttled to some extent.

This follows `user-role` (in this view) in being a Bit Weird because it's accepting query string arguments in a POST request. but given the way we use the body of a request implicitly as the contents of the new object, supplying it there would be an even weirder option.