### PR TITLE
Update SQLAlchemy from 1.2.18 to 1.3.15

### DIFF
--- a/migrations/versions/1210_add_outcome_model.py
+++ b/migrations/versions/1210_add_outcome_model.py
@@ -18,7 +18,7 @@ down_revision = '1200'
 def upgrade():
     op.create_unique_constraint('uq_brief_responses_id_brief_id', 'brief_responses', ['id', 'brief_id'])
     op.create_unique_constraint(
-        'uq_direct_award_search_result_entries_archived_service_id_search_id',
+        'uq_direct_award_search_result_entries_archived_service_id_searc',
         'direct_award_search_result_entries',
         ['archived_service_id', 'search_id'],
     )
@@ -119,7 +119,7 @@ def downgrade():
     op.drop_table('outcomes')
     op.drop_constraint('uq_direct_award_searches_id_project_id', 'direct_award_searches', type_='unique')
     op.drop_constraint(
-        'uq_direct_award_search_result_entries_archived_service_id_search_id',
+        'uq_direct_award_search_result_entries_archived_service_id_searc',
         'direct_award_search_result_entries',
         type_='unique',
     )

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -45,7 +45,7 @@ requests-mock==1.7.0      # via -r requirements-dev.in
 requests==2.23.0          # via -c requirements.txt, coveralls, requests-mock
 six==1.14.0               # via -c requirements.txt, freezegun, isodate, jsonschema, packaging, pip-tools, python-dateutil, requests-mock
 sortedcontainers==2.1.0   # via hypothesis
-sqlalchemy==1.2.18        # via -c requirements.txt, alchemyjsonschema
+sqlalchemy==1.3.15        # via -c requirements.txt, alchemyjsonschema
 strict-rfc3339==0.7       # via -c requirements.txt, alchemyjsonschema
 testfixtures==6.13.0      # via -r requirements-dev.in
 urllib3==1.25.8           # via -c requirements.txt, requests

--- a/requirements.in
+++ b/requirements.in
@@ -7,7 +7,7 @@ git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.5.0#egg=digi
 Flask==1.0.4 # pyup: >=1.0.0,<1.1.0
 Flask-Bcrypt==0.7.1
 Flask-Migrate==2.0.3 # pyup: ignore
-Flask-SQLAlchemy==2.1 # pyup: ignore
+Flask-SQLAlchemy>=2.4.1,<=2.5.0 # pyup: ignore
 itsdangerous==0.24 # pyup: ignore
 --no-binary=psycopg2
 psycopg2==2.8.4

--- a/requirements.in
+++ b/requirements.in
@@ -11,7 +11,7 @@ Flask-SQLAlchemy==2.1 # pyup: ignore
 itsdangerous==0.24 # pyup: ignore
 --no-binary=psycopg2
 psycopg2==2.8.4
-SQLAlchemy==1.2.18 # pyup: ignore
+SQLAlchemy>=1.3.0,<=1.4.0 # pyup: ignore
 SQLAlchemy-Utils==0.36.1
 sqlalchemy-json==0.2.3
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ flask-gzip==0.2           # via digitalmarketplace-utils
 flask-login==0.5.0        # via digitalmarketplace-utils
 flask-migrate==2.0.3      # via -r requirements.in
 flask-script==2.0.6       # via digitalmarketplace-utils, flask-migrate
-flask-sqlalchemy==2.1     # via -r requirements.in, flask-migrate
+flask-sqlalchemy==2.4.1   # via -r requirements.in, flask-migrate
 flask-wtf==0.14.3         # via digitalmarketplace-utils
 flask==1.0.4              # via -r requirements.in, digitalmarketplace-utils, flask-bcrypt, flask-gzip, flask-login, flask-migrate, flask-script, flask-sqlalchemy, flask-wtf, gds-metrics
 fleep==1.0.1              # via digitalmarketplace-utils

--- a/requirements.txt
+++ b/requirements.txt
@@ -63,7 +63,7 @@ s3transfer==0.3.3         # via boto3
 six==1.14.0               # via bcrypt, cryptography, jsonschema, pyrsistent, python-dateutil, sqlalchemy-json, sqlalchemy-utils
 sqlalchemy-json==0.2.3    # via -r requirements.in
 sqlalchemy-utils==0.36.1  # via -r requirements.in, sqlalchemy-json
-sqlalchemy==1.2.18        # via -r requirements.in, alembic, flask-sqlalchemy, sqlalchemy-json, sqlalchemy-utils
+sqlalchemy==1.3.15        # via -r requirements.in, alembic, flask-sqlalchemy, sqlalchemy-json, sqlalchemy-utils
 strict-rfc3339==0.7       # via -r requirements.in
 unicodecsv==0.14.1        # via digitalmarketplace-utils
 urllib3==1.25.8           # via botocore, requests


### PR DESCRIPTION
Closes https://trello.com/c/Z9YDGp8w/1527-sql-injection-cves

One breaking change in SQLAlchemy 1.3 is that too long identifiers cause an exception (where previously they were passed on to PostgresSQL to be silently truncated) [1]. We don't have any too long identifiers in our model but we did in our migrations, which caused tests to error out; this PR includes a tweak to that migration.

Another issue is the increased use of deprecation warnings by SQLAlchemy (to the point where Travis breaks from too many log messages). Most of the deprecated uses seem to be from Flask-SQLAlchemy; to fix this we have to upgrade Flask-SQLAlchemy as well.

### Changelogs

#### SQLAlchemy from 1.2.18 to 1.3.15

https://docs.sqlalchemy.org/en/13/changelog/changelog_13.html

#### Flask-SQLAlchemy from 2.1 to 2.4.1

https://flask-sqlalchemy.palletsprojects.com/en/2.x/changelog/#version-2-4-1

[1]: https://docs.sqlalchemy.org/en/13/changelog/migration_13.html#new-multi-column-naming-convention-tokens-long-name-truncation