### PR TITLE
Add optional Employment Status question to brief journey

### DIFF
--- a/json_schemas/brief-responses-digital-outcomes-and-specialists-5-digital-outcomes.json
+++ b/json_schemas/brief-responses-digital-outcomes-and-specialists-5-digital-outcomes.json
@@ -3,8 +3,7 @@
   "additionalProperties": false,
   "properties": {
     "availability": {
-      "maxLength": 100,
-      "minLength": 1,
+      "format": "date",
       "type": "string"
     },
     "essentialRequirements": {

--- a/json_schemas/brief-responses-digital-outcomes-and-specialists-5-digital-specialists.json
+++ b/json_schemas/brief-responses-digital-outcomes-and-specialists-5-digital-specialists.json
@@ -3,8 +3,7 @@
   "additionalProperties": false,
   "properties": {
     "availability": {
-      "maxLength": 100,
-      "minLength": 1,
+      "format": "date",
       "type": "string"
     },
     "dayRate": {

--- a/json_schemas/brief-responses-digital-outcomes-and-specialists-5-user-research-participants.json
+++ b/json_schemas/brief-responses-digital-outcomes-and-specialists-5-user-research-participants.json
@@ -3,8 +3,7 @@
   "additionalProperties": false,
   "properties": {
     "availability": {
-      "maxLength": 100,
-      "minLength": 1,
+      "format": "date",
       "type": "string"
     },
     "essentialRequirements": {

--- a/json_schemas/briefs-digital-outcomes-and-specialists-5-digital-outcomes.json
+++ b/json_schemas/briefs-digital-outcomes-and-specialists-5-digital-outcomes.json
@@ -42,6 +42,12 @@
       "pattern": "^$|(^(?:\\S+\\s+){0,199}\\S+$)",
       "type": "string"
     },
+    "employmentStatus": {
+      "enum": [
+        "Contracted out service: the off-payroll rules do not apply",
+        "Supply of resource: the off-payroll rules will apply to any workers engaged through a qualifying intermediary, such as their own limited company"
+      ]
+    },
     "endUsers": {
       "minLength": 1,
       "pattern": "^(?:\\S+\\s+){0,199}\\S+$",
@@ -78,7 +84,6 @@
     },
     "location": {
       "enum": [
-        "Scotland",
         "North East England",
         "North West England",
         "Yorkshire and the Humber",
@@ -88,6 +93,7 @@
         "London",
         "South East England",
         "South West England",
+        "Scotland",
         "Wales",
         "Northern Ireland",
         "Offsite"
@@ -199,6 +205,7 @@
     "backgroundInformation",
     "culturalFitCriteria",
     "culturalWeighting",
+    "employmentStatus",
     "endUsers",
     "essentialRequirements",
     "existingTeam",

--- a/json_schemas/briefs-digital-outcomes-and-specialists-5-digital-outcomes.json
+++ b/json_schemas/briefs-digital-outcomes-and-specialists-5-digital-outcomes.json
@@ -205,7 +205,6 @@
     "backgroundInformation",
     "culturalFitCriteria",
     "culturalWeighting",
-    "employmentStatus",
     "endUsers",
     "essentialRequirements",
     "existingTeam",

--- a/json_schemas/briefs-digital-outcomes-and-specialists-5-digital-specialists.json
+++ b/json_schemas/briefs-digital-outcomes-and-specialists-5-digital-specialists.json
@@ -37,6 +37,12 @@
       "pattern": "^$|(^(?:\\S+\\s+){0,199}\\S+$)",
       "type": "string"
     },
+    "employmentStatus": {
+      "enum": [
+        "Contracted out service: the off-payroll rules do not apply",
+        "Supply of resource: the off-payroll rules will apply to any workers engaged through a qualifying intermediary, such as their own limited company"
+      ]
+    },
     "essentialRequirements": {
       "items": {
         "maxLength": 300,
@@ -68,7 +74,6 @@
     },
     "location": {
       "enum": [
-        "Scotland",
         "North East England",
         "North West England",
         "Yorkshire and the Humber",
@@ -78,6 +83,7 @@
         "London",
         "South East England",
         "South West England",
+        "Scotland",
         "Wales",
         "Northern Ireland",
         "Offsite"
@@ -186,6 +192,7 @@
   "required": [
     "culturalFitCriteria",
     "culturalWeighting",
+    "employmentStatus",
     "essentialRequirements",
     "existingTeam",
     "location",

--- a/json_schemas/briefs-digital-outcomes-and-specialists-5-digital-specialists.json
+++ b/json_schemas/briefs-digital-outcomes-and-specialists-5-digital-specialists.json
@@ -192,7 +192,6 @@
   "required": [
     "culturalFitCriteria",
     "culturalWeighting",
-    "employmentStatus",
     "essentialRequirements",
     "existingTeam",
     "location",

--- a/json_schemas/briefs-digital-outcomes-and-specialists-5-user-research-participants.json
+++ b/json_schemas/briefs-digital-outcomes-and-specialists-5-user-research-participants.json
@@ -52,7 +52,6 @@
     },
     "location": {
       "enum": [
-        "Scotland",
         "North East England",
         "North West England",
         "Yorkshire and the Humber",
@@ -62,6 +61,7 @@
         "London",
         "South East England",
         "South West England",
+        "Scotland",
         "Wales",
         "Northern Ireland",
         "International (outside the UK)"

--- a/json_schemas/services-digital-outcomes-and-specialists-5-user-research-participants.json
+++ b/json_schemas/services-digital-outcomes-and-specialists-5-user-research-participants.json
@@ -8,17 +8,17 @@
     "locations": {
       "items": {
         "enum": [
-          "Scotland",
           "North East England",
           "North West England",
           "Yorkshire and the Humber",
           "East Midlands",
           "West Midlands",
           "East of England",
-          "Wales",
           "London",
           "South East England",
           "South West England",
+          "Scotland",
+          "Wales",
           "Northern Ireland",
           "International (outside the UK)"
         ]


### PR DESCRIPTION
Reverts alphagov/digitalmarketplace-api#1145

Readd the employment status question that was added in #1145 but broke the functional tests. This time, however, make it optional temporarily while we release everything.

Without this change we can't release the new question to production without causing a period of time where buyers can't create new briefs. This is because both the briefs FE and the API require the changes in the other app to have already been deployed for everything to work.

With the question as optional in the API (but not in the briefs frontend), we can release the API first, then the briefs FE, then update the API to make the question required. This will allow us to release everything without breaking things for our buyers.

https://trello.com/c/l9lnd1GD/14-2-add-new-ir35-question-to-the-create-an-opportunity-journey