### PR TITLE
E-signature boolean from denylist 

### DIFF
--- a/app/main/views/agreements.py
+++ b/app/main/views/agreements.py
@@ -19,8 +19,6 @@ from ...supplier_utils import validate_agreement_details_data
 
 RESOURCE_NAME = "agreement"
 
-E_SIGNATURE_LIVE_DATE = datetime(2020, 9, 28)
-
 
 @main.route('/agreements', methods=['POST'])
 def create_framework_agreement():
@@ -102,9 +100,7 @@ def update_framework_agreement(agreement_id):
         abort(400, "Can not update signedAgreementDetails or signedAgreementPath if agreement has been signed")
 
     # For G-Cloud 12 onwards (e-signature frameworks), CCS Admins do not have to approve for countersigning
-    is_esignature_framework = (
-        framework_agreement.supplier_framework.framework.framework_live_at_utc > E_SIGNATURE_LIVE_DATE
-    )
+    is_esignature_framework = framework_agreement.supplier_framework.framework.is_esignature_supported
     if (
         'countersignedAgreementPath' in update_json and not
         (framework_agreement.countersigned_agreement_returned_at or is_esignature_framework)

--- a/app/models/main.py
+++ b/app/models/main.py
@@ -140,6 +140,9 @@ class Framework(db.Model):
         'digital-outcomes-and-specialists',
     )
     MANUAL_SIGNATURE_FRAMEWORK_SLUGS = [
+        "g-cloud-4",
+        "g-cloud-5",
+        "g-cloud-6",
         "g-cloud-7",
         "g-cloud-8",
         "g-cloud-9",

--- a/app/models/main.py
+++ b/app/models/main.py
@@ -139,6 +139,17 @@ class Framework(db.Model):
         'g-cloud',
         'digital-outcomes-and-specialists',
     )
+    MANUAL_SIGNATURE_FRAMEWORK_SLUGS = [
+        "g-cloud-7",
+        "g-cloud-8",
+        "g-cloud-9",
+        "g-cloud-10",
+        "g-cloud-11",
+        "digital-outcomes-and-specialists",
+        "digital-outcomes-and-specialists-2",
+        "digital-outcomes-and-specialists-3",
+        "digital-outcomes-and-specialists-4",
+    ]
     UNIX_EPOCH = datetime.strptime('1970-01-01T00:00:00.000000Z', DATETIME_FORMAT)
 
     id = db.Column(db.Integer, primary_key=True)
@@ -230,8 +241,12 @@ class Framework(db.Model):
             'variations': (self.framework_agreement_details or {}).get("variations", {}),
             'hasDirectAward': self.has_direct_award,
             'hasFurtherCompetition': self.has_further_competition,
-            'isESignatureSupported': self.framework_live_at_utc > datetime(2020, 9, 28),
+            'isESignatureSupported': self.is_esignature_supported,
         }
+
+    @property
+    def is_esignature_supported(self):
+        return self.slug not in Framework.MANUAL_SIGNATURE_FRAMEWORK_SLUGS
 
     def get_supplier_ids_for_completed_service(self):
         """Only suppliers whose service has a status of submitted or failed."""

--- a/tests/main/views/test_agreements.py
+++ b/tests/main/views/test_agreements.py
@@ -589,6 +589,12 @@ class TestUpdateFrameworkAgreement(BaseFrameworkAgreementTest):
         assert res2.status_code == 200
         assert json.loads(res2.get_data(as_text=True))['agreement'] == expected_agreement_json
 
