### PR TITLE
list_services: conditionally compress responses if they can't have any "further competition" services

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -6,6 +6,7 @@ from sqlalchemy import MetaData
 
 import dmapiclient
 from dmutils.flask_init import init_app, api_error_handlers
+from dmutils.flask import DMGzipMiddleware
 
 from config import configs
 
@@ -50,6 +51,8 @@ def create_app(config_name):
     application.register_blueprint(status_blueprint)
 
     gds_metrics.init_app(application)
+
+    DMGzipMiddleware(application, compress_by_default=False)
 
     return application
 

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -1,7 +1,7 @@
 # Run `make freeze-requirements` to update requirements.txt
 # with package version changes made in requirements-app.txt
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@48.4.0#egg=digitalmarketplace-utils==48.4.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@48.6.1#egg=digitalmarketplace-utils==48.6.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.3.0#egg=digitalmarketplace-apiclient==21.3.0
 
 Flask==1.0.4 # pyup: >=1.0.0,<1.1.0
@@ -14,6 +14,7 @@ psycopg2==2.8.3
 SQLAlchemy==1.2.18 # pyup: ignore
 SQLAlchemy-Utils==0.34.2
 sqlalchemy-json==0.2.3
+Werkzeug==0.15.6 # pyup: <0.16
 
 # For schema validation
 jsonschema==3.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # Run `make freeze-requirements` to update requirements.txt
 # with package version changes made in requirements-app.txt
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@48.4.0#egg=digitalmarketplace-utils==48.4.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@48.6.1#egg=digitalmarketplace-utils==48.6.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.3.0#egg=digitalmarketplace-apiclient==21.3.0
 
 Flask==1.0.4 # pyup: >=1.0.0,<1.1.0
@@ -15,6 +15,7 @@ psycopg2==2.8.3
 SQLAlchemy==1.2.18 # pyup: ignore
 SQLAlchemy-Utils==0.34.2
 sqlalchemy-json==0.2.3
+Werkzeug==0.15.6 # pyup: <0.16
 
 # For schema validation
 jsonschema==3.0.2
@@ -22,22 +23,23 @@ rfc3987==1.3.8
 strict-rfc3339==0.7
 
 ## The following requirements were added by pip freeze:
-alembic==1.1.0
+alembic==1.2.1
 asn1crypto==0.24.0
 attrs==19.1.0
 bcrypt==3.1.7
 blinker==1.4
-boto3==1.9.216
-botocore==1.12.216
-certifi==2019.6.16
+boto3==1.9.238
+botocore==1.12.238
+certifi==2019.9.11
 cffi==1.12.3
 chardet==3.0.4
 Click==7.0
-contextlib2==0.5.5
+contextlib2==0.6.0
 cryptography==2.3.1
 defusedxml==0.6.0
 docopt==0.6.2
 docutils==0.15.2
+Flask-gzip==0.2
 Flask-Login==0.4.1
 Flask-Script==2.0.6
 Flask-WTF==0.14.2
@@ -66,7 +68,6 @@ requests==2.22.0
 s3transfer==0.2.1
 six==1.12.0
 unicodecsv==0.14.1
-urllib3==1.25.3
-Werkzeug==0.15.5
+urllib3==1.25.6
 workdays==1.4
 WTForms==2.2.1

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -244,18 +244,26 @@ class FixtureMixin(object):
                 data=data,
             )
 
-    def setup_dummy_services_including_unpublished(self, n):
+    def setup_dummy_services_including_unpublished(self, n, framework_id=1, lot_id=1, data=None):
         self.setup_dummy_suppliers(TEST_SUPPLIERS_COUNT)
-        self.setup_dummy_services(n)
+        self.setup_dummy_services(n, framework_id=framework_id, lot_id=lot_id, data=data)
         # Add extra 'enabled' and 'disabled' services
         self.setup_dummy_service(
             service_id=str(n + 2000000001),
             supplier_id=n % TEST_SUPPLIERS_COUNT,
-            status='disabled')
+            status='disabled',
+            framework_id=framework_id,
+            lot_id=lot_id,
+            data=data,
+        )
         self.setup_dummy_service(
             service_id=str(n + 2000000002),
             supplier_id=n % TEST_SUPPLIERS_COUNT,
-            status='enabled')
+            status='enabled',
+            framework_id=framework_id,
+            lot_id=lot_id,
+            data=data,
+        )
         # Add an extra supplier that will have no services
         db.session.add(
             Supplier(supplier_id=TEST_SUPPLIERS_COUNT, name=u'Supplier {}'


### PR DESCRIPTION
https://trello.com/c/ybTmY6ZT

The indexing job has failed a few times paging through the list of services. Our current preferred way to avoid this is to reduce the size of response bodies. For direct award services, the full content is pretty much public anyway, so it's probably fairly safe to compress. For further competition services, there's hypothetically commercially sensitive content in there (prices?), so leave it uncompressed.