### PR TITLE
Distinguish G12 recovery suppliers

### DIFF
--- a/app/main/views/drafts.py
+++ b/app/main/views/drafts.py
@@ -8,6 +8,7 @@ from datetime import datetime
 
 from .. import main
 from ... import db
+from ...supplier_utils import is_g12_recovery_supplier
 from ...validation import is_valid_service_id_or_400
 from ...models import Service, DraftService, Supplier, AuditEvent, Framework, Lot
 from ...utils import (
@@ -508,7 +509,8 @@ def create_new_draft_service():
 
     framework, lot, supplier = validate_and_return_related_objects(draft_json)
 
-    if framework.status != 'open':
+    if not (framework.status == 'open' or
+            (framework.slug == 'g-cloud-12' and is_g12_recovery_supplier(supplier.supplier_id))):
         abort(400, "'{}' is not open for submissions".format(framework.slug))
 
     if lot.one_service_limit:

--- a/app/supplier_utils.py
+++ b/app/supplier_utils.py
@@ -1,6 +1,7 @@
 import inspect
+from typing import Union
 
-from flask import abort
+from flask import abort, current_app
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import lazyload
 
@@ -123,3 +124,18 @@ def update_open_declarations_with_company_details(db, supplier_id, updater_json,
                 },
             )
         )
+
+
+def is_g12_recovery_supplier(supplier_id: Union[str, int]) -> bool:
+    supplier_ids_string = current_app.config.get('DM_G12_RECOVERY_SUPPLIER_IDS') or ''
+
+    try:
+        supplier_ids = [int(s) for s in supplier_ids_string.split(sep=',')]
+    except AttributeError as e:
+        current_app.logger.error("DM_G12_RECOVERY_SUPPLIER_IDS not a string", extra={'error': str(e)})
+        return False
+    except ValueError as e:
+        current_app.logger.error("DM_G12_RECOVERY_SUPPLIER_IDS not a list of supplier IDs", extra={'error': str(e)})
+        return False
+
+    return int(supplier_id) in supplier_ids

--- a/config.py
+++ b/config.py
@@ -67,6 +67,8 @@ class Config:
         },
     }
 
+    DM_G12_RECOVERY_SUPPLIER_IDS = None
+
 
 class Test(Config):
     SERVER_NAME = '127.0.0.1:5000'
@@ -85,6 +87,8 @@ class Test(Config):
 
     DM_API_PROJECTS_PAGE_SIZE = 5
 
+    DM_G12_RECOVERY_SUPPLIER_IDS = "577184"
+
 
 class Development(Config):
     DEBUG = True
@@ -94,6 +98,8 @@ class Development(Config):
     DM_API_CALLBACK_AUTH_TOKENS = 'myToken'
     DM_SEARCH_API_AUTH_TOKEN = 'myToken'
     DM_SEARCH_API_URL = f"http://localhost:{os.getenv('DM_SEARCH_API_PORT', 5009)}"
+
+    DM_G12_RECOVERY_SUPPLIER_IDS = "577184"
 
 
 class Live(Config):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -213,6 +213,19 @@ def _framework_fixture_inner(request, app, slug, **kwargs):
 
 _generic_framework_agreement_details = {"frameworkAgreementVersion": "v1.0"}
 
