### PR TITLE
Add API endpoint to un-award a brief

### DIFF
--- a/app/main/views/briefs.py
+++ b/app/main/views/briefs.py
@@ -364,6 +364,10 @@ def award_brief_details(brief_id, brief_response_id):
 def un_award_brief_details(brief_id, brief_response_id):
     updater_json = validate_and_return_updater_request()
 
+    brief = Brief.query.filter(
+        Brief.id == brief_id
+    ).first_or_404()
+
     brief_response = BriefResponse.query.filter(
         BriefResponse.brief_id == brief_id,
         BriefResponse.id == brief_response_id
@@ -391,9 +395,6 @@ def un_award_brief_details(brief_id, brief_response_id):
     db.session.add_all([brief_response, audit_event])
     db.session.commit()
 
-    brief = Brief.query.filter(
-        Brief.id == brief_id
-    ).first_or_404()
     return single_result_response(RESOURCE_NAME, brief), 200
 
 

--- a/app/models/main.py
+++ b/app/models/main.py
@@ -1833,8 +1833,8 @@ class BriefResponse(db.Model):
 
     @validates('awarded_at')
     def validates_awarded_at(self, key, awarded_at):
-        if self.awarded_at is not None:
-            raise ValidationError('Cannot remove or change award datestamp on previously awarded Brief Response')
+        if (self.awarded_at is not None) and (awarded_at is not None):
+            raise ValidationError('Cannot change award datestamp on previously awarded Brief Response')
         if not awarded_at:
             return None
         if self.brief.status != "closed":


### PR DESCRIPTION
https://trello.com/c/rELvaDeA/2174-add-a-way-for-developers-to-award-a-brief-to-a-different-brief-response
https://govuk.zendesk.com/agent/tickets/4467615

We need the ability to un-award briefs. This will allow us to fix a brief that was accidentally awarded to the wrong supplier. This API method will not be exposed via any frontend app, so will be accessible to developers only.

Once a developer has un-awarded the brief using this new method, the buyer can then follow the usual process to award the brief to the correct supplier.

Update the validation rules on `awarded_at` accordingly.