### PR TITLE
Reorganise README for consistency with other apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ make test
 To only run the Python tests:
 
 ```
-make test-python
+make test-unit
 ```
 
 To run the `flake8` linter:

--- a/README.md
+++ b/README.md
@@ -1,105 +1,74 @@
-# digitalmarketplace-api
+# Digital Marketplace API
 
-[![Build Status](https://travis-ci.org/alphagov/digitalmarketplace-api.svg?branch=master)](https://travis-ci.org/alphagov/digitalmarketplace-api)
 [![Coverage Status](https://coveralls.io/repos/alphagov/digitalmarketplace-api/badge.svg?branch=master&service=github)](https://coveralls.io/github/alphagov/digitalmarketplace-api?branch=master)
-[![Requirements Status](https://requires.io/github/alphagov/digitalmarketplace-api/requirements.svg?branch=master)](https://requires.io/github/alphagov/digitalmarketplace-api/requirements/?branch=master)
 ![Python 3.6](https://img.shields.io/badge/python-3.6-blue.svg)
 
-API tier for Digital Marketplace.
+API application for Digital Marketplace.
 
 - Python app, based on the [Flask framework](http://flask.pocoo.org/)
 
+This app provides an interface for our Postgres database backing service, using the SQLAlchemy ORM.
+
 ## Quickstart
 
-Bootstrap the database
-```
-make bootstrap
-```
+It's recommended to use the [DM Runner](https://github.com/alphagov/digitalmarketplace-runner)
+tool, which will install and run the app (and a Postgres instance) as part of the full suite of apps.
 
-Install dependencies, run migrations and run the app
+If you want to run the app as a stand-alone process, you'll need to set the `SQLALCHEMY_DATABASE_URI` env variable
+to your own local Postgres instance. See the [Developer Manual](https://alphagov.github.io/digitalmarketplace-manual/developing-the-digital-marketplace/developer-setup.html)
+for more details.
+
+You can then clone the repo and run:
+
 ```
 make run-all
 ```
 
-## Full setup
+This command will install dependencies and start the app.
 
-Ensure you have Postgres running locally, and then bootstrap your development
-environment
+By default, the app will be served at [http://127.0.0.1:5000](http://127.0.0.1:5000).
 
-```
-make bootstrap
-```
-
-On Debian Jessie, the following packages are required for bootstrapping to work:
-
-```
-apt-get install gcc python3-dev libffi-dev libpq-dev python3-venv
-```
-
-### Activate the virtual environment
-
-```
-source ./venv/bin/activate
-```
-
-### Upgrade database schema
-
-When new database migrations are added you can bring your local database schema
-up to date by running upgrade.
-
-```make run-migrations```
-
-### Upgrade dependencies
-
-Install new Python dependencies with pip
-
-```make requirements-dev```
-
-### Run the tests
-
-This will run the linter, validate the migrations and run the unit tests.
-
-```make test```
-
-To test individual parts of the test stack use the `test-flake8`, `test-migrations`
-or `test-unit` targets.
-
-### Run the development server
-
-Run the API with environment variables required for local development set.
-This will install requirements, run database migrations and run the app.
-
-```make run-all```
-
-To just run the application use the `run-app` target.
-
-## Using the API locally
+## Using the API
 
 Calls to the API require a valid bearer token. Tokens to be accepted can be set
-using the `DM_AUTH_TOKENS` environment variable (a colon-separated list), e.g.:
+using the `DM_AUTH_TOKENS` environment variable (a colon-separated list), for example:
 
 ```export DM_API_AUTH_TOKENS=myToken1:myToken2```
 
 If `DM_API_AUTH_TOKENS` is not explicitly set then the run script sets
-it to `myToken`. You should include a valid token in your request headers, 
-e.g.:
+it to `myToken`. You should include a valid token in your request headers,
+for example:
 
 ```
 curl -i -H "Authorization: Bearer myToken" 127.0.0.1:5000/services
 ```
 
-When running the API locally it listens on port 5000 by default. This can be
-changed by setting the `DM_API_PORT` environment variable, e.g. to set the api
-port number to 9000:
+POST requests will require a `Content-Type` header, set to `application/json`.
+
+## Testing
+
+Run the full test suite:
 
 ```
-export DM_API_PORT=9000
+make test
 ```
 
-## Updating application dependencies
+To only run the Python tests:
 
-`requirements.txt` file is generated from the `requirements-app.txt` in order to pin
-versions of all nested dependencies. If `requirements-app.txt` has been changed (or
+```
+make test-python
+```
+
+To run the `flake8` linter:
+
+```
+make test-flake8
+```
+
+### Updating Python dependencies
+
+`requirements.txt` file is generated from the `requirements.in` in order to pin
+versions of all nested dependencies. If `requirements.in` has been changed (or
 we want to update the unpinned nested dependencies) `requirements.txt` should be
 regenerated with
 
@@ -107,33 +76,61 @@ regenerated with
 make freeze-requirements
 ```
 
-`requirements.txt` should be commited alongside `requirements-app.txt` changes.
+`requirements.txt` should be committed alongside `requirements.in` changes.
+
+## Migrations
 
 ## Creating a new database migration
 
 After editing `models.py` to add/edit/remove models for the database, you'll need to generate a new migration script.
-The easiest way to do this is to run `flask db migrate --rev-id <revision_id> -m '<description'>`. Our
-revision IDs increment by 10 each time; check the output of `flask db show` to find the current
-revision. Until you run the migration to update the database state, you can delete the generated revision and
+
+The easiest way to do this is to run
+
+```
+flask db migrate --rev-id <revision_id> -m '<description'>
+```
+
+Our revision IDs increment by 10 each time. Check the output of `flask db show` to find the current
+revision.
+
+Until you apply the migration, you can delete the generated revision and
 re-generate it as you need to.
 
-## Utility scripts
+To apply new migrations:
+
+```make run-migrations```
 
 ### Getting a list of migration versions
 
 `./scripts/list_migrations.py` checks that there are no branches in the DB migrations and prints a
-list of migration versions
+list of migration versions.
+
+## Utility scripts
 
 ### Getting a list of application URLs
 
-`flask routes` prints a full list of registered application URLs with supported HTTP methods
+`flask routes` prints a full list of registered application URLs with supported HTTP methods.
 
 
-## Model schemas
+### Model schemas
 
 `app/generate_model_schemas.py` uses the `alchemyjsonschema` library to generate reference schemas of our database models.
+
 Note that the `alchemyjsonschema` library is a dev requirement only.
 
+## Contributing
+
+This repository is maintained by the Digital Marketplace team at the [Government Digital Service](https://github.com/alphagov).
+
+If you have a suggestion for improvement, please raise an issue on this repo.
+
+### Reporting Vulnerabilities
+
+If you have discovered a security vulnerability in this code, we appreciate your help in disclosing it to us in a
+responsible manner.
+
+Please follow the [GDS vulnerability reporting steps](https://github.com/alphagov/.github/blob/master/SECURITY.md),
+giving details of any issue you find. Appropriate credit will be given to those reporting confirmed issues.
 
 ## Licence
 


### PR DESCRIPTION
https://trello.com/c/Du4aEv02/468-update-readmes-for-our-repos

Aligns with the newly-reorganised Buyer FE README (see alphagov/digitalmarketplace-buyer-frontend#1012), but with some API-specific sections, e.g. migrations.