### PR TITLE
Add 'deleted' service status

### DIFF
--- a/app/main/views/services.py
+++ b/app/main/views/services.py
@@ -325,7 +325,8 @@ def update_service_status(service_id, status):
     valid_statuses = [
         "published",
         "enabled",
-        "disabled"
+        "disabled",
+        "deleted",
     ]
 
     is_valid_service_id_or_400(service_id)

--- a/app/models/main.py
+++ b/app/models/main.py
@@ -1010,7 +1010,7 @@ listen(
 
 class ServiceTableMixin(object):
 
-    STATUSES = ('disabled', 'enabled', 'published')
+    STATUSES = ('disabled', 'enabled', 'published', 'deleted',)
 
     # not used as the externally-visible "pk" by actual Services in favour of service_id
     id = db.Column(db.Integer, primary_key=True)

--- a/migrations/versions/1460_add_deleted_service_status.py
+++ b/migrations/versions/1460_add_deleted_service_status.py
@@ -1,0 +1,40 @@
+"""Add deleted service status
+
+Revision ID: 1460
+Revises: 1450
+Create Date: 2021-03-09 08:35:41.713530
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '1460'
+down_revision = '1450'
+
+
+def upgrade():
+    with op.get_context().autocommit_block():
+        op.execute("""
+            ALTER TABLE services
+                DROP CONSTRAINT ck_services_status,
+                ADD CONSTRAINT ck_services_status CHECK(status::text = ANY(ARRAY['disabled', 'enabled', 'published', 'deleted']));
+        """)
+        op.execute("""
+            ALTER TABLE archived_services
+                DROP CONSTRAINT ck_archived_services_status,
+                ADD CONSTRAINT ck_archived_services_status CHECK(status::text = ANY(ARRAY['disabled', 'enabled', 'published', 'deleted']));
+        """)
+
+def downgrade():
+    with op.get_context().autocommit_block():
+        op.execute("""
+            ALTER TABLE services
+                DROP CONSTRAINT ck_services_status,
+                ADD CONSTRAINT ck_services_status CHECK(status::text = ANY(ARRAY['disabled', 'enabled', 'published']));
+        """)
+        op.execute("""
+            ALTER TABLE archived_services
+                DROP CONSTRAINT ck_archived_services_status,
+                ADD CONSTRAINT ck_archived_services_status CHECK(status::text = ANY(ARRAY['disabled', 'enabled', 'published']));
+        """)

--- a/tests/main/views/test_services.py
+++ b/tests/main/views/test_services.py
@@ -983,7 +983,7 @@ class TestUpdateServiceStatus(BaseApplicationTest, FixtureMixin):
                 **payload
             )
 
-        assert db.session.query(Service).count() == 3
+        assert db.session.query(Service).count() == 4
 
     def _get_service_from_database_by_service_id(self, service_id):
         return Service.query.filter(
@@ -1131,6 +1131,16 @@ class TestUpdateServiceStatus(BaseApplicationTest, FixtureMixin):
 
         assert response.status_code == 200
 
+    def test_should_allow_deleted_status(self):
+
+        self._post_update_status(
+            old_status='published',
+            new_status='deleted',
+            service_is_indexed=False,
+            service_is_deleted=True,
+            expected_status_code=200,
+        )
+
 
 class TestPutService(BaseApplicationTest, JSONUpdateTestMixin, FixtureMixin):
     method = "put"
@@ -1171,7 +1181,7 @@ class TestPutService(BaseApplicationTest, JSONUpdateTestMixin, FixtureMixin):
             assert status == data['services']['status']
             if status in ('disabled', 'enabled'):
                 assert index_object.called is False
-            else:
+            elif status == 'published':
                 assert index_object.mock_calls == [
                     mock.call(
                         doc_type='services',


### PR DESCRIPTION
This status is used for when we want to remove a service page completely and show a 404, rather than the `disabled` status which leaves the page up with a warning message. The user-facing change to allow this behaviour was added in https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/1150 - this PR adds the new status as an allowed option in the API.

Alembic won't autodetect migrations like this (see [the docs](https://alembic.sqlalchemy.org/en/latest/autogenerate.html#what-does-autogenerate-detect-and-what-does-it-not-detect)) so I wrote the migration script myself. I have tested upgrades and downgrades locally and it appears to be working, but I'd encourage the reviewer to do the same.

Team manual update with documentation for the new status & when to use it is coming soon.

https://trello.com/c/qqL3sqWV/2182-remove-supplier-92526-from-g-cloud