### PR TITLE
Add DOS5 to ES index mapping

### DIFF
--- a/config.py
+++ b/config.py
@@ -65,6 +65,9 @@ class Config:
         'digital-outcomes-and-specialists-4': {
             'briefs': 'briefs-digital-outcomes-and-specialists'
         },
+        'digital-outcomes-and-specialists-5': {
+            'briefs': 'briefs-digital-outcomes-and-specialists'
+        },
     }
 
     DM_G12_RECOVERY_SUPPLIER_IDS = None


### PR DESCRIPTION
This will allow newly created DOS5 briefs to appear in searches straight away.

See https://alphagov.github.io/digitalmarketplace-manual/content-and-frameworks/framework-lifecycle-for-developers.html#making-dos-services-live