### PR TITLE
Add test of email addresses to `/users` endpoint

### DIFF
--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -30,6 +30,7 @@ from ...validation import (
     admin_email_address_has_approved_domain,
     buyer_email_address_has_approved_domain,
     buyer_email_address_first_approved_domain,
+    is_valid_email_address,
     validate_user_auth_json_or_400,
     validate_user_json_or_400,
 )
@@ -115,6 +116,8 @@ def list_users():
     # email_address is a primary key
     email_address = request.args.get('email_address')
     if email_address:
+        if not is_valid_email_address(email_address):
+            abort(400, "email_address must be a valid email address")
         single_user = user_query.filter(
             User.email_address == email_address.lower()
         ).first_or_404()

--- a/app/validation.py
+++ b/app/validation.py
@@ -405,3 +405,11 @@ def admin_email_address_has_approved_domain(email_address):
     :return: boolean
     """
     return email_address.split('@')[-1] in current_app.config.get('DM_ALLOWED_ADMIN_DOMAINS', [])
+
+
+def is_valid_email_address(email_address: str) -> bool:
+    "Check the email address is valid"
+    # regex from Mozilla Developer Network
+    # https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/email#Validation
+    pattern = r"^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$"  # noqa: E501
+    return bool(re.fullmatch(pattern, email_address))

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -8,9 +8,19 @@ import mock
 from jsonschema import validate, SchemaError, ValidationError
 
 from app.utils import drop_foreign_fields
-from app.validation import validates_against_schema, is_valid_service_id, is_valid_date, \
-    is_valid_acknowledged_state, get_validation_errors, is_valid_string, min_price_less_than_max_price, \
-    translate_json_schema_errors, buyer_email_address_has_approved_domain, is_approved_buyer_domain
+from app.validation import (
+    validates_against_schema,
+    is_valid_service_id,
+    is_valid_date,
+    is_valid_acknowledged_state,
+    get_validation_errors,
+    is_valid_email_address,
+    is_valid_string,
+    min_price_less_than_max_price,
+    translate_json_schema_errors,
+    buyer_email_address_has_approved_domain,
+    is_approved_buyer_domain,
+)
 from tests.helpers import load_example_listing
 
 
@@ -809,3 +819,18 @@ def test_is_approved_buyer_domain(domain, expected_result):
     ]
 
     assert is_approved_buyer_domain(existing_domains, domain) == expected_result
+
+
+@pytest.mark.parametrize(
+    ("email_address", "is_valid"),
+    (
+        ("me@example.com", True),
+        ("very.common@example.com", True),
+        ("disposable.style.email.with+symbol@example.com", True),
+        ("", False),
+        ("Abc.example.com", False),
+        ("email-address-with-NUL\x00@example.com", False),
+        (r'a"b(c)d,e:f;g<h>i[j\k]l@example.com', False),
+    ))
+def test_is_valid_email_address(email_address, is_valid):
+    assert is_valid_email_address(email_address) is is_valid


### PR DESCRIPTION
We had an issue where a request to `/users?email_address=...` with a NUL character in the query string caused a number of HTTP `500`s. See the [2nd line ticket](https://trello.com/c/bcchmats/1353-bad-user-input-on-login-form-causing-500s) for details.

@katstevens convinced me that an invalid email address should result in a `400`, so I've added a validation helper function and a test to the endpoint.

Note that the pattern used to check whether the email address is valid is NOT the same as that used in our JSON schemas for authentication; this because the regex used in our JSON schemas will still let NUL characters through (and thus cause a 500). I'm not sure what the implications of changing our schema are, so I haven't done it yet.