### PR TITLE
Revert "Add employment status question to briefs schema"

### DIFF
--- a/json_schemas/brief-responses-digital-outcomes-and-specialists-5-digital-outcomes.json
+++ b/json_schemas/brief-responses-digital-outcomes-and-specialists-5-digital-outcomes.json
@@ -3,7 +3,8 @@
   "additionalProperties": false,
   "properties": {
     "availability": {
-      "format": "date",
+      "maxLength": 100,
+      "minLength": 1,
       "type": "string"
     },
     "essentialRequirements": {

--- a/json_schemas/brief-responses-digital-outcomes-and-specialists-5-digital-specialists.json
+++ b/json_schemas/brief-responses-digital-outcomes-and-specialists-5-digital-specialists.json
@@ -3,7 +3,8 @@
   "additionalProperties": false,
   "properties": {
     "availability": {
-      "format": "date",
+      "maxLength": 100,
+      "minLength": 1,
       "type": "string"
     },
     "dayRate": {

--- a/json_schemas/brief-responses-digital-outcomes-and-specialists-5-user-research-participants.json
+++ b/json_schemas/brief-responses-digital-outcomes-and-specialists-5-user-research-participants.json
@@ -3,7 +3,8 @@
   "additionalProperties": false,
   "properties": {
     "availability": {
-      "format": "date",
+      "maxLength": 100,
+      "minLength": 1,
       "type": "string"
     },
     "essentialRequirements": {

--- a/json_schemas/briefs-digital-outcomes-and-specialists-5-digital-outcomes.json
+++ b/json_schemas/briefs-digital-outcomes-and-specialists-5-digital-outcomes.json
@@ -42,12 +42,6 @@
       "pattern": "^$|(^(?:\\S+\\s+){0,199}\\S+$)",
       "type": "string"
     },
-    "employmentStatus": {
-      "enum": [
-        "Contracted out service: the off-payroll rules do not apply",
-        "Supply of resource: the off-payroll rules will apply to any workers engaged through a qualifying intermediary, such as their own limited company"
-      ]
-    },
     "endUsers": {
       "minLength": 1,
       "pattern": "^(?:\\S+\\s+){0,199}\\S+$",
@@ -84,6 +78,7 @@
     },
     "location": {
       "enum": [
+        "Scotland",
         "North East England",
         "North West England",
         "Yorkshire and the Humber",
@@ -93,7 +88,6 @@
         "London",
         "South East England",
         "South West England",
-        "Scotland",
         "Wales",
         "Northern Ireland",
         "Offsite"
@@ -205,7 +199,6 @@
     "backgroundInformation",
     "culturalFitCriteria",
     "culturalWeighting",
-    "employmentStatus",
     "endUsers",
     "essentialRequirements",
     "existingTeam",

--- a/json_schemas/briefs-digital-outcomes-and-specialists-5-digital-specialists.json
+++ b/json_schemas/briefs-digital-outcomes-and-specialists-5-digital-specialists.json
@@ -37,12 +37,6 @@
       "pattern": "^$|(^(?:\\S+\\s+){0,199}\\S+$)",
       "type": "string"
     },
-    "employmentStatus": {
-      "enum": [
-        "Contracted out service: the off-payroll rules do not apply",
-        "Supply of resource: the off-payroll rules will apply to any workers engaged through a qualifying intermediary, such as their own limited company"
-      ]
-    },
     "essentialRequirements": {
       "items": {
         "maxLength": 300,
@@ -74,6 +68,7 @@
     },
     "location": {
       "enum": [
+        "Scotland",
         "North East England",
         "North West England",
         "Yorkshire and the Humber",
@@ -83,7 +78,6 @@
         "London",
         "South East England",
         "South West England",
-        "Scotland",
         "Wales",
         "Northern Ireland",
         "Offsite"
@@ -192,7 +186,6 @@
   "required": [
     "culturalFitCriteria",
     "culturalWeighting",
-    "employmentStatus",
     "essentialRequirements",
     "existingTeam",
     "location",

--- a/json_schemas/briefs-digital-outcomes-and-specialists-5-user-research-participants.json
+++ b/json_schemas/briefs-digital-outcomes-and-specialists-5-user-research-participants.json
@@ -52,6 +52,7 @@
     },
     "location": {
       "enum": [
+        "Scotland",
         "North East England",
         "North West England",
         "Yorkshire and the Humber",
@@ -61,7 +62,6 @@
         "London",
         "South East England",
         "South West England",
-        "Scotland",
         "Wales",
         "Northern Ireland",
         "International (outside the UK)"

--- a/json_schemas/services-digital-outcomes-and-specialists-5-user-research-participants.json
+++ b/json_schemas/services-digital-outcomes-and-specialists-5-user-research-participants.json
@@ -8,17 +8,17 @@
     "locations": {
       "items": {
         "enum": [
+          "Scotland",
           "North East England",
           "North West England",
           "Yorkshire and the Humber",
           "East Midlands",
           "West Midlands",
           "East of England",
+          "Wales",
           "London",
           "South East England",
           "South West England",
-          "Scotland",
-          "Wales",
           "Northern Ireland",
           "International (outside the UK)"
         ]


### PR DESCRIPTION
Reverts alphagov/digitalmarketplace-api#1133

This breaks our functional tests and will also mean that people are unable to create new briefs on production in the time between the API getting released and the briefs frontend being released. We'll need to work out a more robust plan to release it all so we minimise the risk of user-facing errors. 