### PR TITLE
Add endpoint to delete buyer email domains

### DIFF
--- a/app/main/views/buyer_domains.py
+++ b/app/main/views/buyer_domains.py
@@ -1,6 +1,6 @@
 from dmapiclient.audit import AuditTypes
 from sqlalchemy.exc import IntegrityError
-from flask import abort, current_app, request
+from flask import abort, current_app, request, jsonify
 
 from .. import main
 from ... import db
@@ -18,15 +18,18 @@ from ...utils import (
 RESOURCE_NAME = "buyerEmailDomains"
 
 
-@main.route('/buyer-email-domains', methods=['POST'])
-def create_buyer_email_domain():
-    updater_json = validate_and_return_updater_request()
-
+def get_domain_from_request():
     json_payload = get_json_from_request()
     json_has_required_keys(json_payload, ["buyerEmailDomains"])
     validate_buyer_email_domain_json_or_400(json_payload["buyerEmailDomains"])
 
-    new_domain = json_payload["buyerEmailDomains"]['domainName'].lower()
+    return json_payload["buyerEmailDomains"]['domainName'].lower()
+
+
+@main.route('/buyer-email-domains', methods=['POST'])
+def create_buyer_email_domain():
+    updater_json = validate_and_return_updater_request()
+    new_domain = get_domain_from_request()
 
     if is_approved_buyer_domain(BuyerEmailDomain.query.all(), new_domain):
         abort(409, "Domain name {} has already been approved".format(new_domain))
@@ -53,6 +56,35 @@ def create_buyer_email_domain():
     db.session.commit()
 
     return single_result_response(RESOURCE_NAME, buyer_email_domain), 201
+
+
+@main.route('/buyer-email-domains', methods=['DELETE'])
+def delete_buyer_email_domain():
+    updater_json = validate_and_return_updater_request()
+
+    buyer_email_domain = BuyerEmailDomain.query.filter(
+        BuyerEmailDomain.domain_name == get_domain_from_request()
+    ).first_or_404()
+
+    audit = AuditEvent(
+        audit_type=AuditTypes.delete_buyer_email_domain,
+        user=updater_json['updated_by'],
+        data={
+            'buyerEmailDomainId': buyer_email_domain.id,
+            'buyerEmailDomainJson': {'domainName': buyer_email_domain.domain_name}
+        },
+        db_object=None
+    )
+
+    db.session.delete(buyer_email_domain)
+    db.session.add(audit)
+    try:
+        db.session.commit()
+    except IntegrityError as e:
+        db.session.rollback()
+        abort(400, format(e))
+
+    return jsonify(message="done"), 200
 
 
 @main.route('/buyer-email-domains', methods=['GET'])

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,7 @@ cryptography==3.3.2
     # via digitalmarketplace-utils
 defusedxml==0.6.0
     # via odfpy
-digitalmarketplace-apiclient==21.11.1
+digitalmarketplace-apiclient==21.12.0
     # via -r requirements.in
 digitalmarketplace-utils==56.1.2
     # via -r requirements.in


### PR DESCRIPTION
https://govuk.zendesk.com/agent/tickets/4475776

The buyer email domain list acts as an allow-list controlling who can sign up as a buyer. Currently, admins are able to view and add domains to the allow list.

A domain was recently mistakenly added to the allow-list. So we need to create a new API endpoint to allow us to remove it from the list. This is the first time this has happened. So we're not going to do the work to expose this API method to admins - it'll be available to developers only.

Uses a [new audit event type](https://github.com/alphagov/digitalmarketplace-apiclient/pull/245).