### PR TITLE
Update validation for question word lengths

### DIFF
--- a/json_schemas/briefs-digital-outcomes-and-specialists-4-digital-outcomes.json
+++ b/json_schemas/briefs-digital-outcomes-and-specialists-4-digital-outcomes.json
@@ -9,7 +9,7 @@
     },
     "backgroundInformation": {
       "minLength": 1,
-      "pattern": "^(?:\\S+\\s+){0,99}\\S+$",
+      "pattern": "^(?:\\S+\\s+){0,199}\\S+$",
       "type": "string"
     },
     "budgetRange": {
@@ -44,7 +44,7 @@
     },
     "endUsers": {
       "minLength": 1,
-      "pattern": "^(?:\\S+\\s+){0,99}\\S+$",
+      "pattern": "^(?:\\S+\\s+){0,199}\\S+$",
       "type": "string"
     },
     "essentialRequirements": {
@@ -115,7 +115,7 @@
     },
     "outcome": {
       "minLength": 1,
-      "pattern": "^(?:\\S+\\s+){0,99}\\S+$",
+      "pattern": "^(?:\\S+\\s+){0,199}\\S+$",
       "type": "string"
     },
     "phase": {


### PR DESCRIPTION
https://trello.com/c/YELMUI7V/316-buyer-questions-should-have-longer-word-limit

Updates the DOS4 brief outcomes schema following changes made in https://github.com/alphagov/digitalmarketplace-frameworks/pull/594. 