### PR TITLE
Bump docker base image to 7.1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM digitalmarketplace/base-api:7.0.0
+FROM digitalmarketplace/base-api:7.1.0


### PR DESCRIPTION
https://trello.com/c/H9IOZZ4O

Has no effect for APIs, but we should be on the latest version so we get security bumps anyway.