### PR TITLE
Make employment status question required

### DIFF
--- a/json_schemas/briefs-digital-outcomes-and-specialists-5-digital-outcomes.json
+++ b/json_schemas/briefs-digital-outcomes-and-specialists-5-digital-outcomes.json
@@ -205,6 +205,7 @@
     "backgroundInformation",
     "culturalFitCriteria",
     "culturalWeighting",
+    "employmentStatus",
     "endUsers",
     "essentialRequirements",
     "existingTeam",

--- a/json_schemas/briefs-digital-outcomes-and-specialists-5-digital-specialists.json
+++ b/json_schemas/briefs-digital-outcomes-and-specialists-5-digital-specialists.json
@@ -192,6 +192,7 @@
   "required": [
     "culturalFitCriteria",
     "culturalWeighting",
+    "employmentStatus",
     "essentialRequirements",
     "existingTeam",
     "location",


### PR DESCRIPTION
In #1146 we added a new question to the brief creation journey. This question is required, but we left it as optional to make the process of releasing the question and updating the tests easier.

All that work's now done, so we can mark the question as required so the validation schema in the API now matches what's generated from the frameworks repo.

https://trello.com/c/l9lnd1GD/14-2-add-new-ir35-question-to-the-create-an-opportunity-journey