### PR TITLE
remove deprecated config option COMMIT_ON_TEARDOWN

### DIFF
--- a/config.py
+++ b/config.py
@@ -31,7 +31,6 @@ class Config:
     DM_ALLOWED_ADMIN_DOMAINS = ['digital.cabinet-office.gov.uk', 'crowncommercial.gov.uk', 'user.marketplace.team',
                                 'notifications.service.gov.uk']
 
-    SQLALCHEMY_COMMIT_ON_TEARDOWN = False
     SQLALCHEMY_DATABASE_URI = 'postgresql://localhost/digitalmarketplace'
     SQLALCHEMY_RECORD_QUERIES = True
     SQLALCHEMY_TRACK_MODIFICATIONS = False


### PR DESCRIPTION
https://trello.com/c/Q8YktMAK/1707-remove-sql-alchemy-deprecated-commitonteardown
We need to remove this to prevent a deprecation message appearing after updating sql alchemy, please see related context: 
https://github.com/pallets/flask-sqlalchemy/pull/829
https://github.com/alphagov/digitalmarketplace-api/pull/1033