### PR TITLE
Try out Python 3.7 and 3.8 Travis checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
   - "3.8"
 addons:
   postgresql: "9.5"
-dist: "trusty"
+dist: "xenial"
 env:
   - SQLALCHEMY_DATABASE_URI=postgresql://postgres:@localhost:5432/digitalmarketplace_test
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 python:
   - "3.6"
+  - "3.7"
+  - "3.8"
 addons:
   postgresql: "9.5"
 dist: "trusty"

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -2,7 +2,7 @@
 # with package version changes made in requirements-app.txt
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@50.0.1#egg=digitalmarketplace-utils==50.0.1
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.3.0#egg=digitalmarketplace-apiclient==21.3.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.1#egg=digitalmarketplace-apiclient==21.4.1
 
 Flask==1.0.4 # pyup: >=1.0.0,<1.1.0
 Flask-Bcrypt==0.7.1

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -1,7 +1,7 @@
 # Run `make freeze-requirements` to update requirements.txt
 # with package version changes made in requirements-app.txt
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@48.6.1#egg=digitalmarketplace-utils==48.6.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@50.0.1#egg=digitalmarketplace-utils==50.0.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.3.0#egg=digitalmarketplace-apiclient==21.3.0
 
 Flask==1.0.4 # pyup: >=1.0.0,<1.1.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,7 +13,7 @@ python-dotenv==0.10.3  # used to load .flaskenv
 requests-mock==1.6.0
 testfixtures==6.9.0
 
-git+https://github.com/alphagov/digitalmarketplace-test-utils.git@2.6.0#egg=digitalmarketplace-test-utils==2.6.0
+git+https://github.com/alphagov/digitalmarketplace-test-utils.git@2.6.1#egg=digitalmarketplace-test-utils==2.6.1
 
 # For schema generation
 alchemyjsonschema==0.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # Run `make freeze-requirements` to update requirements.txt
 # with package version changes made in requirements-app.txt
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@48.6.1#egg=digitalmarketplace-utils==48.6.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@50.0.1#egg=digitalmarketplace-utils==50.0.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.3.0#egg=digitalmarketplace-apiclient==21.3.0
 
 Flask==1.0.4 # pyup: >=1.0.0,<1.1.0
@@ -23,13 +23,13 @@ rfc3987==1.3.8
 strict-rfc3339==0.7
 
 ## The following requirements were added by pip freeze:
-alembic==1.3.0
+alembic==1.3.1
 asn1crypto==1.2.0
 attrs==19.3.0
 bcrypt==3.1.7
 blinker==1.4
-boto3==1.10.8
-botocore==1.13.8
+boto3==1.10.20
+botocore==1.13.20
 certifi==2019.9.11
 cffi==1.13.2
 chardet==3.0.4
@@ -68,9 +68,9 @@ python-json-logger==0.1.11
 pytz==2019.3
 requests==2.22.0
 s3transfer==0.2.1
-six==1.12.0
+six==1.13.0
 unicodecsv==0.14.1
-urllib3==1.25.6
+urllib3==1.25.7
 workdays==1.4
 WTForms==2.2.1
 zipp==0.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 # with package version changes made in requirements-app.txt
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@50.0.1#egg=digitalmarketplace-utils==50.0.1
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.3.0#egg=digitalmarketplace-apiclient==21.3.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.1#egg=digitalmarketplace-apiclient==21.4.1
 
 Flask==1.0.4 # pyup: >=1.0.0,<1.1.0
 Flask-Bcrypt==0.7.1


### PR DESCRIPTION
https://trello.com/c/GsDBHBo7/135-switch-on-python-37-and-38-travis-checks-to-check-potential-dependency-problems-before-upgrade

Trying this on the API first, as there are a whole lot of unit tests and dependencies to deal with...

Aha! Travis needs `xenial` rather than `trusty` to support 3.7+.