### PR TITLE
1270-remove-orguk-from-buyer-domain-list

### DIFF
--- a/app/models/main.py
+++ b/app/models/main.py
@@ -965,7 +965,10 @@ class User(db.Model, RemovePersonalDataModelMixin):
     def remove_personal_data(self):
         """This method needs to remove all personal data from this object."""
         if self.role == 'buyer' or self.role in self.ADMIN_ROLES:
-            self.email_address = re.sub(r'.+?\@', '<removed><{}>@'.format(uuid4()), self.email_address)
+            self.email_address = '<removed><{uuid}>@{domain}'.format(
+                uuid=str(uuid4()),
+                domain='user.marketplace.team'
+            )
         else:
             self.email_address = '<removed>@{uuid}.com'.format(uuid=str(uuid4()))
         self.personal_data_removed = True

--- a/tests/main/views/test_users.py
+++ b/tests/main/views/test_users.py
@@ -1482,7 +1482,7 @@ class TestUsersRemovePersonalData(BaseUserTest):
         assert data['users']['active'] is False
         assert data['users']['name'] == '<removed>'
         assert data['users']['phoneNumber'] == '<removed>'
-        assert data['users']['emailAddress'] == '<removed><111>@digital.cabinet-office.gov.uk'
+        assert data['users']['emailAddress'] == '<removed><111>@user.marketplace.team'
         assert data['users']['userResearchOptedIn'] is False
         assert data['users']['personalDataRemoved'] is True
         assert data['users']['failedLoginCount'] == 0
@@ -1490,8 +1490,11 @@ class TestUsersRemovePersonalData(BaseUserTest):
     @mock.patch('app.models.main.uuid4', return_value='111')
     def test_remove_buyer_user_personal_data(self, uuid4):
         now = datetime.utcnow()
-        buyer_email_domain = BuyerEmailDomain(domain_name='digital.cabinet-office.gov.uk')
-        db.session.add(buyer_email_domain)
+        buyer_email_domains = [
+            BuyerEmailDomain(domain_name='digital.cabinet-office.gov.uk'),
+            BuyerEmailDomain(domain_name='user.marketplace.team')
+        ]
+        db.session.bulk_save_objects(buyer_email_domains)
         db.session.commit()
 
         user = User(
@@ -1520,7 +1523,7 @@ class TestUsersRemovePersonalData(BaseUserTest):
         assert data['users']['active'] is False
         assert data['users']['name'] == '<removed>'
         assert data['users']['phoneNumber'] == '<removed>'
-        assert data['users']['emailAddress'] == '<removed><111>@digital.cabinet-office.gov.uk'
+        assert data['users']['emailAddress'] == '<removed><111>@user.marketplace.team'
         assert data['users']['userResearchOptedIn'] is False
         assert data['users']['personalDataRemoved'] is True
         assert data['users']['failedLoginCount'] == 0

--- a/tests/models/test_main.py
+++ b/tests/models/test_main.py
@@ -191,6 +191,8 @@ class TestUser(BaseApplicationTest, FixtureMixin):
     def test_remove_personal_data_should_set_personal_data_removed_flag(self, role):
         self.default_buyer_domain = "digital.cabinet-office.gov.uk"
         self.setup_default_buyer_domain()
+        self.default_buyer_domain = "user.marketplace.team"
+        self.setup_default_buyer_domain()
         now = datetime.utcnow()
         user = User(
             email_address='email@digital.cabinet-office.gov.uk',
@@ -219,6 +221,8 @@ class TestUser(BaseApplicationTest, FixtureMixin):
     def test_remove_personal_data_should_remove_personal_data(self, generate_password_hash, uuid4, role):
         self.default_buyer_domain = "digital.cabinet-office.gov.uk"
         self.setup_default_buyer_domain()
+        self.default_buyer_domain = "user.marketplace.team"
+        self.setup_default_buyer_domain()
         now = datetime.utcnow()
         user = User(
             email_address='email@digital.cabinet-office.gov.uk',
@@ -242,7 +246,7 @@ class TestUser(BaseApplicationTest, FixtureMixin):
         assert user.active is False
         assert user.name == '<removed>'
         assert user.phone_number == '<removed>'
-        assert user.email_address == '<removed><111>@digital.cabinet-office.gov.uk'
+        assert user.email_address == '<removed><111>@user.marketplace.team'
         assert user.user_research_opted_in is False
         assert user.password == '222'
 
@@ -285,6 +289,8 @@ class TestUser(BaseApplicationTest, FixtureMixin):
     @pytest.mark.parametrize('role', set(User.ROLES))
     def test_cannot_change_once_personal_data_removed(self, role):
         self.default_buyer_domain = "digital.cabinet-office.gov.uk"
+        self.setup_default_buyer_domain()
+        self.default_buyer_domain = "user.marketplace.team"
         self.setup_default_buyer_domain()
         now = datetime.utcnow()
         user = User(


### PR DESCRIPTION
https://trello.com/c/g35ht5xw/1270-remove-orguk-from-buyer-domain-list

* Make remove_personal_data set domain to user.marketplace.team
* Update tests to expect remove_personal_data to set domain to user.marketplace.team for buyer users