### PR TITLE
Replace make with invoke

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -12,3 +12,4 @@ max-line-length = 120
 per-file-ignores =
     app/*/__init__.py : E402, F401
     app/explorer/__init__.py : E402
+    tasks.py: F401

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,10 +38,12 @@ jobs:
           path: venv
           key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/requirements*.txt') }}
 
+      - name: Install developer tools
+        run: make bootstrap
 
       - name: Install packages and run tests
         run: |
-          make requirements-dev
-          make test
+          invoke requirements-dev
+          invoke test
         env:
           SQLALCHEMY_DATABASE_URI: postgresql://postgres:postgres@localhost:5432/digitalmarketplace_test

--- a/Makefile
+++ b/Makefile
@@ -1,67 +1,20 @@
-SHELL := /bin/bash
-VIRTUALENV_ROOT := $(shell [ -z $$VIRTUAL_ENV ] && echo $$(pwd)/venv || echo $$VIRTUAL_ENV)
-DATABASE_HOST := localhost
 
-.PHONY: run-all
-run-all: requirements run-migrations run-app
+.DEFAULT_GOAL := bootstrap
 
-.PHONY: run-app
-run-app: virtualenv
-	${VIRTUALENV_ROOT}/bin/flask run
+%:
+	@[ -z $$TERM ] || tput setaf 1  # red
+	@echo 2>1 warning: calling '`make`' is being deprecated in this repo, you should use '`invoke` (https://pyinvoke.org)' instead.
+	@[ -z $$TERM ] || tput setaf 9  # default
+	@# pass goals to '`invoke`'
+	invoke $(or $(MAKECMDGOALS), $@)
 
-.PHONY: run-migrations
-run-migrations: virtualenv
-	${VIRTUALENV_ROOT}/bin/flask db upgrade
+help:
+	invoke --list
 
-.PHONY: virtualenv
-virtualenv:
-	[ -z $$VIRTUAL_ENV ] && [ ! -d venv ] && python3 -m venv venv || true
-
-.PHONY: upgrade-pip
-upgrade-pip: virtualenv
-	${VIRTUALENV_ROOT}/bin/pip install --upgrade pip
-
-.PHONY: requirements
-requirements: virtualenv upgrade-pip requirements.in
-	${VIRTUALENV_ROOT}/bin/pip install -r requirements.txt
-
-.PHONY: requirements-dev
-requirements-dev: virtualenv upgrade-pip requirements.txt requirements-dev.txt
-	${VIRTUALENV_ROOT}/bin/pip install -r requirements.txt -r requirements-dev.txt
-
-.PHONY: freeze-requirements
-freeze-requirements: requirements-dev requirements.in requirements-dev.in
-	${VIRTUALENV_ROOT}/bin/pip-compile requirements.in
-	${VIRTUALENV_ROOT}/bin/pip-compile requirements-dev.in
-
-.PHONY: test
-test: test-flake8 test-migrations test-unit
-
-.PHONY: test-bootstrap
-test-bootstrap: virtualenv
-	dropdb -h ${DATABASE_HOST} --if-exists digitalmarketplace_test
-	createdb -h ${DATABASE_HOST} digitalmarketplace_test
-
-.PHONY: test-flake8
-test-flake8: virtualenv requirements-dev
-	${VIRTUALENV_ROOT}/bin/flake8 .
-
-.PHONY: test-migrations
-test-migrations: virtualenv requirements-dev
-	${VIRTUALENV_ROOT}/bin/python ./scripts/list_migrations.py 1>/dev/null
-
-.PHONY: test-unit
-test-unit: virtualenv requirements-dev
-	${VIRTUALENV_ROOT}/bin/py.test ${PYTEST_ARGS}
-
-.PHONY: docker-build
-docker-build:
-	$(if ${RELEASE_NAME},,$(eval export RELEASE_NAME=$(shell git describe)))
-	@echo "Building a docker image for ${RELEASE_NAME}..."
-	docker build -t digitalmarketplace/api --build-arg release_name=${RELEASE_NAME} .
-	docker tag digitalmarketplace/api digitalmarketplace/api:${RELEASE_NAME}
-
-.PHONY: docker-push
-docker-push:
-	$(if ${RELEASE_NAME},,$(eval export RELEASE_NAME=$(shell git describe)))
-	docker push digitalmarketplace/api:${RELEASE_NAME}
+.PHONY: bootstrap
+bootstrap:
+	pip install git+https://github.com/alphagov/digitalmarketplace-developer-tools.git#egg=digitalmarketplace-developer-tools
+	@echo done
+	@[ -z $$TERM ] || tput setaf 2  # green
+	@echo 2>1 dmdevtools has been installed globally, run developer tasks with '`invoke`'
+	@[ -z $$TERM ] || tput setaf 9  # default

--- a/tasks.py
+++ b/tasks.py
@@ -1,0 +1,38 @@
+from invoke import task
+
+from dmdevtools.invoke_tasks import (
+    api_app_tasks,
+    requirements_dev,
+    virtualenv,
+)
+
+
+@task(virtualenv)
+def run_migrations(c):
+    """Upgrade database schema"""
+    c.run(f"flask db upgrade")
+
+
+@task(virtualenv, requirements_dev)
+def test_migrations(c):
+    """Check that migrations parse"""
+    c.run("python scripts/list_migrations.py", hide=True)
+
+
+@task(virtualenv)
+def test_bootstrap(c, database_host="localhost"):
+    """Create a clean database for testing"""
+    c.run(f"dropdb -h {database_host} --if-exists digitalmarketplace_test")
+    c.run(f"createdb -h {database_host} digitalmarketplace_test")
+
+
+ns = api_app_tasks
+ns.add_task(run_migrations)
+ns.add_task(test_migrations)
+ns.add_task(test_bootstrap)
+
+# add run-migrations to run-all
+ns["run-all"].pre.insert(1, run_migrations)
+
+# add test-migrations to test
+ns["test"].pre.insert(1, test_migrations)


### PR DESCRIPTION
Ticket: https://trello.com/c/hCCo28Bc/1329-add-makefiles-to-digitalmarketplace-utils-and-reduce-duplication-across-apps

We want to be able to reduce duplication of code across our repos; one of the places we have a lot of duplicated code is in our Makefiles; all of our repos have very similar Makefiles with small historical differences.

This commit replaces Make with invoke, using the tasks from alphagov/digitalmarketplace-developer-tools.

See alphagov/digitalmarketplace-developer-tools#1 for more details.

---

Note: the tests won't pass until alphagov/digitalmarketplace-developer-tools#1 is merged, as they now depend on invoke