### PR TITLE
Allow update_service view to move service to different supplier

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -159,8 +159,10 @@ def update_service(service_id):
             abort(400, "Invalid value for 'copiedToFollowingFramework' supplied")
         service.copied_to_following_framework = update['copiedToFollowingFramework']
 
-    if 'supplierId' in update:
+    if 'supplierId' in update and update['supplierId'] != service.supplier_id:
         audit_type = AuditTypes.update_service_supplier
+        if len(update.keys()) > 1:
+            abort(400, "Cannot update supplierID and other fields at the same time")
         # Discard any other updates
         update = {
             'supplierId': update['supplierId']

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -159,13 +159,17 @@ def update_service(service_id):
             abort(400, "Invalid value for 'copiedToFollowingFramework' supplied")
         service.copied_to_following_framework = update['copiedToFollowingFramework']
 
-    updated_service = update_and_validate_service(service, update)
     if 'supplierId' in update:
         audit_type = AuditTypes.update_service_supplier
+        # Discard any other updates
+        update = {
+            'supplierId': update['supplierId']
+        }
     else:
         audit_type = (
             AuditTypes.update_service_admin if request.args.get('user-role') == 'admin' else AuditTypes.update_service
         )
+    updated_service = update_and_validate_service(service, update)
 
     commit_and_archive_service(updated_service, update_details, audit_type)
     index_service(updated_service, wait_for_response=convert_to_boolean(request.args.get("wait-for-index", "true")))

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -160,9 +160,12 @@ def update_service(service_id):
         service.copied_to_following_framework = update['copiedToFollowingFramework']
 
     updated_service = update_and_validate_service(service, update)
-    audit_type = (
-        AuditTypes.update_service_admin if request.args.get('user-role') == 'admin' else AuditTypes.update_service
-    )
+    if 'supplierId' in update:
+        audit_type = AuditTypes.update_service_supplier
+    else:
+        audit_type = (
+            AuditTypes.update_service_admin if request.args.get('user-role') == 'admin' else AuditTypes.update_service
+        )
 
     commit_and_archive_service(updated_service, update_details, audit_type)
     index_service(updated_service, wait_for_response=convert_to_boolean(request.args.get("wait-for-index", "true")))

--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -159,13 +159,13 @@ def update_service(service_id):
             abort(400, "Invalid value for 'copiedToFollowingFramework' supplied")
         service.copied_to_following_framework = update['copiedToFollowingFramework']
 
-    if 'supplierId' in update and update['supplierId'] != service.supplier_id:
+    if 'supplierId' in update and int(update['supplierId']) != service.supplier_id:
         audit_type = AuditTypes.update_service_supplier
         if len(update.keys()) > 1:
             abort(400, "Cannot update supplierID and other fields at the same time")
         # Discard any other updates
         update = {
-            'supplierId': update['supplierId']
+            'supplierId': int(update['supplierId'])
         }
     else:
         audit_type = (

--- a/app/models/main.py
+++ b/app/models/main.py
@@ -1146,6 +1146,10 @@ class ServiceTableMixin(object):
         current_data = dict(self.data.items())
         current_data.update(data)
 
+        # Enables us to transfer services between suppliers
+        if 'supplierId' in data:
+            self.supplier_id = data['supplierId']
+
         self.data = current_data
 
     def __repr__(self):

--- a/app/service_utils.py
+++ b/app/service_utils.py
@@ -122,6 +122,8 @@ def commit_and_archive_service(updated_service, update_details,
         })
 
         if audit_type == AuditTypes.update_service_supplier:
+            # The updated_service.supplier.supplier_id foreign key won't be updated
+            # until the commit() below, so use the updated .supplier_id attribute
             audit_data.update({
                 'previousSupplierId': service_to_archive.supplier_id,
                 'previousSupplierName': service_to_archive.supplier.name,

--- a/app/service_utils.py
+++ b/app/service_utils.py
@@ -16,6 +16,11 @@ def validate_and_return_service_request(service_id):
     json_payload = get_json_from_request()
     json_has_required_keys(json_payload, ['services'])
     json_has_matching_id(json_payload['services'], service_id)
+
+    if 'supplierId' in json_payload['services']:
+        if len(json_payload['services'].keys()) > 1:
+            abort(400, "Cannot update supplierID and other fields at the same time")
+
     return json_payload['services']
 
 

--- a/app/service_utils.py
+++ b/app/service_utils.py
@@ -17,10 +17,6 @@ def validate_and_return_service_request(service_id):
     json_has_required_keys(json_payload, ['services'])
     json_has_matching_id(json_payload['services'], service_id)
 
-    if 'supplierId' in json_payload['services']:
-        if len(json_payload['services'].keys()) > 1:
-            abort(400, "Cannot update supplierID and other fields at the same time")
-
     return json_payload['services']
 
 

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -2,7 +2,7 @@
 # with package version changes made in requirements-app.txt
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@51.0.0#egg=digitalmarketplace-utils==51.0.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.1#egg=digitalmarketplace-apiclient==21.4.1
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.5.0#egg=digitalmarketplace-apiclient==21.5.0
 
 Flask==1.0.4 # pyup: >=1.0.0,<1.1.0
 Flask-Bcrypt==0.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 # with package version changes made in requirements-app.txt
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@51.0.0#egg=digitalmarketplace-utils==51.0.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.1#egg=digitalmarketplace-apiclient==21.4.1
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.5.0#egg=digitalmarketplace-apiclient==21.5.0
 
 Flask==1.0.4 # pyup: >=1.0.0,<1.1.0
 Flask-Bcrypt==0.7.1

--- a/tests/main/views/test_services.py
+++ b/tests/main/views/test_services.py
@@ -732,9 +732,10 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin, FixtureMixin):
         assert len(updated_auth_controls['value']) == 1
         assert ('Authentication federation' in updated_auth_controls['value']) is True
 
+    @pytest.mark.parametrize('posted_supplier_id', (2, "2"))
     @mock.patch('app.main.views.services.index_service', autospec=True)
-    def test_can_change_the_supplier_id_for_a_service(self, index_service):
-        response = self._post_service_update({'supplierId': 2})
+    def test_can_change_the_supplier_id_for_a_service(self, index_service, posted_supplier_id):
+        response = self._post_service_update({'supplierId': posted_supplier_id})
         assert response.status_code == 200
         assert index_service.called is True
 

--- a/tests/main/views/test_services.py
+++ b/tests/main/views/test_services.py
@@ -733,13 +733,15 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin, FixtureMixin):
 
     @mock.patch('app.main.views.services.index_service', autospec=True)
     def test_can_change_the_supplier_id_for_a_service(self, index_service):
-        response = self._post_service_update({'supplierId': 2})
+        response = self._post_service_update({'supplierId': 2, 'foo': 'bar'})
         assert response.status_code == 200
         assert index_service.called is True
 
         response = self.client.get('/services/{}'.format(self.service_id))
         data = json.loads(response.get_data())
         assert data['services']['supplierId'] == 2
+        # Other fields are ignored
+        assert 'foo' not in data['services'].keys()
 
         audit_response = self.client.get('/audit-events')
         assert audit_response.status_code == 200
@@ -749,6 +751,8 @@ class TestPostService(BaseApplicationTest, JSONUpdateTestMixin, FixtureMixin):
         assert data['auditEvents'][0]['type'] == 'update_service_supplier'
         assert data['auditEvents'][0]['data']['supplierId'] == 2
         assert data['auditEvents'][0]['data']['previousSupplierId'] == 1
+        # Other fields are ignored
+        assert 'foo' not in data['auditEvents'][0]['data'].keys()
 
     @mock.patch('app.main.views.services.index_service', autospec=True)
     def test_invalid_field_not_accepted_on_update(self, index_service):

--- a/tests/test_service_utils.py
+++ b/tests/test_service_utils.py
@@ -29,7 +29,7 @@ class TestValidateAndReturnServiceJSON(BaseApplicationTest):
         assert exc.value.code == 400
         assert str(exc.value) == "400 Bad Request: id parameter must match id in data"
 
-    def test_service_request_accepts_multiple_non_supplier_id_fields(self, get_json_from_request):
+    def test_service_request_happy_path(self, get_json_from_request):
         get_json_from_request.return_value = {
             'services': {
                 'foo': 'bar',
@@ -40,28 +40,6 @@ class TestValidateAndReturnServiceJSON(BaseApplicationTest):
             'foo': 'bar',
             'baz': 'bork'
         }
-
-    def test_service_request_accepts_supplier_id_on_its_own(self, get_json_from_request):
-        get_json_from_request.return_value = {
-            'services': {
-                'supplierId': 12345
-            }
-        }
-        assert validate_and_return_service_request('any_service_id') == {
-            'supplierId': 12345
-        }
-
-    def test_service_request_invalid_if_supplier_id_and_other_fields(self, get_json_from_request):
-        get_json_from_request.return_value = {
-            'services': {
-                'supplierId': 12345,
-                'foo': 'bar'
-            }
-        }
-        with pytest.raises(BadRequest) as exc:
-            validate_and_return_service_request('any_service_id')
-        assert exc.value.code == 400
-        assert str(exc.value) == "400 Bad Request: Cannot update supplierID and other fields at the same time"
 
 
 @mock.patch('app.service_utils.index_object', autospec=True)


### PR DESCRIPTION
https://trello.com/c/mLU7vty9/1343-inconsistency-with-supplier-on-the-dos4-framework-amaze-realize

Depends on https://github.com/alphagov/digitalmarketplace-apiclient/pull/228.

We currently have no auditable way of moving a service from one supplier to another. This will be useful for any future novations as well as addressing an inconsistency on one of our supplier's services.

The `update_service` view uses a new `AuditType` to allow us to link the old and new supplier IDs on the same audit event. There's a bit of stickiness around fetching the supplier_id from the new object before we do the commit, any suggestions for improvements welcome. 

The new audit event type will also mean these changes shouldn't appear on the service edits view for Category Admins, but I haven't tested that yet...  

