### PR TITLE
DraftService: enforce lot's one_service_limit using database constraint (part 1)

### DIFF
--- a/app/main/views/drafts.py
+++ b/app/main/views/drafts.py
@@ -455,7 +455,8 @@ def create_new_draft_service():
         lot=lot,
         supplier=supplier,
         data=draft_json,
-        status="not-submitted"
+        status="not-submitted",
+        lot_one_service_limit=lot.one_service_limit,
     )
 
     validate_service_data(draft, enforce_required=False, required_fields=page_questions)

--- a/app/models/main.py
+++ b/app/models/main.py
@@ -1221,6 +1221,13 @@ class DraftService(db.Model, ServiceTableMixin):
     service_id = db.Column(db.String, index=True, unique=False, nullable=True,
                            default=None)
 
+    # this column will enforce its consistency with the related lot's one_service_limit, but will *not* auto-populate
+    # itself. must be initialized on DraftService creation.
+    lot_one_service_limit = db.Column(
+        db.Boolean,
+        nullable=True,
+    )
+
     @staticmethod
     def from_service(service, questions_to_copy=None, target_framework_id=None):
         draft_not_on_same_framework_as_service = target_framework_id and target_framework_id != service.framework.id
@@ -1237,6 +1244,7 @@ class DraftService(db.Model, ServiceTableMixin):
             } if draft_not_on_same_framework_as_service else service.data,
             'status': service.status if not target_framework_id or
             target_framework_id == service.framework.id else 'not-submitted',
+            'lot_one_service_limit': service.lot.one_service_limit,
         }
 
         if draft_not_on_same_framework_as_service:
@@ -1266,6 +1274,7 @@ class DraftService(db.Model, ServiceTableMixin):
             supplier=self.supplier,
             data=data,
             status='not-submitted',
+            lot_one_service_limit=self.lot.one_service_limit,
         )
 
     def serialize(self):

--- a/migrations/versions/1410_draft_services_add_lot_one_service_limit.py
+++ b/migrations/versions/1410_draft_services_add_lot_one_service_limit.py
@@ -1,0 +1,26 @@
+"""draft services: add lot_one_service_limit column
+
+Revision ID: 1410
+Revises: 1400
+Create Date: 2020-01-07 15:55:53.583221
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+
+# revision identifiers, used by Alembic.
+revision = '1410'
+down_revision = '1400'
+
+
+def upgrade():
+    op.add_column(
+        'draft_services',
+        sa.Column('lot_one_service_limit', sa.Boolean(), nullable=True,),
+    )
+
+
+def downgrade():
+    op.drop_column('draft_services', 'lot_one_service_limit')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,7 +76,8 @@ def draft_service(request, app, supplier_framework):
             data={},
             status='submitted',
             updated_at=datetime.now(),
-            created_at=datetime.now()
+            created_at=datetime.now(),
+            lot_one_service_limit=lot.one_service_limit,
         )
         db.session.add(fl)
         db.session.add(ds)

--- a/tests/main/views/test_frameworks.py
+++ b/tests/main/views/test_frameworks.py
@@ -584,6 +584,7 @@ class TestFrameworkStats(BaseApplicationTest, FixtureMixin):
                         supplier_id=supplier_id,
                         data={},
                         status="not-submitted" if ind < unsub_count else "submitted",
+                        lot_one_service_limit=lot.one_service_limit,
                     )
                 )
 

--- a/tests/main/views/test_suppliers.py
+++ b/tests/main/views/test_suppliers.py
@@ -6,7 +6,7 @@ import pytest
 
 from app import db
 from app.models import Supplier, ContactInformation, AuditEvent, \
-    SupplierFramework, Framework, FrameworkAgreement, DraftService, Service
+    SupplierFramework, Framework, FrameworkAgreement, DraftService, Service, Lot
 from mock import mock
 from sqlalchemy.exc import DataError, IntegrityError
 from tests.bases import BaseApplicationTest, JSONTestMixin, JSONUpdateTestMixin
@@ -1731,7 +1731,8 @@ class TestGetSupplierFrameworks(BaseApplicationTest):
                 service_id="0987654321",
                 supplier_id=1,
                 data={},
-                status='not-submitted'
+                status='not-submitted',
+                lot_one_service_limit=Lot.query.get(1).one_service_limit,
             ),
             DraftService(
                 framework_id=1,
@@ -1739,7 +1740,8 @@ class TestGetSupplierFrameworks(BaseApplicationTest):
                 service_id="1234567890",
                 supplier_id=1,
                 data={},
-                status='submitted'
+                status='submitted',
+                lot_one_service_limit=Lot.query.get(2).one_service_limit,
             ),
             Service(
                 framework_id=1,
@@ -1747,7 +1749,7 @@ class TestGetSupplierFrameworks(BaseApplicationTest):
                 service_id="1234567890",
                 supplier_id=2,
                 data={},
-                status='published'
+                status='published',
             )
         ])
         db.session.commit()

--- a/tests/models/test_main.py
+++ b/tests/models/test_main.py
@@ -2200,6 +2200,7 @@ class TestDraftService(BaseApplicationTest, FixtureMixin):
             status="enabled",
             created_at="2017-04-07T12:34:00.000000Z",
             updated_at="2017-05-08T13:24:00.000000Z",
+            lot_one_service_limit=Lot.query.get(9).one_service_limit,
         )
         db.session.add(draft_service)
         db.session.commit()


### PR DESCRIPTION
This is part 1 of the for-real version of #1000. Please see discussion there.

https://trello.com/c/bqmbNLBu