+_g12_framework_defaults = {
+    "slug": "g-cloud-12",
+    "framework": "g-cloud",
+    "framework_agreement_details": _generic_framework_agreement_details,
+    "applications_close_at_utc": "2000-01-01T00:00:00.000000Z",
+    "intention_to_award_at_utc": "2000-01-01T00:00:00.000000Z",
+    "clarifications_close_at_utc": "2000-01-01T00:00:00.000000Z",
+    "clarifications_publish_at_utc": "2000-01-01T00:00:00.000000Z",
+    "framework_live_at_utc": "2000-01-01T00:00:00.000000Z",
+    "framework_expires_at_utc": "2000-01-01T00:00:00.000000Z",
+    "has_direct_award": True,
+    "has_further_competition": False,
+}
 _g8_framework_defaults = {
     "slug": "g-cloud-8",
     "framework": "g-cloud",
@@ -446,6 +459,14 @@ def open_g6_framework(request, app):
 @pytest.fixture()
 def expired_g6_framework(request, app):
     return _framework_fixture_inner(request, app, **dict(_g6_framework_defaults, status="expired"))
+
+
+@pytest.fixture()
+def live_g12_framework(request, app):
+    framework = _framework_fixture_inner(request, app, **dict(_g12_framework_defaults, status="live"))
+    lots = ["cloud-hosting", "cloud-software", "cloud-support"]
+    _add_lots_for_framework(request, app, _g12_framework_defaults["slug"], lots)
+    return framework
 
 
 @pytest.fixture()

--- a/tests/main/views/test_drafts.py
+++ b/tests/main/views/test_drafts.py
@@ -916,6 +916,38 @@ class TestDraftServices(DraftsHelpersMixin):
         assert res.status_code == 400
         assert "'g-cloud-5' is not open for submissions" in data['error']
 
+    def test_should_not_create_g12_draft_on_not_open_framework(self, live_g12_framework):
+        draft_json = self.create_draft_json.copy()
+        draft_json['services'] = {
+            'frameworkSlug': 'g-cloud-12',
+            'lot': 'cloud-hosting',
+            'supplierId': 1
+        }
+        res = self.client.post(
+            '/draft-services',
+            data=json.dumps(draft_json),
+            content_type='application/json')
+
+        data = json.loads(res.get_data())
+        assert res.status_code == 400
+        assert "'g-cloud-12' is not open for submissions" in data['error']
+
+    def test_should_create_draft_for_g12_recovery_supplier(self, live_g12_framework):
+        draft_json = self.create_draft_json.copy()
+        draft_json['services'] = {
+            'frameworkSlug': 'g-cloud-12',
+            'lot': 'cloud-hosting',
+            'supplierId': 1
+        }
+        self.app.config['DM_G12_RECOVERY_SUPPLIER_IDS'] = "1"
+
+        res = self.client.post(
+            '/draft-services',
+            data=json.dumps(draft_json),
+            content_type='application/json')
+
+        assert res.status_code == 201
+
     def test_should_not_create_draft_with_invalid_lot(self):
         draft_json = self.create_draft_json.copy()
         draft_json['services']['lot'] = 'newlot'

--- a/tests/test_supplier_utils.py
+++ b/tests/test_supplier_utils.py
@@ -1,0 +1,22 @@
+import pytest
+
+from app.supplier_utils import is_g12_recovery_supplier
+from tests.bases import BaseApplicationTest
+
+
+class TestG12RecoverySupplier(BaseApplicationTest):
+    @pytest.mark.parametrize(
+        'g12_recovery_supplier_ids, expected_result',
+        [
+            (None, False),
+            ('', False),
+            (42, False),
+            ('12:32', False),
+            ([123456, 789012], False),
+            ('123456', True),
+            ('123456,789012', True),
+        ]
+    )
+    def test_returns_expected_value_for_input(self, g12_recovery_supplier_ids, expected_result):
+        self.app.config['DM_G12_RECOVERY_SUPPLIER_IDS'] = g12_recovery_supplier_ids
+        assert is_g12_recovery_supplier(123456) is expected_result


### PR DESCRIPTION
Trello: https://trello.com/c/KikQx3R2/593-as-a-g12-recovery-supplier-i-can-see-something-other-suppliers-cannot

We had an outage during G12 closing. Some suppliers will be involved in a recovery process to account for the outage causing them to fail to submit their services in time.

We have previously provided a list of the affected supplier IDs via the environment - see alphagov/digitalmarketplace-credentials#359 and alphagov/digitalmarketplace-aws#797. This PR allows suppliers who are part of the G12 recovery to create G12 draft services when G12 is not 'open'. Tests show that this is working correctly.

We don't expect real suppliers to use this API endpoint - we hope to have loaded all their drafts into the system already. However, we will need the ability to create draft services for testing with.

This also shows that we've wired everything up correctly.