### PR TITLE
Change data removal endpoint to keep email domain for admin users

### DIFF
--- a/app/models/main.py
+++ b/app/models/main.py
@@ -964,11 +964,14 @@ class User(db.Model, RemovePersonalDataModelMixin):
 
     def remove_personal_data(self):
         """This method needs to remove all personal data from this object."""
-        if self.role == 'buyer' or self.role in self.ADMIN_ROLES:
+        if self.role == 'buyer':
             self.email_address = '<removed><{uuid}>@{domain}'.format(
                 uuid=str(uuid4()),
                 domain='user.marketplace.team'
             )
+        elif self.role in self.ADMIN_ROLES:
+            # replace the local part but keep the domain name
+            self.email_address = re.sub(r'.+?\@', '<removed><{}>@'.format(uuid4()), self.email_address)
         else:
             self.email_address = '<removed>@{uuid}.com'.format(uuid=str(uuid4()))
         self.personal_data_removed = True

--- a/tests/main/views/test_users.py
+++ b/tests/main/views/test_users.py
@@ -1482,7 +1482,7 @@ class TestUsersRemovePersonalData(BaseUserTest):
         assert data['users']['active'] is False
         assert data['users']['name'] == '<removed>'
         assert data['users']['phoneNumber'] == '<removed>'
-        assert data['users']['emailAddress'] == '<removed><111>@user.marketplace.team'
+        assert data['users']['emailAddress'] == '<removed><111>@digital.cabinet-office.gov.uk'
         assert data['users']['userResearchOptedIn'] is False
         assert data['users']['personalDataRemoved'] is True
         assert data['users']['failedLoginCount'] == 0

--- a/tests/models/test_main.py
+++ b/tests/models/test_main.py
@@ -246,7 +246,10 @@ class TestUser(BaseApplicationTest, FixtureMixin):
         assert user.active is False
         assert user.name == '<removed>'
         assert user.phone_number == '<removed>'
-        assert user.email_address == '<removed><111>@user.marketplace.team'
+        if role == "buyer":
+            assert user.email_address == "<removed><111>@user.marketplace.team"
+        else:
+            assert user.email_address == "<removed><111>@digital.cabinet-office.gov.uk"
         assert user.user_research_opted_in is False
         assert user.password == '222'
 


### PR DESCRIPTION
Reverts part of #991.

This should fix the data retention job that failed this morning, see ticket https://trello.com/c/uXIwszoX/1305-data-retention-job-failure