### PR TITLE
Filter draft services by lot

### DIFF
--- a/app/main/views/drafts.py
+++ b/app/main/views/drafts.py
@@ -302,9 +302,11 @@ def find_draft_services_by_framework(framework_slug):
     # Includes options to filter by
     # - status (submitted / not-submitted)
     # - supplier_id (i.e. a paginated version of .list_draft_services_by_supplier above)
+    # - lot slug (eg cloud-software)
     page = get_valid_page_or_1()
     status = request.args.get('status')
     supplier_id = get_int_or_400(request.args, 'supplier_id')
+    lot_slug = request.args.get('lot')
 
     framework = Framework.query.filter(
         Framework.slug == framework_slug
@@ -326,6 +328,11 @@ def find_draft_services_by_framework(framework_slug):
         if not supplier:
             abort(404, "Supplier_id '{}' not found".format(supplier_id))
         draft_service_query = draft_service_query.filter(DraftService.supplier_id == supplier_id)
+
+    if lot_slug:
+        if not framework.get_lot(lot_slug):
+            abort(400, "Invalid argument: lot not recognised")
+        draft_service_query = draft_service_query.in_lot(lot_slug)
 
     pagination_params = request.args.to_dict()
     pagination_params['framework_slug'] = framework_slug

--- a/app/models/main.py
+++ b/app/models/main.py
@@ -1327,6 +1327,10 @@ class DraftService(db.Model, ServiceTableMixin):
     def get_link(self):
         return url_for("main.fetch_draft_service", draft_id=self.id)
 
+    class query_class(BaseQuery):
+        def in_lot(self, lot_slug):
+            return self.filter(DraftService.lot.has(Lot.slug == lot_slug))
+
 
 class AuditEvent(db.Model):
     __tablename__ = 'audit_events'

--- a/tests/main/views/test_drafts.py
+++ b/tests/main/views/test_drafts.py
@@ -1751,6 +1751,16 @@ class TestListDraftServiceByFramework(DraftsHelpersMixin):
         assert data['meta']['total'] == 1
         assert data['services'][0]['supplierId'] == 2
 
+    @pytest.mark.parametrize('lot_slug, expected_count', [('scs', 1), ('saas', 0)])
+    def test_list_drafts_filters_by_lot_slug(self, lot_slug, expected_count):
+        self.create_draft_service()  # Creates a G7 'scs' service
+
+        res = self.client.get(f'/draft-services/framework/g-cloud-7?lot={lot_slug}')
+        assert res.status_code == 200
+        data = json.loads(res.get_data(as_text=True))
+
+        assert data['meta']['total'] == expected_count
+
     def test_list_drafts_page_out_of_range_returns_404(self):
         for i in range(1, 11):
             self.create_draft_service()
@@ -1779,6 +1789,13 @@ class TestListDraftServiceByFramework(DraftsHelpersMixin):
 
         assert res.status_code == 400
         assert data['error'] == "Invalid supplier_id: the-human-league"
+
+    def test_list_drafts_requires_valid_lot_slug(self):
+        res = self.client.get(f'/draft-services/framework/g-cloud-7?lot=flock-of-seagulls')
+        data = json.loads(res.get_data(as_text=True))
+
+        assert res.status_code == 400
+        assert data['error'] == "Invalid argument: lot not recognised"
 
     def test_list_drafts_requires_supplier_id_to_exist(self):
         res = self.client.get(f'/draft-services/framework/g-cloud-7?supplier_id=999')

--- a/tests/models/test_main.py
+++ b/tests/models/test_main.py
@@ -2226,6 +2226,18 @@ class TestDraftService(BaseApplicationTest, FixtureMixin):
 
         assert draft_service.serialize() == stub.response()
 
+    @pytest.mark.parametrize('lot_slug, expected_count', [('scs', 0), ('saas', 1)])
+    def test_draft_service_filtering_by_lot(self, lot_slug, expected_count):
+        # Create a single DraftService on the 'saas' lot
+        service = Service.query.filter(Service.service_id == '1000000000').first()
+        draft_service = DraftService.from_service(service)
+
+        db.session.add(draft_service)
+        db.session.commit()
+
+        drafts = DraftService.query.in_lot(lot_slug)
+        assert drafts.count() == expected_count
+
 
 class TestSupplierFrameworks(BaseApplicationTest, FixtureMixin):
     def test_nulls_are_stripped_from_declaration(self):


### PR DESCRIPTION
https://trello.com/c/p8qUfLUA/

Allow our new(ish) `find_draft_services_by_framework ` endpoint to filter draft services by a given `lot_slug`. 

This will allow us to get the total number of submitted services for a supplier on a single lot (included in the `meta` response data), meaning our apps and scripts won't have to iterate through all the drafts for a supplier. 

The filtering query class is based on the equivalent for live `Service` objects.

The API client will need updating once this is merged.