### PR TITLE
Add E-signature boolean to model

### DIFF
--- a/app/models/main.py
+++ b/app/models/main.py
@@ -230,6 +230,7 @@ class Framework(db.Model):
             'variations': (self.framework_agreement_details or {}).get("variations", {}),
             'hasDirectAward': self.has_direct_award,
             'hasFurtherCompetition': self.has_further_competition,
+            'isESignatureSupported': self.framework_live_at_utc > datetime(2020, 9, 28),
         }
 
     def get_supplier_ids_for_completed_service(self):

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -13,7 +13,7 @@ python-dotenv  # used to load .flaskenv
 requests-mock
 testfixtures
 
-git+https://github.com/alphagov/digitalmarketplace-test-utils.git@2.6.1#egg=digitalmarketplace-test-utils
+git+https://github.com/alphagov/digitalmarketplace-test-utils.git@update-stub-esignature#egg=digitalmarketplace-test-utils
 
 # For schema generation
 alchemyjsonschema==0.5.0

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -13,7 +13,7 @@ python-dotenv  # used to load .flaskenv
 requests-mock
 testfixtures
 
-git+https://github.com/alphagov/digitalmarketplace-test-utils.git@update-stub-esignature#egg=digitalmarketplace-test-utils
+git+https://github.com/alphagov/digitalmarketplace-test-utils.git@2.8.2#egg=digitalmarketplace-test-utils
 
 # For schema generation
 alchemyjsonschema==0.5.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,7 +13,7 @@ chardet==3.0.4            # via -c requirements.txt, requests
 click==7.0                # via -c requirements.txt, pip-tools
 coverage==5.0.3           # via -r requirements-dev.in, pytest-cov
 dictknife==0.13.0         # via alchemyjsonschema
-git+https://github.com/alphagov/digitalmarketplace-test-utils.git@2.6.1#egg=digitalmarketplace-test-utils  # via -r requirements-dev.in
+git+https://github.com/alphagov/digitalmarketplace-test-utils.git@update-stub-esignature#egg=digitalmarketplace-test-utils  # via -r requirements-dev.in
 entrypoints==0.3          # via flake8
 flake8==3.7.9             # via -r requirements-dev.in
 freezegun==0.3.15         # via -r requirements-dev.in

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,7 +13,7 @@ chardet==3.0.4            # via -c requirements.txt, requests
 click==7.0                # via -c requirements.txt, pip-tools
 coverage==5.0.3           # via -r requirements-dev.in, pytest-cov
 dictknife==0.13.0         # via alchemyjsonschema
-git+https://github.com/alphagov/digitalmarketplace-test-utils.git@update-stub-esignature#egg=digitalmarketplace-test-utils  # via -r requirements-dev.in
+git+https://github.com/alphagov/digitalmarketplace-test-utils.git@2.8.2#egg=digitalmarketplace-test-utils  # via -r requirements-dev.in
 entrypoints==0.3          # via flake8
 flake8==3.7.9             # via -r requirements-dev.in
 freezegun==0.3.15         # via -r requirements-dev.in

--- a/tests/main/views/test_frameworks.py
+++ b/tests/main/views/test_frameworks.py
@@ -43,6 +43,7 @@ class TestListFrameworks(BaseApplicationTest):
             'variations',
             'hasDirectAward',
             'hasFurtherCompetition',
+            'isESignatureSupported',
         ])
 
 

--- a/tests/main/views/test_frameworks.py
+++ b/tests/main/views/test_frameworks.py
@@ -252,6 +252,20 @@ class TestGetFramework(BaseApplicationTest):
 
         assert response.status_code == 404
 
+    def test_framework_live_after_date_is_e_signature_supported_true(self):
+        self.client.post(
+            "/frameworks/g-cloud-7",
+            data=json.dumps({
+                "updated_by": "🤖",
+                "frameworks": {
+                    "frameworkLiveAtUTC": "2020-09-28T12:00:00.000000Z"
+                }
+            }),
+            content_type="application/json"
+        )
+        get_framework = self.client.get('/frameworks/g-cloud-7')
+        assert get_framework.json['frameworks']['isESignatureSupported'] is True
+
 
 class TestUpdateFramework(BaseApplicationTest, JSONUpdateTestMixin, FixtureMixin):
     endpoint = '/frameworks/example'

--- a/tests/models/test_main.py
+++ b/tests/models/test_main.py
@@ -503,7 +503,6 @@ class TestFrameworks(BaseApplicationTest):
             'isESignatureSupported': False
         }
 
-    @pytest.mark.skip(reason="We need to update test-utils before this will pass")
     def test_framework_serialize_keys_match_api_stub_keys(self):
         # Ensures our dmtestutils.api_model_stubs are kept up to date
         framework = Framework(

--- a/tests/models/test_main.py
+++ b/tests/models/test_main.py
@@ -462,6 +462,7 @@ class TestFrameworks(BaseApplicationTest):
             'variations': {},
             'hasDirectAward': True,
             'hasFurtherCompetition': False,
+            'isESignatureSupported': False
         }
 
     def test_framework_serialization_with_default_datetimes(self):
@@ -499,8 +500,10 @@ class TestFrameworks(BaseApplicationTest):
             'variations': {},
             'hasDirectAward': True,
             'hasFurtherCompetition': False,
+            'isESignatureSupported': False
         }
 
+    @pytest.mark.skip(reason="We need to update test-utils before this will pass")
     def test_framework_serialize_keys_match_api_stub_keys(self):
         # Ensures our dmtestutils.api_model_stubs are kept up to date
         framework = Framework(
@@ -509,7 +512,7 @@ class TestFrameworks(BaseApplicationTest):
             slug='foo-109',
             framework='g-cloud',
             has_direct_award=True,
-            has_further_competition=False,
+            has_further_competition=False
         )
         db.session.add(framework)
         db.session.commit()


### PR DESCRIPTION
https://trello.com/c/ktfgxwkb/1438-add-isesignaturesupported-boolean-field-to-framework-api-response
This adds an `isESignatureSupported` boolean field to frameworks as a way to resolve this in the API rather than hardcoding in various ways on a per-app basis as currently.

Note, this depends on sister changes in https://github.com/alphagov/digitalmarketplace-test-utils/compare/update-stub-esignature once this PR is approved I will make a PR and release with those changes.