### PR TITLE
Bump digitalmarketplace-test-utils from git to PyPI

### DIFF
--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -2,6 +2,9 @@
 
 pip-tools>=5.4.0
 
+# For schema generation
+alchemyjsonschema==0.5.0
+
 # For tests
 coverage
 flake8
@@ -13,7 +16,4 @@ python-dotenv  # used to load .flaskenv
 requests-mock
 testfixtures
 
-git+https://github.com/alphagov/digitalmarketplace-test-utils.git@2.8.2#egg=digitalmarketplace-test-utils
-
-# For schema generation
-alchemyjsonschema==0.5.0
+digitalmarketplace-test-utils

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,47 +6,132 @@
 #
 --no-binary psycopg2
 
-alchemyjsonschema==0.5.0  # via -r requirements-dev.in
-attrs==19.3.0             # via -c requirements.txt, jsonschema, pytest
-certifi==2019.11.28       # via -c requirements.txt, requests
-chardet==3.0.4            # via -c requirements.txt, requests
-click==7.0                # via -c requirements.txt, pip-tools
-coverage==5.0.3           # via -r requirements-dev.in, pytest-cov
-dictknife==0.13.0         # via alchemyjsonschema
-git+https://github.com/alphagov/digitalmarketplace-test-utils.git@2.8.2#egg=digitalmarketplace-test-utils  # via -r requirements-dev.in
-entrypoints==0.3          # via flake8
-flake8==3.7.9             # via -r requirements-dev.in
-freezegun==0.3.15         # via -r requirements-dev.in
-idna==2.9                 # via -c requirements.txt, requests
-importlib-metadata==1.6.0  # via -c requirements.txt, jsonschema, pluggy, pytest
-isodate==0.6.0            # via alchemyjsonschema
-jsonschema==3.2.0         # via -c requirements.txt, alchemyjsonschema
-magicalimport==0.9.1      # via alchemyjsonschema
-mccabe==0.6.1             # via flake8
-mock==4.0.1               # via -r requirements-dev.in
-more-itertools==8.2.0     # via pytest
-packaging==20.1           # via pytest
-pip-tools==5.4.0          # via -r requirements-dev.in
-pluggy==0.13.1            # via pytest
-py==1.8.1                 # via pytest
-pycodestyle==2.5.0        # via flake8
-pyflakes==2.1.1           # via flake8
-pyparsing==2.4.6          # via packaging
-pyrsistent==0.15.7        # via -c requirements.txt, jsonschema
-pytest-cov==2.8.1         # via -r requirements-dev.in
-pytest==5.3.5             # via -r requirements-dev.in, pytest-cov
-python-dateutil==2.8.1    # via -c requirements.txt, freezegun
-python-dotenv==0.11.0     # via -r requirements-dev.in
-pytz==2019.3              # via -c requirements.txt, alchemyjsonschema
-requests-mock==1.7.0      # via -r requirements-dev.in
-requests==2.23.0          # via -c requirements.txt, requests-mock
-six==1.14.0               # via -c requirements.txt, freezegun, isodate, jsonschema, packaging, pip-tools, python-dateutil, requests-mock
-sqlalchemy==1.3.20        # via -c requirements.txt, alchemyjsonschema
-strict-rfc3339==0.7       # via -c requirements.txt, alchemyjsonschema
-testfixtures==6.13.0      # via -r requirements-dev.in
-urllib3==1.25.10          # via -c requirements.txt, requests
-wcwidth==0.1.8            # via pytest
-zipp==3.1.0               # via -c requirements.txt, importlib-metadata
+alchemyjsonschema==0.5.0
+    # via -r requirements-dev.in
+attrs==19.3.0
+    # via
+    #   -c requirements.txt
+    #   jsonschema
+    #   pytest
+certifi==2019.11.28
+    # via
+    #   -c requirements.txt
+    #   requests
+chardet==3.0.4
+    # via
+    #   -c requirements.txt
+    #   requests
+click==7.0
+    # via
+    #   -c requirements.txt
+    #   pip-tools
+coverage==5.0.3
+    # via
+    #   -r requirements-dev.in
+    #   pytest-cov
+dictknife==0.13.0
+    # via alchemyjsonschema
+git+https://github.com/alphagov/digitalmarketplace-test-utils.git@2.8.2#egg=digitalmarketplace-test-utils
+    # via -r requirements-dev.in
+entrypoints==0.3
+    # via flake8
+flake8==3.7.9
+    # via -r requirements-dev.in
+freezegun==0.3.15
+    # via -r requirements-dev.in
+idna==2.9
+    # via
+    #   -c requirements.txt
+    #   requests
+importlib-metadata==1.6.0
+    # via
+    #   -c requirements.txt
+    #   jsonschema
+    #   pluggy
+    #   pytest
+isodate==0.6.0
+    # via alchemyjsonschema
+jsonschema==3.2.0
+    # via
+    #   -c requirements.txt
+    #   alchemyjsonschema
+magicalimport==0.9.1
+    # via alchemyjsonschema
+mccabe==0.6.1
+    # via flake8
+mock==4.0.1
+    # via -r requirements-dev.in
+more-itertools==8.2.0
+    # via pytest
+packaging==20.1
+    # via pytest
+pip-tools==5.5.0
+    # via -r requirements-dev.in
+pluggy==0.13.1
+    # via pytest
+py==1.8.1
+    # via pytest
+pycodestyle==2.5.0
+    # via flake8
+pyflakes==2.1.1
+    # via flake8
+pyparsing==2.4.6
+    # via packaging
+pyrsistent==0.15.7
+    # via
+    #   -c requirements.txt
+    #   jsonschema
+pytest-cov==2.8.1
+    # via -r requirements-dev.in
+pytest==5.3.5
+    # via
+    #   -r requirements-dev.in
+    #   pytest-cov
+python-dateutil==2.8.1
+    # via
+    #   -c requirements.txt
+    #   freezegun
+python-dotenv==0.11.0
+    # via -r requirements-dev.in
+pytz==2019.3
+    # via
+    #   -c requirements.txt
+    #   alchemyjsonschema
+requests-mock==1.7.0
+    # via -r requirements-dev.in
+requests==2.23.0
+    # via
+    #   -c requirements.txt
+    #   requests-mock
+six==1.14.0
+    # via
+    #   -c requirements.txt
+    #   freezegun
+    #   isodate
+    #   jsonschema
+    #   packaging
+    #   python-dateutil
+    #   requests-mock
+sqlalchemy==1.3.20
+    # via
+    #   -c requirements.txt
+    #   alchemyjsonschema
+strict-rfc3339==0.7
+    # via
+    #   -c requirements.txt
+    #   alchemyjsonschema
+testfixtures==6.13.0
+    # via -r requirements-dev.in
+urllib3==1.25.10
+    # via
+    #   -c requirements.txt
+    #   requests
+wcwidth==0.1.8
+    # via pytest
+zipp==3.1.0
+    # via
+    #   -c requirements.txt
+    #   importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -31,7 +31,7 @@ coverage==5.0.3
     #   pytest-cov
 dictknife==0.13.0
     # via alchemyjsonschema
