### PR TITLE
bump alchemyjsonschema

### DIFF
--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -3,7 +3,7 @@
 pip-tools>=5.4.0
 
 # For schema generation
-alchemyjsonschema==0.5.0
+alchemyjsonschema==0.7.1
 
 # For tests
 coverage

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@
 #
 --no-binary psycopg2
 
-alchemyjsonschema==0.5.0
+alchemyjsonschema==0.7.1
     # via -r requirements-dev.in
 attrs==19.3.0
     # via

--- a/tests/test_generate_model_schemas.py
+++ b/tests/test_generate_model_schemas.py
@@ -62,7 +62,6 @@ def test_generate_schema():
         "required": [
             "id",
             "framework_id",
-            "is_a_copy",
             "lot_id"
         ]
     }


### PR DESCRIPTION
https://trello.com/c/UIj9AODz/2212-upgrade-sqlalchemy-in-digitalmarketplace-api

We need to update `alchemyjsonschema` to a version which supports sqlalchemy 1.4 as part of the work to upgrade to that version.

In this version it no longer reports one boolean field as 'required', this is due to a change in the definition of 'required' by the library, see 06c65a8 for more details.