### PR TITLE
remove deprecated GET endpoints

### DIFF
--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -430,17 +430,6 @@ def export_users_for_framework(framework_slug):
     return jsonify(users=user_rows), 200
 
 
-# deprecated
-@main.route("/users/check-buyer-email", methods=["GET"])
-def email_has_valid_buyer_domain():
-    email_address = request.args.get('email_address')
-    if not email_address:
-        abort(400, "'email_address' is a required parameter")
-
-    domain_ok = buyer_email_address_has_approved_domain(BuyerEmailDomain.query.all(), email_address)
-    return jsonify(valid=domain_ok), 200
-
-
 @main.route("/users/check-buyer-email", methods=["POST"])
 def email_has_valid_buyer_domain_post():
     json_payload = get_json_from_request()
@@ -448,17 +437,6 @@ def email_has_valid_buyer_domain_post():
     email_address = json_payload['emailAddress']
     domain_ok = buyer_email_address_has_approved_domain(BuyerEmailDomain.query.all(), email_address)
     return jsonify(valid=domain_ok), 200
-
-
-# deprecated
-@main.route("/users/valid-admin-email", methods=["GET"])
-def email_is_valid_for_admin_user():
-    email_address = request.args.get('email_address')
-    if not email_address:
-        abort(400, "'email_address' is a required parameter")
-
-    valid = admin_email_address_has_approved_domain(email_address)
-    return jsonify(valid=valid), 200
 
 
 @main.route("/users/valid-admin-email", methods=["POST"])

--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -431,7 +431,7 @@ def export_users_for_framework(framework_slug):
 
 
 @main.route("/users/check-buyer-email", methods=["POST"])
-def email_has_valid_buyer_domain_post():
+def email_has_valid_buyer_domain():
     json_payload = get_json_from_request()
     json_only_has_required_keys(json_payload, ['emailAddress'])
     email_address = json_payload['emailAddress']
@@ -440,7 +440,7 @@ def email_has_valid_buyer_domain_post():
 
 
 @main.route("/users/valid-admin-email", methods=["POST"])
-def email_is_valid_for_admin_user_post():
+def email_is_valid_for_admin_user():
     json_payload = get_json_from_request()
     json_only_has_required_keys(json_payload, ['emailAddress'])
     email_address = json_payload['emailAddress']

--- a/tests/main/views/test_users.py
+++ b/tests/main/views/test_users.py
@@ -2113,12 +2113,6 @@ class TestUsersEmailCheck(BaseUserTest):
         db.session.add(BuyerEmailDomain(domain_name="bananas.org"))
         db.session.commit()
 
