### PR TITLE
Enable choice of what to sort audit messages by

### DIFF
--- a/app/main/views/audits.py
+++ b/app/main/views/audits.py
@@ -181,7 +181,8 @@ def list_audits():
         audits = AuditEvent.query.join(audits_subquery, audits_subquery.c.id == AuditEvent.id)
 
     sort_order = db.desc if convert_to_boolean(request.args.get('latest_first')) else db.asc
-    audits = audits.order_by(sort_order(AuditEvent.created_at), sort_order(AuditEvent.id))
+    sort_by = getattr(AuditEvent, request.args.get('sort_by', 'created_at'))
+    audits = audits.order_by(sort_order(sort_by), sort_order(AuditEvent.id))
 
     return paginated_result_response(
         result_name=RESOURCE_NAME,

--- a/tests/main/views/test_audits.py
+++ b/tests/main/views/test_audits.py
@@ -689,6 +689,15 @@ class TestAuditEvents(BaseTestAuditEvents):
         assert data['auditEvents'][0]['user'] == '4'
         assert data['auditEvents'][4]['user'] == '0'
 
+    def test_should_get_audit_events_sorted_by_custom_field(self):
+        for user in [2, 1, 3]:
+            self.add_audit_event(user=user, type=AuditTypes.update_service)
+        response = self.client.get('/audit-events?sort_by=user&audit-type=update_service')
+        data = json.loads(response.get_data())
+
+        assert response.status_code == 200
+        assert [audit['user'] for audit in data['auditEvents']] == ['1', '2', '3']
+
     def test_should_get_audit_event_using_audit_date(self):
         today = datetime.utcnow().strftime("%Y-%m-%d")
 


### PR DESCRIPTION
https://trello.com/c/LZadC8NQ/2152-send-ccs-list-of-approved-service-edits-for-month-past

Currently, we always sort audit messages by the date they're created. This can be inconvenient when we want them sorted differently. For example, it would be useful to be able to sort by the date of acknowledgement when creating the report of approved service edits.

Add a new parameter to the `list_audits` API method to allow people with API access to choose what attribute they want to use for sorting. Default back to the creation date if this is not provided.