### PR TITLE
Add G-Cloud 12 to search index mapping

### DIFF
--- a/config.py
+++ b/config.py
@@ -50,6 +50,9 @@ class Config:
         'g-cloud-11': {
             'services': 'g-cloud-11'
         },
+        'g-cloud-12': {
+            'services': 'g-cloud-12'
+        },
         'digital-outcomes-and-specialists': {
             'briefs': 'briefs-digital-outcomes-and-specialists'
         },


### PR DESCRIPTION
In preparation for making G-Cloud 12 live (and so we can make it live on preview), we need to let the API know which index to send G-Cloud 12 service edits to.

https://alphagov.github.io/digitalmarketplace-manual/content-and-frameworks/framework-lifecycle-for-developers.html#id5