### PR TITLE
bump utils version

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -21,6 +21,7 @@ flake8==3.7.9             # via -r requirements-dev.in
 freezegun==0.3.15         # via -r requirements-dev.in
 hypothesis==5.5.4         # via -r requirements-dev.in
 idna==2.9                 # via -c requirements.txt, requests
+importlib-metadata==1.6.0  # via -c requirements.txt, jsonschema, pluggy, pytest
 isodate==0.6.0            # via alchemyjsonschema
 jsonschema==3.2.0         # via -c requirements.txt, alchemyjsonschema
 magicalimport==0.9.1      # via alchemyjsonschema
@@ -49,6 +50,7 @@ strict-rfc3339==0.7       # via -c requirements.txt, alchemyjsonschema
 testfixtures==6.13.0      # via -r requirements-dev.in
 urllib3==1.25.8           # via -c requirements.txt, requests
 wcwidth==0.1.8            # via pytest
+zipp==3.1.0               # via -c requirements.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,7 @@
 # Run `make freeze-requirements` to update requirements.txt
 # with package version changes made in requirements.in
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@51.5.0#egg=digitalmarketplace-utils==51.5.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@52.3.0#egg=digitalmarketplace-utils==52.3.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.5.0#egg=digitalmarketplace-apiclient==21.5.0
 
 Flask==1.0.4                     # pyup: >=1.0.0,<1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ contextlib2==0.6.0.post1  # via digitalmarketplace-utils
 cryptography==2.3.1       # via digitalmarketplace-utils
 defusedxml==0.6.0         # via odfpy
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.5.0#egg=digitalmarketplace-apiclient==21.5.0  # via -r requirements.in
-git+https://github.com/alphagov/digitalmarketplace-utils.git@51.5.0#egg=digitalmarketplace-utils==51.5.0  # via -r requirements.in
+git+https://github.com/alphagov/digitalmarketplace-utils.git@52.3.0#egg=digitalmarketplace-utils==52.3.0  # via -r requirements.in
 docopt==0.6.2             # via notifications-python-client
 docutils==0.15.2          # via botocore
 flask-bcrypt==0.7.1       # via -r requirements.in
@@ -37,6 +37,7 @@ future==0.18.2            # via notifications-python-client
 gds-metrics==0.2.0        # via digitalmarketplace-utils
 govuk-country-register==0.5.0  # via digitalmarketplace-utils
 idna==2.9                 # via cryptography, requests
+importlib-metadata==1.6.0  # via jsonschema
 itsdangerous==1.1.0       # via -r requirements.in, flask, flask-wtf
 jinja2==2.11.1            # via flask
 jmespath==0.9.4           # via boto3, botocore
@@ -69,6 +70,7 @@ urllib3==1.25.8           # via botocore, requests
 werkzeug==1.0.0           # via digitalmarketplace-utils, flask
 workdays==1.4             # via digitalmarketplace-utils
 wtforms==2.2.1            # via flask-wtf
+zipp==3.1.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
part of https://trello.com/c/PTdD5lEh/102-our-logs-show-paas-instance-guid-but-not-paas-instance-index﻿
I don't think the breaking change should effect this app: https://github.com/alphagov/digitalmarketplace-utils/blob/master/CHANGELOG.md#5200