### PR TITLE
remove postgres 9.5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         python-version: [ 3.6, 3.7, 3.8, 3.9 ]
-        postgres-version: [ 9.5, 10.15, 12 ]
+        postgres-version: [ 10.15, 12 ]
     services:
       postgres:
         image: postgres:${{ matrix.postgres-version }}


### PR DESCRIPTION
https://trello.com/c/OCXZhldK/704-2-migrate-to-postgres-10
We are no longer running this version