### PR TITLE
Bump docker base image to 9.1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM digitalmarketplace/base-api:9.0.0
+FROM digitalmarketplace/base-api:9.1.0


### PR DESCRIPTION
To incorporate https://github.com/alphagov/digitalmarketplace-docker-base/pull/69