### PR TITLE
Add employment status question to briefs schema

### DIFF
--- a/json_schemas/brief-responses-digital-outcomes-and-specialists-5-digital-outcomes.json
+++ b/json_schemas/brief-responses-digital-outcomes-and-specialists-5-digital-outcomes.json
@@ -3,8 +3,7 @@
   "additionalProperties": false,
   "properties": {
     "availability": {
-      "maxLength": 100,
-      "minLength": 1,
+      "format": "date",
       "type": "string"
     },
     "essentialRequirements": {

--- a/json_schemas/brief-responses-digital-outcomes-and-specialists-5-digital-specialists.json
+++ b/json_schemas/brief-responses-digital-outcomes-and-specialists-5-digital-specialists.json
@@ -3,8 +3,7 @@
   "additionalProperties": false,
   "properties": {
     "availability": {
-      "maxLength": 100,
-      "minLength": 1,
+      "format": "date",
       "type": "string"
     },
     "dayRate": {

--- a/json_schemas/brief-responses-digital-outcomes-and-specialists-5-user-research-participants.json
+++ b/json_schemas/brief-responses-digital-outcomes-and-specialists-5-user-research-participants.json
@@ -3,8 +3,7 @@
   "additionalProperties": false,
   "properties": {
     "availability": {
-      "maxLength": 100,
-      "minLength": 1,
+      "format": "date",
       "type": "string"
     },
     "essentialRequirements": {

--- a/json_schemas/briefs-digital-outcomes-and-specialists-5-digital-outcomes.json
+++ b/json_schemas/briefs-digital-outcomes-and-specialists-5-digital-outcomes.json
@@ -42,6 +42,12 @@
       "pattern": "^$|(^(?:\\S+\\s+){0,199}\\S+$)",
       "type": "string"
     },
+    "employmentStatus": {
+      "enum": [
+        "Contracted out service: the off-payroll rules do not apply",
+        "Supply of resource: the off-payroll rules will apply to any workers engaged through a qualifying intermediary, such as their own limited company"
+      ]
+    },
     "endUsers": {
       "minLength": 1,
       "pattern": "^(?:\\S+\\s+){0,199}\\S+$",
@@ -78,7 +84,6 @@
     },
     "location": {
       "enum": [
-        "Scotland",
         "North East England",
         "North West England",
         "Yorkshire and the Humber",
@@ -88,6 +93,7 @@
         "London",
         "South East England",
         "South West England",
+        "Scotland",
         "Wales",
         "Northern Ireland",
         "Offsite"
@@ -199,6 +205,7 @@
     "backgroundInformation",
     "culturalFitCriteria",
     "culturalWeighting",
+    "employmentStatus",
     "endUsers",
     "essentialRequirements",
     "existingTeam",

--- a/json_schemas/briefs-digital-outcomes-and-specialists-5-digital-specialists.json
+++ b/json_schemas/briefs-digital-outcomes-and-specialists-5-digital-specialists.json
@@ -37,6 +37,12 @@
       "pattern": "^$|(^(?:\\S+\\s+){0,199}\\S+$)",
       "type": "string"
     },
+    "employmentStatus": {
+      "enum": [
+        "Contracted out service: the off-payroll rules do not apply",
+        "Supply of resource: the off-payroll rules will apply to any workers engaged through a qualifying intermediary, such as their own limited company"
+      ]
+    },
     "essentialRequirements": {
       "items": {
         "maxLength": 300,
@@ -68,7 +74,6 @@
     },
     "location": {
       "enum": [
-        "Scotland",
         "North East England",
         "North West England",
         "Yorkshire and the Humber",
@@ -78,6 +83,7 @@
         "London",
         "South East England",
         "South West England",
+        "Scotland",
         "Wales",
         "Northern Ireland",
         "Offsite"
@@ -186,6 +192,7 @@
   "required": [
     "culturalFitCriteria",
     "culturalWeighting",
+    "employmentStatus",
     "essentialRequirements",
     "existingTeam",
     "location",

--- a/json_schemas/briefs-digital-outcomes-and-specialists-5-user-research-participants.json
+++ b/json_schemas/briefs-digital-outcomes-and-specialists-5-user-research-participants.json
@@ -52,7 +52,6 @@
     },
     "location": {
       "enum": [
-        "Scotland",
         "North East England",
         "North West England",
         "Yorkshire and the Humber",
@@ -62,6 +61,7 @@
         "London",
         "South East England",
         "South West England",
+        "Scotland",
         "Wales",
         "Northern Ireland",
         "International (outside the UK)"

--- a/json_schemas/services-digital-outcomes-and-specialists-5-user-research-participants.json
+++ b/json_schemas/services-digital-outcomes-and-specialists-5-user-research-participants.json
@@ -8,17 +8,17 @@
     "locations": {
       "items": {
         "enum": [
-          "Scotland",
           "North East England",
           "North West England",
           "Yorkshire and the Humber",
           "East Midlands",
           "West Midlands",
           "East of England",
-          "Wales",
           "London",
           "South East England",
           "South West England",
+          "Scotland",
+          "Wales",
           "Northern Ireland",
           "International (outside the UK)"
         ]


### PR DESCRIPTION
Pull in the updated JSON validation schemas from https://github.com/alphagov/digitalmarketplace-frameworks/pull/685 

They're generated by [a script](https://github.com/alphagov/digitalmarketplace-frameworks/blob/main/scripts/generate-validation-schemas.py) so I'm reasonably sure they're correct. 

https://trello.com/c/aIJAqcQ4/954-3-allow-briefs-to-store-the-answer-to-the-new-ir35-question