### PR TITLE
DraftService: enforce lot's one_service_limit using database constraint

### DIFF
--- a/app/models/main.py
+++ b/app/models/main.py
@@ -1040,9 +1040,30 @@ class ServiceTableMixin(object):
 
     @declared_attr
     def __table_args__(cls):
-        return (db.ForeignKeyConstraint([cls.framework_id, cls.lot_id],
-                                        ['framework_lots.framework_id', 'framework_lots.lot_id']),
-                {})
+        return (
+            db.ForeignKeyConstraint(
+                (cls.framework_id, cls.lot_id,),
+                ("framework_lots.framework_id", "framework_lots.lot_id",),
+            ),
+        ) + (() if not hasattr(cls, "lot_one_service_limit") else (
+            # if the model has a field named lot_one_service_limit, we enforce the one service limit where appropriate
+            # on this table using a database constraint. first a constraint to ensure the lot_one_service_limit is in
+            # sync with the value in the lots table
+            db.ForeignKeyConstraint(
+                (cls.lot_id, cls.lot_one_service_limit,),
+                ("lots.id", "lots.one_service_limit",),
+                name=f"fk_{cls.__tablename__}_lot_id_one_service_limit",
+            ),
+            # and now a conditional unique constraint where lot_one_service_limit is true
+            db.Index(
+                f"idx_{cls.__tablename__}_enforce_one_service_limit",
+                cls.supplier_id,
+                cls.lot_id,
+                cls.framework_id,
+                postgresql_where=cls.lot_one_service_limit,
+                unique=True,
+            ),
+        ))
 
     @declared_attr
     def lot_id(cls):
@@ -1059,7 +1080,7 @@ class ServiceTableMixin(object):
 
     @declared_attr
     def lot(cls):
-        return db.relationship(Lot, lazy='joined', innerjoin=True)
+        return db.relationship(Lot, lazy='joined', innerjoin=True, foreign_keys=(cls.lot_id,))
 
     @validates('service_id')
     def validate_service_id(self, key, value):

--- a/app/models/main.py
+++ b/app/models/main.py
@@ -102,6 +102,13 @@ class Lot(db.Model):
     one_service_limit = db.Column(db.Boolean, nullable=False, default=False)
     data = db.Column(JSON)
 
+    __table_args__ = (
+        # this may appear tautological (id is a unique column *on its own*, so clearly the combination of
+        # id/one_service_limit is), but is required by postgres to be able to make a compound foreign key to
+        # these together. fortunately it's not a big index to create.
+        db.UniqueConstraint(id, one_service_limit, name="uq_lots_id_one_service_limit"),
+    )
+
     @property
     def allows_brief(self):
         return self.one_service_limit

--- a/app/models/main.py
+++ b/app/models/main.py
@@ -1225,7 +1225,7 @@ class DraftService(db.Model, ServiceTableMixin):
     # itself. must be initialized on DraftService creation.
     lot_one_service_limit = db.Column(
         db.Boolean,
-        nullable=True,
+        nullable=False,
     )
 
     @staticmethod

--- a/migrations/versions/1420_draft_services_populate_lot_one_service_limit.py
+++ b/migrations/versions/1420_draft_services_populate_lot_one_service_limit.py
@@ -1,0 +1,44 @@
+"""draft services: populate lot_one_service_limit, set non-nullable
+
+Revision ID: 1420
+Revises: 1410
+Create Date: 2020-01-07 16:14:04.461198
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+
+# revision identifiers, used by Alembic.
+revision = '1420'
+down_revision = '1410'
+
+
+def upgrade():
+    op.execute(
+        """UPDATE
+            draft_services
+        SET
+            lot_one_service_limit = lots.one_service_limit
+        FROM
+            lots
+        WHERE
+            lots.id = draft_services.lot_id"""
+    )
+    op.alter_column(
+        'draft_services',
+        'lot_one_service_limit',
+        existing_type=sa.BOOLEAN(),
+        nullable=False,
+    )
+
+
+def downgrade():
+    op.alter_column(
+        'draft_services',
+        'lot_one_service_limit',
+        existing_type=sa.BOOLEAN(),
+        nullable=True,
+    )
+

--- a/migrations/versions/1430_lots_add_id_one_service_limit_unique_.py
+++ b/migrations/versions/1430_lots_add_id_one_service_limit_unique_.py
@@ -1,0 +1,23 @@
+"""lots: add id/one_service_limit unique constraint
+
+Revision ID: 1430
+Revises: 1420
+Create Date: 2020-01-08 11:35:28.932921
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+
+# revision identifiers, used by Alembic.
+revision = '1430'
+down_revision = '1420'
+
+
+def upgrade():
+    op.create_unique_constraint('uq_lots_id_one_service_limit', 'lots', ['id', 'one_service_limit'])
+
+
+def downgrade():
+    op.drop_constraint('uq_lots_id_one_service_limit', 'lots', type_='unique')

--- a/migrations/versions/1440_draft_services_lot_one_service_limit_.py
+++ b/migrations/versions/1440_draft_services_lot_one_service_limit_.py
@@ -1,0 +1,37 @@
+"""draft_services.lot_one_service_limit: add constraints
+
+Revision ID: 1440
+Revises: 1430
+Create Date: 2020-01-08 11:37:16.449391
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+
+# revision identifiers, used by Alembic.
+revision = '1440'
+down_revision = '1430'
+
+
+def upgrade():
+    op.create_foreign_key(
+        'fk_draft_services_lot_id_one_service_limit',
+        'draft_services',
+        'lots',
+        ['lot_id', 'lot_one_service_limit'],
+        ['id', 'one_service_limit'],
+    )
+    op.create_index(
+        'idx_draft_services_enforce_one_service_limit',
+        'draft_services',
+        ['supplier_id', 'lot_id', 'framework_id'],
+        unique=True,
+        postgresql_where=sa.text('lot_one_service_limit'),
+    )
+
+
+def downgrade():
+    op.drop_index('idx_draft_services_enforce_one_service_limit', table_name='draft_services')
+    op.drop_constraint('fk_draft_services_lot_id_one_service_limit', 'draft_services', type_='foreignkey')


### PR DESCRIPTION
~**I'm not planning on merging this PR directly, at merge time I will take the first two commits and submit them separately.** This is just here to allow people to review it conveniently.~ This _is_ now the second half., the first half having been merged as #1005 

https://trello.com/c/bqmbNLBu

Please read commit comments for more detailed information - I've tried to document it step by step.

In short, it's actually implemented largely in the abstract `ServiceTableMixin` and only _enabled_ when the concrete model contains a `lot_one_service_limit` field. For now, that's only `DraftService`.

It would be good to test the first two commits work fine for you on their own before testing the full branch...