-    # Deprecated
-    def test_get_valid_email_is_ok_if_domain_found_in_database(self):
-        get_response = self.client.get('/users/check-buyer-email', query_string={'email_address': 'buyer@bananas.org'})
-        assert get_response.status_code == 200
-        assert json.loads(get_response.get_data())['valid'] is True
-
     def test_post_valid_email_is_ok_if_domain_found_in_database(self):
         post_response = self.client.post('/users/check-buyer-email',
                                          data=json.dumps({'emailAddress': 'buyer@bananas.org'}),
@@ -2126,30 +2120,12 @@ class TestUsersEmailCheck(BaseUserTest):
         assert post_response.status_code == 200
         assert json.loads(post_response.get_data())['valid'] is True
 
-    # Deprecated
-    def test_get_invalid_email_is_not_ok(self):
-        get_response = self.client.get('/users/check-buyer-email', query_string={'email_address': 'someone@notgov.uk'})
-        assert get_response.status_code == 200
-        assert json.loads(get_response.get_data())['valid'] is False
-
-        post_response = self.client.post('/users/check-buyer-email',
-                                         data=json.dumps({'emailAddress': 'someone@notgov.uk'}),
-                                         content_type='application/json')
-        assert post_response.status_code == 200
-        assert json.loads(post_response.get_data())['valid'] is False
-
     def test_post_invalid_email_is_not_ok(self):
         post_response = self.client.post('/users/check-buyer-email',
                                          data=json.dumps({'emailAddress': 'someone@notgov.uk'}),
                                          content_type='application/json')
         assert post_response.status_code == 200
         assert json.loads(post_response.get_data())['valid'] is False
-
-    # deprecated
-    def test_get_email_address_is_required(self):
-        get_response = self.client.get('/users/check-buyer-email')
-        assert get_response.status_code == 400
-        assert json.loads(get_response.get_data())['error'] == "'email_address' is a required parameter"
 
     def test_post_email_address_is_required(self):
         post_response = self.client.post('/users/check-buyer-email', content_type='application/json',
@@ -2174,12 +2150,6 @@ class TestAdminEmailCheck(BaseUserTest):
         super(TestAdminEmailCheck, self).setup()
         self.app.config['DM_ALLOWED_ADMIN_DOMAINS'] = ['bananas.org']
 
-    # deprecated
-    def test_email_address_is_required_get(self):
-        response = self.client.get('/users/valid-admin-email')
-        assert response.status_code == 400
-        assert json.loads(response.get_data())['error'] == "'email_address' is a required parameter"
-
     def test_email_address_is_required_post(self):
         response = self.client.post('/users/valid-admin-email', content_type='application/json', data=json.dumps({}))
         assert response.status_code == 400
@@ -2195,15 +2165,6 @@ class TestAdminEmailCheck(BaseUserTest):
         assert response.status_code == 400
         assert json.loads(response.get_data())['error'] == "Unexpected Content-Type, expecting 'application/json'"
 
-    # deprecated
-    def test_invalid_email_is_not_ok_get(self):
-        response = self.client.get(
-            '/users/valid-admin-email',
-            query_string={'email_address': 'buyer@i-dislike-bananas.org'}
-        )
-        assert response.status_code == 200
-        assert json.loads(response.get_data())['valid'] is False
-
     def test_invalid_email_is_not_ok_post(self):
         response = self.client.post(
             '/users/valid-admin-email',
@@ -2212,26 +2173,12 @@ class TestAdminEmailCheck(BaseUserTest):
         assert response.status_code == 200
         assert json.loads(response.get_data())['valid'] is False
 
-    # deprecated
-    def test_valid_email_is_ok_if_admin_domain_found_in_config_get(self):
-        response = self.client.get('/users/valid-admin-email', query_string={'email_address': 'buyer@bananas.org'})
-        assert response.status_code == 200
-        assert json.loads(response.get_data())['valid'] is True
-
     def test_valid_email_is_ok_if_admin_domain_found_in_config_post(self):
         response = self.client.post('/users/valid-admin-email',
                                     data=json.dumps({'emailAddress': 'buyer@bananas.org'}),
                                     content_type='application/json')
         assert response.status_code == 200
         assert json.loads(response.get_data())['valid'] is True
-
-    # deprecated
-    def test_returns_invalid_if_no_config_value_set_get(self):
-        self.app.config.pop('DM_ALLOWED_ADMIN_DOMAINS')
-
-        response = self.client.get('/users/valid-admin-email', query_string={'email_address': 'buyer@bananas.org'})
-        assert response.status_code == 200
-        assert json.loads(response.get_data())['valid'] is False
 
     def test_returns_invalid_if_no_config_value_set_post(self):
         self.app.config.pop('DM_ALLOWED_ADMIN_DOMAINS')

--- a/tests/main/views/test_users.py
+++ b/tests/main/views/test_users.py
@@ -2113,35 +2113,35 @@ class TestUsersEmailCheck(BaseUserTest):
         db.session.add(BuyerEmailDomain(domain_name="bananas.org"))
         db.session.commit()
 
-    def test_post_valid_email_is_ok_if_domain_found_in_database(self):
-        post_response = self.client.post('/users/check-buyer-email',
-                                         data=json.dumps({'emailAddress': 'buyer@bananas.org'}),
-                                         content_type='application/json')
-        assert post_response.status_code == 200
-        assert json.loads(post_response.get_data())['valid'] is True
+    def test_valid_email_is_ok_if_domain_found_in_database(self):
+        response = self.client.post('/users/check-buyer-email',
+                                    data=json.dumps({'emailAddress': 'buyer@bananas.org'}),
+                                    content_type='application/json')
+        assert response.status_code == 200
+        assert json.loads(response.get_data())['valid'] is True
 
-    def test_post_invalid_email_is_not_ok(self):
-        post_response = self.client.post('/users/check-buyer-email',
-                                         data=json.dumps({'emailAddress': 'someone@notgov.uk'}),
-                                         content_type='application/json')
-        assert post_response.status_code == 200
-        assert json.loads(post_response.get_data())['valid'] is False
+    def test_invalid_email_is_not_ok(self):
+        response = self.client.post('/users/check-buyer-email',
+                                    data=json.dumps({'emailAddress': 'someone@notgov.uk'}),
+                                    content_type='application/json')
+        assert response.status_code == 200
+        assert json.loads(response.get_data())['valid'] is False
 
-    def test_post_email_address_is_required(self):
-        post_response = self.client.post('/users/check-buyer-email', content_type='application/json',
-                                         data=json.dumps({}))
-        assert post_response.status_code == 400
-        assert json.loads(post_response.get_data())['error'] == "Invalid JSON must only have ['emailAddress'] keys"
+    def test_email_address_is_required(self):
+        response = self.client.post('/users/check-buyer-email', content_type='application/json',
+                                    data=json.dumps({}))
+        assert response.status_code == 400
+        assert json.loads(response.get_data())['error'] == "Invalid JSON must only have ['emailAddress'] keys"
 
-    def test_post_email_address_json_body_is_required(self):
-        post_response = self.client.post('/users/check-buyer-email', content_type='application/json')
-        assert post_response.status_code == 400
-        assert json.loads(post_response.get_data())['error'] == "Invalid JSON; must be a valid JSON object"
+    def test_email_address_json_body_is_required(self):
+        response = self.client.post('/users/check-buyer-email', content_type='application/json')
+        assert response.status_code == 400
+        assert json.loads(response.get_data())['error'] == "Invalid JSON; must be a valid JSON object"
 
-    def test_post_email_address_json_content_type_is_required(self):
-        post_response = self.client.post('/users/check-buyer-email')
-        assert post_response.status_code == 400
-        assert json.loads(post_response.get_data())['error'] == "Unexpected Content-Type, expecting 'application/json'"
+    def test_email_address_json_content_type_is_required(self):
+        response = self.client.post('/users/check-buyer-email')
+        assert response.status_code == 400
+        assert json.loads(response.get_data())['error'] == "Unexpected Content-Type, expecting 'application/json'"
 
 
 class TestAdminEmailCheck(BaseUserTest):
@@ -2150,22 +2150,22 @@ class TestAdminEmailCheck(BaseUserTest):
         super(TestAdminEmailCheck, self).setup()
         self.app.config['DM_ALLOWED_ADMIN_DOMAINS'] = ['bananas.org']
 
-    def test_email_address_is_required_post(self):
+    def test_email_address_is_required(self):
         response = self.client.post('/users/valid-admin-email', content_type='application/json', data=json.dumps({}))
         assert response.status_code == 400
         assert json.loads(response.get_data())['error'] == "Invalid JSON must only have ['emailAddress'] keys"
 
-    def test_json_body_is_required_post(self):
+    def test_json_body_is_required(self):
         response = self.client.post('users/valid-admin-email', content_type='application/json')
         assert response.status_code == 400
         assert json.loads(response.get_data())['error'] == "Invalid JSON; must be a valid JSON object"
 
-    def test_json_content_type_is_required_post(self):
+    def test_json_content_type_is_required(self):
         response = self.client.post('users/valid-admin-email')
         assert response.status_code == 400
         assert json.loads(response.get_data())['error'] == "Unexpected Content-Type, expecting 'application/json'"
 
-    def test_invalid_email_is_not_ok_post(self):
+    def test_invalid_email_is_not_ok(self):
         response = self.client.post(
             '/users/valid-admin-email',
             data=json.dumps({'emailAddress': 'buyer@i-dislike-bananas.org'}),
@@ -2173,14 +2173,14 @@ class TestAdminEmailCheck(BaseUserTest):
         assert response.status_code == 200
         assert json.loads(response.get_data())['valid'] is False
 
-    def test_valid_email_is_ok_if_admin_domain_found_in_config_post(self):
+    def test_valid_email_is_ok_if_admin_domain_found_in_config(self):
         response = self.client.post('/users/valid-admin-email',
                                     data=json.dumps({'emailAddress': 'buyer@bananas.org'}),
                                     content_type='application/json')
         assert response.status_code == 200
         assert json.loads(response.get_data())['valid'] is True
 
-    def test_returns_invalid_if_no_config_value_set_post(self):
+    def test_returns_invalid_if_no_config_value_set(self):
         self.app.config.pop('DM_ALLOWED_ADMIN_DOMAINS')
 
         response = self.client.post('/users/valid-admin-email',


### PR DESCRIPTION
part of https://trello.com/c/CUik4BTJ/103-3-we-store-email-addresses-of-users-who-try-to-create-a-buyer-account-in-our-logs-in-plaintext

Please see previous PRs for context:
https://github.com/alphagov/digitalmarketplace-apiclient/pull/231
https://github.com/alphagov/digitalmarketplace-admin-frontend/pull/655
https://github.com/alphagov/digitalmarketplace-briefs-frontend/pull/322

remove deprecated GET endpoints now all clients are using POST endpoints ﻿

(I have confirmed in Kibana the GET endpoints are getting no traffic)
