### PR TITLE
Remove Python 2 import compatibility

### DIFF
--- a/tests/test_generate_model_schemas.py
+++ b/tests/test_generate_model_schemas.py
@@ -1,8 +1,5 @@
+import builtins
 import mock
-try:
-    import __builtin__ as builtins
-except ImportError:
-    import builtins
 
 from app.generate_model_schemas import generate_schemas, DMModelSchema, get_models_for_all_db_tables
 from app.models import Brief, BriefClarificationQuestion


### PR DESCRIPTION
We can simplify the imports - we now only support Python 3.6+, which has builtins. __builtins__ was a Python 2 thing.