### PR TITLE
Add missing manual signing framework

### DIFF
--- a/app/models/main.py
+++ b/app/models/main.py
@@ -140,6 +140,7 @@ class Framework(db.Model):
         'digital-outcomes-and-specialists',
     )
     MANUAL_SIGNATURE_FRAMEWORK_SLUGS = [
+        "g-cloud-6",  # The earliest G-Cloud framework on the Digital Marketplace
         "g-cloud-7",
         "g-cloud-8",
         "g-cloud-9",


### PR DESCRIPTION
I forgot that the universe began with G6: https://technology.blog.gov.uk/2016/05/24/digital-marketplace-moving-from-portal-towards-a-platform/

Missed from https://github.com/alphagov/digitalmarketplace-api/pull/1101/, this should fix the current test failures.