### PR TITLE
1227-dos4-supplier-affected-by-our-data-retention-policy

### DIFF
--- a/app/models/main.py
+++ b/app/models/main.py
@@ -353,7 +353,7 @@ class ContactInformation(db.Model, RemovePersonalDataModelMixin):
 
         self.contact_name = '<removed>'
         self.phone_number = '<removed>'
-        self.email = '<removed>'
+        self.email = '<removed>@{uuid}.com'.format(uuid=str(uuid4()))
         self.address1 = '<removed>'
         self.city = '<removed>'
         self.postcode = '<removed>'

--- a/migrations/versions/1400_repair_contact_information_emails_post_data_retention_removal.py
+++ b/migrations/versions/1400_repair_contact_information_emails_post_data_retention_removal.py
@@ -1,0 +1,55 @@
+"""Replace '<removed>' with '<removed>@{uuid}.com'.format(uuid=str(uuid4())) in contact_information to pass validation.
+
+Revision ID: 1400
+Revises: 1390
+Create Date: 2019-10-29 09:09:00.000000
+
+"""
+from uuid import uuid4
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.sql import table, column
+
+
+# revision identifiers, used by Alembic.
+revision = '1400'
+down_revision = '1390'
+
+
+contact_information = table(
+    'contact_information',
+    column('id', sa.INTEGER),
+    column('email', sa.VARCHAR),
+)
+
+
+def upgrade():
+    """Update any contact_information rows where the email is set to '<removed>' to use the UUID email format we use
+    on the user object in User.remove_personal_data
+
+    Loop over the ids so we get a unique UUID for each update.
+    """
+    conn = op.get_bind()
+
+    # SELECT id FROM contact_information WHERE email = '<removed>';
+    query = contact_information.select().where(
+        contact_information.c.email == '<removed>'
+    ).with_only_columns(
+        (contact_information.c.id,)
+    )
+
+    ci_ids = (ci_id for ci_id, in conn.execute(query).fetchall())
+
+    for ci_id in ci_ids:
+        # UPDATE contact_information SET email = '<removed>@uuid-etc.com' WHERE id = <ci_id>;
+        query = contact_information.update().where(
+            contact_information.c.id == ci_id
+        ).values(
+            email='<removed>@{uuid}.com'.format(uuid=str(uuid4()))
+        )
+
+        conn.execute(query)
+
+
+def downgrade():
+    pass

--- a/tests/main/views/test_suppliers.py
+++ b/tests/main/views/test_suppliers.py
@@ -970,7 +970,8 @@ class TestRemoveContactInformationPersonalData(BaseApplicationTest):
         db.session.add_all([self.supplier, self.contact_information])
         db.session.commit()
 
-    def test_remove_contact_information_personal_data(self):
+    @mock.patch('app.models.main.uuid4', return_value='111')
+    def test_remove_contact_information_personal_data(self, uuid_mock):
         url = '/suppliers/{}/contact-information/{}/remove-personal-data'.format(
             self.supplier.supplier_id,
             self.contact_information.id
@@ -987,7 +988,7 @@ class TestRemoveContactInformationPersonalData(BaseApplicationTest):
         assert data['contactInformation']['address1'] == '<removed>'
         assert data['contactInformation']['city'] == '<removed>'
         assert data['contactInformation']['contactName'] == '<removed>'
-        assert data['contactInformation']['email'] == '<removed>'
+        assert data['contactInformation']['email'] == '<removed>@111.com'
         assert data['contactInformation']['phoneNumber'] == '<removed>'
         assert data['contactInformation']['postcode'] == '<removed>'
 

--- a/tests/models/test_main.py
+++ b/tests/models/test_main.py
@@ -332,7 +332,8 @@ class TestContactInformation(BaseApplicationTest):
         )
         db.session.add_all([self.supplier, self.contact_information])
 
-    def test_remove_personal_data(self):
+    @mock.patch('app.models.main.uuid4', return_value='111')
+    def test_remove_personal_data(self, uuid_mock):
         self.contact_information.remove_personal_data()
         db.session.add(self.contact_information)
         db.session.commit()
@@ -340,7 +341,7 @@ class TestContactInformation(BaseApplicationTest):
         assert self.contact_information.personal_data_removed
         assert self.contact_information.contact_name == '<removed>'
         assert self.contact_information.phone_number == '<removed>'
-        assert self.contact_information.email == '<removed>'
+        assert self.contact_information.email == '<removed>@111.com'
         assert self.contact_information.address1 == '<removed>'
         assert self.contact_information.city == '<removed>'
         assert self.contact_information.postcode == '<removed>'


### PR DESCRIPTION
* Stop contact_information from being populated with invalid email address placeholder.
* Add migration to replace existing '<removed>' with '<removed>@{uuid}.com' format used on user object

https://trello.com/c/iTOqAYUT/1227-dos4-supplier-affected-by-our-data-retention-policy