### PR TITLE
Allow DMp team to create G12 drafts

### DIFF
--- a/app/main/views/drafts.py
+++ b/app/main/views/drafts.py
@@ -8,7 +8,6 @@ from datetime import datetime
 
 from .. import main
 from ... import db
-from ...supplier_utils import is_g12_recovery_supplier
 from ...validation import is_valid_service_id_or_400
 from ...models import Service, DraftService, Supplier, AuditEvent, Framework, Lot
 from ...utils import (
@@ -510,7 +509,7 @@ def create_new_draft_service():
     framework, lot, supplier = validate_and_return_related_objects(draft_json)
 
     if not (framework.status == 'open' or
-            (framework.slug == 'g-cloud-12' and is_g12_recovery_supplier(supplier.supplier_id))):
+            (framework.slug == 'g-cloud-12' and updater_json['updated_by'].endswith('@digital.cabinet-office.gov.uk'))):
         abort(400, "'{}' is not open for submissions".format(framework.slug))
 
     if lot.one_service_limit:

--- a/tests/main/views/test_drafts.py
+++ b/tests/main/views/test_drafts.py
@@ -1,3 +1,5 @@
+from typing import Dict, Union
+
 import pytest
 from tests.bases import BaseApplicationTest, JSONUpdateTestMixin
 from datetime import datetime
@@ -13,7 +15,7 @@ from tests.helpers import FixtureMixin, load_example_listing
 class DraftsHelpersMixin(BaseApplicationTest, FixtureMixin):
     service_id = None
     updater_json = None
-    create_draft_json = None
+    create_draft_json: Dict[str, Union[str, dict]] = None
     basic_questions_json = None
     exclude_questions_json = None
 
@@ -934,12 +936,12 @@ class TestDraftServices(DraftsHelpersMixin):
 
     def test_should_create_draft_for_g12_recovery_supplier(self, live_g12_framework):
         draft_json = self.create_draft_json.copy()
+        draft_json['updated_by'] = "test@digital.cabinet-office.gov.uk"
         draft_json['services'] = {
             'frameworkSlug': 'g-cloud-12',
             'lot': 'cloud-hosting',
-            'supplierId': 1
+            'supplierId': 1,
         }
-        self.app.config['DM_G12_RECOVERY_SUPPLIER_IDS'] = "1"
 
         res = self.client.post(
             '/draft-services',


### PR DESCRIPTION
Trello: https://trello.com/c/13Ryt5o5

For the G12 recovery, suppliers will only be able to submit the drafts that are part of the G12 recovery. We won't be allowing them to create any extra. This is already disabled in supplier-frontend, so we can remove it here as well.

Instead, we need to be able to create arbitrary G12 drafts. This is because some of the G12 recovery services don't have corresponding drafts, so [we need to create them](https://github.com/alphagov/digitalmarketplace-scripts/pull/616). And we don't want to add the suppliers to the list of G12 recovery suppliers until the recovery process opens, because it makes user-visible changes to the website.

This is a terrible hack, and I feel bad about introducing it to the codebase. However, we will be deleting all the G12 recovery code in a month's time, so I think it's OK.

I've tested this manually locally, and it seems to work just fine.