### PR TITLE
create_user view: add qualifyingBuyerEmailDomain to audit data

### DIFF
--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -29,6 +29,7 @@ from ...utils import (
 from ...validation import (
     admin_email_address_has_approved_domain,
     buyer_email_address_has_approved_domain,
+    buyer_email_address_first_approved_domain,
     validate_user_auth_json_or_400,
     validate_user_json_or_400,
 )
@@ -195,6 +196,12 @@ def create_user():
     )
 
     audit_data = {}
+
+    if user.role == "buyer":
+        audit_data["qualifyingBuyerEmailDomain"] = buyer_email_address_first_approved_domain(
+            BuyerEmailDomain.query.all(),
+            user.email_address,
+        ).domain_name
 
     if "supplierId" in json_payload:
         user.supplier_id = json_payload['supplierId']


### PR DESCRIPTION
https://trello.com/c/j6YDMslP

Required an amount of refactoring of the validation functions. Also set me off on a mission to make the `create_user` tests actually assert resulting database state following the request.

~Something I haven't done (but feel I probably should) is something equivalent for creation of admin accounts...~