### PR TITLE
change database connection URL to use postgresql:// protocol

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -38,7 +38,8 @@ def create_app(config_name):
 
     if application.config['VCAP_SERVICES']:
         cf_services = json.loads(application.config['VCAP_SERVICES'])
-        application.config['SQLALCHEMY_DATABASE_URI'] = cf_services['postgres'][0]['credentials']['uri']
+        application.config['SQLALCHEMY_DATABASE_URI'] = (cf_services['postgres'][0]['credentials']['uri']
+                                                         .replace('postgres://', "postgresql://", 1))
 
     from .metrics import metrics as metrics_blueprint, gds_metrics
     from .main import main as main_blueprint


### PR DESCRIPTION
https://trello.com/c/UIj9AODz/2212-upgrade-sqlalchemy-in-digitalmarketplace-api

The postgres:// protocol has been [deprecated in sqlalchemy since 0.6](https://github.com/sqlalchemy/sqlalchemy/blob/8fc5005dfe3eb66a46470ad8a8c7b95fc4d6bdca/lib/sqlalchemy/dialects/postgres.py): 
It is [removed in the 1.4 release](https://help.heroku.com/ZKNTJQSK/why-is-sqlalchemy-1-4-x-not-connecting-to-heroku-postgres) but we can change the protocol now.
