### PR TITLE
run tests against postgres 12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         python-version: [ 3.6, 3.7, 3.8, 3.9 ]
-        postgres-version: [ 9.5, 10.15 ]
+        postgres-version: [ 9.5, 10.15, 12 ]
     services:
       postgres:
         image: postgres:${{ matrix.postgres-version }}


### PR DESCRIPTION
https://trello.com/c/yUrkl9Tk/707-ensure-dmp-is-compatible-with-postgres-12
We want to test against postgres 12 to check compatibility prior to upgrading. Note I did not specify a minor version as PaaS doesn't specify one.