### PR TITLE
Mitigate timing attacks on login endpoint

### DIFF
--- a/app/encryption.py
+++ b/app/encryption.py
@@ -2,7 +2,7 @@ from flask_bcrypt import generate_password_hash, check_password_hash
 
 
 def authenticate_user(password, user):
-    return not user.locked and checkpw(password, user.password)
+    return checkpw(password, user.password) and not user.locked
 
 
 def hashpw(password):

--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -74,6 +74,10 @@ def auth_user():
         return single_result_response(RESOURCE_NAME, user), 200
 
     else:
+        if user.locked:
+            # Hash the locked user's password and ignore the result, to mitigate against timing attacks
+            encryption.checkpw("not a real password", user.password)
+
         user.failed_login_count += 1
         db.session.add(user)
         db.session.flush()
@@ -94,10 +98,6 @@ def auth_user():
 
         db.session.add(audit)
         db.session.commit()
-
-        if user.locked:
-            # Hash the locked user's password and ignore the result, to mitigate against timing attacks
-            encryption.checkpw("not a real password", user.password)
 
         return jsonify(authorization=False), 403
 

--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -4,6 +4,7 @@ from dmapiclient.audit import AuditTypes
 from sqlalchemy import func
 from sqlalchemy.orm import lazyload
 from sqlalchemy.exc import DataError, IntegrityError
+from sqlalchemy.sql.expression import false as sql_false, and_ as sql_and
 from flask import abort, current_app, jsonify, request
 
 from dmutils.config import convert_to_boolean
@@ -52,6 +53,16 @@ def auth_user():
     ).with_for_update(of=User).first()
 
     if user is None:
+        # 'Authenticate' an inactive, unlocked user and ignore the result, to mitigate against timing attacks.
+        # The extra DB query provides us with roughly the correct timing, which avoids us having to serialize and return
+        # a dummy User in the response.
+        user = User.query.filter(
+            sql_and(
+                User.active == sql_false(),
+                User.failed_login_count <= current_app.config['DM_FAILED_LOGIN_LIMIT']
+            )
+        ).first()
+        encryption.authenticate_user("not a real password", user)
         return jsonify(authorization=False), 404
 
     elif encryption.authenticate_user(json_payload['password'], user) and user.active:
@@ -83,6 +94,10 @@ def auth_user():
 
         db.session.add(audit)
         db.session.commit()
+
+        if user.locked:
+            # Hash the locked user's password and ignore the result, to mitigate against timing attacks
+            encryption.checkpw("not a real password", user.password)
 
         return jsonify(authorization=False), 403
 

--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -74,10 +74,6 @@ def auth_user():
         return single_result_response(RESOURCE_NAME, user), 200
 
     else:
-        if user.locked:
-            # Hash the locked user's password and ignore the result, to mitigate against timing attacks
-            encryption.checkpw("not a real password", user.password)
-
         user.failed_login_count += 1
         db.session.add(user)
         db.session.flush()

--- a/tests/main/views/test_users.py
+++ b/tests/main/views/test_users.py
@@ -195,8 +195,8 @@ class TestUsersAuth(BaseUserTest):
         db.session.commit()
         self._return_post_login(status_code=403)
         self.assert_failed_login_audit_is_created(failed_login_count=2)
-        # Check the throwaway password hash has been done
-        assert checkpw.call_args_list == [mock.call('not a real password', mock.ANY)]
+        # Check that the password hash has been done regardless of locked status
+        assert checkpw.call_args_list == [mock.call('1234567890', mock.ANY)]
 
     @pytest.mark.parametrize('http_x_real_ip, expected_audit_client_ip',
                              (

--- a/tests/test_encryption.py
+++ b/tests/test_encryption.py
@@ -1,4 +1,15 @@
-from app.encryption import checkpw, hashpw
+import mock
+import pytest
+from app.encryption import checkpw, hashpw, authenticate_user
+
+
+@pytest.mark.parametrize('user_is_locked, expected_auth_result', [(True, False), (False, True)])
+def test_authenticate_user(user_is_locked, expected_auth_result):
+    password = "mypassword"
+    password_hash = hashpw(password)
+    mock_user = mock.Mock(password=password_hash, locked=user_is_locked)
+
+    assert authenticate_user(password, mock_user) == expected_auth_result
 
 
 def test_should_hash_password():


### PR DESCRIPTION
https://trello.com/c/DYccCWBt/1167-address-user-enumeration-at-login-vulnerability

## Problem
For the login view, the difference between the average response time for existing and non-existing users entering the wrong password is consistently over ~50ms. See ticket for details/risk of the potential attack.

I also found that existing locked users don't otherwise have their password hashed by the encryption module and so have a noticeably shorter response time.

## Solution
For locked users, simply adding a throwaway password hashing step (and ignoring the result) reduced the gap sufficiently (to ~10ms).

For non-existent users, this step didn't quite reduce the gap enough - the other paths have additional DB commits that take extra time. 

I tried serializing a fake User object and returning it, but that had too many side effects for FE apps wanting to consume the response. Creating/updating a dedicated DB object and committing it would have been annoying to test/maintain/document/etc.

Instead, I tried running a moderately big query (getting all inactive unlocked Users and picking the first one), which seems to bring the timing gap down to consistently under ~10ms (when the query is cached), and has the bonus of providing us with a salted user password to do the throwaway password hashing step with. 

## Caveats
Not sure if we should worry too much about the timing difference between a cached/non-cached queries - an attacker would have to remove outliers from any timing calculations anyway. If reviewers think this is a significant factor I'm happy to discuss alternatives. 

Obviously this has only been tested on my local env so far - if there's still a significant different on preview we can review the approach.

This solution relies on there being at least 1 inactive unlocked User in the DB, which means a slight tweak to the test setup to create one. If there isn't at least one such user in a live environment, we probably have a bigger problems!

Comments/questions very welcome.