-git+https://github.com/alphagov/digitalmarketplace-test-utils.git@2.8.2#egg=digitalmarketplace-test-utils
+digitalmarketplace-test-utils==2.8.2
     # via -r requirements-dev.in
 entrypoints==0.3
     # via flake8

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,69 +6,176 @@
 #
 --no-binary psycopg2
 
-alembic==1.4.0            # via flask-migrate
-attrs==19.3.0             # via jsonschema
-bcrypt==3.1.7             # via flask-bcrypt
-blinker==1.4              # via gds-metrics
-boto3==1.12.3             # via digitalmarketplace-utils
-botocore==1.15.3          # via boto3, s3transfer
-certifi==2019.11.28       # via requests
-cffi==1.14.0              # via bcrypt, cryptography
-chardet==3.0.4            # via requests
-click==7.0                # via flask
-contextlib2==0.6.0.post1  # via digitalmarketplace-utils
-cryptography==3.2.1       # via digitalmarketplace-utils
-defusedxml==0.6.0         # via odfpy
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.5.0#egg=digitalmarketplace-apiclient==21.5.0  # via -r requirements.in
-git+https://github.com/alphagov/digitalmarketplace-utils.git@54.1.1#egg=digitalmarketplace-utils==54.1.1  # via -r requirements.in
-docopt==0.6.2             # via notifications-python-client
-docutils==0.15.2          # via botocore
-flask-bcrypt==0.7.1       # via -r requirements.in
-flask-gzip==0.2           # via digitalmarketplace-utils
-flask-login==0.5.0        # via digitalmarketplace-utils
-flask-migrate==2.5.3      # via -r requirements.in
-flask-sqlalchemy==2.4.4   # via -r requirements.in, flask-migrate
-flask-wtf==0.14.3         # via digitalmarketplace-utils
-flask==1.0.4              # via -r requirements.in, digitalmarketplace-utils, flask-bcrypt, flask-gzip, flask-login, flask-migrate, flask-sqlalchemy, flask-wtf, gds-metrics
-fleep==1.0.1              # via digitalmarketplace-utils
-future==0.18.2            # via notifications-python-client
-gds-metrics==0.2.0        # via digitalmarketplace-utils
-govuk-country-register==0.5.0  # via digitalmarketplace-utils
-idna==2.9                 # via requests
-importlib-metadata==1.6.0  # via jsonschema
-itsdangerous==1.1.0       # via -r requirements.in, flask, flask-wtf
-jinja2==2.11.1            # via flask
-jmespath==0.9.4           # via boto3, botocore
-jsonschema==3.2.0         # via -r requirements.in
-mailchimp3==3.0.6         # via digitalmarketplace-utils
-mako==1.1.1               # via alembic
-markupsafe==1.1.1         # via jinja2, mako
-monotonic==1.5            # via notifications-python-client
-notifications-python-client==5.5.1  # via digitalmarketplace-utils
-odfpy==1.4.1              # via digitalmarketplace-utils
-prometheus-client==0.2.0  # via gds-metrics
-psycopg2==2.8.6           # via -r requirements.in
-pycparser==2.19           # via cffi
-pyjwt==1.7.1              # via notifications-python-client
-pyrsistent==0.15.7        # via jsonschema
-python-dateutil==2.8.1    # via alembic, botocore
-python-editor==1.0.4      # via alembic
-python-json-logger==0.1.11  # via digitalmarketplace-utils
-pytz==2019.3              # via digitalmarketplace-utils
-requests==2.23.0          # via digitalmarketplace-apiclient, digitalmarketplace-utils, mailchimp3, notifications-python-client
-rfc3987==1.3.8            # via -r requirements.in
-s3transfer==0.3.3         # via boto3
-six==1.14.0               # via bcrypt, cryptography, jsonschema, pyrsistent, python-dateutil, sqlalchemy-json, sqlalchemy-utils
-sqlalchemy-json==0.4.0    # via -r requirements.in
-sqlalchemy-utils==0.36.8  # via -r requirements.in
-sqlalchemy==1.3.20        # via -r requirements.in, alembic, flask-sqlalchemy, sqlalchemy-json, sqlalchemy-utils
-strict-rfc3339==0.7       # via -r requirements.in
-unicodecsv==0.14.1        # via digitalmarketplace-utils
-urllib3==1.25.10          # via botocore, requests
-werkzeug==1.0.0           # via digitalmarketplace-utils, flask
-workdays==1.4             # via digitalmarketplace-utils
-wtforms==2.2.1            # via flask-wtf
-zipp==3.1.0               # via importlib-metadata
+alembic==1.4.0
+    # via flask-migrate
+attrs==19.3.0
+    # via jsonschema
+bcrypt==3.1.7
+    # via flask-bcrypt
+blinker==1.4
+    # via gds-metrics
+boto3==1.12.3
+    # via digitalmarketplace-utils
+botocore==1.15.3
+    # via
+    #   boto3
+    #   s3transfer
+certifi==2019.11.28
+    # via requests
+cffi==1.14.0
+    # via
+    #   bcrypt
+    #   cryptography
+chardet==3.0.4
+    # via requests
+click==7.0
+    # via flask
+contextlib2==0.6.0.post1
+    # via digitalmarketplace-utils
+cryptography==3.2.1
+    # via digitalmarketplace-utils
+defusedxml==0.6.0
+    # via odfpy
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.5.0#egg=digitalmarketplace-apiclient==21.5.0
+    # via -r requirements.in
+git+https://github.com/alphagov/digitalmarketplace-utils.git@54.1.1#egg=digitalmarketplace-utils==54.1.1
+    # via -r requirements.in
+docopt==0.6.2
+    # via notifications-python-client
+docutils==0.15.2
+    # via botocore
+flask-bcrypt==0.7.1
+    # via -r requirements.in
+flask-gzip==0.2
+    # via digitalmarketplace-utils
+flask-login==0.5.0
+    # via digitalmarketplace-utils
+flask-migrate==2.5.3
+    # via -r requirements.in
+flask-sqlalchemy==2.4.4
+    # via
+    #   -r requirements.in
+    #   flask-migrate
+flask-wtf==0.14.3
+    # via digitalmarketplace-utils
+flask==1.0.4
+    # via
+    #   -r requirements.in
+    #   digitalmarketplace-utils
+    #   flask-bcrypt
+    #   flask-gzip
+    #   flask-login
+    #   flask-migrate
+    #   flask-sqlalchemy
+    #   flask-wtf
+    #   gds-metrics
+fleep==1.0.1
+    # via digitalmarketplace-utils
+future==0.18.2
+    # via notifications-python-client
+gds-metrics==0.2.0
+    # via digitalmarketplace-utils
+govuk-country-register==0.5.0
+    # via digitalmarketplace-utils
+idna==2.9
+    # via requests
+importlib-metadata==1.6.0
+    # via jsonschema
+itsdangerous==1.1.0
+    # via
+    #   -r requirements.in
+    #   flask
+    #   flask-wtf
+jinja2==2.11.1
+    # via flask
+jmespath==0.9.4
+    # via
+    #   boto3
+    #   botocore
+jsonschema==3.2.0
+    # via -r requirements.in
+mailchimp3==3.0.6
+    # via digitalmarketplace-utils
+mako==1.1.1
+    # via alembic
+markupsafe==1.1.1
+    # via
+    #   jinja2
+    #   mako
+monotonic==1.5
+    # via notifications-python-client
+notifications-python-client==5.5.1
+    # via digitalmarketplace-utils
+odfpy==1.4.1
+    # via digitalmarketplace-utils
+prometheus-client==0.2.0
+    # via gds-metrics
+psycopg2==2.8.6
+    # via -r requirements.in
+pycparser==2.19
+    # via cffi
+pyjwt==1.7.1
+    # via notifications-python-client
+pyrsistent==0.15.7
+    # via jsonschema
+python-dateutil==2.8.1
+    # via
+    #   alembic
+    #   botocore
+python-editor==1.0.4
+    # via alembic
+python-json-logger==0.1.11
+    # via digitalmarketplace-utils
+pytz==2019.3
+    # via digitalmarketplace-utils
+requests==2.23.0
+    # via
+    #   digitalmarketplace-apiclient
+    #   digitalmarketplace-utils
+    #   mailchimp3
+    #   notifications-python-client
+rfc3987==1.3.8
+    # via -r requirements.in
+s3transfer==0.3.3
+    # via boto3
+six==1.14.0
+    # via
+    #   bcrypt
+    #   cryptography
+    #   jsonschema
+    #   pyrsistent
+    #   python-dateutil
+    #   sqlalchemy-json
+    #   sqlalchemy-utils
+sqlalchemy-json==0.4.0
+    # via -r requirements.in
+sqlalchemy-utils==0.36.8
+    # via -r requirements.in
+sqlalchemy==1.3.20
+    # via
+    #   -r requirements.in
+    #   alembic
+    #   flask-sqlalchemy
+    #   sqlalchemy-json
+    #   sqlalchemy-utils
+strict-rfc3339==0.7
+    # via -r requirements.in
+unicodecsv==0.14.1
+    # via digitalmarketplace-utils
+urllib3==1.25.10
+    # via
+    #   botocore
+    #   requests
+werkzeug==1.0.0
+    # via
+    #   digitalmarketplace-utils
+    #   flask
+workdays==1.4
+    # via digitalmarketplace-utils
+wtforms==2.2.1
+    # via flask-wtf
+zipp==3.1.0
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
We want to install digitalmarketplace-test-utils from PyPI instead of VCS, so we can rely on Dependabot to update our apps automatically when a new version is available.