### PR TITLE
get_validator: use required_fields to also filter enforced "dependencies"

### DIFF
--- a/app/validation.py
+++ b/app/validation.py
@@ -50,6 +50,11 @@ def get_validator(schema_name, enforce_required=True, required_fields=None):
             field for field in schema.get('required', [])
             if field in required_fields
         ]
+        schema['dependencies'] = {
+            k: v
+            for k, v in schema.get('dependencies', {}).items()
+            if k in required_fields
+        }
         schema.pop('anyOf', None)
     return validator_for(schema)(schema, format_checker=FORMAT_CHECKER)
 

--- a/tests/main/views/test_drafts.py
+++ b/tests/main/views/test_drafts.py
@@ -2046,7 +2046,7 @@ class TestDOSServices(BaseApplicationTest, FixtureMixin):
                 # missing "developerLocations"
                 "dataProtocols": True,
                 "developerPriceMin": "1"},
-            page_questions=[]
+            page_questions=["dataProtocols", "developerPriceMin"],
         )
         data = json.loads(update.get_data())
         for key in ['developerLocations', 'developerPriceMax']:

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -730,6 +730,41 @@ def test_g9_followup_questions(schema_name, required_fields, input_data, expecte
     ) == expected_errors
 
 
+@pytest.mark.parametrize("required_fields,input_data,expected_errors", (
+    (
+        ["openStandardsPrinciples", "dataProtocols"],
+        {
+            "openStandardsPrinciples": True,
+            "dataProtocols": True,
+            "designerPriceMax": "900",
+        },
+        {},
+    ),
+    # by including designerPriceMax in the required_fields we're stating that its dependencies must also be satisfied
+    (
+        ["openStandardsPrinciples", "dataProtocols", "designerPriceMax"],
+        {
+            "openStandardsPrinciples": True,
+            "dataProtocols": True,
+            "designerPriceMax": "900",
+        },
+        {
+            'designerAccessibleApplications': 'answer_required',
+            'designerLocations': 'answer_required',
+            'designerPriceMin': 'answer_required',
+        },
+    ),
+))
+def test_dos4_dependent_questions(required_fields, input_data, expected_errors):
+    # specifically dos4 services because they have "dependencies"
+    assert get_validation_errors(
+        "services-digital-outcomes-and-specialists-4-digital-specialists",
+        input_data,
+        enforce_required=False,
+        required_fields=required_fields,
+    ) == expected_errors
+
+
 def test_api_type_is_optional():
     data = load_example_listing("G6-PaaS")
     del data["apiType"]


### PR DESCRIPTION
Neglecting to remove irrelevant dependencies caused errors present in "other sections" to be raised on all sections of a submission. This should fix the notorious https://trello.com/c/ShyReqk5 - more details there.

As a precursor I also converted a bunch of this function's tests to proper parametrized tests from ghetto-parametrized tests to help me get a grip of what's going on here...