### PR TITLE
Upgrade Flask to 1.1.4

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -4,11 +4,11 @@
 digitalmarketplace-apiclient
 digitalmarketplace-utils
 
-Flask==1.0.4
+Flask>=1.1,<2
 Flask-Bcrypt==0.7.1
 Flask-Migrate==3.0.1
 Flask-SQLAlchemy>=2.4.1,<2.6.0
-itsdangerous==1.1.0
+itsdangerous
 
 --no-binary=psycopg2
 psycopg2==2.8.6

--- a/requirements.in
+++ b/requirements.in
@@ -4,15 +4,15 @@
 digitalmarketplace-apiclient
 digitalmarketplace-utils
 
-Flask==1.0.4                     # pyup: >=1.0.0,<1.1.0
-Flask-Bcrypt==0.7.1              # pyup: >=0.7.1,<0.8.0
-Flask-Migrate==3.0.1             # pyup: ignore
-Flask-SQLAlchemy>=2.4.1,<2.6.0  # pyup: ignore
-itsdangerous==1.1.0               # pyup: ignore
+Flask==1.0.4
+Flask-Bcrypt==0.7.1
+Flask-Migrate==3.0.1
+Flask-SQLAlchemy>=2.4.1,<2.6.0
+itsdangerous==1.1.0
 
 --no-binary=psycopg2
 psycopg2==2.8.6
-SQLAlchemy>=1.3.0,<1.5.0  # pyup: ignore
+SQLAlchemy>=1.3.0,<1.5.0
 SQLAlchemy-Utils==0.37.4
 sqlalchemy-json==0.4.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ defusedxml==0.6.0
     # via odfpy
 digitalmarketplace-apiclient==22.0.0
     # via -r requirements.in
-digitalmarketplace-utils==58.1.0
+digitalmarketplace-utils==59.0.0
     # via -r requirements.in
 docopt==0.6.2
     # via notifications-python-client
@@ -62,7 +62,7 @@ flask-sqlalchemy==2.5.1
     #   flask-migrate
 flask-wtf==0.14.3
     # via digitalmarketplace-utils
-flask==1.0.4
+flask==1.1.4
     # via
     #   -r requirements.in
     #   digitalmarketplace-utils
@@ -178,9 +178,7 @@ urllib3==1.25.10
     #   botocore
     #   requests
 werkzeug==1.0.0
-    # via
-    #   digitalmarketplace-utils
-    #   flask
+    # via flask
 workdays==1.4
     # via digitalmarketplace-utils
 wtforms==2.2.1

--- a/tests/callbacks/views/test_notify.py
+++ b/tests/callbacks/views/test_notify.py
@@ -42,7 +42,7 @@ class TestNotifyCallback(BaseApplicationTest):
     def test_callbacks_are_logged(self, status):
         notify_data = self.notify_data(status=status)
 
-        with logcapture.LogCapture(names=('flask.app',), level=logging.INFO) as logs:
+        with logcapture.LogCapture(names=('app',), level=logging.INFO) as logs:
             self.client.post(
                 '/callbacks/notify',
                 data=json.dumps(notify_data),
@@ -62,7 +62,7 @@ class TestNotifyCallback(BaseApplicationTest):
         user = User.query.filter(User.email_address == 'test+1@digital.gov.uk').first()
         assert user.active is True
 
-        with logcapture.LogCapture(names=('flask.app',), level=logging.INFO) as logs:
+        with logcapture.LogCapture(names=('app',), level=logging.INFO) as logs:
             response = self.client.post('/callbacks/notify',
                                         data=json.dumps(notify_data),
                                         content_type='application/json')
@@ -92,7 +92,7 @@ class TestNotifyCallback(BaseApplicationTest):
     def test_error_logged_on_technical_delivery_failure(self):
         notify_data = self.notify_data(status='technical-failure')
 
-        with logcapture.LogCapture(names=('flask.app',), level=logging.WARNING) as logs:
+        with logcapture.LogCapture(names=('app',), level=logging.WARNING) as logs:
             response = self.client.post('/callbacks/notify',
                                         data=json.dumps(notify_data),
                                         content_type='application/json')


### PR DESCRIPTION
Pin requirements to 1.1 or greater, but less than 2. Flask 1.1 is the last planned v1 release before 2.0.0, so take patch versions of 1.1 for security but not 2.0 which we're not ready for yet.

Take new versions of utils and content-loader which have been updated for Flask 1.1

Also remove the pin for `itsdangerous` - Flask now controls the supported versions. See https://github.com/pallets/flask/blob/1.1.4/setup.py#L58

Also remove pyup comments - we don't need them now we're using dependabot.

Essentially the same as https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/1436

https://trello.com/c/obh5gpQp/2250-update-to-flask-114