### PR TITLE
Exclude questions when copying draft services

### DIFF
--- a/app/draft_utils.py
+++ b/app/draft_utils.py
@@ -8,3 +8,24 @@ def validate_and_return_draft_request(draft_id=0):
     if draft_id:
         json_has_matching_id(json_payload['services'], draft_id)
     return json_payload['services']
+
+
+def get_copiable_service_data(service, questions_to_exclude=None, questions_to_copy=None):
+    """
+    Filter out any service data that shouldn't be copied to a new draft service, by either including
+    copyable questions or excluding non-copyable questions.
+    There is validation at view-level to prevent both `to_copy` and `to_exclude` lists being supplied, so
+    this function should only receive one or the other. However we want to deprecate use of `to_copy`, so
+    if both are somehow supplied, we use the `to_exclude` list.
+    If neither list is provided, then all data fields on the service are included.
+
+    :param service: service object with a JSON dict `data` attribute (required)
+    :param questions_to_exclude: iterable of question IDs that must not be copied
+    :param questions_to_copy: iterable of question IDs that may be copied (to be deprecated)
+    :return: JSON dict of service data
+    """
+    if questions_to_exclude:
+        return {key: value for key, value in service.data.items() if key not in questions_to_exclude}
+    if questions_to_copy:
+        return {key: value for key, value in service.data.items() if key in questions_to_copy}
+    return service.data

--- a/app/draft_utils.py
+++ b/app/draft_utils.py
@@ -10,7 +10,7 @@ def validate_and_return_draft_request(draft_id=0):
     return json_payload['services']
 
 
-def get_copiable_service_data(service, questions_to_exclude=None, questions_to_copy=None):
+def get_copiable_service_data(service, *, questions_to_exclude=None, questions_to_copy=None):
     """
     Filter out any service data that shouldn't be copied to a new draft service, by either including
     copyable questions or excluding non-copyable questions.

--- a/app/models/main.py
+++ b/app/models/main.py
@@ -1265,8 +1265,11 @@ class DraftService(db.Model, ServiceTableMixin):
     def from_service(service, questions_to_copy=None, target_framework_id=None, questions_to_exclude=None):
         draft_not_on_same_framework_as_service = target_framework_id and target_framework_id != service.framework.id
 
-        service_data = get_copiable_service_data(service, questions_to_exclude, questions_to_copy) if \
-            draft_not_on_same_framework_as_service else service.data
+        service_data = get_copiable_service_data(
+            service,
+            questions_to_exclude=questions_to_exclude,
+            questions_to_copy=questions_to_copy
+        ) if draft_not_on_same_framework_as_service else service.data
 
         kwargs = {
             'framework_id': service.framework_id if not target_framework_id else target_framework_id,

--- a/tests/test_draft_utils.py
+++ b/tests/test_draft_utils.py
@@ -1,0 +1,41 @@
+import mock
+
+from app.draft_utils import get_copiable_service_data
+
+
+class TestGetCopiableServiceData:
+
+    service_data = mock.Mock()
+    service_data.data = {
+        "niceField": "nice value",
+        "badField": "bad value",
+        "neutralField": "neutral value"
+    }
+
+    def test_get_copiable_service_data_returns_all_data_by_default(self):
+        assert get_copiable_service_data(self.service_data) == {
+            "niceField": "nice value",
+            "badField": "bad value",
+            "neutralField": "neutral value"
+        }
+
+    def test_get_copiable_service_data_only_copies_fields_to_copy(self):
+        assert get_copiable_service_data(self.service_data, questions_to_copy=['niceField']) == {
+            "niceField": "nice value"
+        }
+
+    def test_get_copiable_service_data_filters_out_fields_to_exclude(self):
+        assert get_copiable_service_data(self.service_data, questions_to_exclude=['badField']) == {
+            "niceField": "nice value",
+            "neutralField": "neutral value"
+        }
+
+    def test_get_copiable_service_data_excludes_fields_if_both_options_supplied(self):
+        assert get_copiable_service_data(
+            self.service_data,
+            questions_to_exclude=['badField'],
+            questions_to_copy=['niceField'],
+        ) == {
+            "niceField": "nice value",
+            "neutralField": "neutral value"
+        }


### PR DESCRIPTION
https://trello.com/c/WBjRZd14/80-2-frameworks-repo-copyservices-list-exclude-rather-than-include-fields

When copying draft services from a previous framework, we currently specify a list of questions to include. This list is hardcoded in the frameworks repo, and is proving difficult to manage between iterations (introducing a serious bug for G11 applications, and we nearly had the same issue for G12). To make this easier to manage, we'd like to specify a list of fields to exclude instead. These might be questions where the type has changed (from boolean to text, say), or it's been removed entirely. The vast majority of questions on a service are copiable, so the exclude lists should be shorter, and it should be easier to see what can be reintroduced in the following iteration.

However given G12 applications are still open, we want to ensure the current 'include' system is still supported for now. 

There are two service copying endpoints: one for copying a single service, one for bulk-copying all services on a particular lot. I've split the changes for these into separate commits, but they're pretty much doing the same thing. (Saying that, the test setup for the bulk-copying is a bit odd - I haven't tried to refactor that too much in this PR though, due to time constraints). 

Once this PR is merged, we'll need:
- changes to API client
- changes to supplier FE 
- example change in frameworks repo for DOS5/G13?