### PR TITLE
list_brief_responses: add "with-data" query parameter 

### DIFF
--- a/app/models/main.py
+++ b/app/models/main.py
@@ -1848,6 +1848,13 @@ class BriefResponse(db.Model):
             raise ValidationError(errs)
 
     def serialize(self, with_data: bool = True):
+        """
+            :param with_data: allows serialization to be produced while omitting the majority of the content
+            that comes from the `data` field. This tends to constitute the bulk of the volume of the serialized
+            result, so this is useful in cases where response size is becoming an issue. the
+            `essentialRequirementsMet` key (present in DOS2 BRs onwards)is pragmatically included anyway because it
+            is referenced in some important listing views.
+        """
         data = {k: v for k, v in self.data.items() if with_data or k == "essentialRequirementsMet"}
         parent_brief = self.brief.serialize()
         parent_brief_fields = ['id', 'title', 'status', 'applicationsClosedAt', 'framework']

--- a/app/models/main.py
+++ b/app/models/main.py
@@ -1847,8 +1847,8 @@ class BriefResponse(db.Model):
         if errs:
             raise ValidationError(errs)
 
-    def serialize(self):
-        data = self.data.copy()
+    def serialize(self, with_data: bool = True):
+        data = {k: v for k, v in self.data.items() if with_data or k == "essentialRequirementsMet"}
         parent_brief = self.brief.serialize()
         parent_brief_fields = ['id', 'title', 'status', 'applicationsClosedAt', 'framework']
         data.update({

--- a/tests/example_listings.py
+++ b/tests/example_listings.py
@@ -63,6 +63,7 @@ _brief_response_availability = text(min_size=1, max_size=100, alphabet=_descript
 
 def brief_response_data(essential_count=5, nice_to_have_count=5):
     return fixed_dictionaries({
+        "essentialRequirementsMet": booleans(),
         "essentialRequirements": requirements_list(essential_count, answers=True),
         "niceToHaveRequirements": requirements_list(nice_to_have_count, answers=True),
         "availability": _brief_response_availability,
@@ -72,6 +73,7 @@ def brief_response_data(essential_count=5, nice_to_have_count=5):
 
 def specialists_brief_response_data(min_day_rate=1, max_day_rate=1000):
     return fixed_dictionaries({
+        "essentialRequirementsMet": booleans(),
         "essentialRequirements": requirements_list(5, answers=True),
         "niceToHaveRequirements": requirements_list(5, answers=True),
         "respondToEmailAddress": just("supplier@email.com"),

--- a/tests/main/views/test_brief_response.py
+++ b/tests/main/views/test_brief_response.py
@@ -110,7 +110,7 @@ class BaseBriefResponseTest(BaseApplicationTest, FixtureMixin):
     def get_brief_response(self, brief_response_id):
         return self.client.get('/brief-responses/{}'.format(brief_response_id))
 
-    def list_brief_responses(self, **parameters):
+    def list_brief_responses(self, parameters={}):
         return self.client.get('/brief-responses', query_string=parameters)
 
     def _update_brief_response(self, brief_response_id, brief_response_data):
@@ -713,7 +713,7 @@ class TestListBriefResponses(BaseBriefResponseTest):
         assert len(data['briefResponses']) == 5
         assert 'next' in data['links']
 
-        res = self.list_brief_responses(page=2)
+        res = self.list_brief_responses(dict(page=2))
         data = json.loads(res.get_data(as_text=True))
 
         assert res.status_code == 200
@@ -725,7 +725,7 @@ class TestListBriefResponses(BaseBriefResponseTest):
             self.setup_dummy_brief_response(supplier_id=0)
             self.setup_dummy_brief_response(supplier_id=1)
 
-        res = self.list_brief_responses(supplier_id=1)
+        res = self.list_brief_responses(dict(supplier_id=1))
         data = json.loads(res.get_data(as_text=True))
 
         assert res.status_code == 200
@@ -746,7 +746,7 @@ class TestListBriefResponses(BaseBriefResponseTest):
             self.setup_dummy_brief_response(brief_id=self.brief_id, supplier_id=0)
             self.setup_dummy_brief_response(brief_id=another_brief_id, supplier_id=0)
 
-        res = self.list_brief_responses(brief_id=another_brief_id)
+        res = self.list_brief_responses(dict(brief_id=another_brief_id))
         data = json.loads(res.get_data(as_text=True))
 
         assert res.status_code == 200
@@ -769,7 +769,7 @@ class TestListBriefResponses(BaseBriefResponseTest):
             self.setup_dummy_brief_response(brief_id=self.brief_id, supplier_id=0)
             self.setup_dummy_brief_response(brief_id=dos2_brief_id, supplier_id=0)
 
-        res = self.list_brief_responses(framework='digital-outcomes-and-specialists-2')
+        res = self.list_brief_responses(dict(framework='digital-outcomes-and-specialists-2'))
         data = json.loads(res.get_data(as_text=True))
 
         assert res.status_code == 200
@@ -795,9 +795,9 @@ class TestListBriefResponses(BaseBriefResponseTest):
             self.setup_dummy_brief_response(brief_id=self.brief_id, supplier_id=0)
             self.setup_dummy_brief_response(brief_id=dos2_brief_id, supplier_id=0)
 
-        res = self.list_brief_responses(
+        res = self.list_brief_responses(dict(
             framework='digital-outcomes-and-specialists, digital-outcomes-and-specialists-2'
-        )
+        ))
         data = json.loads(res.get_data(as_text=True))
 
         assert res.status_code == 200
@@ -813,14 +813,14 @@ class TestListBriefResponses(BaseBriefResponseTest):
         assert len(dos1_br) == len(dos2_br) == 2
 
     def test_cannot_list_brief_responses_for_non_integer_brief_id(self):
-        res = self.list_brief_responses(brief_id="not-valid")
+        res = self.list_brief_responses(dict(brief_id="not-valid"))
         data = json.loads(res.get_data(as_text=True))
 
         assert res.status_code == 400
         assert data['error'] == 'Invalid brief_id: not-valid'
 
     def test_cannot_list_brief_responses_for_non_integer_supplier_id(self):
-        res = self.list_brief_responses(supplier_id="not-valid")
+        res = self.list_brief_responses(dict(supplier_id="not-valid"))
         data = json.loads(res.get_data(as_text=True))
 
         assert res.status_code == 400
@@ -844,7 +844,7 @@ class TestListBriefResponses(BaseBriefResponseTest):
         self.setup_dummy_brief_response()
         expected_brief_id = self.setup_dummy_brief_response(submitted_at=None)
 
-        res = self.list_brief_responses(status='draft')
+        res = self.list_brief_responses(dict(status='draft'))
         data = json.loads(res.get_data(as_text=True))
 
         assert res.status_code == 200
@@ -855,7 +855,7 @@ class TestListBriefResponses(BaseBriefResponseTest):
         expected_brief_id = self.setup_dummy_brief_response()
         self.setup_dummy_brief_response(submitted_at=None)
 
-        res = self.list_brief_responses(status='submitted')
+        res = self.list_brief_responses(dict(status='submitted'))
         data = json.loads(res.get_data(as_text=True))
 
         assert res.status_code == 200
@@ -868,7 +868,7 @@ class TestListBriefResponses(BaseBriefResponseTest):
         self.setup_dummy_brief_response(award_details={"pending": True})
         self.setup_dummy_awarded_brief_response(brief_id=111)
 
-        res = self.list_brief_responses(status='draft,submitted,awarded,pending-awarded')
+        res = self.list_brief_responses(dict(status='draft,submitted,awarded,pending-awarded'))
         data = json.loads(res.get_data(as_text=True))
 
         assert res.status_code == 200
@@ -881,7 +881,7 @@ class TestListBriefResponses(BaseBriefResponseTest):
         self.setup_dummy_awarded_brief_response(brief_id=222, awarded_at=yesterday - timedelta(days=5))
         self.setup_dummy_brief_response(award_details={"pending": True})
 
-        res = self.list_brief_responses(awarded_at=yesterday.strftime(DATE_FORMAT))
+        res = self.list_brief_responses(dict(awarded_at=yesterday.strftime(DATE_FORMAT)))
         data = json.loads(res.get_data(as_text=True))
 
         assert res.status_code == 200

--- a/tests/models/test_main.py
+++ b/tests/models/test_main.py
@@ -1381,6 +1381,50 @@ class TestBriefResponses(BaseApplicationTest, FixtureMixin):
                 }
             }
 
+    def test_brief_response_can_be_serialized_with_data_false(self):
+        brief_response = BriefResponse(
+            data={
+                'foo': 'bar',
+                'essentialRequirementsMet': 'true',
+            },
+            brief=self.brief,
+            supplier=self.supplier,
+            submitted_at=datetime(2016, 9, 28),
+        )
+        db.session.add(brief_response)
+        db.session.commit()
+
+        with mock.patch('app.models.main.url_for') as url_for:
+            url_for.side_effect = lambda *args, **kwargs: (args, kwargs)
+            assert brief_response.serialize(with_data=False) == {
+                'id': brief_response.id,
+                'brief': {
+                    'applicationsClosedAt': '2016-03-10T23:59:59.000000Z',
+                    'id': self.brief.id,
+                    'status': self.brief.status,
+                    'title': self.brief_title,
+                    'framework': {
+                        'family': 'digital-outcomes-and-specialists',
+                        'name': 'Digital Outcomes and Specialists',
+                        'slug': 'digital-outcomes-and-specialists',
+                        'status': self.brief.framework.status
+                    }
+                },
+                'briefId': self.brief.id,
+                'supplierId': 0,
+                'supplierName': 'Supplier 0',
+                'supplierOrganisationSize': 'small',
+                'createdAt': mock.ANY,
+                'submittedAt': '2016-09-28T00:00:00.000000Z',
+                'status': 'submitted',
+                'essentialRequirementsMet': 'true',
+                'links': {
+                    'self': (('main.get_brief_response',), {'brief_response_id': brief_response.id}),
+                    'brief': (('main.get_brief',), {'brief_id': self.brief.id}),
+                    'supplier': (('main.get_supplier',), {'supplier_id': 0}),
+                }
+            }
+
     def test_brief_response_can_be_serialized_with_no_submitted_at_time(self):
         brief_response = BriefResponse(
             data={'foo': 'bar'}, brief=self.brief, supplier=self.supplier


### PR DESCRIPTION
https://trello.com/c/2FBIg5LP

This is one of those things that reveals the farce of living with an "API" - we're really not supposed to acknowledge the existence of e.g. `essentialRequirementsMet` or any explicit key in `.data`, but the specific frontend view we've got in mind for this feature _does_ use `essentialRequirementsMet`, so we can't omit it. Whereas the other members of `.data` are where a lot of the bulk data we don't need resides.