### PR TITLE
192-cause-additionalchecks-to-always-be-run-regardless-of-ignore-dependencies-on-status-endpoint

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -1,7 +1,7 @@
 # Run `make freeze-requirements` to update requirements.txt
 # with package version changes made in requirements-app.txt
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@50.0.1#egg=digitalmarketplace-utils==50.0.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@51.0.0#egg=digitalmarketplace-utils==51.0.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.1#egg=digitalmarketplace-apiclient==21.4.1
 
 Flask==1.0.4 # pyup: >=1.0.0,<1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # Run `make freeze-requirements` to update requirements.txt
 # with package version changes made in requirements-app.txt
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@50.0.1#egg=digitalmarketplace-utils==50.0.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@51.0.0#egg=digitalmarketplace-utils==51.0.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.1#egg=digitalmarketplace-apiclient==21.4.1
 
 Flask==1.0.4 # pyup: >=1.0.0,<1.1.0
@@ -23,14 +23,14 @@ rfc3987==1.3.8
 strict-rfc3339==0.7
 
 ## The following requirements were added by pip freeze:
-alembic==1.3.1
+alembic==1.3.2
 asn1crypto==1.2.0
 attrs==19.3.0
 bcrypt==3.1.7
 blinker==1.4
-boto3==1.10.20
-botocore==1.13.20
-certifi==2019.9.11
+boto3==1.10.40
+botocore==1.13.40
+certifi==2019.11.28
 cffi==1.13.2
 chardet==3.0.4
 Click==7.0
@@ -48,20 +48,20 @@ future==0.18.2
 gds-metrics==0.2.0
 govuk-country-register==0.5.0
 idna==2.8
-importlib-metadata==0.23
+importlib-metadata==1.3.0
 Jinja2==2.10.3
 jmespath==0.9.4
 mailchimp3==3.0.6
 Mako==1.1.0
 MarkupSafe==1.1.1
 monotonic==1.5
-more-itertools==7.2.0
-notifications-python-client==5.4.0
+more-itertools==8.0.2
+notifications-python-client==5.4.1
 odfpy==1.4.0
 prometheus-client==0.2.0
 pycparser==2.19
 PyJWT==1.7.1
-pyrsistent==0.15.5
+pyrsistent==0.15.6
 python-dateutil==2.8.1
 python-editor==1.0.4
 python-json-logger==0.1.11


### PR DESCRIPTION
Update api to use new utils including causing run of additional_checks regardless of `include-dependencies` parameter

See:
https://trello.com/c/B2GfZgfO/192-cause-additionalchecks-to-always-be-run-regardless-of-ignore-dependencies-on-status-endpoint
https://github.com/alphagov/digitalmarketplace-utils/blob/master/CHANGELOG.md#5100