+    @fixture_params(
+        'live_example_framework', {
+            'framework_agreement_details': {'frameworkAgreementVersion': 'v1.0'},
+            'slug': 'g-cloud-11',
+        }
+    )
     def test_cannot_update_countersigned_agreement_path_if_agreement_has_not_been_approved(self, supplier_framework):
         agreement_id = self.create_agreement(
             supplier_framework,
@@ -608,7 +614,6 @@ class TestUpdateFrameworkAgreement(BaseFrameworkAgreementTest):
         'live_example_framework', {
             'framework_agreement_details': {'frameworkAgreementVersion': 'v1.0'},
             'slug': 'g-cloud-12',
-            'framework_live_at_utc': '2020-09-28T09:00:00.000000Z',  # Past the G12 go-live date
         }
     )
     def test_can_update_countersigned_agreement_path_without_approval_for_esignature_framework(

--- a/tests/main/views/test_frameworks.py
+++ b/tests/main/views/test_frameworks.py
@@ -252,20 +252,6 @@ class TestGetFramework(BaseApplicationTest):
 
         assert response.status_code == 404
 
-    def test_framework_live_after_date_is_e_signature_supported_true(self):
-        self.client.post(
-            "/frameworks/g-cloud-7",
-            data=json.dumps({
-                "updated_by": "🤖",
-                "frameworks": {
-                    "frameworkLiveAtUTC": "2020-09-28T12:00:00.000000Z"
-                }
-            }),
-            content_type="application/json"
-        )
-        get_framework = self.client.get('/frameworks/g-cloud-7')
-        assert get_framework.json['frameworks']['isESignatureSupported'] is True
-
 
 class TestUpdateFramework(BaseApplicationTest, JSONUpdateTestMixin, FixtureMixin):
     endpoint = '/frameworks/example'

--- a/tests/models/test_main.py
+++ b/tests/models/test_main.py
@@ -521,8 +521,20 @@ class TestFrameworks(BaseApplicationTest):
 
     @pytest.mark.parametrize("slug,is_esignature_supported", [
         ('g-cloud-11', False),
+        ('g-cloud-10', False),
+        ('g-cloud-9', False),
+        ('g-cloud-8', False),
+        ('g-cloud-7', False),
+        ('g-cloud-6', False),
+        ('g-cloud-5', False),
+        ('g-cloud-4', False),
         ('g-cloud-12', True),
+        ('g-cloud-100', True),
         ('digital-outcomes-and-specialists', False),
+        ('digital-outcomes-and-specialists-2', False),
+        ('digital-outcomes-and-specialists-3', False),
+        ('digital-outcomes-and-specialists-4', False),
+        ('digital-outcomes-and-specialists-5', True),
         ('digital-outcomes-and-specialists-100', True),
     ])
     def test_framework_esignature_supported(self, slug, is_esignature_supported):

--- a/tests/models/test_main.py
+++ b/tests/models/test_main.py
@@ -462,7 +462,7 @@ class TestFrameworks(BaseApplicationTest):
             'variations': {},
             'hasDirectAward': True,
             'hasFurtherCompetition': False,
-            'isESignatureSupported': False
+            'isESignatureSupported': True
         }
 
     def test_framework_serialization_with_default_datetimes(self):
@@ -500,7 +500,7 @@ class TestFrameworks(BaseApplicationTest):
             'variations': {},
             'hasDirectAward': True,
             'hasFurtherCompetition': False,
-            'isESignatureSupported': False
+            'isESignatureSupported': True
         }
 
     def test_framework_serialize_keys_match_api_stub_keys(self):
@@ -518,6 +518,24 @@ class TestFrameworks(BaseApplicationTest):
 
         framework_stub = FrameworkStub()
         assert sorted(framework.serialize().keys()) == sorted(framework_stub.response().keys())
+
+    @pytest.mark.parametrize("slug,is_esignature_supported", [
+        ('g-cloud-11', False),
+        ('g-cloud-12', True),
+        ('digital-outcomes-and-specialists', False),
+        ('digital-outcomes-and-specialists-100', True),
+    ])
+    def test_framework_esignature_supported(self, slug, is_esignature_supported):
+        framework = Framework(
+            id=109,
+            name='foo',
+            slug=slug,
+            framework='g-cloud',
+            has_direct_award=True,
+            has_further_competition=False
+        )
+
+        assert framework.is_esignature_supported == is_esignature_supported
 
 
 class TestBriefs(BaseApplicationTest, FixtureMixin):


### PR DESCRIPTION
Reprises #1101 with a more comprehensive list of frameworks. I based the possible frameworks list on querying the `frameworks` database table in different environments.

This is useful as we have found when editing framework statuses for testing it can change the `frameworkLiveAtUtc` date causing unexpected behaviours.

I have run the functional tests locally against this branch, I did get some failures locally but they seemed unrelated e.g. Notify, so I _hope_ this should work on Preview.