### PR TITLE
list_briefs view: selectively compress response if draft & withdrawn briefs are filtered out

### DIFF
--- a/tests/main/views/test_briefs.py
+++ b/tests/main/views/test_briefs.py
@@ -717,7 +717,7 @@ class TestListBrief(FrameworkSetupAndTeardown):
 
     @pytest.mark.parametrize('date_arg', ['published_on', 'withdrawn_on', 'cancelled_on', 'unsuccessful_on'])
     def test_list_briefs_filter_by_single_day(self, date_arg):
-        for i, brief_status in enumerate(["draft", "withdrawn", "published", "cancelled", "unsuccessful"]):
+        for i, brief_status in enumerate(["draft", "withdrawn", "live", "cancelled", "unsuccessful"]):
             with freeze_time('2017-01-01 00:00:00'):
                 self.setup_dummy_briefs(1, lot='digital-outcomes', status=brief_status, brief_start=i + 1)
             with freeze_time('2017-01-01 23:59:59.999999'):
@@ -740,7 +740,7 @@ class TestListBrief(FrameworkSetupAndTeardown):
         [('published_before', 5), ('withdrawn_before', 1), ('cancelled_before', 1), ('unsuccessful_before', 1)]
     )
     def test_list_briefs_filter_before_date(self, date_arg, expected_count):
-        for i, brief_status in enumerate(["draft", "withdrawn", "published", "cancelled", "unsuccessful"]):
+        for i, brief_status in enumerate(["draft", "withdrawn", "live", "cancelled", "unsuccessful"]):
             with freeze_time('2016-12-31 23:59:59.999999'):
                 self.setup_dummy_briefs(1, lot='digital-outcomes', status=brief_status, brief_start=i + 1)
             # The following briefs should be filtered out ('before' is not inclusive)
@@ -759,7 +759,7 @@ class TestListBrief(FrameworkSetupAndTeardown):
         'date_arg', ['published_after', 'withdrawn_after', 'cancelled_after', 'unsuccessful_after']
     )
     def test_list_briefs_filter_after_date(self, date_arg):
-        for i, brief_status in enumerate(["draft", "withdrawn", "published", "cancelled", "unsuccessful"]):
+        for i, brief_status in enumerate(["draft", "withdrawn", "live", "cancelled", "unsuccessful"]):
             with freeze_time('2017-01-02 00:00:00'):
                 self.setup_dummy_briefs(1, lot='digital-outcomes', status=brief_status, brief_start=i + 1)
             # The following briefs should be filtered out ('after' is not inclusive)


### PR DESCRIPTION
https://trello.com/c/d1jpHXSp

Provided we modify the indexing script to actually *filter out* these briefs (which it doesn't need anyway), this should give us a far lower likelihood of incomplete responses during the indexing job.