### PR TITLE
Add supplierId to audit events in brief responses

### DIFF
--- a/app/main/views/brief_responses.py
+++ b/app/main/views/brief_responses.py
@@ -85,6 +85,7 @@ def create_brief_response():
         data={
             'briefResponseId': brief_response.id,
             'briefResponseJson': brief_response_json,
+            'supplierId': supplier.supplier_id,
         },
         db_object=brief_response,
     )
@@ -132,7 +133,8 @@ def update_brief_response(brief_response_id):
         user=updater_json['updated_by'],
         data={
             'briefResponseId': brief_response.id,
-            'briefResponseData': brief_response_json
+            'briefResponseData': brief_response_json,
+            'supplierId': supplier.supplier_id,
         },
         db_object=brief_response,
     )
@@ -180,7 +182,8 @@ def submit_brief_response(brief_response_id):
         audit_type=AuditTypes.submit_brief_response,
         user=updater_json['updated_by'],
         data={
-            'briefResponseId': brief_response.id
+            'briefResponseId': brief_response.id,
+            'supplierId': supplier.supplier_id,
         },
         db_object=brief_response,
     )

--- a/tests/main/views/test_brief_response.py
+++ b/tests/main/views/test_brief_response.py
@@ -202,7 +202,8 @@ class TestCreateBriefResponse(BaseBriefResponseTest, JSONUpdateTestMixin):
             'briefResponseJson': {
                 'briefId': self.brief_id,
                 'supplierId': 0,
-            }
+            },
+            'supplierId': 0,
         }
 
     def test_cannot_create_brief_response_with_empty_json(self, live_dos_framework):
@@ -405,7 +406,8 @@ class TestUpdateBriefResponse(BaseBriefResponseTest):
         assert len(audit_events) == 1
         assert audit_events[0].data == {
             'briefResponseId': self.brief_response_id,
-            'briefResponseData': {'essentialRequirementsMet': True}
+            'briefResponseData': {'essentialRequirementsMet': True},
+            'supplierId': 0,
         }
 
     def test_update_brief_response_with_expired_framework(self, expired_dos_framework):
@@ -556,7 +558,8 @@ class TestSubmitBriefResponse(BaseBriefResponseTest):
 
         assert len(audit_events) == 1
         assert audit_events[0].data == {
-            'briefResponseId': self.brief_response_id
+            'briefResponseId': self.brief_response_id,
+            'supplierId': 0,
         }
 
     def test_submit_brief_response_that_doesnt_exist_will_404(self):


### PR DESCRIPTION
We found that it was a real struggle to find brief responses by supplier ID. This capability is useful when we receive inquiries from customers about when a response to a brief was submitted. I've added supplier ID in all three audit events created in the brief_responses view

Before merging this branch I'll squash these two commits together. [Ticket](https://trello.com/c/K7idSJht/320-add-supplierid-to-auditevents-for-newly-created-and-submitted-briefresponses)