### PR TITLE
Run CI against postgres 10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
       postgres:
         image: postgres:${{ matrix.postgres-version }}
         env:
-          POSTGRES_PASSWORD: postgres
+          POSTGRES_PASSWORD: postgres # pragma: allowlist secret
           POSTGRES_DB: digitalmarketplace_test
         # Set health checks to wait until postgres has started
         options: >-
@@ -45,4 +45,4 @@ jobs:
           make requirements-dev
           make test
         env:
-          SQLALCHEMY_DATABASE_URI: postgresql://postgres:postgres@localhost:5432/digitalmarketplace_test
+          SQLALCHEMY_DATABASE_URI: postgresql://postgres:postgres@localhost:5432/digitalmarketplace_test # pragma: allowlist secret

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,9 +7,10 @@ jobs:
     strategy:
       matrix:
         python-version: [ 3.6, 3.7, 3.8, 3.9 ]
+        postgres-version: [ 9.5, 10.15 ]
     services:
       postgres:
-        image: postgres:9.5
+        image: postgres:${{ matrix.postgres-version }}
         env:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: digitalmarketplace_test


### PR DESCRIPTION
Trello: https://trello.com/c/WdULXylT/2141-upgrade-postgresql

We need to upgrade to Postgres 12 by 11 February. Let's start by seeing what breaks if we start with Postgres 10.

We'll first upgrade our pre-merge CI. Once this is gone in, I'll test against Postgres 10 locally. Then we can think about upgrading Preview.