### PR TITLE
Add error handling for social value 

### DIFF
--- a/app/brief_utils.py
+++ b/app/brief_utils.py
@@ -7,7 +7,7 @@ from .utils import index_object
 
 
 def validate_brief_data(brief, enforce_required=True, required_fields=None):
-    errs = get_validation_errors(
+    errors = get_validation_errors(
         'briefs-{}-{}'.format(brief.framework.slug, brief.lot.slug),
         brief.data,
         enforce_required=enforce_required,
@@ -19,14 +19,14 @@ def validate_brief_data(brief, enforce_required=True, required_fields=None):
     if 'socialWeighting' in brief.data and brief.data['socialWeighting'] >= 10:
         criteria_weighting_keys.append('socialWeighting')
     # Only check total if all weightings are set
-    if not errs and all(key in brief.data for key in criteria_weighting_keys):
+    if not errors and all(key in brief.data for key in criteria_weighting_keys):
         criteria_weightings = sum(brief.data[key] for key in criteria_weighting_keys)
         if criteria_weightings != 100:
             for key in criteria_weighting_keys:
-                errs[key] = 'total_should_be_100'
+                errors[key] = 'total_should_be_100'
 
-    if errs:
-        abort(400, errs)
+    if errors:
+        abort(400, errors)
 
 
 def get_supplier_service_eligible_for_brief(supplier, brief):

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -817,7 +817,22 @@ def test_translate_oneof_errors():
     }]) == {'example': [{'error': 'answer_required', 'field': 'example-field', 'index': 0}]}
 
 
-def test_translate_unknown_oneoff_eerror():
+def test_translate_social_value_oneof_errors():
+    assert api_error([{
+        'validator': 'oneOf',
+        'message': "failed",
+        'path': ['socialValue'],
+        'validator_value': [{'maximum': 20, 'minimum': 10, 'type': 'integer'},
+                            {'maximum': 0, 'minimum': 0, 'type': 'integer'}],
+        'context': [
+            {'message': "failed",
+             'validator': 'oneOf'
+             }
+        ],
+    }]) == {'socialValue': 'not_a_number'}
+
+
+def test_translate_unknown_oneof_error():
     assert api_error([{
         'validator': 'oneOf',
         'message': "failed",


### PR DESCRIPTION
The social weighting question introduces a new validation case which was not previously handled. We can differentiate between the other `oneOf` error handling as only one item is returned in the error path.  We then add some new logic to the `_translate_json_schema_error` function to translate this validation error to the desired error code.